### PR TITLE
Consent form phone number fixes

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -198,7 +198,7 @@ class ConsentForm < ApplicationRecord
   end
 
   def parent_phone=(str)
-    super str.nil? ? nil : str.to_s.gsub(/\s/, "")
+    super str.blank? ? nil : str.to_s.gsub(/\s/, "")
   end
 
   def address_postcode=(str)

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -91,11 +91,9 @@
       end
     end
 
-    if @consent.parent_phone.present?
-      summary_list.with_row do |row|
-        row.with_key { "Phone number" }
-        row.with_value { @consent.parent_phone }
-      end
+    summary_list.with_row do |row|
+      row.with_key { "Phone number" }
+      row.with_value { @consent.parent_phone.presence || "Not provided" }
     end
 
     if @consent.parent_contact_method.present?

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -458,6 +458,11 @@ RSpec.describe ConsentForm, type: :model do
       consent_form = build(:consent_form, parent_phone: nil)
       expect(consent_form.parent_phone).to eq(nil)
     end
+
+    it "sets the phone number to nil if it's blank" do
+      consent_form = build(:consent_form, parent_phone: "")
+      expect(consent_form.parent_phone).to eq(nil)
+    end
   end
 
   describe "#each_health_answer" do


### PR DESCRIPTION
* Ensure that if the parent/carer doesn't provide a contact phone number, it's saved as `nil` on `ConsentForm` (currently `""`)
* If a phone number isn't provided, still show the row on the consent details page in Mavis, just populate the row with "Not provided"