### PR TITLE
Avoid persisting empty health answers for verbal refusals

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -178,12 +178,7 @@ class ManageConsentsController < ApplicationController
   def create_params
     route = params.permit(:consent)[:consent]
 
-    attrs = {
-      patient: @patient,
-      campaign: @session.campaign,
-      route:,
-      health_answers: @session.health_questions.to_health_answers
-    }
+    attrs = { patient: @patient, campaign: @session.campaign, route: }
 
     no_consent =
       @patient.consents.submitted_for_campaign(@session.campaign).empty?

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -237,4 +237,36 @@ RSpec.describe Consent do
       expect(consent).not_to be_recorded
     end
   end
+
+  it "resets unused fields after a consent refusal" do
+    consent =
+      build(
+        :consent,
+        health_answers: [],
+        response: "refused",
+        reason_for_refusal: "contains_gelatine",
+        reason_for_refusal_notes: "I'm vegan"
+      )
+    expect(consent.health_answers).to be_empty
+
+    consent.update!(response: "given")
+
+    expect(consent.reason_for_refusal).to be_nil
+    expect(consent.reason_for_refusal_notes).to be_nil
+
+    expect(consent.health_answers).not_to be_empty
+    expect(consent.health_answers.count).to eq(
+      consent.campaign.vaccines.first.health_questions.count
+    )
+    expect(consent.health_answers.map(&:response)).to all(be_nil)
+  end
+
+  it "resets unused fields after a consent being given" do
+    consent = build(:consent, :given)
+    expect(consent.health_answers).not_to be_empty
+
+    consent.update!(response: "refused")
+
+    expect(consent.health_answers).to be_empty
+  end
 end


### PR DESCRIPTION
Before this fix, when verbal consent was recorded, it incorrectly included questions with nil answers, when in fact it should have been persisting an empty `health_answers` field.

Solve this issue by resetting unused fields before saving, similarly to how it's done in `ConsentForm` (see #1238). This fix means that the controller doesn't need to pre-seed health questions during `Consent` creation.