### PR TITLE
Visual fixes (margin, extra borders) on the patient page

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if patient_session.consents.present? %>
-  <%= govuk_table do |table| %>
+  <%= govuk_table(classes: "nhsuk-u-margin-bottom-4") do |table| %>
     <%= table.with_head do |head| %>
       <%= head.with_row do |row| %>
         <%= row.with_cell(text: 'Name') %>

--- a/app/components/app_patient_details_component.rb
+++ b/app/components/app_patient_details_component.rb
@@ -15,7 +15,7 @@ class AppPatientDetailsComponent < ViewComponent::Base
 
   def call
     govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border"
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
     ) do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Name" }


### PR DESCRIPTION
Compared to the prototype, the areas of the patient page below have excessive whitespace, compared to the prototype:

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/7c320800-2d64-44c8-b466-acb676018ef6)
