### PR TITLE
Allow users to edit their account details

### DIFF
--- a/app/controllers/users/accounts_controller.rb
+++ b/app/controllers/users/accounts_controller.rb
@@ -1,0 +1,31 @@
+module Users
+  class AccountsController < ApplicationController
+    before_action :set_user
+
+    layout "two_thirds"
+
+    def show
+    end
+
+    def update
+      if @user.update(user_params)
+        redirect_to users_account_path(@user),
+                    flash: {
+                      success: "Your account has been updated"
+                    }
+      else
+        render :show, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def set_user
+      @user = policy_scope(User).find(params.fetch(:id))
+    end
+
+    def user_params
+      params.require(:user).permit(:full_name, :email, :registration)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,16 @@ class User < ApplicationRecord
   encrypts :email, deterministic: true
   encrypts :full_name
 
+  validates :full_name, presence: true, length: { maximum: 255 }
+  validates :registration, length: { maximum: 255 }
+  validates :email,
+            presence: true,
+            length: {
+              maximum: 255
+            },
+            uniqueness: true,
+            email: true
+
   scope :recently_active,
         -> { where(last_sign_in_at: 1.week.ago..Time.current) }
 

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,12 @@
+class UserPolicy
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      @scope.where(id: @user.id)
+    end
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -24,3 +24,8 @@
   <%= link_to "Add a new session", sessions_path, class: "nhsuk-link--no-visited-state" %>
 </h2>
 <p>Create a new session or clinic for a campaign.</p>
+
+<h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+  <%= link_to "Your account", users_account_path(current_user), class: "nhsuk-link--no-visited-state" %>
+</h2>
+<p>Change your email address, name, or registration number.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,9 +53,7 @@
               <%= link_to "Vaccines", vaccines_path, class: "nhsuk-header__navigation-link" %>
             </li>
             <li class="nhsuk-header__navigation-item">
-              <span class="nhsuk-header__navigation-link app-u-text-decoration-none">
-                <%= current_user.email %>
-              </span>
+              <%= link_to current_user.email, users_account_path(current_user), class: "nhsuk-header__navigation-link" %>
             </li>
             <li class="nhsuk-header__navigation-item">
               <%= button_to destroy_user_session_path, class: "app-header__button-link", method: :delete do %>

--- a/app/views/users/accounts/show.html.erb
+++ b/app/views/users/accounts/show.html.erb
@@ -1,0 +1,14 @@
+<%= h1 "Your account", size: "xl" %>
+
+<%= form_for @user, url: users_account_path(@user), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
+  <%= f.govuk_text_field :email, label: { text: "Email address" } %>
+  <%= f.govuk_text_field :registration,
+    width: 10,
+    label: { text: "Registration number" },
+    hint: { text: "Also known as a GMC number or nurse’s pin number" } %>
+
+  <%= f.govuk_submit "Save changes" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,6 +485,9 @@ en:
           attributes:
             email:
               blank: Enter an email address
+              invalid: Enter a valid email address, such as j.doe@gmail.com
+              too_long: Enter an email address that is less than 255 characters long
+              taken: This email address is already in use
             password:
               blank: Enter a password
               too_short: Enter a password that is at least 10 characters long
@@ -493,6 +496,11 @@ en:
               confirmation: The password and confirmation do not match
             unlock_token:
               invalid: The unlock token is invalid
+            full_name:
+              blank: Enter your full name
+              too_long: Enter a full name that is less than 255 characters long
+            registration:
+              too_long: Enter a registration number that is less than 255 characters long
         registration:
           attributes:
             address_line_1:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -227,6 +227,10 @@ Rails.application.routes.draw do
          as: :match
   end
 
+  namespace :users do
+    resources :accounts, only: %i[show update]
+  end
+
   scope via: :all do
     get "/404", to: "errors#not_found"
     get "/422", to: "errors#unprocessable_entity"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -30,7 +30,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:full_name) { |n| "Test User #{n}" }
-    sequence(:email) { |n| "test-#{n}@localhost" }
+    sequence(:email) { |n| "test-#{n}@example.com" }
     sequence(:teams) { [Team.first || create(:team)] }
     password { "power overwhelming!" } # avoid a password that was found in a data breach
     registration { "SW608658 (HCPC)" }

--- a/spec/features/user_account_spec.rb
+++ b/spec/features/user_account_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe "User account", type: :feature do
+  scenario "Users can edit their account details" do
+    given_that_i_am_signed_in
+    when_i_visit_my_account_page
+    then_i_should_see_my_account_details
+
+    when_i_edit_my_account_details
+    then_i_should_see_the_updated_account_details
+
+    when_i_submit_the_form_with_invalid_details
+    then_i_should_see_the_error_messages
+  end
+
+  def given_that_i_am_signed_in
+    @user = create(:user)
+    sign_in @user
+  end
+
+  def when_i_visit_my_account_page
+    visit users_account_path(@user)
+  end
+
+  def then_i_should_see_my_account_details
+    expect(find_field("Full name").value).to eq(@user.full_name)
+    expect(find_field("Email").value).to eq(@user.email)
+    expect(find_field("Registration number").value).to eq(@user.registration)
+  end
+
+  def when_i_edit_my_account_details
+    fill_in "Full name", with: "New Name"
+    fill_in "Email", with: "newemail@example.com"
+    fill_in "Registration number", with: "123456"
+    click_button "Save changes"
+  end
+
+  def then_i_should_see_the_updated_account_details
+    expect(find_field("Full name").value).to eq("New Name")
+    expect(find_field("Email").value).to eq("newemail@example.com")
+    expect(find_field("Registration number").value).to eq("123456")
+  end
+
+  def when_i_submit_the_form_with_invalid_details
+    fill_in "Full name", with: ""
+    fill_in "Email", with: "invalid-email"
+    fill_in "Registration number", with: "a" * 256
+    click_button "Save changes"
+  end
+
+  def then_i_should_see_the_error_messages
+    expect(page).to have_content(
+      "Enter a valid email address, such as j.doe@gmail.com"
+    )
+    expect(page).to have_content("Enter your full name")
+    expect(page).to have_content(
+      "Enter a registration number that is less than 255 characters long"
+    )
+  end
+end


### PR DESCRIPTION
This adds a `/users/accounts/1` path that users can access in order to edit their name/email/registration number.

Pundit is used to prevent unauthorised users from accessing and modifying other people's accounts.

### Screenshots

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/0e61fac3-2cee-4ec7-b17e-d8955093eab4)

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/711a87b1-e041-4109-924f-a50f00decb8c)

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/3f6bba66-7cf9-4496-b634-ef8a99453f2f)
