### PR TITLE
Update vaccinations pages to use page loads

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -27,7 +27,7 @@ class VaccinationsController < ApplicationController
       ],
       vaccinated: %w[vaccinated],
       vaccinate_later: %w[delay_vaccination],
-      not_vaccinated: %w[
+      could_not_vaccinate: %w[
         consent_refused
         consent_conflicts
         triaged_do_not_vaccinate

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -11,55 +11,41 @@
 
 <%= h1 page_title, page_title: %>
 
-<%=
-render AppTabComponent.new(title: "Vaccinations", classes: 'nhsuk-tabs') do |c|
-  c.with_tab(id: "action-needed", label: t("states.action_needed.label") + " (#{ @partitioned_patient_sessions[:action_needed].size })", classes: 'nhsuk-tabs__panel') do
-    if @partitioned_patient_sessions[:action_needed].any?
-      render "patients_with_actions",
- id: "action-needed",
- caption: t("states.action_needed.title"),
- patient_sessions: @partitioned_patient_sessions[:action_needed]
-else
-  render AppEmptyListComponent.new(
-    title: t("states.action_needed.title")
-  )
-end
-end
-c.with_tab(id: "vaccinated", label: t("states.vaccinated.label") + " (#{ @partitioned_patient_sessions[:vaccinated].size })", classes: 'nhsuk-tabs__panel') do
-  if @partitioned_patient_sessions[:vaccinated].any?
-    render "patients_with_outcomes",
- id: "vaccinated",
- caption: t("states.vaccinated.title"),
- patient_sessions: @partitioned_patient_sessions[:vaccinated]
-else
-  render AppEmptyListComponent.new(
-    title: t("states.vaccinated.title")
-  )
-end
-end
-c.with_tab(id: "vaccinate-later", label: t("states.vaccinate_later.label") + " (#{ @partitioned_patient_sessions[:vaccinate_later].size })", classes: 'nhsuk-tabs__panel') do
-  if @partitioned_patient_sessions[:vaccinate_later].any?
-    render "patients_with_outcomes",
- id: "vaccinate-later",
- caption: t("states.vaccinate_later.title"),
- patient_sessions: @partitioned_patient_sessions[:vaccinate_later]
-else
-  render AppEmptyListComponent.new(
-    title: t("states.vaccinate_later.title")
-  )
-end
-end
-c.with_tab(id: "could-not-vaccinate", label: t("states.could_not_vaccinate.label") + " (#{ @partitioned_patient_sessions[:could_not_vaccinate].size })", classes: 'nhsuk-tabs__panel') do
-  if @partitioned_patient_sessions[:could_not_vaccinate].any?
-    render "patients_with_outcomes",
- id: "could-not-vaccinate",
- caption: t("states.could_not_vaccinate.title"),
- patient_sessions: @partitioned_patient_sessions[:could_not_vaccinate]
-else
-  render AppEmptyListComponent.new(
-    title: t("states.could_not_vaccinate.title")
-  )
-end
-end
-end
-%>
+<% def tab_content(slot, state, tab_path, page_type:, columns: %i[name dob])
+  label = t("states.#{state}.label")
+  selected = state == @current_tab
+  path = vaccinations_tab_session_path(@session, tab: tab_path)
+  count = @tab_counts[state]
+
+  slot.with_tab(
+    id: label.parameterize,
+    link: path,
+    label: "#{label} (#{count})",
+    classes: 'nhsuk-tabs__panel',
+    selected:
+  ) do
+    if selected && @patient_sessions.size > 0
+      if page_type == :actions
+        render "patients_with_actions",
+               id: label.parameterize,
+               caption: t("states.#{state}.title"),
+               patient_sessions: @patient_sessions
+     else
+       render "patients_with_outcomes",
+              id: label.parameterize,
+              caption: t("states.#{state}.title"),
+              patient_sessions: @patient_sessions
+     end
+   else
+     ""
+   end
+ end
+end %>
+
+
+<%= render AppTabComponent.new title: "Vaccinations", classes: 'nhsuk-tabs' do |slot|
+  tab_content(slot, :action_needed, :actions, page_type: :actions)
+  tab_content(slot, :vaccinated, :vaccinated, page_type: :outcomes)
+  tab_content(slot, :vaccinate_later, :later, page_type: :outcomes)
+  tab_content(slot, :could_not_vaccinate, :"could-not", page_type: :outcomes)
+end %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -16,50 +16,50 @@ render AppTabComponent.new(title: "Vaccinations", classes: 'nhsuk-tabs') do |c|
   c.with_tab(id: "action-needed", label: t("states.action_needed.label") + " (#{ @partitioned_patient_sessions[:action_needed].size })", classes: 'nhsuk-tabs__panel') do
     if @partitioned_patient_sessions[:action_needed].any?
       render "patients_with_actions",
-            id: "action-needed",
-            caption: t("states.action_needed.title"),
-            patient_sessions: @partitioned_patient_sessions[:action_needed]
-    else
-      render AppEmptyListComponent.new(
-        title: t("states.action_needed.title")
-      )
-    end
-  end
-  c.with_tab(id: "vaccinated", label: t("states.vaccinated.label") + " (#{ @partitioned_patient_sessions[:vaccinated].size })", classes: 'nhsuk-tabs__panel') do
-    if @partitioned_patient_sessions[:vaccinated].any?
-      render "patients_with_outcomes",
-            id: "vaccinated",
-            caption: t("states.vaccinated.title"),
-            patient_sessions: @partitioned_patient_sessions[:vaccinated]
-    else
-      render AppEmptyListComponent.new(
-        title: t("states.vaccinated.title")
-      )
-    end
-  end
-  c.with_tab(id: "vaccinate-later", label: t("states.vaccinate_later.label") + " (#{ @partitioned_patient_sessions[:vaccinate_later].size })", classes: 'nhsuk-tabs__panel') do
-    if @partitioned_patient_sessions[:vaccinate_later].any?
-      render "patients_with_outcomes",
-           id: "vaccinate-later",
-           caption: t("states.vaccinate_later.title"),
-           patient_sessions: @partitioned_patient_sessions[:vaccinate_later]
-    else
-      render AppEmptyListComponent.new(
-        title: t("states.not_vaccinated.title")
-      )
-    end
-  end
-  c.with_tab(id: "could-not-vaccinate", label: t("states.not_vaccinated.label") + " (#{ @partitioned_patient_sessions[:not_vaccinated].size })", classes: 'nhsuk-tabs__panel') do
-    if @partitioned_patient_sessions[:not_vaccinated].any?
-      render "patients_with_outcomes",
-           id: "could-not-vaccinate",
-           caption: t("states.not_vaccinated.title"),
-           patient_sessions: @partitioned_patient_sessions[:not_vaccinated]
-    else
-      render AppEmptyListComponent.new(
-        title: t("states.not_vaccinated.title")
-      )
-    end
-  end
+ id: "action-needed",
+ caption: t("states.action_needed.title"),
+ patient_sessions: @partitioned_patient_sessions[:action_needed]
+else
+  render AppEmptyListComponent.new(
+    title: t("states.action_needed.title")
+  )
+end
+end
+c.with_tab(id: "vaccinated", label: t("states.vaccinated.label") + " (#{ @partitioned_patient_sessions[:vaccinated].size })", classes: 'nhsuk-tabs__panel') do
+  if @partitioned_patient_sessions[:vaccinated].any?
+    render "patients_with_outcomes",
+ id: "vaccinated",
+ caption: t("states.vaccinated.title"),
+ patient_sessions: @partitioned_patient_sessions[:vaccinated]
+else
+  render AppEmptyListComponent.new(
+    title: t("states.vaccinated.title")
+  )
+end
+end
+c.with_tab(id: "vaccinate-later", label: t("states.vaccinate_later.label") + " (#{ @partitioned_patient_sessions[:vaccinate_later].size })", classes: 'nhsuk-tabs__panel') do
+  if @partitioned_patient_sessions[:vaccinate_later].any?
+    render "patients_with_outcomes",
+ id: "vaccinate-later",
+ caption: t("states.vaccinate_later.title"),
+ patient_sessions: @partitioned_patient_sessions[:vaccinate_later]
+else
+  render AppEmptyListComponent.new(
+    title: t("states.vaccinate_later.title")
+  )
+end
+end
+c.with_tab(id: "could-not-vaccinate", label: t("states.could_not_vaccinate.label") + " (#{ @partitioned_patient_sessions[:could_not_vaccinate].size })", classes: 'nhsuk-tabs__panel') do
+  if @partitioned_patient_sessions[:could_not_vaccinate].any?
+    render "patients_with_outcomes",
+ id: "could-not-vaccinate",
+ caption: t("states.could_not_vaccinate.title"),
+ patient_sessions: @partitioned_patient_sessions[:could_not_vaccinate]
+else
+  render AppEmptyListComponent.new(
+    title: t("states.could_not_vaccinate.title")
+  )
+end
+end
 end
 %>

--- a/config/initializers/tab_paths.rb
+++ b/config/initializers/tab_paths.rb
@@ -11,5 +11,11 @@ TAB_PATHS = {
     "needed" => :needs_triage,
     "completed" => :triage_complete,
     "not-needed" => :no_triage_needed
+  },
+  vaccinations: {
+    "actions" => :action_needed,
+    "vaccinated" => :vaccinated,
+    "later" => :vaccinate_later,
+    "could-not" => :could_not_vaccinate
   }
 }.with_indifferent_access

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,7 @@ en:
     vaccinate_later:
       label: Vaccinate later
       title: Children who will be vaccinated later
-    not_vaccinated:
+    could_not_vaccinate:
       label: Could not vaccinate
       title: Children who could not be vaccinated
   service:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,19 @@ Rails.application.routes.draw do
         on: :member,
         as: :triage_tab,
         tab: /#{TAB_PATHS[:triage].keys.join("|")}/
-    get "vaccinations", to: "vaccinations#index", on: :member
+
+    get "vaccinations",
+        to:
+          redirect(
+            "/sessions/%{id}/vaccinations/#{TAB_PATHS[:vaccinations].keys.first}"
+          ),
+        as: :vaccinations,
+        on: :member
+    get "vaccinations/:tab",
+        to: "vaccinations#index",
+        on: :member,
+        as: :vaccinations_tab,
+        tab: /#{TAB_PATHS[:vaccinations].keys.join("|")}/
 
     resources :edit_sessions, only: %i[show update], path: "edit", as: :edit
 

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Triage" do
     when_i_go_to_the_triage_completed_tab
     then_i_see_the_patient
 
-    when_i_access_the_record_vaccinations_area
-    then_i_see_the_patient_in_the_vaccinate_later_tab
+    when_i_access_the_vaccinate_later_page
+    then_i_see_the_patient
 
     when_i_view_the_child_record
     then_they_should_have_the_status_banner_delay_vaccination
@@ -73,15 +73,14 @@ RSpec.describe "Triage" do
     end
   end
 
-  def when_i_access_the_record_vaccinations_area
+  def when_i_access_the_vaccinate_later_page
     click_on @school.name, match: :first
     click_on "Record vaccinations"
+    click_on "Vaccinate later"
   end
 
-  def then_i_see_the_patient_in_the_vaccinate_later_tab
-    within "div#vaccinate-later" do
-      expect(page).to have_content(@patient.full_name)
-    end
+  def then_i_see_the_patient
+    expect(page).to have_content(@patient.full_name)
   end
 
   def when_i_view_the_child_record

--- a/spec/routing/vaccinations_routing_spec.rb
+++ b/spec/routing/vaccinations_routing_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe VaccinationsController, type: :routing do
   describe "routing" do
     it "routes to #index" do
-      expect(get: "/sessions/1/vaccinations").to route_to(
+      expect(get: "/sessions/1/vaccinations/actions").to route_to(
         "vaccinations#index",
-        id: "1"
+        id: "1",
+        tab: "actions"
       )
     end
   end

--- a/tests/vaccination.spec.ts
+++ b/tests/vaccination.spec.ts
@@ -93,7 +93,7 @@ async function then_i_should_see_a_success_message() {
 }
 
 async function and_i_should_see_the_outcome_as_vaccinated() {
-  await p.getByRole("tab", { name: /^Vaccinated/ }).click();
+  await p.getByRole("link", { name: /^Vaccinated/ }).click();
   const row = p.locator(`tr`, {
     hasText: fixtures.patientThatNeedsVaccination,
   });
@@ -116,7 +116,7 @@ async function then_i_should_see_the_vaccination_details() {
 }
 
 async function when_i_click_on_the_vaccinated_tab() {
-  await p.getByRole("tab", { name: /^Vaccinated/ }).click();
+  await p.getByRole("link", { name: /^Vaccinated/ }).click();
 }
 
 async function when_i_record_an_unsuccessful_vaccination() {


### PR DESCRIPTION
Last section to do. There is still some more refactoring that can be done to the PatientTabsConcern, e.g. moving the conditions and states that define each section into it. This would make it cleaner to test the tabs and which patients go into each. There are also design changes that can start to be implemented.