### PR TITLE
Refactor activity log to separate component

### DIFF
--- a/app/components/app_activity_log_component.html.erb
+++ b/app/components/app_activity_log_component.html.erb
@@ -1,0 +1,19 @@
+<% events_by_day.each do |day, events| %>
+  <h2 class="nhsuk-heading-xs nhsuk-u-secondary-text-color
+             nhsuk-u-font-weight-normal">
+    <%= day %>
+  </h2>
+
+  <% events.each do |event| %>
+    <div class="nhsuk-card">
+      <div class="nhsuk-card__content">
+        <h3 class="nhsuk-card__heading nhsuk-heading-s">
+          <%= event[:title] %>
+        </h3>
+        <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
+          <%= event[:time].to_fs(:app_date_time) %>
+        </p>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -1,0 +1,26 @@
+class AppActivityLogComponent < ViewComponent::Base
+  def initialize(patient_session)
+    super
+
+    @patient_session = patient_session
+  end
+
+  def events_by_day
+    consent_events.group_by { _1[:time].to_fs(:nhsuk_date) }
+  end
+
+  def consent_events
+    @patient_session
+      .patient
+      .consents
+      .recorded
+      .order(recorded_at: :desc)
+      .map do |consent|
+        {
+          title:
+            "Consent #{consent.response} by #{consent.parent_name} (#{consent.who_responded})",
+          time: consent.recorded_at
+        }
+      end
+  end
+end

--- a/app/views/patients/log.html.erb
+++ b/app/views/patients/log.html.erb
@@ -19,16 +19,4 @@
       }
     end %>
 
-<% @patient.consents.recorded.each do |consent| %>
-  <div class="nhsuk-card">
-    <div class="nhsuk-card__content">
-      <h2 class="nhsuk-card__heading nhsuk-heading-s">
-        Consent <%= consent.response %> by <%= consent.parent_name %>
-        (<%= consent.who_responded %>)
-      </h2>
-      <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
-        <%= consent.recorded_at.to_fs(:app_date_time) %>
-      </p>
-    </div>
-  </div>
-<% end %>
+<%= render AppActivityLogComponent.new(@patient_session) %>

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+shared_examples "card" do |params|
+  it "renders card ##{params[:nth]} '#{params[:title]}'" do
+    expect(page).to have_css(
+      ".nhsuk-card:nth-of-type(#{params[:nth]}) h3",
+      text: params[:title]
+    )
+    expect(page).to have_css(
+      ".nhsuk-card:nth-of-type(#{params[:nth]}) p",
+      text: params[:date]
+    )
+  end
+end
+
+describe AppActivityLogComponent, type: :component do
+  let(:campaign) { create(:campaign) }
+  let(:session) { create(:session, campaign:) }
+  let(:patient) { create(:patient) }
+  let!(:consents) do
+    [
+      create(
+        :consent,
+        :given,
+        :from_mum,
+        campaign:,
+        patient:,
+        parent_name: "Jane Doe",
+        recorded_at: Time.zone.parse("2024-05-30 12:00")
+      ),
+      create(
+        :consent,
+        :refused,
+        :from_dad,
+        campaign:,
+        patient:,
+        parent_name: "John Doe",
+        recorded_at: Time.zone.parse("2024-05-30 13:00")
+      )
+    ]
+  end
+
+  let(:patient_session) { create(:patient_session, patient:, session:) }
+  let(:component) { described_class.new(patient_session) }
+
+  before { render_inline(component) }
+
+  subject { page }
+
+  it "renders heading #1 correctly" do
+    expect(page).to have_css("h2:nth-of-type(1)", text: "30 May 2024")
+  end
+
+  include_examples "card",
+                   nth: 1,
+                   title: "Consent refused by John Doe (Dad)",
+                   date: "30 May 2024 at 1:00pm"
+
+  include_examples "card",
+                   nth: 2,
+                   title: "Consent given by Jane Doe (Mum)",
+                   date: "30 May 2024 at 12:00pm"
+end

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -1,0 +1,41 @@
+class AppActivityLogComponentPreview < ViewComponent::Preview
+  def default
+    setup
+
+    render AppActivityLogComponent.new(patient_session)
+  end
+
+  private
+
+  attr_reader :patient_session, :campaign, :session, :patient, :consents
+
+  def setup
+    @campaign = Campaign.first
+    @session = @campaign.sessions.first
+    @patient = FactoryBot.create(:patient)
+
+    @consents = [
+      FactoryBot.create(
+        :consent,
+        :given,
+        :from_mum,
+        campaign: @campaign,
+        patient: @patient,
+        parent_name: "Jane Doe",
+        recorded_at: Time.zone.parse("2024-05-30 12:00")
+      ),
+      FactoryBot.create(
+        :consent,
+        :refused,
+        :from_dad,
+        campaign: @campaign,
+        patient: @patient,
+        parent_name: "John Doe",
+        recorded_at: Time.zone.parse("2024-05-30 13:00")
+      )
+    ]
+
+    @patient_session =
+      FactoryBot.create(:patient_session, patient: @patient, session: @session)
+  end
+end


### PR DESCRIPTION
Prerequisite: https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1355

This refactors the log to a component, allowing us to more easily unit test the output against multiple scenarios without relying on heavy feature tests.

It also improves the component by adding the consolidated headers and by creating an `events` array that has a unified structure in the component class. We can add to this with all the different event types in follow-up PRs.

TODO:

- [x] Add consolidated headings as per the prototype
- [x] Component preview screenshots

### Component preview

http://localhost:4000/rails/view_components/app_activity_log_component/default

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/33e078fb-0c9d-45f7-985f-d625ad6ec316)
