### PR TITLE
Fix flakey patient sorting spec

### DIFF
--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -5,28 +5,31 @@
                   class: "app-patients__filters",
                   data: { module: "autosubmit",
                           turbo: "true",
-                          turbo_action: "replace",
-                          turbo_permanent: "" },
+                          turbo_action: "replace" },
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_fieldset legend: { text: "Filter results", size: "s" } do %>
         <%= f.govuk_text_field :name, label: { text: "By name" },
                                       value: params[:name],
                                       autocomplete: "off",
                                       "data-autosubmit-target": "field",
-                                      "data-action": "autosubmit#submit" %>
+                                      "data-action": "autosubmit#submit",
+                                      "data-turbo-permanent": "true" %>
         <%= f.govuk_text_field :dob, label: { text: "By date of birth" },
                                      hint: { text: "e.g. 2005 or 01/03/2014" },
                                      value: params[:dob],
                                      "data-autosubmit-target": "field",
-                                     "data-action": "autosubmit#submit" %>
+                                     "data-action": "autosubmit#submit",
+                                     "data-turbo-permanent": "true" %>
         <%= f.hidden_field :sort, value: params[:sort] %>
         <%= f.hidden_field :direction, value: params[:direction] %>
         <%= f.govuk_submit "Reset filters", type: "reset",
                                             secondary: true,
                                             "data-autosubmit-target": "reset",
                                             "data-action": "autosubmit#submit",
+                                            "data-turbo-permanent": "true",
                                             class: "nhsuk-u-display-block" %>
-        <%= f.govuk_submit "Filter", "data-autosubmit-target": "filter" %>
+        <%= f.govuk_submit "Filter", "data-autosubmit-target": "filter",
+                                     "data-turbo-permanent": "true" %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Patient sorting and filtering" do
     then_i_see_patients_with_names_starting_with_cas_by_name_desc
 
     when_i_reset_filters
-    then_i_see_patients_ordered_by_name_asc
+    then_i_see_patients_ordered_by_name_desc
   end
 
   def given_that_i_am_signed_in
@@ -120,17 +120,17 @@ RSpec.describe "Patient sorting and filtering" do
   end
 
   def then_i_see_patients_with_names_starting_with_cas_by_name_desc
+    expect(page).not_to have_selector("tr:nth-child(3)")
     expect(page).to have_selector("tr:nth-child(1)", text: "Cassidy")
     expect(page).to have_selector("tr:nth-child(2)", text: "Casey")
-    expect(page).not_to have_selector("tr:nth-child(3)")
   end
   alias_method :then_i_see_patients_with_names_starting_with_cas_by_dob_desc,
                :then_i_see_patients_with_names_starting_with_cas_by_name_desc
 
   def then_i_see_patients_with_names_starting_with_cas_by_name_asc
+    expect(page).not_to have_selector("tr:nth-child(3)")
     expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
     expect(page).to have_selector("tr:nth-child(2)", text: "Cassidy")
-    expect(page).not_to have_selector("tr:nth-child(3)")
   end
   alias_method :then_i_see_patients_with_names_starting_with_cas_by_dob_asc,
                :then_i_see_patients_with_names_starting_with_cas_by_name_asc
@@ -144,9 +144,9 @@ RSpec.describe "Patient sorting and filtering" do
   end
 
   def then_i_see_patients_with_dob_01_2002
+    expect(page).not_to have_selector("tr:nth-child(3)")
     expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
     expect(page).to have_selector("tr:nth-child(2)", text: "Cassidy")
-    expect(page).not_to have_selector("tr:nth-child(3)")
   end
 
   def when_i_filter_by_dob_01_01_2002
@@ -154,8 +154,8 @@ RSpec.describe "Patient sorting and filtering" do
   end
 
   def then_i_see_patients_with_dob_01_01_2002
-    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
     expect(page).not_to have_selector("tr:nth-child(2)")
+    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
   end
 
   def when_i_reset_filters


### PR DESCRIPTION
This test was relying on a race condition and the hidden behaviour of `expect` in rspec system tests.

Because system specs often trigger JavaScript and network requests, they have a built-in "sleep". If the assertion fails immediately, they try again after a short while, and only fail if all the tries fail.

This test was sorting the list as such:

```
- Cassidy
- Casey
- Blair
- Alex
```

And then testing that after filtering for `cas` that we're left with:

```
expect Cassidy
expect Casey
expect no third item
```

However, the implementation had a bug. Namely that `sort` and `direction` parameters were being lost upon using the name filtering. So the actual list from the server would be:

```
- Casey
- Cassidy
```

So why did the test succeed? The first two `expects` should fail. The reason comes back to the aforementioned built-in sleeps: in some scenarios, the first two `expect`s would run and succeed as they run immediately, before the server replies with the new HTML. Then the third would wait for the filtering to finish and then succeed as well, despite the fact that now the sorting has been lost.

This commit makes the tests more reliable by checking for the total number of items first.

It also fixes the underlying issue of losing the sorting order when filtering. `data-turbo-permanent` on the wrapping `<form>` was causing the hidden `sort` and `direction` fields to persist between page morphs, so instead this makes the buttons and `name`/`dob` fields permanent but the rest impermanent.