### PR TITLE
Improve output of view component tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,4 +96,5 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include FactoryBot::Syntax::Methods
   config.include ViewComponent::TestHelpers, type: :component
+  config.include Capybara::RSpecMatchers, type: :component
 end


### PR DESCRIPTION
From https://viewcomponent.org/guide/testing.html#rspec-configuration

Before:

```bash
Failure/Error: it { should have_text("Consent Given by John Doe (Mother)") }
       expected `#<Capybara::Node::Simple tag="" path="/">.has_text?("Consent Given by John Doe (Mother)")`
       to be truthy, got false
```

After:

```bash
Failure/Error: it { should have_text("Consent Given by John Doe (Mother)") }
       expected to find text "Consent Given by John Doe (Mother)" in "Foobar\n"
```