### PR TITLE
Ensure patient_relationship exists on factory'd consents

### DIFF
--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -41,10 +41,6 @@ RSpec.describe AppPatientDetailsComponent, type: :component do
       )
     end
 
-    it "should not render the address" do
-      expect(page).not_to have_css(".nhsuk-summary-list__row", text: "Address")
-    end
-
     it "should render the school name" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "School#{school.name}")

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AppSimpleStatusBannerComponent, type: :component do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Consent refused") }
-    it { should have_text("Mum refused to give consent") }
+    it { should have_text("refused to give consent") }
   end
 
   context "state is triaged_kept_in_triage" do

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -39,20 +39,19 @@ FactoryBot.define do
     transient do
       random { Random.new }
       health_questions_list { ["Is there anything else we should know?"] }
-      # Allow caller to provide patient_session as a shortcut to produce
-      # patient and campaign
-      patient_session { nil }
     end
 
-    patient { patient_session&.patient || create(:patient) }
-    campaign { patient_session&.session&.campaign || create(:campaign) }
+    patient { create(:patient) }
+    campaign { create(:campaign) }
     response { "given" }
-    parent_name { Faker::Name.name }
-    parent_email { Faker::Internet.email(domain: "example.com") }
-    # Replace first two digits with 07 to make it a mobile number
-    parent_phone { "07700 900#{random.rand(0..999).to_s.rjust(3, "0")}" }
     route { "website" }
     recorded_at { Time.zone.now }
+
+    parent_name { patient.parent_name }
+    parent_email { patient.parent_email }
+    parent_phone { patient.parent_phone }
+    parent_relationship { patient.parent_relationship }
+    parent_relationship_other { patient.parent_relationship_other }
 
     health_answers do
       health_questions_list.map do |question|

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
 
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
-    date_of_birth { Faker::Date.birthday(min_age: 3, max_age: 9) }
+    date_of_birth { Faker::Date.birthday(min_age: 12, max_age: 13) }
     patient_sessions { [] }
     location { session&.location }
     parent_name { "#{parent_first_name} #{last_name}" }
@@ -70,27 +70,14 @@ FactoryBot.define do
     # Replace first two digits with 07 to make it a mobile number
     parent_phone { "07700 900#{random.rand(0..999).to_s.rjust(3, "0")}" }
 
-    trait :of_hpv_vaccination_age do
-      date_of_birth { Faker::Date.birthday(min_age: 12, max_age: 13) }
-    end
-
-    trait :with_address do
-      address_line_1 { Faker::Address.street_address }
-      address_line_2 { Faker::Address.secondary_address }
-      address_town { Faker::Address.city }
-      address_postcode { Faker::Address.postcode }
-    end
+    address_line_1 { Faker::Address.street_address }
+    address_line_2 { Faker::Address.secondary_address }
+    address_town { Faker::Address.city }
+    address_postcode { Faker::Address.postcode }
 
     trait :consent_given_triage_not_needed do
       consents do
-        create_list(
-          :consent,
-          1,
-          :given,
-          campaign:,
-          patient: instance,
-          parent_relationship: instance.parent_relationship
-        )
+        create_list(:consent, 1, :given, campaign:, patient: instance)
       end
     end
 
@@ -150,36 +137,6 @@ FactoryBot.define do
       parent_relationship_other { nil }
       parent_phone { nil }
       parent_email { nil }
-    end
-
-    factory :patient_with_consent_given_triage_not_needed do
-      patient_sessions { [build(:patient_session, session:)] }
-
-      consents { [build(:consent, :given, campaign:, parent_relationship:)] }
-    end
-
-    factory :patient_with_consent_given_triage_needed do
-      patient_sessions { [build(:patient_session, session:)] }
-
-      consents do
-        [
-          build(
-            :consent,
-            :given,
-            :needing_triage,
-            campaign:,
-            parent_relationship:
-          )
-        ]
-      end
-    end
-
-    factory :patient_with_consent_refused do
-      patient_sessions do
-        [build(:patient_session, session:, state: "consent_refused")]
-      end
-
-      consents { [build(:consent, :refused, campaign:, parent_relationship:)] }
     end
   end
 end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -26,10 +26,10 @@ describe "HPV Vaccination" do
     @session = create(:session, campaign:, location: team.locations.first)
     @patient =
       create(
-        :patient_with_consent_given_triage_not_needed,
-        session: @session,
-        location: @session.location
-      )
+        :patient_session,
+        :consent_given_triage_not_needed,
+        session: @session
+      ).patient
 
     sign_in team.users.first
   end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -25,10 +25,10 @@ describe "HPV Vaccination" do
     @session = create(:session, campaign:, location: @team.locations.first)
     @patient =
       create(
-        :patient_with_consent_given_triage_not_needed,
-        session: @session,
-        location: @session.location
-      )
+        :patient_session,
+        :consent_given_triage_not_needed,
+        session: @session
+      ).patient
 
     sign_in @team.users.first
   end

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -26,10 +26,10 @@ describe "HPV Vaccination" do
     @session = create(:session, campaign:, location: team.locations.first)
     @patient =
       create(
-        :patient_with_consent_given_triage_not_needed,
-        session: @session,
-        location: @session.location
-      )
+        :patient_session,
+        :consent_given_triage_not_needed,
+        session: @session
+      ).patient
 
     sign_in team.users.first
   end

