### PR TITLE
Add vaccines show page

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -53,7 +53,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def vaccine_summary
-    type = vaccination_record.vaccine.type
+    type = I18n.t("vaccines.#{vaccination_record.vaccine.type}")
     brand = vaccination_record.vaccine.brand
     batch = vaccination_record.batch.name
     "#{type} (#{brand}, #{batch})"

--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -1,8 +1,14 @@
 class VaccinesController < ApplicationController
   include TodaysBatchConcern
 
+  layout "two_thirds"
+
   def index
     @vaccines = policy_scope(Vaccine).order(:name)
     @todays_batch_id = todays_batch_id
+  end
+
+  def show
+    @vaccine = policy_scope(Vaccine).find(params[:id])
   end
 end

--- a/app/helpers/vaccines_helper.rb
+++ b/app/helpers/vaccines_helper.rb
@@ -1,0 +1,5 @@
+module VaccinesHelper
+  def vaccine_heading(vaccine)
+    "%s (%s)" % [vaccine.brand, t(vaccine.type.downcase, scope: "vaccines")]
+  end
+end

--- a/app/helpers/vaccines_helper.rb
+++ b/app/helpers/vaccines_helper.rb
@@ -1,5 +1,5 @@
 module VaccinesHelper
   def vaccine_heading(vaccine)
-    "%s (%s)" % [vaccine.brand, t(vaccine.type.downcase, scope: "vaccines")]
+    sprintf("%s (%s)", vaccine.brand, t(vaccine.type, scope: "vaccines"))
   end
 end

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -1,7 +1,7 @@
 <%= h1 "Vaccines", size: "xl" %>
 
 <% @vaccines.each do |vaccine| %>
-  <%= render AppCardComponent.new(heading: vaccine_heading(vaccine)) do %>
+  <%= render AppCardComponent.new(heading: link_to(vaccine_heading(vaccine), vaccine_path(vaccine))) do %>
     <p class="nhsuk-body-s nhsuk-secondary-text-color">
       <%= vaccine.supplier %>,
       GTIN: <span class="app-u-monospace"><%= vaccine.gtin %></span>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -1,7 +1,7 @@
 <%= h1 "Vaccines", size: "xl" %>
 
 <% @vaccines.each do |vaccine| %>
-  <%= render AppCardComponent.new(heading: "#{vaccine.brand} (#{vaccine.type})") do %>
+  <%= render AppCardComponent.new(heading: vaccine_heading(vaccine)) do %>
     <p class="nhsuk-body-s nhsuk-secondary-text-color">
       <%= vaccine.supplier %>,
       GTIN: <span class="app-u-monospace"><%= vaccine.gtin %></span>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -1,0 +1,65 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: vaccines_path,
+    name: "vaccines page"
+  ) %>
+<% end %>
+
+<%= h1 "#{@vaccine.brand} (#{@vaccine.type})", size: "l" %>
+
+<%= render AppCardComponent.new(heading: "Vaccine details") do %>
+  <dl class="nhsuk-summary-list">
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        GTIN
+      </dt>
+      <dd class="nhsuk-summary-list__value app-u-monospace">
+        <%= @vaccine.gtin %>
+      </dd>
+    </div>
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Vaccine
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        <%= @vaccine.type %>
+      </dd>
+    </div>
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Brand
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        <%= @vaccine.brand %>
+      </dd>
+    </div>
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Supplier
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        <%= @vaccine.supplier %>
+      </dd>
+    </div>
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Method
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        <%= @vaccine.method %>
+      </dd>
+    </div>
+    <div class="nhsuk-summary-list__row">
+      <dt class="nhsuk-summary-list__key">
+        Health questions
+      </dt>
+      <dd class="nhsuk-summary-list__value">
+        <ul class="nhsuk-list nhsuk-list--bullet">
+          <% @vaccine.health_questions.each do |question| %>
+            <li><%= question.question %></li>
+          <% end %>
+        </ul>
+      </dd>
+    </div>
+  </dl>
+<% end %>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "#{@vaccine.brand} (#{@vaccine.type})", size: "l" %>
+<%= h1 vaccine_heading(@vaccine), size: "l" %>
 
 <%= render AppCardComponent.new(heading: "Vaccine details") do %>
   <dl class="nhsuk-summary-list">
@@ -22,7 +22,7 @@
         Vaccine
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <%= @vaccine.type %>
+        <%= t("vaccines.#{@vaccine.type}") %>
       </dd>
     </div>
     <div class="nhsuk-summary-list__row">
@@ -46,7 +46,7 @@
         Method
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <%= @vaccine.method %>
+        <%= @vaccine.human_enum_name(:method).humanize %>
       </dd>
     </div>
     <div class="nhsuk-summary-list__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -347,6 +347,10 @@ en:
           already_had: "Already had the vaccine"
           absent_from_school: "Absent from school"
           absent_from_session: "Absent from session"
+      vaccine:
+        methods:
+          injection: Injection
+          nasal: Nasal spray
     errors:
       models:
         offline_password:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -183,7 +183,7 @@ Rails.application.routes.draw do
     get "/:tab", to: "errors#not_found", as: "section_tab"
   end
 
-  resources :vaccines, only: %i[index] do
+  resources :vaccines, only: %i[index show] do
     resources :batches, only: %i[create edit new update] do
       post "make-default", on: :member, as: :make_default
       post "remove-default", on: :member, as: :remove_default

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -80,7 +80,7 @@ FactoryBot.define do
     end
 
     trait :gardasil_9 do
-      type { "HPV" }
+      type { "hpv" }
       brand { "Gardasil 9" }
       supplier { "Merck Sharp & Dohme (UK) Ltd" }
       gtin { "00191778001693" }

--- a/spec/features/manage_vaccines_spec.rb
+++ b/spec/features/manage_vaccines_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "Manage vaccines" do
+  scenario "Viewing a vaccine" do
+    given_my_team_is_running_an_hpv_vaccination_campaign
+
+    when_i_manage_vaccines
+    then_i_see_an_hpv_vaccine_listed
+    when_i_click_on_the_vaccine
+    then_i_see_the_vaccine_details
+
+    when_i_click_back
+    then_i_see_the_vaccine_list
+  end
+
+  def given_my_team_is_running_an_hpv_vaccination_campaign
+    @team = create(:team, :with_one_nurse, :with_one_location)
+    @campaign = create(:campaign, :hpv_no_batches, team: @team)
+    @vaccine = @campaign.vaccines.first
+  end
+
+  def when_i_manage_vaccines
+    sign_in @team.users.first
+
+    visit "/dashboard"
+    click_on "Vaccines", match: :first
+  end
+
+  def then_i_see_an_hpv_vaccine_listed
+    expect(page).to have_content("Gardasil 9 (HPV)")
+  end
+
+  def when_i_click_on_the_vaccine
+    click_on "Gardasil 9 (HPV)"
+  end
+
+  def then_i_see_the_vaccine_details
+    expect(page).to have_selector :heading, "Gardasil 9 (HPV)"
+    expect(page).to have_selector :heading, "Vaccine details"
+  end
+
+  def when_i_click_back
+    click_on "Back"
+  end
+
+  def then_i_see_the_vaccine_list
+    expect(page).to have_selector :heading, "Vaccines"
+  end
+end


### PR DESCRIPTION
Adds show page for vaccines.

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/15608/ed969956-05fb-4f52-99eb-670d5e6c3f16)

The layout is currently two-thirds but looks like it should be three-quarters looking at the prototype. To be addressed later. The prototype also adds the "Dose" field and pre-screening questions, which we don't have yet. Will add these later.
