### PR TITLE
Patient page: use a table to present consents, tuck the consent details away onto a dedicated page

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -7,7 +7,6 @@
 <% end %>
 
 <% if patient_session.consents.present? %>
-  <% consents = patient_session.consents.order(:recorded_at) %>
   <%= govuk_table do |table| %>
     <%= table.with_head do |head| %>
       <%= head.with_row do |row| %>
@@ -18,7 +17,7 @@
     <% end %>
 
     <%= table.with_body do |body| %>
-      <% patient_session.consents.order(recorded_at: :desc).each do |consent| %>
+      <% consents.each do |consent| %>
         <%= body.with_row do |row| %>
           <%= row.with_cell do %>
             <%= govuk_link_to consent.parent_name, details_session_patient_manage_consents_path(consent, session_id: session.id, patient_id: patient.id, section:, tab:) %>

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -21,7 +21,7 @@
       <% patient_session.consents.order(recorded_at: :desc).each do |consent| %>
         <%= body.with_row do |row| %>
           <%= row.with_cell do %>
-            <%= consent.parent_name %>
+            <%= govuk_link_to consent.parent_name, details_session_patient_manage_consents_path(consent, session_id: session.id, patient_id: patient.id, section:, tab:) %>
             <br>
             <span class="nhsuk-u-font-size-16"><%= consent.human_enum_name(:parent_relationship).humanize %></span>
           <% end %>

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -7,27 +7,46 @@
 <% end %>
 
 <% if patient_session.consents.present? %>
-  <% consents_grouped_by_parent.each do |summary, consents| %>
-    <%= render AppDetailsComponent.new(summary:, open: open_consents?) do %>
-      <%= render AppConsentSummaryComponent.new(**grouped_consents(consents)) %>
-
-      <% if consents.any?(&:response_refused?) %>
-        <p><%= contact_parent_or_guardian_link(consents) %></p>
-      <% elsif consents.any?(&:response_not_provided?) %>
-        <%= govuk_button_link_to(
-          "Get consent",
-          session_patient_manage_consent_path(
-            session,
-            patient,
-            consents.first.id,
-            :agree,
-            section: @section,
-            tab: @tab
-          ),
-          secondary: true
-        ) %>
+  <% consents = patient_session.consents.order(:recorded_at) %>
+  <%= govuk_table do |table| %>
+    <%= table.with_head do |head| %>
+      <%= head.with_row do |row| %>
+        <%= row.with_cell(text: 'Name') %>
+        <%= row.with_cell(text: 'Response date') %>
+        <%= row.with_cell(text: 'Decision') %>
       <% end %>
     <% end %>
+
+    <%= table.with_body do |body| %>
+      <% patient_session.consents.order(recorded_at: :desc).each do |consent| %>
+        <%= body.with_row do |row| %>
+          <%= row.with_cell do %>
+            <%= consent.parent_name %>
+            <br>
+            <span class="nhsuk-u-font-size-16"><%= consent.human_enum_name(:parent_relationship).humanize %></span>
+          <% end %>
+          <%= row.with_cell(text: consent.recorded_at.to_fs(:app_date_time)) %>
+          <%= row.with_cell(text: consent.human_enum_name(:response).humanize) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if consents.any?(&:response_refused?) %>
+    <p><%= contact_parent_or_guardian_link(consents) %></p>
+  <% elsif consents.any?(&:response_not_provided?) %>
+    <%= govuk_button_link_to(
+      "Get consent",
+      session_patient_manage_consent_path(
+        session,
+        patient,
+        consents.first.id,
+        :agree,
+        section: @section,
+        tab: @tab
+      ),
+      secondary: true
+    ) %>
   <% end %>
 <% else %>
   <p>

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -17,15 +17,6 @@ class AppConsentComponent < ViewComponent::Base
       @patient_session.able_to_vaccinate?
   end
 
-  def open_consents?
-    !@patient_session.state.to_sym.in? %i[
-                                        triaged_do_not_vaccinate
-                                        unable_to_vaccinate
-                                        unable_to_vaccinate_not_gillick_competent
-                                        vaccinated
-                                      ]
-  end
-
   def contact_parent_or_guardian_link(consents)
     consent = consents.first
     role =
@@ -43,43 +34,5 @@ class AppConsentComponent < ViewComponent::Base
       ),
       class: "nhsuk-u-font-weight-bold"
     )
