### PR TITLE
Patient page: display Gillick assessment results and other Gillick-related tweaks

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -54,11 +54,6 @@
       method: :post,
       builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_submit "Get consent", name: "consent", value: "phone" %>
-
-      <% if display_gillick_consent_button? %>
-        <%= f.govuk_submit "Assess Gillick competence", secondary: true,
-          name: "consent", value: "self_consent" %>
-      <% end %>
     <% end %>
   </p>
 <% end %>

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -12,11 +12,6 @@ class AppConsentComponent < ViewComponent::Base
   delegate :patient, to: :patient_session
   delegate :session, to: :patient_session
 
-  def display_gillick_consent_button?
-    patient_session.session.in_progress? && patient_session.consents.empty? &&
-      patient_session.able_to_vaccinate?
-  end
-
   def contact_parent_or_guardian_link(consents)
     consent = consents.first
     role =

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -31,13 +31,13 @@
         <% end %>
       <% end %>
     <% else %>
-      <%= form_for :consent,
-        url: session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
-        method: :post,
-        builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-        <%= f.govuk_submit "Assess Gillick competence", secondary: true,
-          name: "consent", value: "self_consent" %>
-      <% end %>
+      <%= govuk_button_to(
+        "Assess Gillick competence",
+        session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
+        secondary: true,
+        name: "consent", value: "self_consent",
+        prevent_double_click: true
+      ) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -17,6 +17,31 @@
   <%= render AppPatientDetailsComponent.new(patient:, session:) %>
 <% end %>
 
