### PR TITLE
Add more events to activity log

### DIFF
--- a/app/components/app_activity_log_component.html.erb
+++ b/app/components/app_activity_log_component.html.erb
@@ -12,6 +12,7 @@
         </h3>
         <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
           <%= event[:time].to_fs(:app_date_time) %>
+          <% if event[:by] %> · <%= event[:by] %><% end %>
         </p>
       </div>
     </div>

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -12,7 +12,17 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def all_events
-    [session_events, consent_events, triage_events].flatten
+    [vaccination_events, triage_events, consent_events, session_events].flatten
+  end
+
+  def vaccination_events
+    @patient_session.vaccination_records.map do
+      {
+        title: "Vaccinated with #{helpers.vaccine_heading(_1.vaccine)}",
+        time: _1.created_at,
+        by: _1.user.full_name
+      }
+    end
   end
 
   def triage_events

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -12,7 +12,17 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def all_events
-    [session_events, consent_events].flatten
+    [session_events, consent_events, triage_events].flatten
+  end
+
+  def triage_events
+    @patient_session.triage.map do
+      {
+        title: "Triage decision: #{_1.human_enum_name(:status)}",
+        time: _1.created_at,
+        by: _1.user.full_name
+      }
+    end
   end
 
   def consent_events

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -1,21 +1,10 @@
 require "rails_helper"
 
 shared_examples "card" do |params|
-  it "renders card ##{params[:nth]} '#{params[:title]}'" do
-    expect(page).to have_css(
-      ".nhsuk-card:nth-of-type(#{params[:nth]}) h3",
-      text: params[:title]
-    )
-    expect(page).to have_css(
-      ".nhsuk-card:nth-of-type(#{params[:nth]}) p",
-      text: params[:date]
-    )
-    if params[:by]
-      expect(page).to have_css(
-        ".nhsuk-card:nth-of-type(#{params[:nth]}) p",
-        text: params[:by]
-      )
-    end
+  it "renders card '#{params[:title]}'" do
+    expect(page).to have_css(".nhsuk-card h3", text: params[:title])
+    expect(page).to have_css(".nhsuk-card p", text: params[:date])
+    expect(page).to have_css(".nhsuk-card p", text: params[:by]) if params[:by]
   end
 end
 
@@ -26,6 +15,7 @@ describe AppActivityLogComponent, type: :component do
   let(:location) { create(:location, team:, name: "Hogwarts") }
   let(:session) { create(:session, campaign:, location:) }
   let(:patient) { create(:patient, location:) }
+
   let!(:consents) do
     [
       create(
@@ -48,6 +38,7 @@ describe AppActivityLogComponent, type: :component do
       )
     ]
   end
+
   let!(:triages) do
     [
       create(
@@ -55,6 +46,24 @@ describe AppActivityLogComponent, type: :component do
         :kept_in_triage,
         patient_session:,
         created_at: Time.zone.parse("2024-05-30 14:00"),
+        user:
+      ),
+      create(
+        :triage,
+        :vaccinate,
+        patient_session:,
+        created_at: Time.zone.parse("2024-05-30 14:30"),
+        user:
+      )
+    ]
+  end
+
+  let!(:vaccination_records) do
+    [
+      create(
+        :vaccination_record,
+        patient_session:,
+        created_at: Time.zone.parse("2024-05-31 12:00"),
         user:
       )
     ]
@@ -74,32 +83,36 @@ describe AppActivityLogComponent, type: :component do
 
   subject { page }
 
-  it "renders heading #1 correctly" do
-    expect(page).to have_css("h2:nth-of-type(1)", text: "30 May 2024")
+  it "renders headings in correct order" do
+    expect(page).to have_css("h2:nth-of-type(1)", text: "31 May 2024")
+    expect(page).to have_css("h2:nth-of-type(2)", text: "30 May 2024")
+    expect(page).to have_css("h2:nth-of-type(3)", text: "29 May 2024")
   end
 
   include_examples "card",
