### PR TITLE
Handle case where patient is absent from school

### DIFF
--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -15,6 +15,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
           default: "",
           full_name:,
           triage_nurse:,
+          vaccination_nurse:,
           who_responded:,
           who_refused:
         )
@@ -31,6 +32,11 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def most_recent_triage
     @most_recent_triage ||= @patient_session.triage.order(:created_at).last
+  end
+
+  def most_recent_vaccination
+    @most_recent_vaccination ||=
+      @patient_session.vaccination_records.order(:created_at).last
   end
 
   def who_responded
@@ -52,6 +58,10 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def triage_nurse
     most_recent_triage&.user&.full_name
+  end
+
+  def vaccination_nurse
+    most_recent_vaccination&.user&.full_name
   end
 
   def state

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -14,8 +14,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
           "patient_session_statuses.#{state}.banner_explanation",
           default: "",
           full_name:,
-          triage_nurse:,
-          vaccination_nurse:,
+          nurse:,
           who_responded:,
           who_refused:
         )
@@ -56,12 +55,13 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
     @patient_session.patient.full_name
   end
 
-  def triage_nurse
-    most_recent_triage&.user&.full_name
-  end
+  def nurse
+    most_recent_event = [
+      most_recent_triage,
+      most_recent_vaccination
+    ].compact.max_by(&:created_at)
 
-  def vaccination_nurse
-    most_recent_vaccination&.user&.full_name
+    most_recent_event&.user&.full_name
   end
 
   def state

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -8,7 +8,7 @@ class VaccinationMailer < ApplicationMailer
 
   def hpv_vaccination_has_not_taken_place(vaccination_record:)
     template_mail(
-      EMAILS[:confirming_the_hpv_vaccination_didnt_happen],
+      EMAILS[:confirmation_the_hpv_vaccination_didnt_happen],
       **opts(vaccination_record)
     )
   end

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -145,7 +145,8 @@ module PatientSessionStateConcern
         (
           vaccination_record.not_well? ||
             vaccination_record.contraindications? ||
-            vaccination_record.absent_from_session?
+            vaccination_record.absent_from_session? ||
+            vaccination_record.absent_from_school?
         )
     end
 

--- a/config/initializers/email_templates.rb
+++ b/config/initializers/email_templates.rb
@@ -4,7 +4,7 @@ EMAILS = {
   hpv_session_session_reminder: "79e131b2-7816-46d0-9c74-ae14956dd77d",
   confirmation_the_hpv_vaccination_has_taken_place:
     "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
-  confirming_the_hpv_vaccination_didnt_happen:
+  confirmation_the_hpv_vaccination_didnt_happen:
     "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
   triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
   triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f",

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -29,7 +29,7 @@ en:
       colour: red
       text: Delay vaccination to a later date
       banner_title: Delay vaccination to a later date
-      banner_explanation: "%{vaccination_nurse} decided that %{full_name}’s vaccination should be delayed"
+      banner_explanation: "%{nurse} decided that %{full_name}’s vaccination should be delayed"
     triaged_do_not_vaccinate:
       colour: red
       text: Do not vaccinate
@@ -43,7 +43,7 @@ en:
       colour: purple
       text: Vaccinate
       banner_title: Safe to vaccinate
-      banner_explanation: "%{triage_nurse} decided that %{full_name} is safe to vaccinate"
+      banner_explanation: "%{nurse} decided that %{full_name} is safe to vaccinate"
     unable_to_vaccinate:
       colour: red
       text: Could not vaccinate

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -29,7 +29,7 @@ en:
       colour: red
       text: Delay vaccination to a later date
       banner_title: Delay vaccination to a later date
-      banner_explanation: "%{triage_nurse} decided that %{full_name}’s vaccination should be delayed"
+      banner_explanation: "%{vaccination_nurse} decided that %{full_name}’s vaccination should be delayed"
     triaged_do_not_vaccinate:
       colour: red
       text: Do not vaccinate

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe AppSimpleStatusBannerComponent, type: :component do
   let(:component) { described_class.new(patient_session:) }
   let!(:rendered) { render_inline(component) }
   let(:triage_nurse_name) { patient_session.triage.last.user.full_name }
+  let(:vaccination_nurse_name) do
+    patient_session.vaccination_records.last.user.full_name
+  end
   let(:patient_name) { patient_session.patient.full_name }
 
   subject { page }
@@ -66,6 +69,18 @@ RSpec.describe AppSimpleStatusBannerComponent, type: :component do
     it do
       should have_text(
                "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
+             )
+    end
+  end
+
+  context "state is delay_vaccination" do
+    let(:patient_session) { create :patient_session, :delay_vaccination }
+
+    it { should have_css(".app-card--red") }
+    it { should have_css(".nhsuk-card__heading", text: "Delay vaccination") }
+    it do
+      should have_text(
+               "#{vaccination_nurse_name} decided that #{patient_name}’s vaccination should be delayed"
              )
     end
   end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -76,6 +76,15 @@ FactoryBot.define do
     trait :delay_vaccination do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :delay_vaccination)] }
