### PR TITLE
Add PatientTabsConcern for controllers

### DIFF
--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -1,0 +1,25 @@
+module PatientTabsConcern
+  extend ActiveSupport::Concern
+
+  def group_patient_sessions_by_conditions(all_patient_sessions, tab_conditions)
+    all_patient_sessions
+      .group_by do |patient_session| # rubocop:disable Style/BlockDelimiters
+        tab_conditions
+          .find { |_, conditions| conditions.any? { patient_session.send(_1) } }
+          &.first
+      end
+      .tap { |groups| tab_conditions.each_key { groups[_1] ||= [] } }
+  end
+
+  def group_patient_sessions_by_state(all_patient_sessions, tab_states)
+    all_patient_sessions
+      .group_by do |patient_session| # rubocop:disable Style/BlockDelimiters
+        tab_states.find { |_, states| patient_session.state.in? states }&.first
+      end
+      .tap { |groups| tab_states.each_key { groups[_1] ||= [] } }
+  end
+
+  def count_patient_sessions(tab_patient_sessions)
+    tab_patient_sessions.transform_values(&:count)
+  end
+end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -1,4 +1,6 @@
 class ConsentsController < ApplicationController
+  include PatientTabsConcern
+
   before_action :set_session
 
   layout "two_thirds", except: :index
@@ -26,17 +28,11 @@ class ConsentsController < ApplicationController
         :unmatched_responses
       ]
 
-    @current_tab = TAB_PATHS[:consent][params[:tab]]
-
     tab_patient_sessions =
-      all_patient_sessions.group_by do |patient_session|
-        tab_conditions
-          .find { |_, conditions| conditions.any? { patient_session.send(_1) } }
-          &.first
-      end
-    @tab_counts = tab_patient_sessions.transform_values(&:count)
-    tab_conditions.each_key { |tab| @tab_counts[tab] ||= 0 }
+      group_patient_sessions_by_conditions(all_patient_sessions, tab_conditions)
 
+    @current_tab = TAB_PATHS[:consent][params[:tab]]
+    @tab_counts = count_patient_sessions(tab_patient_sessions)
     @patient_sessions = tab_patient_sessions[@current_tab] || []
 
     session[:current_section] = "consents"

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -1,5 +1,6 @@
 class TriageController < ApplicationController
   include TriageMailerConcern
+  include PatientTabsConcern
 
   before_action :set_session, only: %i[index create update]
   before_action :set_patient, only: %i[create update]
@@ -34,16 +35,13 @@ class TriageController < ApplicationController
       ]
     }
 
-    @current_tab = TAB_PATHS[:triage][params[:tab]]
-    tabs_to_states[@current_tab]
     tab_patient_sessions =
-      all_patient_sessions.group_by do |patient_session|
-        tabs_to_states
-          .find { |_, states| patient_session.state.in? states }
-          &.first
-      end
-    @tab_counts = tab_patient_sessions.transform_values(&:count)
+      group_patient_sessions_by_state(all_patient_sessions, tabs_to_states)
+
+    @current_tab = TAB_PATHS[:triage][params[:tab]]
+    @tab_counts = count_patient_sessions(tab_patient_sessions)
     @patient_sessions = tab_patient_sessions[@current_tab] || []
+
     session[:current_section] = "triage"
   end
 

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+describe PatientTabsConcern do
+  subject { Class.new { include PatientTabsConcern }.new }
+
+  describe "#group_patient_sessions_by_conditions" do
+    let(:patient_session1) { create(:patient_session) }
+    let(:patient_session2) do
+      create(:patient_session, :consent_given_triage_needed)
+    end
+    let(:patient_session3) { create(:patient_session, :consent_refused) }
+
+    it "groups patient sessions by conditions" do
+      tab_conditions = {
+        no_consent: %i[no_consent?],
+        consent_given: %i[consent_given?],
+        consent_refused: %i[consent_refused?]
+      }
+
+      result =
+        subject.group_patient_sessions_by_conditions(
+          [patient_session1, patient_session2, patient_session3],
+          tab_conditions
+        )
+
+      expect(result).to eq(
+        {
+          no_consent: [patient_session1],
+          consent_given: [patient_session2],
+          consent_refused: [patient_session3]
+        }
+      )
+    end
+
+    context "one of the groups is empty" do
+      it "returns an empty array for the empty group" do
+        tab_conditions = {
+          no_consent: %i[no_consent?],
+          consent_given: %i[consent_given?],
+          consent_refused: %i[consent_refused?]
+        }
+
+        result =
+          subject.group_patient_sessions_by_conditions(
+            [patient_session1],
+            tab_conditions
+          )
+
+        expect(result).to eq(
+          {
+            no_consent: [patient_session1],
+            consent_given: [],
+            consent_refused: []
+          }
+        )
+      end
+    end
+  end
+
+  describe "#group_patient_sessions_by_states" do
+    let(:patient_session1) { create(:patient_session) }
+    let(:patient_session2) do
+      create(:patient_session, :consent_given_triage_needed)
+    end
+    let(:patient_session3) do
+      create(:patient_session, :consent_given_triage_not_needed)
+    end
+    let(:patient_sessions) do
+      [patient_session1, patient_session2, patient_session3]
+    end
+
+    it "groups patient sessions by states" do
+      tab_states = {
+        needs_triage: %w[added_to_session],
+        triage_complete: %w[consent_given_triage_needed],
+        no_triage_needed: %w[consent_given_triage_not_needed]
+      }
+
+      result =
+        subject.group_patient_sessions_by_state(patient_sessions, tab_states)
+
+      expect(result).to eq(
+        {
+          needs_triage: [patient_session1],
+          triage_complete: [patient_session2],
+          no_triage_needed: [patient_session3]
+        }
+      )
+    end
+
+    context "one of the groups is empty" do
+      it "returns an empty array for the empty group" do
+        tab_states = {
+          needs_triage: %w[added_to_session],
+          triage_complete: %w[consent_given_triage_needed],
+          no_triage_needed: %w[consent_given_triage_not_needed]
+        }
+
+        result =
+          subject.group_patient_sessions_by_state(
+            [patient_session1],
+            tab_states
+          )
+
+        expect(result).to eq(
+          {
+            needs_triage: [patient_session1],
+            triage_complete: [],
+            no_triage_needed: []
+          }
+        )
+      end
+    end
+  end
+
+  describe "#count_patient_sessions" do
+    let(:patient_session1) { create(:patient_session) }
+    let(:patient_session2) { create(:patient_session) }
+    let(:patient_session3) { create(:patient_session, :consent_refused) }
+
+    it "counts patient session groups" do
+      patient_sessions = {
+        no_consent: [patient_session1, patient_session2],
+        consent_given: [],
+        consent_refused: [patient_session3]
+      }
+
+      result = subject.count_patient_sessions(patient_sessions)
+
+      expect(result).to eq(
+        { no_consent: 2, consent_given: 0, consent_refused: 1 }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This encapsulates logic to split patient_sessions up into groups and to do the counts. We'll continue to move the logic for tab groupings into the concern in follow-up PRs.