-                   nth: 1,
+                   title: "Vaccinated with Gardasil 9 (HPV)",
+                   date: "31 May 2024 at 12:00pm",
+                   by: "Nurse Joy"
+
+  include_examples "card",
+                   title: "Triage decision: Yes, it’s safe to vaccinate",
+                   date: "30 May 2024 at 2:30pm",
+                   by: "Nurse Joy"
+
+  include_examples "card",
                    title: "Triage decision: No, keep in triage",
                    date: "30 May 2024 at 2:00pm",
                    by: "Nurse Joy"
 
   include_examples "card",
-                   nth: 2,
                    title: "Consent refused by John Doe (Dad)",
                    date: "30 May 2024 at 1:00pm"
 
   include_examples "card",
-                   nth: 3,
                    title: "Consent given by Jane Doe (Mum)",
                    date: "30 May 2024 at 12:00pm"
 
-  it "renders heading #2 correctly" do
-    expect(page).to have_css("h2:nth-of-type(2)", text: "29 May 2024")
-  end
-
   include_examples "card",
-                   nth: 4,
                    title: "Invited to session at Hogwarts",
                    date: "29 May 2024 at 12:00pm"
 end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -10,12 +10,20 @@ shared_examples "card" do |params|
       ".nhsuk-card:nth-of-type(#{params[:nth]}) p",
       text: params[:date]
     )
+    if params[:by]
+      expect(page).to have_css(
+        ".nhsuk-card:nth-of-type(#{params[:nth]}) p",
+        text: params[:by]
+      )
+    end
   end
 end
 
 describe AppActivityLogComponent, type: :component do
-  let(:campaign) { create(:campaign) }
-  let(:location) { create(:location, team: campaign.team, name: "Hogwarts") }
+  let(:team) { create(:team) }
+  let(:user) { create(:user, teams: [team], full_name: "Nurse Joy") }
+  let(:campaign) { create(:campaign, team:) }
+  let(:location) { create(:location, team:, name: "Hogwarts") }
   let(:session) { create(:session, campaign:, location:) }
   let(:patient) { create(:patient, location:) }
   let!(:consents) do
@@ -40,6 +48,17 @@ describe AppActivityLogComponent, type: :component do
       )
     ]
   end
