### PR TITLE
Align sign in page to prototype

### DIFF
--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class PasswordsController < Devise::PasswordsController
     layout "two_thirds"
+
+    skip_after_action :verify_policy_scoped
   end
 end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class UnlocksController < Devise::UnlocksController
     layout "two_thirds"
+
+    skip_after_action :verify_policy_scoped
   end
 end

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,11 +1,18 @@
-<%= h1 "Reset your password", size: "xl" %>
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: new_user_session_path,
+    name: "sign in",
+  ) %>
+<% end %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name),
+                       html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email address" } %>
+  <%= h1 "Reset your password", size: "xl" %>
+
+  <%= f.govuk_email_field :email, autocomplete: "email",
+                                  label: { text: "Email address" } %>
 
   <%= f.govuk_submit "Reset password" %>
 <% end %>
-
-<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,7 +1,7 @@
-<%= h1 "Sign in" %>
-
 <%= form_for(resource, as: resource_name, url: user_session_path) do |f| %>
   <%= f.govuk_error_summary %>
+
+  <%= h1 "Sign in", size: "xl" %>
 
   <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email address" } %>
   <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
@@ -12,7 +12,7 @@
     <% end %>
   <% end %>
 
+  <%= render "users/shared/links" %>
+
   <%= f.govuk_submit "Sign in" %>
 <% end %>
-
-<%= render "users/shared/links" %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <p><%= link_to "I forgot my password", new_password_path(resource_name) %></p>
+  <p><%= link_to "I’ve forgotten my password", new_password_path(resource_name) %></p>
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,11 +1,16 @@
-<%= h1 "Resend unlock instructions", size: "xl" %>
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: new_user_session_path,
+    name: "sign in",
+  ) %>
+<% end %>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>
+
+  <%= h1 "Resend unlock instructions", size: "xl" %>
 
   <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email address" } %>
 
   <%= f.govuk_submit "Resend unlock instructions" %>
 <% end %>
-
-<%= render "users/shared/links" %>


### PR DESCRIPTION
Also tweaks the forgot password and account unlock pages to make them consistent.

Disables pundit policy checking on these controllers as it isn't relevant.

Width of input fields isn't set to 20 as that's more involved for the password field and can be done separately.

### After

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/e1ec6970-d7ec-452e-ac39-f02fc2388bea)

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/95207d9e-0358-4523-a6c8-dbe94bf2f198)

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/0482d8bd-a3c6-4e11-acfc-1c5b3e39d128)
