### PR TITLE
Refactor /reset to use factories.

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -7,6 +7,8 @@ class DevController < ApplicationController
   before_action :ensure_dev_env
 
   def reset
+    Faker::Config.locale = "en-GB"
+
     ActiveRecord::Base.connection.transaction do
       data_tables =
         ActiveRecord::Base.connection.tables -
@@ -24,20 +26,15 @@ class DevController < ApplicationController
         )
       end
 
-      LoadExampleCampaign.load(
-        example_file: "db/sample_data/example-hpv-campaign.json",
-        in_progress: true
-      )
-      LoadExampleCampaign.load(
-        example_file: "db/sample_data/example-flu-campaign.json",
-        new_campaign: true,
-        in_progress: true
-      )
-      LoadExampleCampaign.load(
-        example_file: "db/sample_data/example-pilot-campaign.json",
-        new_campaign: true,
-        in_progress: true
-      )
+      user =
+        User.find_by(email: "nurse.joy@example.com") ||
+          FactoryBot.create(
+            :user,
+            full_name: "Nurse Joy",
+            email: "nurse.joy@example.com",
+            password: "nurse.joy@example.com"
+          )
+      FactoryBot.create(:example_in_progress_campaign, :hpv, user:)
     end
 
     redirect_to root_path

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe TriageMailerConcern do
 
       context "when the parents have verbally refused consent" do
         let(:patient_session) { build(:patient_session, :consent_refused) }
-        let(:consent) { build(:consent, :refused, patient_session:) }
 
         it "doesn't send an email" do
           expect(ConsentFormMailer).not_to have_received(:confirmation_refused)
@@ -90,9 +89,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :triaged_ready_to_vaccinate)
         end
-        let(:consent) do
-          build(:consent_given, :needing_triage, patient_session:)
-        end
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying triage was needed and vaccination will happen" do
           expect(TriageMailer).to have_received(:vaccination_will_happen).with(
@@ -105,9 +102,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :triaged_do_not_vaccinate)
         end
-        let(:consent) do
-          build(:consent_given, :needing_triage, patient_session:)
-        end
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying triage was needed but vaccination won't happen" do
           expect(TriageMailer).to have_received(:vaccination_wont_happen).with(
@@ -120,7 +115,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :consent_given_triage_not_needed)
         end
-        let(:consent) { build(:consent_given, patient_session:) }
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying vaccination will happen" do
           expect(ConsentFormMailer).to have_received(:confirmation).with(
@@ -134,9 +129,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :consent_given_triage_needed)
         end
-        let(:consent) do
-          build(:consent_given, :needing_triage, patient_session:)
-        end
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying triage is required" do
           expect(ConsentFormMailer).to have_received(
@@ -147,7 +140,7 @@ RSpec.describe TriageMailerConcern do
 
       context "when the parents have verbally refused consent" do
         let(:patient_session) { build(:patient_session, :consent_refused) }
-        let(:consent) { build(:consent, :refused, patient_session:) }
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email confirming they've refused consent" do
           expect(ConsentFormMailer).to have_received(

--- a/spec/factories/example_campaigns.rb
+++ b/spec/factories/example_campaigns.rb
@@ -1,0 +1,45 @@
+FactoryBot.define do
+  factory :example_in_progress_campaign, parent: :campaign do
+    transient do
+      user { raise "create(:user)" }
+      location { create(:location, team:) }
+    end
+
+    team { create(:team, users: [user]) }
+
+    after(:create) do |campaign, context|
+      location = context.location
+
+      create(:session, :in_progress, campaign:, location:).tap do |session|
+        patients_without_consent = create_list(:patient_session, 8, session:)
+        unmatched_patients = patients_without_consent.sample(4).map(&:patient)
+        unmatched_patients.each do |patient|
+          create(
+            :consent_form,
+            :recorded,
+            first_name: patient.first_name,
+            last_name: patient.last_name,
+            session:
+          )
+        end
+
+        create_list(
+          :patient_session,
+          4,
+          :consent_given_triage_not_needed,
+          session:
+        )
+        create_list(:patient_session, 4, :consent_given_triage_needed, session:)
+        create_list(
+          :patient_session,
+          4,
+          :triaged_ready_to_vaccinate,
+          session:,
+          user: context.user
+        )
+        create_list(:patient_session, 4, :consent_refused, session:)
+        create_list(:patient_session, 2, :consent_conflicting, session:)
+      end
+    end
+  end
+end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -59,7 +59,14 @@ FactoryBot.define do
     trait :triaged_ready_to_vaccinate do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage do
-        [create(:triage, status: :ready_to_vaccinate, notes: "Ok to vaccinate")]
+        [
+          create(
+            :triage,
+            status: :ready_to_vaccinate,
+            notes: "Ok to vaccinate",
+            user:
+          )
+        ]
       end
     end
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -59,15 +59,14 @@ FactoryBot.define do
     trait :triaged_ready_to_vaccinate do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage do
-        [
-          create(
-            :triage,
-            status: :ready_to_vaccinate,
-            notes: "Ok to vaccinate",
-            user:,
-            patient_session: instance
-          )
-        ]
+        create_list(
+          :triage,
+          1,
+          status: :ready_to_vaccinate,
+          notes: "Ok to vaccinate",
+          user:,
+          patient_session: instance
+        )
       end
     end
 
@@ -85,12 +84,14 @@ FactoryBot.define do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :delay_vaccination)] }
 
