### PR TITLE
Tidy up the specs, mostly to avoid creating extra objects

### DIFF
--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -75,7 +75,6 @@ RSpec.describe TriageMailerConcern do
 
       context "when the parents have verbally refused consent" do
         let(:patient_session) { build(:patient_session, :consent_refused) }
-        let(:consent) { build(:consent, :refused, patient_session:) }
 
         it "doesn't send an email" do
           expect(ConsentFormMailer).not_to have_received(:confirmation_refused)
@@ -90,9 +89,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :triaged_ready_to_vaccinate)
         end
-        let(:consent) do
-          build(:consent_given, :needing_triage, patient_session:)
-        end
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying triage was needed and vaccination will happen" do
           expect(TriageMailer).to have_received(:vaccination_will_happen).with(
@@ -105,9 +102,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :triaged_do_not_vaccinate)
         end
-        let(:consent) do
-          build(:consent_given, :needing_triage, patient_session:)
-        end
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying triage was needed but vaccination won't happen" do
           expect(TriageMailer).to have_received(:vaccination_wont_happen).with(
@@ -120,7 +115,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :consent_given_triage_not_needed)
         end
-        let(:consent) { build(:consent_given, patient_session:) }
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying vaccination will happen" do
           expect(ConsentFormMailer).to have_received(:confirmation).with(
@@ -134,9 +129,7 @@ RSpec.describe TriageMailerConcern do
         let(:patient_session) do
           build(:patient_session, :consent_given_triage_needed)
         end
-        let(:consent) do
-          build(:consent_given, :needing_triage, patient_session:)
-        end
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email saying triage is required" do
           expect(ConsentFormMailer).to have_received(
@@ -147,7 +140,7 @@ RSpec.describe TriageMailerConcern do
 
       context "when the parents have verbally refused consent" do
         let(:patient_session) { build(:patient_session, :consent_refused) }
-        let(:consent) { build(:consent, :refused, patient_session:) }
+        let(:consent) { patient_session.consents.first }
 
         it "sends an email confirming they've refused consent" do
           expect(ConsentFormMailer).to have_received(

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -59,15 +59,14 @@ FactoryBot.define do
     trait :triaged_ready_to_vaccinate do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage do
-        [
-          create(
-            :triage,
-            status: :ready_to_vaccinate,
-            notes: "Ok to vaccinate",
-            user:,
-            patient_session: instance
-          )
-        ]
+        create_list(
+          :triage,
+          1,
+          status: :ready_to_vaccinate,
+          notes: "Ok to vaccinate",
+          user:,
+          patient_session: instance
+        )
       end
     end
 
@@ -85,12 +84,14 @@ FactoryBot.define do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :delay_vaccination)] }
 
-      after :create do |patient_session|
-        create(
+      vaccination_records do
+        create_list(
           :vaccination_record,
+          1,
           reason: :absent_from_school,
           administered: false,
-          patient_session:
+          user:,
+          patient_session: instance
         )
       end
     end
@@ -102,12 +103,15 @@ FactoryBot.define do
     trait :unable_to_vaccinate do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
-
-      after :create do |patient_session|
-        create :vaccination_record,
-               reason: :already_had,
-               administered: false,
-               patient_session:
+      vaccination_records do
+        create_list(
+          :vaccination_record,
+          1,
+          reason: :already_had,
+          administered: false,
+          user:,
+          patient_session: instance
+        )
       end
     end
 
@@ -119,23 +123,29 @@ FactoryBot.define do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
 
-      after :create do |patient_session|
-        create :vaccination_record,
-               reason: :already_had,
-               administered: false,
-               patient_session:
+      vaccination_records do
+        create_list(
+          :vaccination_record,
+          1,
+          reason: :already_had,
+          administered: false,
+          user:,
+          patient_session: instance
+        )
       end
     end
 
     trait :vaccinated do
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
-
-      after :create do |patient_session, context|
-        create :vaccination_record,
-               administered: true,
-               patient_session:,
-               user: context.user
+      vaccination_records do
+        create_list(
+          :vaccination_record,
+          1,
+          administered: true,
+          user:,
+          patient_session: instance
+        )
       end
     end
 

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -81,71 +81,65 @@ FactoryBot.define do
     end
 
     trait :consent_given_triage_not_needed do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :given,
-          campaign: evaluator.campaign,
-          patient:,
-          parent_relationship: patient.parent_relationship
+          campaign:,
+          patient: instance,
+          parent_relationship: instance.parent_relationship
         )
       end
     end
 
     trait :consent_given_triage_needed do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :given,
           :health_question_notes,
-          campaign: evaluator.campaign,
-          patient:
+          campaign:,
+          patient: instance
         )
       end
     end
 
     trait :consent_refused do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :refused,
           :from_mum,
-          campaign: evaluator.campaign,
-          patient:
+          campaign:,
+          patient: instance
         )
       end
     end
 
     trait :consent_refused_with_notes do
-      after(:create) do |patient, evaluator|
-        create(
+      consents do
+        create_list(
           :consent,
+          1,
           :refused,
           :from_mum,
-          campaign: evaluator.campaign,
+          campaign:,
           reason_for_refusal: "already_vaccinated",
           reason_for_refusal_notes: "Already had the vaccine at the GP",
-          patient:
+          patient: instance
         )
       end
     end
 
     trait :consent_conflicting do
-      after(:create) do |patient, evaluator|
-        create(
-          :consent,
-          :refused,
-          :from_mum,
-          campaign: evaluator.campaign,
-          patient:
-        )
-        create(
-          :consent,
-          :given,
-          :from_dad,
-          campaign: evaluator.campaign,
-          patient:
-        )
+      consents do
+        [
+          create(:consent, :refused, :from_mum, campaign:, patient: instance),
+          create(:consent, :given, :from_dad, campaign:, patient: instance)
+        ]
       end
     end
 

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -44,11 +44,11 @@ FactoryBot.define do
       date { Time.zone.now - 1.week }
     end
 
-    after :create do |session, context|
+    patients do
       create_list :patient,
-                  context.patients_in_session,
-                  sessions: [session],
-                  location: session.location
+                  patients_in_session,
+                  sessions: [instance],
+                  location: instance.location
     end
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -36,13 +36,16 @@ FactoryBot.define do
         nurse_password { nil }
       end
 
-      after(:create) do |team, evaluator|
-        options = {
-          teams: [team],
-          email: evaluator.nurse_email,
-          password: evaluator.nurse_password
-        }.compact
-        create(:user, **options)
+      users do
+        create_list(
+          :user,
+          1,
+          **{
+            teams: [instance],
+            email: nurse_email,
+            password: nurse_password
+          }.compact
+        )
       end
     end
 


### PR DESCRIPTION
We were using `after :create` blocks in the factories to create `has_one` and `has_many` associations, but there is a better way to do this, implemented here. We also created extra `consent` objects in `triage_mailer_concern_spec.rb`.