### PR TITLE
Move all tab conditions into PatientTabsConcern

### DIFF
--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -1,7 +1,18 @@
 module PatientTabsConcern
   extend ActiveSupport::Concern
 
-  def group_patient_sessions_by_conditions(all_patient_sessions, tab_conditions)
+  TAB_CONDITIONS = {
+    consents: {
+      consent_given: %i[consent_given?],
+      consent_refused: %i[consent_refused?],
+      conflicting_consent: %i[consent_conflicts?],
+      no_consent: %i[no_consent?]
+    }
+  }.with_indifferent_access.freeze
+
+  def group_patient_sessions_by_conditions(all_patient_sessions, section:)
+    tab_conditions = TAB_CONDITIONS.fetch(section)
+
     all_patient_sessions
       .group_by do |patient_session| # rubocop:disable Style/BlockDelimiters
         tab_conditions
@@ -9,6 +20,7 @@ module PatientTabsConcern
           &.first
       end
       .tap { |groups| tab_conditions.each_key { groups[_1] ||= [] } }
+      .with_indifferent_access
   end
 
   def group_patient_sessions_by_state(all_patient_sessions, tab_states)

--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -56,6 +56,7 @@ module PatientTabsConcern
           &.first
       end
       .tap { |groups| tab_conditions.each_key { groups[_1] ||= [] } }
+      .except(nil)
       .with_indifferent_access
   end
 
@@ -71,6 +72,7 @@ module PatientTabsConcern
         tab_states.find { |_, states| patient_session.state.in? states }&.first
       end
       .tap { |groups| tab_states.each_key { groups[_1] ||= [] } }
+      .except(nil)
       .with_indifferent_access
   end
 

--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -14,6 +14,7 @@ module PatientTabsConcern
         consent_given_triage_not_needed
         vaccinated
         unable_to_vaccinate
+        unable_to_vaccinate_not_gillick_competent
       ]
     },
     vaccinations: {

--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -6,8 +6,8 @@ module PatientTabsConcern
       needs_triage: %w[consent_given_triage_needed triaged_kept_in_triage],
       triage_complete: %w[
         delay_vaccination
-        triaged_ready_to_vaccinate
         triaged_do_not_vaccinate
+        triaged_ready_to_vaccinate
       ],
       no_triage_needed: %w[
         consent_refused

--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -1,6 +1,23 @@
 module PatientTabsConcern
   extend ActiveSupport::Concern
 
+  TAB_STATES = {
+    triage: {
+      needs_triage: %w[consent_given_triage_needed triaged_kept_in_triage],
+      triage_complete: %w[
+        delay_vaccination
+        triaged_ready_to_vaccinate
+        triaged_do_not_vaccinate
+      ],
+      no_triage_needed: %w[
+        consent_refused
+        consent_given_triage_not_needed
+        vaccinated
+        unable_to_vaccinate
+      ]
+    }
+  }.with_indifferent_access.freeze
+
   TAB_CONDITIONS = {
     consents: {
       consent_given: %i[consent_given?],
@@ -23,12 +40,19 @@ module PatientTabsConcern
       .with_indifferent_access
   end
 
-  def group_patient_sessions_by_state(all_patient_sessions, tab_states)
+  def group_patient_sessions_by_state(
+    all_patient_sessions,
+    tab_states = nil,
+    section: nil
+  )
+    tab_states ||= TAB_STATES.fetch(section)
+
     all_patient_sessions
       .group_by do |patient_session| # rubocop:disable Style/BlockDelimiters
         tab_states.find { |_, states| patient_session.state.in? states }&.first
       end
       .tap { |groups| tab_states.each_key { groups[_1] ||= [] } }
+      .with_indifferent_access
   end
 
   def count_patient_sessions(tab_patient_sessions)

--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -15,6 +15,25 @@ module PatientTabsConcern
         vaccinated
         unable_to_vaccinate
       ]
+    },
+    vaccinations: {
+      action_needed: %w[
+        consent_given_triage_needed
+        triaged_kept_in_triage
+        triaged_ready_to_vaccinate
+        added_to_session
+        consent_given_triage_not_needed
+      ],
+      vaccinated: %w[vaccinated],
+      vaccinate_later: %w[delay_vaccination],
+      could_not_vaccinate: %w[
+        consent_refused
+        consent_conflicts
+        triaged_do_not_vaccinate
+        unable_to_vaccinate
+        unable_to_vaccinate_not_assessed
+        unable_to_vaccinate_not_gillick_competent
+      ]
     }
   }.with_indifferent_access.freeze
 

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -6,13 +6,6 @@ class ConsentsController < ApplicationController
   layout "two_thirds", except: :index
 
   def index
-    tab_conditions = {
-      consent_given: %i[consent_given?],
-      consent_refused: %i[consent_refused?],
-      conflicting_consent: %i[consent_conflicts?],
-      no_consent: %i[no_consent?]
-    }
-
     all_patient_sessions =
       @session
         .patient_sessions
@@ -29,7 +22,10 @@ class ConsentsController < ApplicationController
       ]
 
     tab_patient_sessions =
