### PR TITLE
Bring back a list of children to vaccinate

### DIFF
--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -18,6 +18,7 @@ module PatientTabsConcern
       ]
     },
     vaccinations: {
+      vaccinate: %w[triaged_ready_to_vaccinate consent_given_triage_not_needed],
       vaccinated: %w[vaccinated],
       could_not_vaccinate: %w[
         consent_refused

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -24,7 +24,7 @@ end %>
   patient_sessions: @patient_sessions,
   caption: t("patients_table.#{@current_tab}.caption",
              children: pluralize_child(@patient_sessions.count)),
-  columns: @current_tab == :action_needed ?
+  columns: @current_tab == :vaccinate ?
     %i[name dob action] :
     %i[name dob outcome],
   section: :vaccinations,

--- a/config/initializers/tab_paths.rb
+++ b/config/initializers/tab_paths.rb
@@ -13,6 +13,7 @@ TAB_PATHS = {
     "not-needed" => :no_triage_needed
   },
   vaccinations: {
+    "vaccinate" => :vaccinate,
     "vaccinated" => :vaccinated,
     "could-not" => :could_not_vaccinate
   }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,9 @@ en:
       caption: "%{children} with no triage needed"
 
     # Vaccinate
+    vaccinate:
+      label: Vaccinate
+      caption: "%{children} to vaccinate"
     vaccinated:
       label: Vaccinated
       caption: "%{children} vaccinated"

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -132,6 +132,10 @@ describe PatientTabsConcern do
 
         expect(result).to eq(
           {
+            vaccinate: [
+              consent_given_triage_not_needed,
+              triaged_ready_to_vaccinate
+            ],
             vaccinated: [vaccinated],
             could_not_vaccinate: [
               consent_conflicts,

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe "Pilot journey" do
     then_i_should_see_that_the_patient_is_ready_for_vaccination
 
     # Vaccination
-    when_i_record_the_successful_vaccination
+    when_i_click_on_the_vaccination_section
+    and_i_record_the_successful_vaccination
     then_i_see_that_the_child_is_vaccinated
   end
 
@@ -186,7 +187,16 @@ RSpec.describe "Pilot journey" do
     expect(page).to have_content "Safe to vaccinate"
   end
 
-  def when_i_record_the_successful_vaccination
+  def when_i_click_on_the_vaccination_section
+    click_link "Back to consents page"
+    click_link "HPV session at Pilot School"
+    click_link "Record vaccinations"
+    click_link "Vaccinate ( 1 )"
+  end
+
+  def and_i_record_the_successful_vaccination
+    click_link "Bobby Tables"
+
     choose "Yes, they got the HPV vaccine"
     choose "Left arm (upper position)"
     click_button "Continue"
@@ -198,6 +208,7 @@ RSpec.describe "Pilot journey" do
   end
 
   def then_i_see_that_the_child_is_vaccinated
+    click_link "Vaccinated ( 1 )"
     expect(page).to have_content "1 child vaccinated"
   end
 end


### PR DESCRIPTION
Without this, the vaccinator needs to navigate to the specific child's page to record a vaccination.

Before:

<img width="1130" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/0baafe3c-8748-4e05-af90-36188fdf1501">

After:

<img width="1127" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/5a0ebc0a-12c1-4b09-be9c-4433617a4cc4">
