### PR TITLE
Add hotwire-livereload in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development do
   gem "asciidoctor"
   gem "asciidoctor-diagram"
   gem "dockerfile-rails", ">= 1.0.0"
+  gem "hotwire-livereload"
   gem "prettier_print", require: false
   gem "rails-erd"
   gem "rladr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (>= 0.6, < 0.8)
+    ffi (1.16.3)
     flipper (1.3.0)
       concurrent-ruby (< 2)
     flipper-active_record (1.3.0)
@@ -216,6 +217,10 @@ GEM
       thor
       tilt
     hashdiff (1.1.0)
+    hotwire-livereload (1.4.0)
+      actioncable (>= 6.0.0)
+      listen (>= 3.0.0)
+      railties (>= 6.0.0)
     html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     i18n (1.14.5)
@@ -245,6 +250,9 @@ GEM
     launchy (3.0.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -360,6 +368,9 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
     rbs (2.8.4)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
@@ -561,6 +572,7 @@ DEPENDENCIES
   govuk-components
   govuk_design_system_formbuilder
   govuk_markdown
+  hotwire-livereload
   jbuilder
   jsbundling-rails
   jsonb_accessor

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,15 @@
 
     <title><%= page_title(@service_name) %></title>
 
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": Rails.env.development? ? "" : "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": Rails.env.development? ? "" : "reload", defer: true %>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= turbo_refreshes_with method: :morph, scroll: :preserve  %>
     <%= yield :head %>
+    <%= hotwire_livereload_tags if Rails.env.development? %>
   </head>
 
   <body class="nhsuk-template__body<%= ' app-signed-in' if current_user.present? %>">


### PR DESCRIPTION
This enables live reloading of CSS, JS, and even HTML in local development, improving the developer experience by shortening the feedback loop between making a change and seeing that change reflected in the frontend.

I've found some caveats when testing this locally:

- CSS is a cascading language, so updates are applied on top of each other, and code that has already been declared can't be "undeclared." As such, if you remove CSS and live-reload a new version of the CSS, those old rules will persist until a hard reload
- The JS for `nhsuk-button` isn't idempotent, and applying it multiple times to the same elements leads to a JS error. I believe it's harmless
- When reloading HTML, the turbo websocket appears to temporarily disconnect. It reconnects on its own in a few seconds but if you attempt to make multiple quick changes back to back, they won't all get livereloaded
- [hotwire-livereload](https://github.com/kirillplatonov/hotwire-livereload) suggests that it depends on Redis to work, but that's not my experience, as it works without in my other projects. But perhaps Redis is necessary to fix the HTML livereloading issue. I don't think it's worth the complexity cost in adding Redis, so let's not, especially since Rails 8 will include improvements that make Redis less relevant for small apps and local development

Even with those caveats, it's worth adding this and using it for local dev.

### JS console output when livereloading

<img width="724" alt="Screenshot 2024-05-23 at 09 52 19" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/fae9a383-6703-4d85-ab38-69769f0914ff">
