### PR TITLE
Allow users to filter patients by name/dob 

### DIFF
--- a/app/assets/stylesheets/_patients.scss
+++ b/app/assets/stylesheets/_patients.scss
@@ -1,28 +1,34 @@
 .app-patients {
   @include top-and-bottom;
 
+  align-items: start;
   background-color: $color_nhsuk-white;
   display: flex;
   flex-wrap: wrap;
 
-  & .app-patients__filters {
+  & &__filters {
     @include nhsuk-responsive-padding(4);
 
+    align-self: stretch;
     background-color: $color_nhsuk-grey-4;
     flex-basis: 15rem;
     flex-grow: 1;
+
+    @include govuk-media-query($from: desktop) {
+      order: 2;
+    }
   }
 
-  & .app-patients__no-results {
-    @include nhsuk-responsive-margin(4);
-  }
-
-  & .app-patients__table {
+  & &__table {
     @include nhsuk-responsive-margin(4);
 
     flex-basis: 0;
     flex-grow: 999;
     min-width: 70%;
+
+    @include govuk-media-query($from: desktop) {
+      order: 1;
+    }
   }
 
   & th[aria-sort] {

--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -1,6 +1,42 @@
 <div class="app-patients">
+  <% if @section != :matching %>
+    <%= form_with url: form_url,
+                  method: :get,
+                  class: "app-patients__filters",
+                  data: { module: "autosubmit",
+                          turbo: "true",
+                          turbo_action: "replace",
+                          turbo_permanent: "" },
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_fieldset legend: { text: "Filter results", size: "s" } do %>
+        <%= f.govuk_text_field :name, label: { text: "By name" },
+                                      value: params[:name],
+                                      autocomplete: "off",
+                                      "data-autosubmit-target": "field",
+                                      "data-action": "autosubmit#submit" %>
+        <%= f.govuk_text_field :dob, label: { text: "By date of birth" },
+                                     hint: { text: "e.g. 2005 or 01/03/2014" },
+                                     value: params[:dob],
+                                     "data-autosubmit-target": "field",
+                                     "data-action": "autosubmit#submit" %>
+        <%= f.hidden_field :sort, value: params[:sort] %>
+        <%= f.hidden_field :direction, value: params[:direction] %>
+        <%= f.govuk_submit "Reset filters", type: "reset",
+                                            secondary: true,
+                                            "data-autosubmit-target": "reset",
+                                            "data-action": "autosubmit#submit",
+                                            class: "nhsuk-u-display-block" %>
+        <%= f.govuk_submit "Filter", "data-autosubmit-target": "filter" %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <%= govuk_table(classes: "app-patients__table") do |table| %>
-    <%= table.with_caption(text: @caption, html_attributes: { class: "nhsuk-u-secondary-text-color nhsuk-u-font-weight-normal nhsuk-u-font-size-19" }) %>
+    <%= table.with_caption(text: @caption, html_attributes: {
+                             class: %w[nhsuk-u-secondary-text-color
+                                       nhsuk-u-font-weight-normal
+                                       nhsuk-u-font-size-19],
+                           }) %>
 
     <%= table.with_head do |head| %>
       <% if @patient_sessions.any? %>

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -138,6 +138,14 @@ class AppPatientTableComponent < ViewComponent::Base
     end
   end
 
+  def form_url
+    session_section_tab_path(
+      session_id: params[:session_id],
+      section: params[:section],
+      tab: params[:tab]
+    )
+  end
+
   def header_attributes(column)
     sort =
       if params[:sort] == column.to_s

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,26 +1,22 @@
 class AppPatientTableComponent < ViewComponent::Base
-  include ApplicationHelper
+  attr_reader :params
 
   def initialize(
     patient_sessions:,
     section:,
     caption: nil,
     columns: %i[name dob],
-    tab: nil,
     consent_form: nil,
-    sort: nil,
-    direction: nil
+    params: {}
   )
     super
 
     @patient_sessions = patient_sessions
     @columns = columns
     @section = section
-    @tab = tab
     @caption = caption
     @consent_form = consent_form
-    @sort = sort
-    @direction = direction
+    @params = params
   end
 
   private
@@ -98,8 +94,8 @@ class AppPatientTableComponent < ViewComponent::Base
                     session_patient_path(
                       patient_session.session,
                       patient_session.patient,
-                      section: @section,
-                      tab: @tab
+                      section: params[:section],
+                      tab: params[:tab]
                     )
     end
   end
@@ -121,14 +117,31 @@ class AppPatientTableComponent < ViewComponent::Base
     when :matching
       column_name(column)
     else
-      session_patient_sort_link(column_name(column), column)
+      direction =
+        if params[:sort] == column.to_s && params[:direction] == "asc"
+          "desc"
+        else
+          "asc"
+        end
+      data = { turbo: "true", turbo_action: "replace" }
+      link_to column_name(column),
+              session_section_tab_path(
+                session_id: params[:session_id],
+                section: params[:section],
+                tab: params[:tab],
+                sort: column,
+                direction:,
+                name: params[:name],
+                dob: params[:dob]
+              ),
+              data:
     end
   end
 
   def header_attributes(column)
     sort =
-      if @sort == column.to_s
-        @direction == "asc" ? "ascending" : "descending"
+      if params[:sort] == column.to_s
+        params[:direction] == "asc" ? "ascending" : "descending"
       else
         "none"
       end

--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -7,12 +7,31 @@ module PatientSortingConcern
     "outcome" => "state"
   }.freeze
 
+  def sort_and_filter_patients!(patient_sessions)
+    sort_patients!(patient_sessions)
+    filter_patients!(patient_sessions)
+  end
+
   def sort_patients!(patient_sessions)
     return if params[:sort].blank?
 
     method_path = SORT_MAPPING[params[:sort]]
     patient_sessions.sort_by! { deep_send(_1, method_path) }
     patient_sessions.reverse! if params[:direction] == "desc"
+  end
+
+  def filter_patients!(patient_sessions)
+    if params[:name].present?
+      patient_sessions.select! do
+        _1.patient.full_name.downcase.include?(params[:name].downcase)
+      end
+    end
+
+    if params[:dob].present?
+      patient_sessions.select! do
+        _1.patient.date_of_birth.strftime("%d/%m/%Y").include?(params[:dob])
+      end
+    end
   end
 
   private

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -32,7 +32,7 @@ class ConsentsController < ApplicationController
     @tab_counts = count_patient_sessions(tab_patient_sessions)
     @patient_sessions = tab_patient_sessions[@current_tab] || []
 
-    sort_patients!(@patient_sessions)
+    sort_and_filter_patients!(@patient_sessions)
 
     session[:current_section] = "consents"
   end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -28,7 +28,7 @@ class TriageController < ApplicationController
     @tab_counts = count_patient_sessions(tab_patient_sessions)
     @patient_sessions = tab_patient_sessions[@current_tab] || []
 
-    sort_patients!(@patient_sessions)
+    sort_and_filter_patients!(@patient_sessions)
 
     session[:current_section] = "triage"
   end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -43,7 +43,7 @@ class VaccinationsController < ApplicationController
       format.json { render json: @patient_outcomes.map(&:first).index_by(&:id) }
     end
 
-    sort_patients!(@patient_sessions)
+    sort_and_filter_patients!(@patient_sessions)
 
     session[:current_section] = "vaccinations"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -29,26 +29,4 @@ or set it with content_for(:page_title)."
 
     [title, service_name].join(" - ")
   end
-
-  def session_patient_sort_link(text, sort)
-    link_to text,
-            session_section_tab_path(
-              session_id: params[:session_id],
-              section: params[:section],
-              tab: params[:tab],
-              sort:,
-              direction:
-                (
-                  if params[:sort] == sort.to_s && params[:direction] == "asc"
-                    "desc"
-                  else
-                    "asc"
-                  end
-                )
-            ),
-            data: {
-              turbo: "true",
-              turbo_action: "replace"
-            }
-  end
 end

--- a/app/javascript/controllers/autosubmit_controller.js
+++ b/app/javascript/controllers/autosubmit_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-module="autosubmit"
+export default class extends Controller {
+  static targets = ["field", "reset", "filter"];
+
+  connect() {
+    this.filterTarget.style.display = "none";
+    this.setResetButtonState();
+  }
+
+  submit() {
+    clearTimeout(this.timeout);
+    this.timeout = setTimeout(() => {
+      this.element.requestSubmit();
+      this.setResetButtonState();
+    }, 250);
+  }
+
+  setResetButtonState() {
+    if (this.fieldTargets.every((f) => f.value === "")) {
+      this.resetTarget.disabled = true;
+    } else {
+      this.resetTarget.disabled = false;
+    }
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application";
 
+import AutosubmitController from "./autosubmit_controller";
+application.register("autosubmit", AutosubmitController);
+
 import CheckAllController from "./check_all_controller";
 application.register("check-all", CheckAllController);
 

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -41,7 +41,5 @@ end %>
              children: pluralize_child(@patient_sessions.count)),
   columns: @current_tab == :consent_refused ? %i[name dob reason] : %i[name dob],
   section: :consents,
-  tab: params[:tab],
-  sort: params[:sort],
-  direction: params[:direction]
+  params:,
 ) %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -26,7 +26,5 @@ end %>
              children: pluralize_child(@patient_sessions.count)),
   columns: %i[name dob],
   section: :triage,
-  tab: params[:tab],
-  sort: params[:sort],
-  direction: params[:direction]
+  params:
 ) %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -28,7 +28,5 @@ end %>
     %i[name dob action] :
     %i[name dob outcome],
   section: :vaccinations,
-  tab: params[:tab],
-  sort: params[:sort],
-  direction: params[:direction]
+  params:
 ) %>

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -7,11 +7,6 @@ RSpec.describe AppPatientTableComponent, type: :component do
     allow(component).to receive(:session_patient_path).and_return(
       "/session/patient/"
     )