-  end
-
-  def consents_grouped_by_parent
-    @consents_grouped_by_parent ||=
-      @patient_session.consents.group_by(&:summary_with_consenter)
-  end
-
-  private
-
-  def grouped_consents(consents)
-    first_consent = consents.first
-    first_refused_consent = consents.find(&:response_refused?)
-
-    props = {
-      name: first_consent.name,
-      response:
-        consents.map do |consent|
-          { text: consent.summary_with_route, timestamp: consent.recorded_at }
-        end
-    }
-    unless first_consent.via_self_consent?
-      props.merge!(
-        relationship: first_consent.who_responded,
-        contact: {
-          phone: first_consent.parent_phone,
-          email: first_consent.parent_email
-        }
-      )
-    end
-
-    if first_refused_consent.present?
-      props[:refusal_reason] = {
-        reason: first_refused_consent.human_enum_name(:reason_for_refusal),
-        notes: first_refused_consent.reason_for_refusal_notes
-      }
-    end
-
-    props
   end
 end

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -13,8 +13,8 @@ class AppConsentComponent < ViewComponent::Base
   delegate :session, to: :patient_session
 
   def display_gillick_consent_button?
-    @patient_session.session.in_progress? && @patient_session.consents.empty? &&
-      @patient_session.able_to_vaccinate?
+    patient_session.session.in_progress? && patient_session.consents.empty? &&
+      patient_session.able_to_vaccinate?
   end
 
   def contact_parent_or_guardian_link(consents)
@@ -34,5 +34,9 @@ class AppConsentComponent < ViewComponent::Base
       ),
       class: "nhsuk-u-font-weight-bold"
     )
+  end
+
+  def consents
+    patient_session.consents.order(recorded_at: :desc)
   end
 end

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -1,5 +1,5 @@
 class AppConsentComponent < ViewComponent::Base
-  attr_reader :patient_session
+  attr_reader :patient_session, :section, :tab
 
   def initialize(patient_session:, section:, tab:)
     super

--- a/app/components/app_health_questions_component.rb
+++ b/app/components/app_health_questions_component.rb
@@ -1,6 +1,6 @@
 class AppHealthQuestionsComponent < ViewComponent::Base
   erb_template <<-ERB
-    <dl class="nhsuk-summary-list app-summary-list--full-width">
+    <dl class="nhsuk-summary-list app-summary-list--full-width nhsuk-u-margin-bottom-0">
       <% health_answers.each do |question, answers| %>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -37,6 +37,10 @@ class ConsentsController < ApplicationController
     session[:current_section] = "consents"
   end
 
+  def show
+    @consent = @session.campaign.consents.find(params[:consent_id])
+  end
+
   private
 
   def set_session

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -243,6 +243,14 @@ class Consent < ApplicationRecord
     recorded_at.present?
   end
 
+  def phone_contact_method_description
+    if parent_contact_method_other.present?
+      "Other – #{parent_contact_method_other}"
+    else
+      human_enum_name(:parent_contact_method)
+    end
+  end
+
   private
 
   def health_answers_valid?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -85,6 +85,14 @@ class Patient < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def parent_relationship_label