--- a/spec/features/nivs_hpv_report_spec.rb
+++ b/spec/features/nivs_hpv_report_spec.rb
@@ -17,14 +17,7 @@ RSpec.describe "NIVS HPV report" do
   def and_vaccinations_have_happened_in_my_teams_hpv_campaign
     campaign = create(:campaign, :hpv, team: @team)
     session = create(:session, campaign:, location: @team.locations.first)
-    create_list(
-      :patient_with_consent_given_triage_not_needed,
-      5,
-      :of_hpv_vaccination_age,
-      :with_address,
-      session:,
-      location: session.location
-    )
+    create_list(:patient_session, 5, :consent_given_triage_not_needed, session:)
     session
       .patient_sessions
       .first(3)

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -28,11 +28,7 @@ RSpec.describe "Triage" do
     session =
       create(:session, campaign:, location: @school, date: Time.zone.today)
     @patient =
-      create(
-        :patient_with_consent_given_triage_needed,
-        session:,
-        location: session.location
-      )
+      create(:patient_session, :consent_given_triage_needed, session:).patient
   end
 
   def and_i_am_signed_in

--- a/spec/features/triage_during_consent_spec.rb
+++ b/spec/features/triage_during_consent_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe "Triage" do
   def and_a_patient_needing_triage
     @patient =
       create(
-        :patient_with_consent_given_triage_needed,
-        session: @session,
-        location: @session.location
-      )
+        :patient_session,
+        :consent_given_triage_needed,
+        session: @session
+      ).patient
   end
 
   def and_i_am_signed_in

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -38,7 +38,8 @@ feature "Verbal consent" do
   end
 
   def and_a_parent_has_refused_consent_for_their_child
-    @child = create(:patient_with_consent_refused, session: @session)
+    @child =
+      create(:patient_session, :consent_refused, session: @session).patient
   end
 
   def and_i_am_logged_in_as_a_nurse

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 
 RSpec.describe TriageMailer, type: :mailer do
   describe "#vaccination_will_happen" do
-    let(:patient_session) { create(:patient_session) }
-    let(:consent) { create(:consent, patient_session:) }
+    let(:patient_session) do
+      create(:patient_session, :consent_given_triage_not_needed)
+    end
+    let(:consent) { patient_session.patient.consents.first }
 
     subject(:mail) { TriageMailer.vaccination_will_happen(patient_session) }
 
@@ -17,8 +19,8 @@ RSpec.describe TriageMailer, type: :mailer do
   end
 
   describe "#vaccination_wont_happen" do
-    let(:patient_session) { create(:patient_session) }
-    let(:consent) { create(:consent, patient_session:) }
+    let(:patient_session) { create(:patient_session, :consent_refused) }
+    let(:consent) { patient_session.patient.consents.first }
 
     subject(:mail) { TriageMailer.vaccination_wont_happen(patient_session) }
 


### PR DESCRIPTION
This is a quick tidy-up of the factories with the main aim of fixing an issue with our generated data that caused consents not to have any `parent_relationship` defined.

To this end, `consents` now always inherit the parent information from the `patient` unless otherwise specified via `:from_mum` or `:from_dad`.

A few other changes:

- Some redundant traits were removed from the `patient` factory that created transient `patient_sessions`. The call-sites of these have been replaced with calls to the `patient_session` factory instead
- All patients now have an `address` by default as that's the more common case
- All patients now have a default age between 12-13 as that's the more common case

### After (parent relationship present)

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/c68bdc73-1123-4ca9-b991-5c19799c3adb)