### PR TITLE
Disable turbo globally

### DIFF
--- a/app/components/app_secondary_navigation_component.html.erb
+++ b/app/components/app_secondary_navigation_component.html.erb
@@ -6,7 +6,7 @@
         <%= 'app-secondary-navigation__list-item--current' if item.selected %>">
         <%= link_to item.href,
           class: "app-secondary-navigation__link",
-          data: { turbo_action: 'replace' } do %>
+          data: { turbo: true, turbo_action: 'replace' } do %>
           <%= item %>
         <% end %>
       </li>

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -47,6 +47,7 @@ or set it with content_for(:page_title)."
                 )
             ),
             data: {
+              turbo: "true",
               turbo_action: "replace"
             }
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,4 +2,6 @@ import "@hotwired/turbo-rails";
 // import { initServiceWorker } from "./serviceworker-companion";
 import "./controllers";
 
+Turbo.session.drive = false;
+
 // initServiceWorker();

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -69,11 +69,11 @@ describe ApplicationHelper do
       params[:tab] = "tab"
       params[:sort] = "name"
       params[:direction] = "asc"
-      expect(helper.session_patient_sort_link("Text", "name")).to eq(
-        '<a data-turbo-action="replace" href="/sessions/1/section/tab?direction=desc&amp;sort=name">Text</a>'
+      expect(helper.session_patient_sort_link("Text", "name")).to include(
+        '/sessions/1/section/tab?direction=desc&amp;sort=name">Text</a>'
       )
-      expect(helper.session_patient_sort_link("Text", "dob")).to eq(
-        '<a data-turbo-action="replace" href="/sessions/1/section/tab?direction=asc&amp;sort=dob">Text</a>'
+      expect(helper.session_patient_sort_link("Text", "dob")).to include(
+        '/sessions/1/section/tab?direction=asc&amp;sort=dob">Text</a>'
       )
     end
   end


### PR DESCRIPTION
We added Turbo and left it on globally which is the default.

This introduced a bug with the parental consent journey that causes users to not reach the confirmation page, which might lead them to think that the service is broken.

Turbo allows an alternate mode of operation where it's off by default and can be introduced on a per-link basis with the `data-turbo="true"` attribute: https://turbo.hotwired.dev/handbook/drive#disabling-turbo-drive-on-specific-links-or-forms

### Successfully submitting the form

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/9c0f4041-e3d3-4d2c-95a4-c8d5c4d93c3e)