-    allow(component).to(
-      receive(:session_patient_sort_link) do |text, sort|
-        "<a href='/session/sort/#{sort}'>#{text}</a>"
-      end
-    )
 
     render_inline(component)
   end
@@ -19,14 +14,14 @@ RSpec.describe AppPatientTableComponent, type: :component do
   subject { page }
 
   let(:section) { :consent }
-  let(:tab) { :needed }
   let(:patient_sessions) { create_list(:patient_session, 2) }
   let(:columns) { %i[name dob] }
-  let(:params) do
-    { patient_sessions:, caption: "Foo", section:, tab:, columns: }
+  let(:params) { { session_id: 1, section:, tab: :needed } }
+  let(:args) do
+    { patient_sessions:, caption: "Foo", section:, columns:, params: }
   end
 
-  let(:component) { described_class.new(**params) }
+  let(:component) { described_class.new(**args) }
 
   def have_column(text)
     have_css(".nhsuk-table__head th", text:)
@@ -87,7 +82,7 @@ RSpec.describe AppPatientTableComponent, type: :component do
 
   describe "columns parameter" do
     context "is not set" do
-      let(:component) { described_class.new(**params.except(:columns)) }
+      let(:component) { described_class.new(**args.except(:columns)) }
 
       it { should have_column("Full name") }
       it { should have_column("Date of birth") }

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -77,4 +77,45 @@ describe PatientSortingConcern do
       end
     end
   end