+
+      after :create do |patient_session|
+        create(
+          :vaccination_record,
+          reason: :absent_from_school,
+          administered: false,
+          patient_session:
+        )
+      end
     end
 
     trait :did_not_need_triage do

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+describe "HPV Vaccination" do
+  include EmailExpectations
+
+  scenario "Delayed" do
+    given_i_am_signed_in
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_record_that_the_patient_was_absent
+    then_i_see_the_confirmation_page
+
+    when_i_confirm_the_details
+    then_i_see_the_record_vaccinations_page
+    and_a_success_message
+
+    when_i_go_to_the_patient
+    then_i_see_that_the_status_is_delayed
+    and_an_email_is_sent_to_the_parent_confirming_the_delay
+  end
+
+  def given_i_am_signed_in
+    @team = create(:team, :with_one_nurse, :with_one_location)
+    campaign = create(:campaign, :hpv, team: @team)
+    @batch = campaign.batches.first
+    @session = create(:session, campaign:, location: @team.locations.first)
+    @patient =
+      create(
+        :patient_with_consent_given_triage_not_needed,
+        session: @session,
+        location: @session.location
+      )
+
+    sign_in @team.users.first
+  end
+
+  def when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    visit vaccinations_session_path(@session)
+    click_link @patient.full_name
+  end
+
+  def and_i_record_that_the_patient_was_absent
+    choose "No, they did not get it"
+    click_button "Continue"
+
+    choose "They were absent from school"
+    click_button "Continue"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content("Child#{@patient.full_name}")
+    expect(page).to have_content("OutcomeAbsent from school")
+  end
+
+  def when_i_confirm_the_details
+    click_button "Confirm"
+  end
+
+  def then_i_see_the_record_vaccinations_page
+    expect(page).to have_content("Record vaccinations")
+  end
+
+  def and_a_success_message
+    expect(page).to have_content("Record saved for #{@patient.full_name}")
+  end
+
+  def when_i_go_to_the_patient
+    click_link "View child record"
+  end
+
+  def then_i_see_that_the_status_is_delayed
+    expect(page).to have_content("Delay vaccination to a later date")
+    expect(page).to have_content("#{@team.users.first.full_name} decided that")
+  end
+
+  def and_an_email_is_sent_to_the_parent_confirming_the_delay
+    expect_email_to(
+      @patient.consents.last.parent_email,
+      EMAILS[:confirmation_the_hpv_vaccination_didnt_happen]
+    )
+  end
+end

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -79,7 +79,7 @@ describe "HPV Vaccination" do
   def and_an_email_is_sent_saying_the_vaccination_didnt_happen
     expect_email_to(
       @patient.consents.last.parent_email,
-      EMAILS[:confirming_the_hpv_vaccination_didnt_happen]
+      EMAILS[:confirmation_the_hpv_vaccination_didnt_happen]
     )
   end
 end

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe VaccinationMailer do
 
     it "has the correct template" do
       expect(mail.header[:template_id].value).to eq(
-        EMAILS[:confirming_the_hpv_vaccination_didnt_happen]
+        EMAILS[:confirmation_the_hpv_vaccination_didnt_happen]
       )
     end
 


### PR DESCRIPTION
This fell through and was not being handled. Patients absent were being treated as "Unable to vaccinate" whereas it should be "Delay vaccination."

Related to https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1157.