### PR TITLE
Update account details flash wording

### DIFF
--- a/app/controllers/users/accounts_controller.rb
+++ b/app/controllers/users/accounts_controller.rb
@@ -11,7 +11,7 @@ module Users
       if @user.update(user_params)
         redirect_to users_account_path(@user),
                     flash: {
-                      success: "Your account has been updated"
+                      success: "Your account details have been updated"
                     }
       else
         render :show, status: :unprocessable_entity

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,7 +500,7 @@ en:
               blank: Enter your full name
               too_long: Enter a full name that is less than 255 characters long
             registration:
-              too_long: Enter a registration number that is less than 255 characters long
+              too_long: Enter a registration number with fewer than 255 characters
         registration:
           attributes:
             address_line_1:

--- a/spec/features/user_account_spec.rb
+++ b/spec/features/user_account_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "User account", type: :feature do
     )
     expect(page).to have_content("Enter your full name")
     expect(page).to have_content(
-      "Enter a registration number that is less than 255 characters long"
+      "Enter a registration number with fewer than 255 characters"
     )
   end
 end


### PR DESCRIPTION
Also update the wording of the error for a registration number that's too long.