+
+  describe "#filter_patients!" do
+    context "when filtering by name" do
+      let(:params) { { name: "Alex" } }
+
+      it "filters patient sessions by patient name" do
+        subject.filter_patients!(patient_sessions)
+        expect(patient_sessions.size).to eq(1)
+        expect(patient_sessions.first.patient.first_name).to eq("Alex")
+      end
+    end
+
+    context "when filtering by date of birth" do
+      let(:params) { { dob: "02/01/2010" } }
+
+      it "filters patient sessions by date of birth" do
+        subject.filter_patients!(patient_sessions)
+        expect(patient_sessions.size).to eq(1)
+        expect(patient_sessions.first.patient.first_name).to eq("Blair")
+      end
+    end
+
+    context "when filtering by name and date of birth" do
+      let(:params) { { name: "Alex", dob: "01/01/2010" } }
+
+      it "filters patient sessions by both name and date of birth" do
+        subject.filter_patients!(patient_sessions)
+        expect(patient_sessions.size).to eq(1)
+        expect(patient_sessions.first.patient.first_name).to eq("Alex")
+      end
+    end
+
+    context "when no filter parameters are provided" do
+      let(:params) { {} }
+
+      it "does not filter patient sessions" do
+        subject.filter_patients!(patient_sessions)
+        expect(patient_sessions.size).to eq(3)
+      end
+    end
+  end
 end

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -1,28 +1,57 @@
 require "rails_helper"
 
-RSpec.describe "User account" do
-  scenario "Users can edit their account details" do
+RSpec.describe "Patient sorting and filtering" do
+  scenario "Users can sort and filter patients" do
     given_that_i_am_signed_in
     when_i_visit_the_consents_page
-    then_i_see_the_list_of_patients_ordered_by_name_asc
+    then_i_see_patients_ordered_by_name_asc # Initial server load is name asc
 
     when_i_click_on_the_name_header
