### PR TITLE
Patient table consent status: new designs

### DIFF
--- a/app/assets/stylesheets/_status.scss
+++ b/app/assets/stylesheets/_status.scss
@@ -8,8 +8,8 @@
     margin-left: nhsuk-spacing(1) * -1;
   }
 
-  &--green {
-    color: $color_nhsuk-green;
+  &--blue {
+    color: $color_nhsuk-blue;
   }
 
   &--red {

--- a/app/components/app_consent_status_component.rb
+++ b/app/components/app_consent_status_component.rb
@@ -1,11 +1,11 @@
 class AppConsentStatusComponent < ViewComponent::Base
   def call
     if @patient_session.consent_given?
-      green_tick "Consent given"
+      blue_tick "Given"
     elsif @patient_session.consent_refused?
-      red_cross "Consent refused"
+      red_cross "Refused"
     elsif @patient_session.consent_conflicts?
-      red_cross "Conflicting consent"
+      red_cross "Conflicts"
     end
   end
 
@@ -17,9 +17,9 @@ class AppConsentStatusComponent < ViewComponent::Base
 
   private
 
-  def green_tick(content)
+  def blue_tick(content)
     template = <<-ERB
-      <p class="app-status app-status--green">
+      <p class="app-status app-status--blue">
         <svg class="nhsuk-icon nhsuk-icon__tick"
              xmlns="http://www.w3.org/2000/svg"
              viewBox="0 0 24 24"

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AppConsentComponent, type: :component do
   context "consent is refused" do
     let(:patient_session) { create(:patient_session, :consent_refused) }
 
-    it { should have_css("p.app-status", text: "Consent refused") }
+    it { should have_css("p.app-status", text: "Refused") }
 
     let(:summary) { "Consent refused by #{consent.parent_name} (#{relation})" }
     it { should have_css("details[open]", text: summary) }
@@ -71,7 +71,7 @@ RSpec.describe AppConsentComponent, type: :component do
       create(:patient_session, :consent_given_triage_needed)
     end
 
-    it { should have_css("p.app-status", text: "Consent given") }
+    it { should have_css("p.app-status", text: "Given") }
 
     let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
     it { should have_css("details[open]", text: summary) }

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -13,18 +13,18 @@ RSpec.describe AppConsentStatusComponent, type: :component do
       create(:patient_session, :consent_given_triage_needed)
     end
 
-    it { should have_css("p.app-status", text: "Consent given") }
+    it { should have_css("p.app-status", text: "Given") }
   end
 
   context "when consent is refused" do
     let(:patient_session) { create(:patient_session, :consent_refused) }
 
-    it { should have_css("p.app-status", text: "Consent refused") }
+    it { should have_css("p.app-status", text: "Refused") }
   end
 
   context "when consent conflicts" do
     let(:patient_session) { create(:patient_session, :consent_conflicting) }
 
-    it { should have_css("p.app-status", text: "Conflicting consent") }
+    it { should have_css("p.app-status", text: "Conflicts") }
   end
 end


### PR DESCRIPTION
Scenario|Before             |  After
:-------------:|:-------------:|:----------------:
Consent given|<img width="212" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/874cf189-b941-4ca7-aaa4-039ddaf1601c">|<img width="178" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/ba6ebf21-af01-4902-b175-60bbf660ed49">
Consent refused|<img width="225" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/05034b6c-e33d-4d9c-8f86-fe140ba076c5">|<img width="179" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/666e2967-17a9-42fd-9644-2b95be9e650b">
Conflicting consent|<img width="241" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/ad346059-a93d-4c3d-8ac8-643cc7f209e0">|<img width="167" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/86edbaf9-4431-48cf-92cd-d2b033505fb2">

One point to check: the prototype doesn't have any icon for conflicting consent. Is this deliberate or not? I kept the cross as it seemed more visually obvious but happy to remove it if its omission is deliberate.