-      after :create do |patient_session|
-        create(
+      vaccination_records do
+        create_list(
           :vaccination_record,
+          1,
           reason: :absent_from_school,
           administered: false,
-          patient_session:
+          user:,
+          patient_session: instance
         )
       end
     end
@@ -102,12 +103,15 @@ FactoryBot.define do
     trait :unable_to_vaccinate do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
-
-      after :create do |patient_session|
-        create :vaccination_record,
-               reason: :already_had,
-               administered: false,
-               patient_session:
+      vaccination_records do
+        create_list(
+          :vaccination_record,
+          1,
+          reason: :already_had,
+          administered: false,
+          user:,
+          patient_session: instance
+        )
       end
     end
 
@@ -119,23 +123,29 @@ FactoryBot.define do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
 
-      after :create do |patient_session|
-        create :vaccination_record,
-               reason: :already_had,
-               administered: false,
-               patient_session:
+      vaccination_records do
+        create_list(
+          :vaccination_record,
+          1,
+          reason: :already_had,
+          administered: false,
+          user:,
+          patient_session: instance
+        )
       end
     end
 
     trait :vaccinated do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
-
-      after :create do |patient_session, context|
-        create :vaccination_record,
-               administered: true,
-               patient_session:,
-               user: context.user
+      vaccination_records do
+        create_list(
+          :vaccination_record,
+          1,
+          administered: true,
+          user:,
+          patient_session: instance
+        )
       end
     end
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -64,7 +64,8 @@ FactoryBot.define do
             :triage,
             status: :ready_to_vaccinate,
             notes: "Ok to vaccinate",
-            user:
+            user:,
+            patient_session: instance
           )
         ]
       end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -81,71 +81,65 @@ FactoryBot.define do
     end
 
     trait :consent_given_triage_not_needed do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :given,
-          campaign: evaluator.campaign,
-          patient:,
-          parent_relationship: patient.parent_relationship
+          campaign:,
+          patient: instance,
+          parent_relationship: instance.parent_relationship
         )
       end
     end
 
     trait :consent_given_triage_needed do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :given,
           :health_question_notes,
-          campaign: evaluator.campaign,
-          patient:
+          campaign:,
+          patient: instance
         )
       end
     end
 
     trait :consent_refused do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :refused,
           :from_mum,
-          campaign: evaluator.campaign,
-          patient:
+          campaign:,
+          patient: instance
         )
       end
     end
 
     trait :consent_refused_with_notes do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :refused,
           :from_mum,
-          campaign: evaluator.campaign,
+          campaign:,
           reason_for_refusal: "already_vaccinated",
           reason_for_refusal_notes: "Already had the vaccine at the GP",
-          patient:
+          patient: instance
         )
       end
     end
 
     trait :consent_conflicting do
-      after(:create) do |patient, evaluator|
-        create(
-          :consent,
-          :refused,
-          :from_mum,
-          campaign: evaluator.campaign,
-          patient:
-        )
-        create(
-          :consent,
-          :given,
-          :from_dad,
-          campaign: evaluator.campaign,
-          patient:
-        )
+      consents do
+        [
+          create(:consent, :refused, :from_mum, campaign:, patient: instance),
+          create(:consent, :given, :from_dad, campaign:, patient: instance)
+        ]
       end
     end
 

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -44,11 +44,11 @@ FactoryBot.define do
       date { Time.zone.now - 1.week }
     end
 
-    after :create do |session, context|
+    patients do
       create_list :patient,
-                  context.patients_in_session,
-                  sessions: [session],
-                  location: session.location
+                  patients_in_session,
+                  sessions: [instance],
+                  location: instance.location
     end
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -36,13 +36,16 @@ FactoryBot.define do
         nurse_password { nil }
       end
 
-      after(:create) do |team, evaluator|
-        options = {
-          teams: [team],
-          email: evaluator.nurse_email,
-          password: evaluator.nurse_password
-        }.compact
-        create(:user, **options)
+      users do
+        create_list(
+          :user,
+          1,
+          **{
+            teams: [instance],
+            email: nurse_email,
+            password: nurse_password
+          }.compact
+        )
       end
     end
 

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -23,8 +23,8 @@ FactoryBot.define do
       sequence(:identifier) { _1 }
     end
 
-    name { "Team #{identifier}" }
-    email { "team-#{identifier}@example.com" }
+    name { "SAIS Team #{identifier}" }
+    email { "sais-team-#{identifier}@example.com" }
     phone { "01234 567890" }
     ods_code { "U#{identifier}" }
     privacy_policy_url { "https://example.com/privacy" }

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Verbal consent" do
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_safe_to_vaccinate
-    and_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    and_an_email_is_sent_to_the_parent_confirming_their_consent
   end
 
   def given_i_am_signed_in
@@ -67,7 +67,7 @@ RSpec.describe "Verbal consent" do
     expect(page).to have_content("Safe to vaccinate")
   end
 
-  def and_an_email_is_sent_to_the_parent_confirming_the_vaccination
+  def and_an_email_is_sent_to_the_parent_confirming_their_consent
     expect(sent_emails.count).to eq 1
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(


### PR DESCRIPTION
We've removed the Playwright tests that rely on the JSON-based example campaigns. The `/reset` endpoint is now used for manual testing and this PR removes the dependence on the example campaign JSON. The benefits of the changes in this PR:

- Brings us closer to being able to remove the JSON-based example campaign generation completely, which would remove a lot of code.
- Also won't have to regenerate the example campaign JSON once we're done.
- With this new implementation we aren't logged out automatically (probably achievable with the JSON-based reset, but this is where we are now).
- We're more reliant on our factories, which is better than relying on the example campaign support code. This has already exposed a couple of issues worth fixing in our factories that has helped speed up the spec runs.
- Faster. Old version was ~2s (importing 2 campaigns), this one is ~0.5 (creating 1 campaign)