-    then_i_see_the_list_of_patients_ordered_by_name_asc
+    then_i_see_patients_ordered_by_name_asc # On first press still name asc
 
     when_i_click_on_the_name_header
-    then_i_see_the_list_of_patients_ordered_by_name_desc
+    then_i_see_patients_ordered_by_name_desc
 
     when_i_click_on_the_name_header
-    then_i_see_the_list_of_patients_ordered_by_name_asc
+    then_i_see_patients_ordered_by_name_asc
 
     when_i_click_on_the_dob_header
-    then_i_see_the_list_of_patients_ordered_by_dob_asc
+    then_i_see_patients_ordered_by_dob_asc
 
     when_i_click_on_the_dob_header
-    then_i_see_the_list_of_patients_ordered_by_dob_desc
+    then_i_see_patients_ordered_by_dob_desc
 
-    when_i_click_on_the_dob_header
-    then_i_see_the_list_of_patients_ordered_by_dob_asc
+    when_i_filter_by_names_starting_with_cas
+    and_i_click_filter
+    then_i_see_patients_with_names_starting_with_cas_by_dob_desc
+    and_by_name_contains_cas
+
+    when_i_click_on_the_name_header
+    then_i_see_patients_with_names_starting_with_cas_by_name_asc
+
+    when_i_filter_by_dob_01_2002
+    and_i_click_filter
+    then_i_see_patients_with_dob_01_2002
+
+    when_i_filter_by_dob_01_01_2002
+    and_i_click_filter
+    then_i_see_patients_with_dob_01_01_2002
+  end
+
+  scenario "Users can sort and filter patients with JS", type: :system do
+    given_that_i_am_signed_in
+    when_i_visit_the_consents_page
+    then_i_see_patients_ordered_by_name_asc
+    and_there_should_be_no_filter_button
+
+    2.times { when_i_click_on_the_name_header }
+    then_i_see_patients_ordered_by_name_desc
+
+    when_i_filter_by_names_starting_with_cas
+    then_i_see_patients_with_names_starting_with_cas_by_name_desc
+
+    when_i_reset_filters
+    then_i_see_patients_ordered_by_name_asc
   end
 
   def given_that_i_am_signed_in
@@ -34,11 +63,14 @@ RSpec.describe "User account" do
         :session,
         campaign: @campaign,
         location: @team.locations.first,
-        patients_in_session: 3
+        patients_in_session: 4
       )
     @session
       .patients
-      .zip(%w[Alex Blair Casey], %w[2000-01-01 2000-01-02 2000-01-03])
+      .zip(
+        %w[Alex Blair Casey Cassidy],
+        %w[2000-01-01 2001-01-01 2002-01-01 2002-01-02]
+      )
       .each do |(patient, name, dob)|
         patient.update!(first_name: name, date_of_birth: dob)
       end
@@ -57,19 +89,77 @@ RSpec.describe "User account" do
     click_link "Date of birth"
   end
 
-  def then_i_see_the_list_of_patients_ordered_by_name_asc
+  def then_i_see_patients_ordered_by_name_asc
     expect(page).to have_selector("tr:nth-child(1)", text: "Alex")
     expect(page).to have_selector("tr:nth-child(2)", text: "Blair")
     expect(page).to have_selector("tr:nth-child(3)", text: "Casey")
+    expect(page).to have_selector("tr:nth-child(4)", text: "Cassidy")
   end
-  alias_method :then_i_see_the_list_of_patients_ordered_by_dob_asc,
-               :then_i_see_the_list_of_patients_ordered_by_name_asc
+  alias_method :then_i_see_patients_ordered_by_dob_asc,
+               :then_i_see_patients_ordered_by_name_asc
 
-  def then_i_see_the_list_of_patients_ordered_by_name_desc
-    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
-    expect(page).to have_selector("tr:nth-child(2)", text: "Blair")
-    expect(page).to have_selector("tr:nth-child(3)", text: "Alex")
+  def then_i_see_patients_ordered_by_name_desc
+    expect(page).to have_selector("tr:nth-child(1)", text: "Cassidy")
+    expect(page).to have_selector("tr:nth-child(2)", text: "Casey")
+    expect(page).to have_selector("tr:nth-child(3)", text: "Blair")
+    expect(page).to have_selector("tr:nth-child(4)", text: "Alex")
   end
