### PR TITLE
Add missing condition in patient session state machine

### DIFF
--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -172,7 +172,10 @@ module PatientSessionStateMachineConcern
 
     def vaccination_can_be_delayed?
       vaccination_not_administered? &&
-        (not_well? || contraindication? || absent_from_session?)
+        (
+          not_well? || contraindication? || absent_from_session? ||
+            absent_from_school?
+        )
     end
 
     def next_step


### PR DESCRIPTION
`Absent from session` and `absent from school` should be treated similarly in this case. However I'm unsure what else needs to change to accommodate the `absent from school` state in other places, and how it ought to be best tested.