### PR TITLE
Use dark orange colour for conflicting status

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -5,10 +5,9 @@
     }
   }
 
-  &--orange {
+  &--dark-orange {
     .nhsuk-card__heading--feature {
-      background-color: $color_nhsuk-warm-yellow;
-      color: $nhsuk-focus-text-color;
+      background-color: $color_app-dark-orange;
     }
   }
 

--- a/app/assets/stylesheets/_status.scss
+++ b/app/assets/stylesheets/_status.scss
@@ -12,6 +12,10 @@
     color: $color_nhsuk-blue;
   }
 
+  &--dark-orange {
+    color: $color_app-dark-orange;
+  }
+
   &--red {
     color: $color_nhsuk-red;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,6 +27,10 @@ $mq-breakpoints: (
 
 // App options
 $app-page-width: 1100px;
+$color_app-dark-orange: darken(
+  mix($color_nhsuk-red, $color_nhsuk-warm-yellow, 55%),
+  10%
+);
 
 // Application components
 @import "action-table";

--- a/app/components/app_consent_status_component.rb
+++ b/app/components/app_consent_status_component.rb
@@ -1,11 +1,11 @@
 class AppConsentStatusComponent < ViewComponent::Base
   def call
     if @patient_session.consent_given?
-      blue_tick "Given"
+      icon_tick "Given", "blue"
     elsif @patient_session.consent_refused?
-      red_cross "Refused"
+      icon_cross "Refused", "red"
     elsif @patient_session.consent_conflicts?
-      red_cross "Conflicts"
+      icon_cross "Conflicts", "dark-orange"
     end
   end
 
@@ -17,9 +17,9 @@ class AppConsentStatusComponent < ViewComponent::Base
 
   private
 
-  def blue_tick(content)
+  def icon_tick(content, color)
     template = <<-ERB
-      <p class="app-status app-status--blue">
+      <p class="app-status app-status--#{color}">
         <svg class="nhsuk-icon nhsuk-icon__tick"
              xmlns="http://www.w3.org/2000/svg"
              viewBox="0 0 24 24"
@@ -36,9 +36,9 @@ class AppConsentStatusComponent < ViewComponent::Base
     template.html_safe
   end
 
-  def red_cross(content)
+  def icon_cross(content, color)
     template = <<-ERB
-      <p class="app-status app-status--red">
+      <p class="app-status app-status--#{color}">
         <svg class="nhsuk-icon nhsuk-icon__cross"
              xmlns="http://www.w3.org/2000/svg"
              viewBox="0 0 24 24"
@@ -47,7 +47,7 @@ class AppConsentStatusComponent < ViewComponent::Base
                   .4-.5 0-.9 0-1.2-.3l-3.9-4-4 4c-.3.3-.5.3-1
                   .3a1.5 1.5 0 0 1-1-2.4l3.9-4-4-4c-.5-.5-.5-1.4 0-2
                   .6-.7 1.5-.7 2.2 0l3.9 3.9 4-4c.6-.6 1.4-.6 2 0Z"
-              fill="currentColor"></path>
+                fill="currentColor"></path>
         </svg>
         #{content}
       </p>

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -16,12 +16,12 @@ en:
       banner_title: Consent given
       banner_explanation: "%{full_name} is ready to vaccinate"
     consent_refused:
-      colour: orange
+      colour: red
       text: Consent refused
       banner_title: Consent refused
       banner_explanation: "%{who_refused} refused to give consent"
     consent_conflicts:
-      colour: orange
+      colour: dark-orange
       text: Conflicting consent
       banner_title: Conflicting consent
       banner_explanation: "You can only vaccinate if all respondents give consent"

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AppSimpleStatusBannerComponent, type: :component do
   context "state is consent_refused" do
     let(:patient_session) { create :patient_session, :consent_refused }
 
-    it { should have_css(".app-card--orange") }
+    it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Consent refused") }
     it { should have_text("Mum refused to give consent") }
   end


### PR DESCRIPTION
Conflicting consent currently uses warm-yellow for the banner heading, with black text (other banner headings use white text). We also use red text to reflect this in the status text further down the page.

To reflect the colour used in the banner in the status text, and have it contrast on white, necessitates using a darker colour.

Let’s fix a few things by:

- Adding a new, app-specific dark orange colour
- Using this for both the conflicting banner heading and its corresponding status text
- Using red for refused consent

## Updated palette

Existing `$color_nhsuk-yellow`, `$color_nhsuk-warm-yellow` and `$color_nhsuk-orange` colours, and the new `$color_app-dark-orange` colour (with a [contrast ratio of 4.72:1](https://webaim.org/resources/contrastchecker/?fcolor=BD5413&bcolor=FFFFFF)):

![The 4 yellow colours](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/813383/b569a624-ada4-461a-8dfc-9532fe1cef10)

## Before

<img width="770" alt="Patient page before." src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/813383/6bf6a4e7-9a52-4b0b-9ae4-2fb0df41eaf9">

## After

<img width="780" alt="Patient page after." src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/813383/fd7f1653-8485-47ed-815b-08fc2bb07835">