+    if parent_relationship == "other"
+      parent_relationship_other
+    else
+      human_enum_name(:parent_relationship)
+    end.capitalize
+  end
+
   def as_json(options = {})
     super.merge("full_name" => full_name, "age" => age)
   end

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -1,0 +1,95 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: session_patient_path(id: @consent.patient.id),
+    name: "patient page",
+  ) %>
+<% end %>
+
+<%= h1 "Consent response from #{@consent.name}" %>
+
+<%= render AppCardComponent.new(heading: "Consent") do %>
+  <%= govuk_summary_list(
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
+    ) do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { "Response date" }
+      row.with_value { @consent.recorded_at.to_fs(:app_date_time) }
+    end
+
+    summary_list.with_row do |row|
+      row.with_key { "Decision" }
+      row.with_value { @consent.human_enum_name(:response).humanize }
+    end
+
+    summary_list.with_row do |row|
+      row.with_key { "Response method" }
+      row.with_value { @consent.human_enum_name(:route).humanize }
+    end
+  end %>
+<% end %>
+
+<%= render AppCardComponent.new(heading: "Child") do %>
+  <%= govuk_summary_list(
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
+    ) do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { "Full name" }
+      row.with_value { @consent.patient.full_name }
+    end
+
+    summary_list.with_row do |row|
+      row.with_key { "Date of birth" }
+      row.with_value { @consent.patient.date_of_birth.to_fs(:nhsuk_date) }
+    end
+
+    if @consent.consent_form.present?
+      summary_list.with_row do |row|
+        row.with_key { "GP surgery" }
+        row.with_value { @consent.consent_form.gp_surgery }
+      end
+    end
+
+    summary_list.with_row do |row|
+      row.with_key { "School" }
+      row.with_value { @consent.patient.location.name }
+    end
+  end %>
+<% end %>
+
+<%= render AppCardComponent.new(heading: "Parent or guardian") do %>
+  <%= govuk_summary_list(
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
+    ) do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { "Name" }
+      row.with_value { @consent.parent_name }
+    end
+
+    summary_list.with_row do |row|
+      row.with_key { "Relationship" }
+      row.with_value { @consent.who_responded.humanize }
+    end
+
+    if @consent.parent_email.present?
+      summary_list.with_row do |row|
+        row.with_key { "Email address" }
+        row.with_value { @consent.parent_email }
+      end
+    end
+
+    if @consent.parent_phone.present?
+      summary_list.with_row do |row|
+        row.with_key { "Phone number" }
+        row.with_value { @consent.parent_phone }
+      end
+    end
+
+    # TODO: add contact method when the design is ready
+  end %>
+<% end %>
+
+<% if @consent.health_answers.present? %>
+  <%= render AppCardComponent.new(heading: "Answers to health questions") do %>
+    <%= render AppHealthQuestionsComponent.new(consents: [@consent]) %>
+  <% end %>
+<% end %>

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -84,7 +84,12 @@
       end
     end
 
-    # TODO: add contact method when the design is ready
+    if @consent.parent_contact_method.present?
+      summary_list.with_row do |row|
+        row.with_key { "Phone contact method" }
+        row.with_value { @consent.phone_contact_method_description }
+      end
+    end
   end %>
 <% end %>
 

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -25,6 +25,20 @@
       row.with_key { "Response method" }
       row.with_value { @consent.human_enum_name(:route).humanize }
     end
+
+    if @consent.reason_for_refusal.present?
+      summary_list.with_row do |row|
+        row.with_key { "Reason for refusal" }
+        row.with_value { @consent.human_enum_name(:reason_for_refusal) }
+      end
+    end
+
+    if @consent.reason_for_refusal_notes.present?
+      summary_list.with_row do |row|
+        row.with_key { "Refusal details" }
+        row.with_value { @consent.reason_for_refusal_notes }
+      end
+    end
   end %>
 <% end %>
 
@@ -93,7 +107,7 @@
   end %>
 <% end %>
 
-<% if @consent.health_answers.present? %>
+<% if @consent.response_given? %>
   <%= render AppCardComponent.new(heading: "Answers to health questions") do %>
     <%= render AppHealthQuestionsComponent.new(consents: [@consent]) %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -252,6 +252,11 @@ en:
   activerecord:
     attributes:
       consent:
+        parent_contact_methods:
+          text: Can only receive text messages
+          voice: Can only receive voice calls
+          any: No specific needs
+          other: Other
         parent_relationships:
           father: dad
           mother: mum

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,9 +66,6 @@ Rails.application.routes.draw do
       end
     end
 
-    resource "consents", only: [] do
-    end
-
     resources :edit_sessions, only: %i[show update], path: "edit", as: :edit
 
     constraints -> { Flipper.enabled?(:make_session_in_progress_button) } do
@@ -81,8 +78,6 @@ Rails.application.routes.draw do
           on: :member,
           controller: "patient_sessions",
           route: /consents|triage|vaccinations/
-
-      # resource :triage, only: %i[create update]
     end
 
     constraints -> { Flipper.enabled? :offline_working } do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
                   only: %i[show update],
                   path: "consents/:consent_id/" do
           post "clone", on: :member
+          get "details", on: :collection, to: "consents#show"
         end
 
         resource :triage, only: %i[create update]

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -38,23 +38,11 @@ RSpec.describe AppConsentComponent, type: :component do
     it { should have_css("p.app-status", text: "Refused") }
 
     let(:summary) { "Consent refused by #{consent.parent_name} (#{relation})" }