+  let!(:triages) do
+    [
+      create(
+        :triage,
+        :kept_in_triage,
+        patient_session:,
+        created_at: Time.zone.parse("2024-05-30 14:00"),
+        user:
+      )
+    ]
+  end
 
   let(:patient_session) do
     create(
@@ -61,11 +80,17 @@ describe AppActivityLogComponent, type: :component do
 
   include_examples "card",
                    nth: 1,
+                   title: "Triage decision: No, keep in triage",
+                   date: "30 May 2024 at 2:00pm",
+                   by: "Nurse Joy"
+
+  include_examples "card",
+                   nth: 2,
                    title: "Consent refused by John Doe (Dad)",
                    date: "30 May 2024 at 1:00pm"
 
   include_examples "card",
-                   nth: 2,
+                   nth: 3,
                    title: "Consent given by Jane Doe (Mum)",
                    date: "30 May 2024 at 12:00pm"
 
@@ -74,7 +99,7 @@ describe AppActivityLogComponent, type: :component do
   end
 
   include_examples "card",
-                   nth: 3,
+                   nth: 4,
                    title: "Invited to session at Hogwarts",
                    date: "29 May 2024 at 12:00pm"
 end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -15,8 +15,9 @@ end
 
 describe AppActivityLogComponent, type: :component do
   let(:campaign) { create(:campaign) }
-  let(:session) { create(:session, campaign:) }
-  let(:patient) { create(:patient) }
+  let(:location) { create(:location, team: campaign.team, name: "Hogwarts") }
+  let(:session) { create(:session, campaign:, location:) }
+  let(:patient) { create(:patient, location:) }
   let!(:consents) do
     [
       create(
@@ -40,7 +41,14 @@ describe AppActivityLogComponent, type: :component do
     ]
   end
 
-  let(:patient_session) { create(:patient_session, patient:, session:) }
+  let(:patient_session) do
+    create(
+      :patient_session,
+      patient:,
+      session:,
+      created_at: Time.zone.parse("2024-05-29 12:00")
+    )
+  end
   let(:component) { described_class.new(patient_session) }
 
   before { render_inline(component) }
@@ -60,4 +68,13 @@ describe AppActivityLogComponent, type: :component do
                    nth: 2,
                    title: "Consent given by Jane Doe (Mum)",
                    date: "30 May 2024 at 12:00pm"
+
+  it "renders heading #2 correctly" do
+    expect(page).to have_css("h2:nth-of-type(2)", text: "29 May 2024")
+  end
+
+  include_examples "card",
+                   nth: 3,
+                   title: "Invited to session at Hogwarts",
+                   date: "29 May 2024 at 12:00pm"
 end

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -53,6 +53,22 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
         patient_session: @patient_session,
         created_at: Time.zone.parse("2024-05-30 14:00"),
         user: @user
+      ),
+      FactoryBot.create(
+        :triage,
+        :vaccinate,
+        patient_session: @patient_session,
+        created_at: Time.zone.parse("2024-05-30 14:30"),
+        user: @user
+      )
+    ]
+
+    @vaccination_records = [
+      FactoryBot.create(
+        :vaccination_record,
+        patient_session: @patient_session,
+        created_at: Time.zone.parse("2024-05-31 12:00"),
+        user: @user
       )
     ]
   end

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -10,7 +10,9 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
   attr_reader :patient_session, :campaign, :session, :patient, :consents
 
   def setup
-    @campaign = Campaign.first
+    @team = Team.first
+    @campaign = @team.campaigns.first
+    @user = @team.users.first
     @session = @campaign.sessions.first
     @location = @session.location
     @patient = FactoryBot.create(:patient, location: @location)
@@ -43,5 +45,15 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
         session: @session,
         created_at: Time.zone.parse("2024-05-29 12:00")
       )
+
+    @triage = [
+      FactoryBot.create(
+        :triage,
+        :kept_in_triage,
+        patient_session: @patient_session,
+        created_at: Time.zone.parse("2024-05-30 14:00"),
+        user: @user
+      )
+    ]
   end
 end

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -12,7 +12,8 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
   def setup
     @campaign = Campaign.first
     @session = @campaign.sessions.first
-    @patient = FactoryBot.create(:patient)
+    @location = @session.location
+    @patient = FactoryBot.create(:patient, location: @location)
 
     @consents = [
       FactoryBot.create(
@@ -36,6 +37,11 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
     ]
 
     @patient_session =
-      FactoryBot.create(:patient_session, patient: @patient, session: @session)
+      FactoryBot.create(
+        :patient_session,
+        patient: @patient,
+        session: @session,
+        created_at: Time.zone.parse("2024-05-29 12:00")
+      )
   end
 end

--- a/spec/factories/triage.rb
+++ b/spec/factories/triage.rb
@@ -27,8 +27,12 @@ FactoryBot.define do
     patient_session { create :patient_session }
     user { create :user }
 
+    trait :vaccinate do
+      status { :ready_to_vaccinate }
+    end
+
     trait :kept_in_triage do
-      status { "needs_follow_up" }
+      status { :needs_follow_up }
     end
   end
 end


### PR DESCRIPTION
Prerequisite: https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1360

Events:

- [x] "Added to session"
- [x] "Triage decision"
- [x] "Vaccinated"

Further refinements:

- [ ] Fix content of "Triage decision" notes (follow-up, after demo)

### Preview 📸 

http://localhost:4000/rails/view_components/app_activity_log_component/default

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/e7fa45d6-6366-4649-84a1-99b70a8c5472)
