### PR TITLE
Ensure patients get a location in factories

### DIFF
--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
       user { create :user }
     end
 
-    patient { create :patient }
+    patient { create :patient, session: }
     session { create(:session, campaign:) }
 
     trait :added_to_session do

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -57,10 +57,7 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     date_of_birth { Faker::Date.birthday(min_age: 3, max_age: 9) }
     patient_sessions { [] }
-    # TODO: We should be taking the location from the session by default. But
-    #       this seems to break the example campaign generator by creating
-    #       duplicate sessions.
-    # location { session&.location }example.com
+    location { session&.location }
     parent_name { "#{parent_first_name} #{last_name}" }
     parent_relationship { parent_sex == "male" ? "father" : "mother" }
     parent_email do


### PR DESCRIPTION
Without this, patients were being created with no location. We may want to look at not allowing that to happen ... perhaps all patients should have a location, but this just fixes the factories to ensure that there's a location set for patients by default.