### PR TITLE
Make layout wider only when signed in

### DIFF
--- a/app/assets/stylesheets/_overrides.scss
+++ b/app/assets/stylesheets/_overrides.scss
@@ -11,16 +11,18 @@ mark {
 }
 
 // `$nhsuk-page-width` isn’t globally editable, so need to apply manually
-.nhsuk-width-container,
-.nhsuk-header__navigation-list,
-.nhsuk-header__container {
-  max-width: $app-page-width;
+.app-signed-in {
+  .nhsuk-width-container,
+  .nhsuk-header__navigation-list,
+  .nhsuk-header__container {
+    max-width: $app-page-width;
 
-  @include govuk-media-query($from: desktop) {
-    margin: 0 $nhsuk-gutter;
-  }
+    @include govuk-media-query($from: desktop) {
+      margin: 0 $nhsuk-gutter;
+    }
 
-  @include mq($and: "(min-width: #{($app-page-width + $nhsuk-gutter * 2)})") {
-    margin: 0 auto;
+    @include mq($and: "(min-width: #{($app-page-width + $nhsuk-gutter * 2)})") {
+      margin: 0 auto;
+    }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <%= csp_meta_tag %>
   </head>
 
-  <body class="nhsuk-template__body">
+  <body class="nhsuk-template__body<%= ' app-signed-in' if current_user.present? %>">
     <script>
       document.body.className += ' js-enabled' +
          ('noModule' in HTMLScriptElement.prototype


### PR DESCRIPTION
Follows the prototype, in order to give more space to the consent/triage/vaccination views.