+<% if gillick_assessment_applicable? %>
+  <%= render AppCardComponent.new(heading: "Gillick assessment") do %>
+    <% if gillick_assessment_recorded? %>
+      <%= govuk_summary_list(classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0") do |summary_list| %>
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { "Are they Gillick competent?" } %>
+          <%= row.with_value { patient_session.gillick_competent ? "Yes, they are Gillick competent" : "No" } %>
+        <% end %>
+        <%= summary_list.with_row do |row| %>
+          <%= row.with_key { "Details of your assessment" } %>
+          <%= row.with_value { patient_session.gillick_competence_notes } %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= form_for :consent,
+        url: session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
+        method: :post,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_submit "Assess Gillick competence", secondary: true,
+          name: "consent", value: "self_consent" %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
 <%= render AppCardComponent.new(heading: "Consent") do %>
   <%= render AppConsentComponent.new(patient_session:, section:, tab:) %>
 <% end %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -29,4 +29,12 @@ class AppPatientPageComponent < ViewComponent::Base
   def display_health_questions?
     @patient_session.consents.any?(&:response_given?)
   end
+
+  def gillick_assessment_applicable?
+    patient_session.session.in_progress?
+  end
+
+  def gillick_assessment_recorded?
+    !patient_session.gillick_competent.nil?
+  end
 end

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe AppConsentComponent, type: :component do
     it { should_not have_css("details", text: "Responses to health questions") }
     it { should have_css("p", text: "No response yet") }
     it { should have_css("button", text: "Get consent") }
-    it { should have_css("button", text: "Assess Gillick competence") }
   end
 
   context "consent is not present and session is not in progress" do

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AppPatientPageComponent, type: :component do
 
   subject { page }
 
-  context "patient in triage" do
+  context "session in progress, patient in triage" do
     let(:patient_session) do
       FactoryBot.create(
         :patient_session,
@@ -31,9 +31,10 @@ RSpec.describe AppPatientPageComponent, type: :component do
     it "does not show the vaccination form" do
       should_not have_css(".nhsuk-card", text: "Did they get the HPV vaccine?")
     end
+    it { should have_css("button", text: "Assess Gillick competence") }
   end
 
-  context "patient ready to vaccinate" do
+  context "session in progress, patient ready to vaccinate" do
     let(:patient_session) do
       FactoryBot.create(
         :patient_session,

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -8,11 +8,12 @@ RSpec.describe "Self-consent" do
     and_it_is_the_day_of_a_vaccination_session
     and_there_is_a_child_without_parental_consent
 
-    when_the_nurse_carries_out_a_gillick_competence_assessment_and_records_it
+    when_the_nurse_assesses_the_child_as_gillick_competent
     then_the_child_can_give_their_own_consent_that_the_nurse_records
 
     when_the_nurse_views_the_childs_record
     then_they_see_that_the_child_has_consent
+    and_the_details_of_the_gillick_competence_assessment_are_visible
     and_the_child_should_be_safe_to_vaccinate
   end
 
@@ -43,7 +44,7 @@ RSpec.describe "Self-consent" do
     expect(page).to have_content(@child.full_name)
   end
 
-  def when_the_nurse_carries_out_a_gillick_competence_assessment_and_records_it
+  def when_the_nurse_assesses_the_child_as_gillick_competent
     click_on @child.full_name
 
     click_on "Assess Gillick competence"
@@ -82,6 +83,13 @@ RSpec.describe "Self-consent" do
       "#{@child.full_name} Child (Gillick competent)"
     )
     expect(page).to have_content("Consent given")
+  end
+
+  def and_the_details_of_the_gillick_competence_assessment_are_visible
+    expect(page).to have_content("Yes, they are Gillick competent")
+    expect(page).to have_content(
+      "They understand the benefits and risks of the vaccine"
+    )
   end
 
   def and_the_child_should_be_safe_to_vaccinate

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Not Gillick competent" do
+  after { Timecop.return }
+
+  scenario "No consent from parent, the child is not Gillick competent" do
+    given_an_hpv_campaign_is_underway
+    and_it_is_the_day_of_a_vaccination_session
+    and_there_is_a_child_without_parental_consent
+
+    when_the_nurse_assesses_the_child_as_not_being_gillick_competent
+    then_the_child_cannot_give_their_own_consent
+    and_the_lack_of_gillick_competence_is_visible_to_the_nurse
+  end
+
+  def given_an_hpv_campaign_is_underway
+    @team = create(:team, :with_one_nurse)
+    campaign = create(:campaign, :hpv, team: @team)
+    location = create(:location, name: "Pilot School", team: @team)
+    @session =
+      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
+    @child = @session.patients.first
+  end
+
+  def and_it_is_the_day_of_a_vaccination_session
+    Timecop.freeze(@session.date)
+  end
+
+  def and_there_is_a_child_without_parental_consent
+    sign_in @team.users.first
+
+    visit "/dashboard"
+
+    click_on "Campaigns", match: :first
+    click_on "HPV"
+    click_on "Pilot School"
+    click_on "Check consent responses"
+
+    expect(page).to have_content("No consent ( 1 )")
+    expect(page).to have_content(@child.full_name)
+  end
+
+  def when_the_nurse_assesses_the_child_as_not_being_gillick_competent
+    click_on @child.full_name
+
+    click_on "Assess Gillick competence"
+    click_on "Give your assessment"
+
+    choose "No"
+
+    fill_in "Give details of your assessment",
+            with: "They didn't understand the benefits and risks of the vaccine"
+    click_on "Continue"
+  end
+
+  def then_the_child_cannot_give_their_own_consent
+    skip "BUG here: the child shouldn't be able to give their own consent, but can"
+  end
+
+  def and_the_lack_of_gillick_competence_is_visible_to_the_nurse
+    expect(page).to have_content(
+      "No-one responded to our requests for consent. When assessed, the child was not Gillick competent"
+    )
+  end
+end


### PR DESCRIPTION
## What's changed

* Display the results of a Gillick assessment on the patient page
* Move the "Assess Gillick competence" button out of the Consent section and into the new Gillick Assessment section
* Add a (skipped) feature spec for a child who doesn't pass a Gillick assessment – there's a bug here currently, as the app lets the child give consent even if they are not Gillick competent

## What's *not* changed

The following will be done in follow-up PRs:

* Turn the Gillick assessment button into a link
* Split up the Gillick assessment and self-consent into separate flows
* Ability to edit the Gillick assessment
* Roll self-consent in with verbal assessment etc
* Fix bug around consent when the child is not Gillick competent

## Screenshots

Scenario|Before             |  After
:-------------:|:-------------:|:----------------:
Planned session|<img width="676" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/550773ea-d958-4493-8ce6-31f259b6f3ae">|no change|
In-progress session, child not yet Gillick-assessed|<img width="683" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/31ba3389-4ee7-4883-82a1-fb8c314fc9ae">|<img width="565" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/978b8eb3-11b3-48d9-a53e-325a0ab0093f">|
In-progress session, child assessed as Gillick competent|<img width="512" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/798ab521-9e16-4630-97f6-98b79a42dc4a">|<img width="522" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/e40051f9-d4aa-4108-abd0-12bb60a21677">
In-progress session, child assessed as not being Gillick competent|<img width="522" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/a80e1855-865b-4d3e-80f5-4b41f2dbfb78">|<img width="515" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/039fe2e9-9d7b-4cb1-9f00-931eeadca9d4">