-  alias_method :then_i_see_the_list_of_patients_ordered_by_dob_desc,
-               :then_i_see_the_list_of_patients_ordered_by_name_desc
+  alias_method :then_i_see_patients_ordered_by_dob_desc,
+               :then_i_see_patients_ordered_by_name_desc
+
+  def when_i_filter_by_names_starting_with_cas
+    fill_in "By name", with: "cas"
+  end
+
+  def and_i_click_filter
+    click_button "Filter"
+  end
+
+  def and_there_should_be_no_filter_button
+    expect(page).not_to have_button "Filter"
+  end
+
+  def then_i_see_patients_with_names_starting_with_cas_by_name_desc
+    expect(page).to have_selector("tr:nth-child(1)", text: "Cassidy")
+    expect(page).to have_selector("tr:nth-child(2)", text: "Casey")
+    expect(page).not_to have_selector("tr:nth-child(3)")
+  end
+  alias_method :then_i_see_patients_with_names_starting_with_cas_by_dob_desc,
+               :then_i_see_patients_with_names_starting_with_cas_by_name_desc
+
+  def then_i_see_patients_with_names_starting_with_cas_by_name_asc
+    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
+    expect(page).to have_selector("tr:nth-child(2)", text: "Cassidy")
+    expect(page).not_to have_selector("tr:nth-child(3)")
+  end
+  alias_method :then_i_see_patients_with_names_starting_with_cas_by_dob_asc,
+               :then_i_see_patients_with_names_starting_with_cas_by_name_asc
+
+  def and_by_name_contains_cas
+    expect(page).to have_field("By name", with: "cas")
+  end
+
+  def when_i_filter_by_dob_01_2002
+    fill_in "By date of birth", with: "01/2002"
+  end
+
+  def then_i_see_patients_with_dob_01_2002
+    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
+    expect(page).to have_selector("tr:nth-child(2)", text: "Cassidy")
+    expect(page).not_to have_selector("tr:nth-child(3)")
+  end
+
+  def when_i_filter_by_dob_01_01_2002
+    fill_in "By date of birth", with: "01/01/2002"
+  end
+
+  def then_i_see_patients_with_dob_01_01_2002
+    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
+    expect(page).not_to have_selector("tr:nth-child(2)")
+  end
+
+  def when_i_reset_filters
+    expect(page).to have_button "Reset filters", disabled: false
+    click_button "Reset filters"
+  end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -61,20 +61,4 @@ describe ApplicationHelper do
       end
     end
   end
-
-  context "#session_patient_sort_link" do
-    it "returns a link to the session section tab path with the correct parameters" do
-      params[:session_id] = 1
-      params[:section] = "section"
-      params[:tab] = "tab"
-      params[:sort] = "name"
-      params[:direction] = "asc"
-      expect(helper.session_patient_sort_link("Text", "name")).to include(
-        '/sessions/1/section/tab?direction=desc&amp;sort=name">Text</a>'
-      )
-      expect(helper.session_patient_sort_link("Text", "dob")).to include(
-        '/sessions/1/section/tab?direction=asc&amp;sort=dob">Text</a>'
-      )
-    end
-  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -93,6 +93,7 @@ RSpec.configure do |config|
 
   config.include ActiveJob::TestHelper, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :system
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
 end


### PR DESCRIPTION
This implements filtering using a server-side request and turbo to progressively enhance it to be in-place.

A form with a method of `GET` is added to the patients table that sends name/dob parameters to the server. These params are handled in the controller to filter the list of patients down. The `sort` and `direction` parameters are maintained through hidden fields, allowing sorting and filtering to occur at the same time.

An `autosubmit` Stimulus controller then progressively enhances the form by hiding the submit button and automatically submitting the fields for the user 250ms after their last input. The content of the input fields are maintained using `data-turbo-permanent`. There is a `Reset filters` button that is set to disabled when the fields are empty and enabled when not.

The `patient_sorting_filtering_spec` is updated with a second scenario that has a type of `:system` and runs with JS. It tests that the submit button disappears, and that filtering and reseting works as expected.

Can be reviewed commit by commit.

TODO:

- [x] CSS 🎨 
- [x] Refactor controller logic to concern
- [x] Fix any broken specs

### Screenshots

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/3403db17-f054-4264-bbfd-15614ec66fab)

#### Filtering by name

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/b235c7de-e37a-4a93-9869-2500964fcdb7)

#### Simultaneous sorting/filtering

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/5179e9f3-dd39-498d-82b4-3ca643381331)

#### Mobile has filters at start

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/3e78f360-0d91-451e-b91f-85ece673df40)
