### PR TITLE
Consent details: fix crash, improve how GP info is shown

### DIFF
--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -59,7 +59,7 @@
     if @consent.consent_form.present?
       summary_list.with_row do |row|
         row.with_key { "GP surgery" }
-        row.with_value { @consent.consent_form.gp_surgery }
+        row.with_value { @consent.consent_form.gp_name }
       end
     end
 

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -59,7 +59,15 @@
     if @consent.consent_form.present?
       summary_list.with_row do |row|
         row.with_key { "GP surgery" }
-        row.with_value { @consent.consent_form.gp_name }
+        row.with_value {
+          if @consent.consent_form.gp_response_yes?
+            @consent.consent_form.gp_name
+          elsif @consent.consent_form.gp_response_no?
+            "Not registered"
+          elsif @consent.consent_form.gp_response_dont_know?
+            "Not known"
+          end
+        }
       end
     end
 

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
     href: @back_link,
-    name: "vaccinations page"
+    name: "#{@section.pluralize} page"
   ) %>
 <% end %>
 

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Parental consent" do
 
     when_the_nurse_checks_the_consent_responses
     then_they_see_that_the_child_has_consent
+    and_they_see_the_full_consent_form
 
     when_they_check_triage
     then_the_patient_should_be_ready_to_vaccinate
@@ -167,6 +168,16 @@ RSpec.describe "Parental consent" do
     expect(page).to have_content("Given")
     click_on "Given"
     expect(page).to have_content(@child.full_name)
+  end
+
+  def and_they_see_the_full_consent_form
+    click_on @child.full_name
+    click_on "Jane #{@child.last_name}"
+    expect(page).to have_content(
+      "Consent response from Jane #{@child.last_name}"
+    )
+    click_on "Back to patient page"
+    click_on "Back to consents page"
   end
 
   def when_they_check_triage


### PR DESCRIPTION
* [Patient page: fix label on back button](https://github.com/nhsuk/manage-vaccinations-in-schools/commit/17bb364a42ecc9eb3d19b3cd9948504f4b69943c)
* [Fix crash on consent details page for digital consent](https://github.com/nhsuk/manage-vaccinations-in-schools/commit/84325e36ef5805f56c23fd5d512cfbfe5da952ae)
* [Handle the parent not knowing the GP reg or child not being registered](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1328/commits/3d880687fe67bd252e07db7c20c5596c8e663fb3)

## GP known

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/f58f66b2-7ec3-49d6-8390-13d002d28613)

## GP unknown

<img width="677" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/cb2c51ae-adc5-46d0-94a8-cddaa9323cd9">

## Not registered at GP

<img width="666" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/2130c9c8-b25f-4e19-afba-16401b3dd880">