-    it { should have_css("details[open]", text: summary) }
-    it { should have_css("div", text: /Name ?#{consent.parent_name}/) }
-    it { should have_css("div", text: /Relationship ?#{relation}/) }
-
-    it "displays the parents phone and email" do
-      should have_css(
-               "div",
-               text: /Contact ?#{consent.parent_phone} ?#{consent.parent_email}/
-             )
-    end
+    it { should have_css("table tr", text: /#{consent.parent_name}/) }
+    it { should have_css("table tr", text: /#{relation}/) }
 
     it "displays the response" do
-      should have_css("div", text: /Response(.*?)Consent refused/m)
-    end
-
-    it "displays only the refusal reason if there are no notes" do
-      should have_css("div", text: /Refusal reason ?Personal choice/)
+      should have_css("table tr", text: /Consent refused/)
     end
 
     it do
@@ -74,8 +62,6 @@ RSpec.describe AppConsentComponent, type: :component do
     it { should have_css("p.app-status", text: "Given") }
 
     let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
-    it { should have_css("details[open]", text: summary) }
-
     it { should_not have_css("a", text: "Contact #{consent.parent_name}") }
   end
 
@@ -83,15 +69,5 @@ RSpec.describe AppConsentComponent, type: :component do
     let(:patient_session) { create(:patient_session, :vaccinated) }
 
     let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
-    it { should have_css("details:not([open])", text: summary) }
-  end
-
-  context "consent given needing triage and patient cannot be vaccinated" do
-    let(:patient_session) do
-      create(:patient_session, :triaged_do_not_vaccinate)
-    end
-
-    let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
-    it { should have_css("details:not([open])", text: summary) }
   end
 end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Verbal consent" do
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_safe_to_vaccinate
+    and_i_can_see_the_consent_response
     and_an_email_is_sent_to_the_parent_confirming_their_consent
   end
 
@@ -65,6 +66,38 @@ RSpec.describe "Verbal consent" do
 
   def then_i_see_that_the_status_is_safe_to_vaccinate
     expect(page).to have_content("Safe to vaccinate")
+  end
+
+  def and_i_can_see_the_consent_response
+    click_link @patient.parent_name
+
+    expect(page).to have_content(
+      "Consent response from #{@patient.parent_name}"
+    )
+    expect(page).to have_content(
+      ["Response date", Time.zone.today.to_fs(:nhsuk_date_short_month)].join
+    )
+    expect(page).to have_content(["Decision", "Consent given"].join)
+    expect(page).to have_content(["Response method", "Phone"].join)
+
+    expect(page).to have_content(["Full name", @patient.full_name].join)
+    expect(page).to have_content(
+      ["Date of birth", @patient.date_of_birth.to_fs(:nhsuk_date)].join
+    )
+    expect(page).to have_content(["School", @patient.location.name].join)
+
+    expect(page).to have_content(["Name", @patient.parent_name].join)
+    expect(page).to have_content(
+      ["Relationship", @patient.parent_relationship_label].join
+    )
+    expect(page).to have_content(["Email address", @patient.parent_email].join)
+    expect(page).to have_content(["Phone number", @patient.parent_phone].join)
+
+    expect(page).to have_content("Answers to health questions")
+    expect(page).to have_content(
+      "#{@patient.parent_relationship_label} responded: No",
+      count: 3
+    )
   end
 
   def and_an_email_is_sent_to_the_parent_confirming_their_consent

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -23,7 +23,10 @@ feature "Verbal consent" do
     and_i_see_the_success_alert
 
     when_i_click_on_the_consent_given_tab
-    then_i_see_the_child_has_consent_given
+    then_i_see_the_child_is_listed
+
+    when_i_visit_the_patient_page
+    then_i_see_that_consent_is_given
   end
 
   def given_an_hpv_campaign_is_underway
@@ -87,7 +90,7 @@ feature "Verbal consent" do
     click_on "Given"
   end
 
-  def then_i_see_the_child_has_consent_given
+  def then_i_see_the_child_is_listed
     expect(page).to have_content(@child.full_name)
   end
 
@@ -101,5 +104,13 @@ feature "Verbal consent" do
 
   def then_i_see_the_patient_page
     expect(page).to have_content(@child.full_name)
+  end
+
+  def when_i_visit_the_patient_page
+    click_on @child.full_name
+  end
+
+  def then_i_see_that_consent_is_given
+    expect(page).to have_content("Safe to vaccinate")
   end
 end

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Verbal consent" do
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_do_not_vaccinate
+    and_i_can_see_the_consent_response
     and_an_email_is_sent_to_the_parent_confirming_the_refusal
   end
 
@@ -71,6 +72,35 @@ RSpec.describe "Verbal consent" do
 
   def then_i_see_that_the_status_is_do_not_vaccinate
     expect(page).to have_content("Do not vaccinate")
+  end
+
+  def and_i_can_see_the_consent_response
+    click_link @patient.parent_name
+
+    expect(page).to have_content(
+      ["Response date", Time.zone.today.to_fs(:nhsuk_date_short_month)].join
+    )
+    expect(page).to have_content(["Decision", "Consent refused"].join)
+    expect(page).to have_content(["Response method", "Phone"].join)
+    expect(page).to have_content(["Reason for refusal", "Medical reasons"].join)
+    expect(page).to have_content(
+      ["Refusal details", "They have a medical condition"].join
+    )
+
+    expect(page).to have_content(["Full name", @patient.full_name].join)
+    expect(page).to have_content(
+      ["Date of birth", @patient.date_of_birth.to_fs(:nhsuk_date)].join
+    )
+    expect(page).to have_content(["School", @patient.location.name].join)
+
+    expect(page).to have_content(["Name", @patient.parent_name].join)
+    expect(page).to have_content(
+      ["Relationship", @patient.parent_relationship_label].join
+    )
+    expect(page).to have_content(["Email address", @patient.parent_email].join)
+    expect(page).to have_content(["Phone number", @patient.parent_phone].join)
+
+    expect(page).not_to have_content("Answers to health questions")
   end
 
   def and_an_email_is_sent_to_the_parent_confirming_the_refusal

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -238,6 +238,46 @@ RSpec.describe Consent do
     end
   end
 
+  describe "#phone_contact_method_description" do
+    it "describes the phone contact method when parent/carer can only receive texts" do
+      consent = build(:consent, parent_contact_method: :text)
+
+      expect(consent.phone_contact_method_description).to eq(
+        "Can only receive text messages"
+      )
+    end
+
+    it "describes the phone contact method when parent/carer can only receive calls" do
+      consent = build(:consent, parent_contact_method: :voice)
+
+      expect(consent.phone_contact_method_description).to eq(
+        "Can only receive voice calls"
+      )
+    end
+
+    it "describes the phone contact method when parent/carer has no preference either way" do
+      consent = build(:consent, parent_contact_method: :any)
+
+      expect(consent.phone_contact_method_description).to eq(
+        "No specific needs"
+      )
+    end
+
+    it "describes the phone contact method when parent/carer has other preferences" do
+      consent =
+        build(
+          :consent,
+          parent_contact_method: :other,
+          parent_contact_method_other:
+            "Please call 01234 567890 ext 8910 between 9am and 5pm."
+        )
+
+      expect(consent.phone_contact_method_description).to eq(
+        "Other – Please call 01234 567890 ext 8910 between 9am and 5pm."
+      )
+    end
+  end
+
   it "resets unused fields after a consent refusal" do
     consent =
       build(


### PR DESCRIPTION
This is a follow-on from https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1307.

## Before – patient page

<img width="758" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/d7bed495-7f5a-4d75-80b2-5eb166b1e35f">

## After – patient page

<img width="745" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/f6c325fb-a0b7-4e8a-9c0f-cff644c680bb">

## After – consent details page (consent given)

![consent-given](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/dcab3c98-658b-4445-b893-4d80005dff61)

## After – consent details page (consent refused)

![consent-refused](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/c8495392-568f-46b8-aeeb-84609f4d973f)

## Reviewer notes

Best reviewed commit-by-commit.

While the previous implementation used a view component, the new implementation is done with a view, and is predominantly tested by feature specs. This approach trades indirection and complexity for reduced reusability.

Looking ahead, consent details will need to be presented in a very similar way on the confirmation page of the redesigned consent recording flow; that page will include edit links so the presentation may not be directly reusable. 