-      group_patient_sessions_by_conditions(all_patient_sessions, tab_conditions)
+      group_patient_sessions_by_conditions(
+        all_patient_sessions,
+        section: :consents
+      )
 
     @current_tab = TAB_PATHS[:consents][params[:tab]]
     @tab_counts = count_patient_sessions(tab_patient_sessions)

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -20,28 +20,11 @@ class TriageController < ApplicationController
         .preload(:consents)
         .order("patients.first_name", "patients.last_name")
 
-    tabs_to_states = {
-      needs_triage: %w[consent_given_triage_needed triaged_kept_in_triage],
-      triage_complete: %w[
-        delay_vaccination
-        triaged_ready_to_vaccinate
-        triaged_do_not_vaccinate
-      ],
-      no_triage_needed: %w[
-        consent_refused
-        consent_given_triage_not_needed
-        vaccinated
-        unable_to_vaccinate
-      ]
-    }
-
-    tab_patient_sessions =
-      group_patient_sessions_by_state(all_patient_sessions, tabs_to_states)
-
     @current_tab = TAB_PATHS[:triage][params[:tab]]
+    tab_patient_sessions =
+      group_patient_sessions_by_state(all_patient_sessions, section: :triage)
     @tab_counts = count_patient_sessions(tab_patient_sessions)
     @patient_sessions = tab_patient_sessions[@current_tab] || []
-
     session[:current_section] = "triage"
   end
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -18,26 +18,6 @@ class VaccinationsController < ApplicationController
   layout "two_thirds", except: :index
 
   def index
-    tab_states = {
-      action_needed: %w[
-        consent_given_triage_needed
-        triaged_kept_in_triage
-        triaged_ready_to_vaccinate
-        added_to_session
-        consent_given_triage_not_needed
-      ],
-      vaccinated: %w[vaccinated],
-      vaccinate_later: %w[delay_vaccination],
-      could_not_vaccinate: %w[
-        consent_refused
-        consent_conflicts
-        triaged_do_not_vaccinate
-        unable_to_vaccinate
-        unable_to_vaccinate_not_assessed
-        unable_to_vaccinate_not_gillick_competent
-      ]
-    }
-
     all_patient_sessions =
       @session
         .patient_sessions
@@ -47,7 +27,10 @@ class VaccinationsController < ApplicationController
         .order("patients.first_name", "patients.last_name")
 
     grouped_patient_sessions =
-      group_patient_sessions_by_state(all_patient_sessions, tab_states)
+      group_patient_sessions_by_state(
+        all_patient_sessions,
+        section: :vaccinations
+      )
 
     @current_tab = TAB_PATHS[:vaccinations][params[:tab]]
     @tab_counts = count_patient_sessions(grouped_patient_sessions)

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -103,6 +103,22 @@ FactoryBot.define do
       end
     end
 
+    trait :unable_to_vaccinate_not_gillick_competent do
+      gillick_competent { false }
+      gillick_competence_notes { "Assessed as not gillick competent" }
+      gillick_competence_assessor { user }
+
+      patient { create :patient, :consent_given_triage_needed, session: }
+      triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
+
+      after :create do |patient_session|
+        create :vaccination_record,
+               reason: :already_had,
+               administered: false,
+               patient_session:
+      end
+    end
+
     trait :vaccinated do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }


### PR DESCRIPTION
This move makes `PatientTabsConcern` centrally responsible for how we group patients into each of the tabs across consents, triage and vaccinations tabs. It also adds more thorough testing.

As part of this work I also tried to convert the triage section's tabs to use conditions instead of states. Unfortunately this didn't work out as some of the patients ended up in the wrong tab. For example, with the condition `needs_triage: %w[triage_needed? triage_keep_in_triage?]` we get the following states in the "needs_triage" tab:

```ruby
(ruby) result["needs_triage"].map &:state
["consent_given_triage_needed", "delay_vaccination", "triaged_do_not_vaccinate", "triaged_kept_in_triage", "triaged_ready_to_vaccinate", "unable_to_vaccinate", "unable_to_vaccinate_not_gillick_competent", "vaccinated"]
```

I think it would complicate things to make conditions work for triage. I think this is will also be the case for the "vaccinations" tabs.

That leaves the question of whether we should just convert the consents tabs to use states over conditions, and remove `group_patient_sessions_by_conditions` altogether. Less code is better, but for consents the conditions are a slightly better fit.