### PR TITLE
Fix assets:precompile in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,6 +41,7 @@
 /coverage
 /spec
 !/spec/factories
+!/spec/support/faker
 /tests
 /terraform
 


### PR DESCRIPTION
Our `.dockerignore` removes the `spec` folder but keeps `spec/factories`. The patient factory requires the `spec/support/faker/national_health_service` patch, which was missing from the Docker build, which causes `assets:precompile` to fail.