### PR TITLE
Use rufo to format erb files

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -1,0 +1,1 @@
+excludes [**/layouts/*,**/*.rb]

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development do
   gem "rails-erd"
   gem "rladr"
   gem "rubocop-govuk", require: false
+  gem "rufo", require: false
   gem "solargraph", require: false
   gem "solargraph-rails", require: false
   gem "syntax_tree", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -456,6 +456,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
+    rufo (0.18.0)
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -599,6 +600,7 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   rubocop-govuk
+  rufo
   sentry-rails
   sentry-ruby
   shoulda-matchers

--- a/app/components/app_breadcrumb_component.html.erb
+++ b/app/components/app_breadcrumb_component.html.erb
@@ -1,12 +1,16 @@
 <nav class="nhsuk-breadcrumb<%= " #{@classes}" if @classes %>"
      aria-label="Breadcrumb"
-     <%= @attributes.map { |name, value| "#{name}=\"#{value}\"" }.join(' ') %>>
+     <%= @attributes.map { |name, value| "#{name}=\"#{value}\"" }.join(" ") %>>
   <div class="nhsuk-width-container">
     <ol class="nhsuk-breadcrumb__list">
       <% @items.each do |item| %>
-        <li class="nhsuk-breadcrumb__item"><%= item[:href].nil? ? item[:text]
-          : govuk_link_to(item[:text], item[:href], class: "nhsuk-breadcrumb__link", attributes: item[:attributes])
-        %></li>
+        <li class="nhsuk-breadcrumb__item">
+          <%= item[:href].nil? ?
+                item[:text] :
+                govuk_link_to(item[:text], item[:href],
+                              class: "nhsuk-breadcrumb__link",
+                              attributes: item[:attributes]) %>
+        </li>
       <% end %>
     </ol>
     <p class="nhsuk-breadcrumb__back">

--- a/app/components/app_compare_consent_form_and_patient_component.html.erb
+++ b/app/components/app_compare_consent_form_and_patient_component.html.erb
@@ -3,14 +3,14 @@
     <%= table.with_head do |head| %>
       <%= head.with_row do |row| %>
         <%= row.with_cell %>
-        <%= row.with_cell(text: 'Consent response') %>
-        <%= row.with_cell(text: 'Child record') %>
+        <%= row.with_cell(text: "Consent response") %>
+        <%= row.with_cell(text: "Child record") %>
       <% end %>
     <% end %>
 
     <%= table.with_body do |body| %>
       <%= body.with_row do |row| %>
-        <%= row.with_cell(text: 'Child’s name', header: true) %>
+        <%= row.with_cell(text: "Child’s name", header: true) %>
         <%= row.with_cell(text: mark(consent_form.full_name, unless: name_match?)) %>
         <%= row.with_cell(text: patient.full_name) %>
       <% end %>
@@ -18,7 +18,7 @@
 
     <%= table.with_body do |body| %>
       <%= body.with_row do |row| %>
-        <%= row.with_cell(text: 'Date of birth', header: true) %>
+        <%= row.with_cell(text: "Date of birth", header: true) %>
         <%= row.with_cell(text: mark(consent_form.date_of_birth.to_fs(:nhsuk_date), unless: date_of_birth_match?)) %>
         <%= row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date)) %>
       <% end %>
@@ -26,7 +26,7 @@
 
     <%= table.with_body do |body| %>
       <%= body.with_row do |row| %>
-        <%= row.with_cell(text: 'Address', header: true) %>
+        <%= row.with_cell(text: "Address", header: true) %>
         <%= row.with_cell(text: mark(safe_join(consent_form.address_fields, tag.br), unless: address_match?)) %>
         <%= row.with_cell(text: safe_join(patient.address_fields, tag.br)) %>
       <% end %>

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -10,9 +10,9 @@
   <%= govuk_table(classes: "nhsuk-u-margin-bottom-4") do |table| %>
     <%= table.with_head do |head| %>
       <%= head.with_row do |row| %>
-        <%= row.with_cell(text: 'Name') %>
-        <%= row.with_cell(text: 'Response date') %>
-        <%= row.with_cell(text: 'Decision') %>
+        <%= row.with_cell(text: "Name") %>
+        <%= row.with_cell(text: "Response date") %>
+        <%= row.with_cell(text: "Decision") %>
       <% end %>
     <% end %>
 
@@ -35,24 +35,24 @@
     <p><%= contact_parent_or_guardian_link(consents) %></p>
   <% elsif consents.any?(&:response_not_provided?) %>
     <%= govuk_button_link_to(
-      "Get consent",
-      session_patient_manage_consent_path(
-        session,
-        patient,
-        consents.first.id,
-        :agree,
-        section: @section,
-        tab: @tab
-      ),
-      secondary: true
-    ) %>
+          "Get consent",
+          session_patient_manage_consent_path(
+            session,
+            patient,
+            consents.first.id,
+            :agree,
+            section: @section,
+            tab: @tab,
+          ),
+          secondary: true,
+        ) %>
   <% end %>
 <% else %>
   <p>
     <%= form_for :consent,
-      url: session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
-      method: :post,
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+                 url: session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
+                 method: :post,
+                 builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_submit "Get consent", name: "consent", value: "phone" %>
     <% end %>
   </p>

--- a/app/components/app_flash_message_component.html.erb
+++ b/app/components/app_flash_message_component.html.erb
@@ -1,11 +1,11 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
     <%= govuk_notification_banner(
-      classes: classes,
-      html_attributes: { role: role },
-      title_text: title,
-      success: success?,
-    ) do |notification_banner| %>
+          classes: classes,
+          html_attributes: { role: role },
+          title_text: title,
+          success: success?,
+        ) do |notification_banner| %>
       <% notification_banner.with_heading(text: heading) if heading.present? %>
       <% if body.present? %>
         <p><%= body.html_safe %></p>

--- a/app/components/app_gillick_card_component.html.erb
+++ b/app/components/app_gillick_card_component.html.erb
@@ -4,32 +4,32 @@
       Gillick competence
     </h2>
 
-    <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { "Assessment" }
-        row.with_value do %>
-          Assessed by <%= @patient_session.gillick_competence_assessor.full_name %><br />
-          <%= (@consent.recorded_at ||
-               @consent.created_at).to_fs(:nhsuk_date) %>
-        <% end
-      end
-
-      if @patient_session.gillick_competent?
-        summary_list.with_row do |row|
-          row.with_key { "Gillick competent" }
-          row.with_value { 'Yes' }
-        end
-
-        summary_list.with_row do |row|
-          row.with_key { 'Consent' }
-          row.with_value { 'Given by child' }
-        end
-      else
-        summary_list.with_row do |row|
-          row.with_key { "Gillick competent" }
-          row.with_value { 'No' }
-        end
-      end
-    end %>
+    <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { "Assessment" }
+            row.with_value do
+              "Assessed by #{@patient_session.gillick_competence_assessor.full_name}" +
+              tag.br +
+              "#{@consent.recorded_at || @consent.created_at}.to_fs(:nhsuk_date)"
+            end
+          end
+        
+          if @patient_session.gillick_competent?
+            summary_list.with_row do |row|
+              row.with_key { "Gillick competent" }
+              row.with_value { "Yes" }
+            end
+        
+            summary_list.with_row do |row|
+              row.with_key { "Consent" }
+              row.with_value { "Given by child" }
+            end
+          else
+            summary_list.with_row do |row|
+              row.with_key { "Gillick competent" }
+              row.with_value { "No" }
+            end
+          end
+        end %>
   </div>
 </div>

--- a/app/components/app_matching_criteria_component.html.erb
+++ b/app/components/app_matching_criteria_component.html.erb
@@ -1,32 +1,32 @@
 <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
-  summary_list.with_row do |row|
-    row.with_key { "Child" }
-    row.with_value { child_full_name }
-  end
-
-  if common_name.present?
-    summary_list.with_row do |row|
-      row.with_key { "Known as" }
-      row.with_value { common_name }
-    end
-  end
-
-  summary_list.with_row do |row|
-    row.with_key { parent_guardian_or_other.capitalize }
-    row.with_value { parent_name }
-  end
-
-  if date_of_birth.present?
-    summary_list.with_row do |row|
-      row.with_key { "Date of birth" }
-      row.with_value { "#{date_of_birth.to_fs(:nhsuk_date)} (aged #{age})" }
-    end
-  end
-
-  if address_present?
-    summary_list.with_row do |row|
-      row.with_key { "Address" }
-      row.with_value { address_fields.join(", ") }
-    end
-  end
-end %>
+     summary_list.with_row do |row|
+       row.with_key { "Child" }
+       row.with_value { child_full_name }
+     end
+   
+     if common_name.present?
+       summary_list.with_row do |row|
+         row.with_key { "Known as" }
+         row.with_value { common_name }
+       end
+     end
+   
+     summary_list.with_row do |row|
+       row.with_key { parent_guardian_or_other.capitalize }
+       row.with_value { parent_name }
+     end
+   
+     if date_of_birth.present?
+       summary_list.with_row do |row|
+         row.with_key { "Date of birth" }
+         row.with_value { "#{date_of_birth.to_fs(:nhsuk_date)} (aged #{age})" }
+       end
+     end
+   
+     if address_present?
+       summary_list.with_row do |row|
+         row.with_key { "Address" }
+         row.with_value { address_fields.join(", ") }
+       end
+     end
+   end %>

--- a/app/components/app_secondary_navigation_component.html.erb
+++ b/app/components/app_secondary_navigation_component.html.erb
@@ -3,10 +3,10 @@
   <ul class="app-secondary-navigation__list">
     <% items.each do |item| %>
       <li class="app-secondary-navigation__list-item
-        <%= 'app-secondary-navigation__list-item--current' if item.selected %>">
+        <%= "app-secondary-navigation__list-item--current" if item.selected %>">
         <%= link_to item.href,
-          class: "app-secondary-navigation__link",
-          data: { turbo: true, turbo_action: 'replace' } do %>
+                    class: "app-secondary-navigation__link",
+                    data: { turbo: true, turbo_action: "replace" } do %>
           <%= item %>
         <% end %>
       </li>

--- a/app/components/app_session_details_component.html.erb
+++ b/app/components/app_session_details_component.html.erb
@@ -1,43 +1,43 @@
 <%= render AppCardComponent.new(heading: "Session") do %>
-  <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "School" }
-      row.with_value { school }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Vaccine" }
-      row.with_value { vaccine }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Date" }
-      row.with_value { date }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Time" }
-      row.with_value { time }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Cohort" }
-      row.with_value { cohort }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Consent requests" }
-      row.with_value { consent_requests }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Reminders" }
-      row.with_value { reminders }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Deadline for responses" }
-      row.with_value { deadline_for_responses }
-    end
-  end %>
+  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "School" }
+          row.with_value { school }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Vaccine" }
+          row.with_value { vaccine }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Date" }
+          row.with_value { date }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Time" }
+          row.with_value { time }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Cohort" }
+          row.with_value { cohort }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Consent requests" }
+          row.with_value { consent_requests }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Reminders" }
+          row.with_value { reminders }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Deadline for responses" }
+          row.with_value { deadline_for_responses }
+        end
+      end %>
 <% end %>

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -1,10 +1,10 @@
 <%= form_with(
-  model: @triage,
-  url:,
-  class: "nhsuk-card",
-  method: :post,
-  builder: GOVUKDesignSystemFormBuilder::FormBuilder
-) do |f| %>
+     model: @triage,
+     url:,
+     class: "nhsuk-card",
+     method: :post,
+     builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+   ) do |f| %>
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
       Is it safe to vaccinate <%= patient.full_name %>?
@@ -12,18 +12,18 @@
     <% content_for(:before_content) { f.govuk_error_summary } %>
 
     <%= f.govuk_collection_radio_buttons(
-      :status,
-      triage_status_options,
-      :first,
-      :second,
-      legend: nil,
-    ) %>
+          :status,
+          triage_status_options,
+          :first,
+          :second,
+          legend: nil,
+        ) %>
 
     <%= f.govuk_text_area(
-      :notes,
-      label: { text: 'Triage notes (optional)' },
-      rows: 5
-    ) %>
+          :notes,
+          label: { text: "Triage notes (optional)" },
+          rows: 5,
+        ) %>
 
     <%= f.submit "Save triage", class: "nhsuk-button" %>
   </div>

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -1,12 +1,10 @@
-<%=
-form_with(
-    model: @vaccination_record,
-    url:,
-    method: :post,
-    class: "nhsuk-card",
-    builder: GOVUKDesignSystemFormBuilder::FormBuilder
-) do |f|
-%>
+<%= form_with(
+     model: @vaccination_record,
+     url:,
+     method: :post,
+     class: "nhsuk-card",
+     builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+   ) do |f| %>
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
       Did they get the <%= campaign_name %> vaccine?
@@ -14,32 +12,28 @@ form_with(
     <% content_for(:before_content) { f.govuk_error_summary } %>
 
     <%= f.govuk_radio_buttons_fieldset(:administered, legend: nil) do %>
-      <%=
-      f.govuk_radio_button(
-        :administered, true,
-        label: { text: t("vaccinations.form.label.#{ session.type.downcase }") },
-        link_errors: true
-      ) do
-      %>
+      <%= f.govuk_radio_button(
+            :administered, true,
+            label: { text: t("vaccinations.form.label.#{session.type.downcase}") },
+            link_errors: true,
+          ) do %>
         <%= f.govuk_collection_radio_buttons(
-          :delivery_site,
-          vaccination_initial_delivery_sites,
-          :value,
-          :label,
-          legend: {
-            text: 'Where did they get it?',
-            hidden: true
-          },
-          bold_labels: false
-        ) %>
+              :delivery_site,
+              vaccination_initial_delivery_sites,
+              :value,
+              :label,
+              legend: {
+                text: "Where did they get it?",
+                hidden: true,
+              },
+              bold_labels: false,
+            ) %>
       <% end %>
-      <%=
-      f.govuk_radio_button(
-        :administered,
-        false,
-        label: { text: 'No, they did not get it' }
-      )
-      %>
+      <%= f.govuk_radio_button(
+            :administered,
+            false,
+            label: { text: "No, they did not get it" },
+          ) %>
     <% end %>
 
     <%= f.hidden_field :delivery_method, value: :intramuscular %>

--- a/app/views/batches/edit.html.erb
+++ b/app/views/batches/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: vaccines_path,
-    name: "manage vaccines"
-  ) %>
+        href: vaccines_path,
+        name: "manage vaccines",
+      ) %>
 <% end %>
 
 <% page_title = "Edit batch #{@batch.name}" %>
@@ -18,7 +18,7 @@
 
   <%= form.govuk_date_field :expiry,
                             legend: { size: "s", text: "Expiry date" },
-                            hint: { text: 'For example, 27 10 2025' },
+                            hint: { text: "For example, 27 10 2025" },
                             link_errors: true %>
   <%= form.govuk_submit "Save changes" %>
 <% end %>

--- a/app/views/batches/new.html.erb
+++ b/app/views/batches/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: vaccines_path,
-    name: "manage vaccines"
-  ) %>
+        href: vaccines_path,
+        name: "manage vaccines",
+      ) %>
 <% end %>
 
 <% page_title = "Add batch" %>
@@ -20,7 +20,7 @@
   <%= form.govuk_text_field :name, label: { text: "Batch" }, width: 10 %>
   <%= form.govuk_date_field :expiry,
                             legend: { text: "Expiry date", size: "s" },
-                            hint: { text: 'For example, 27 10 2025' },
+                            hint: { text: "For example, 27 10 2025" },
                             link_errors: true %>
   <%= form.govuk_submit "Add batch" %>
 <% end %>

--- a/app/views/campaigns/index.html.erb
+++ b/app/views/campaigns/index.html.erb
@@ -5,8 +5,8 @@
   <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
-        <% row.with_cell(text: 'Name') %>
-        <% row.with_cell(text: 'Vaccines') %>
+        <% row.with_cell(text: "Name") %>
+        <% row.with_cell(text: "Vaccines") %>
       <% end %>
     <% end %>
 
@@ -20,8 +20,8 @@
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccines</span>
             <%= campaign.vaccines
-              .map { |vaccine| vaccine.brand }
-              .join("<br>").html_safe %>
+                  .map { |vaccine| vaccine.brand }
+                  .join("<br>").html_safe %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,27 +1,27 @@
 <%= h1 @campaign.name, page_title: "#{@campaign.name} – School sessions",
-  size: "l" %>
+                      size: "l" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Campaigns', href: campaigns_path }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Campaigns", href: campaigns_path },
+                                        ]) %>
 <% end %>
 
 <% [[@in_progress_sessions, "In progress sessions"],
     [@future_sessions, "Planned sessions"],
     [@past_sessions, "Past sessions"]]
-    .select { |sessions, _| sessions.any? }.each do |sessions, title| %>
+     .select { |sessions, _| sessions.any? }.each do |sessions, title| %>
   <div class="nhsuk-table__panel-with-heading-tab">
     <h3 class="nhsuk-table__heading-tab"><%= title %></h3>
     <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
-          <% row.with_cell(text: 'Date') %>
-          <% row.with_cell(text: 'Time') %>
-          <% row.with_cell(text: 'Location') %>
-          <% row.with_cell(text: 'Consent period') %>
-          <% row.with_cell(text: 'Cohort') %>
+          <% row.with_cell(text: "Date") %>
+          <% row.with_cell(text: "Time") %>
+          <% row.with_cell(text: "Location") %>
+          <% row.with_cell(text: "Consent period") %>
+          <% row.with_cell(text: "Cohort") %>
         <% end %>
       <% end %>
 
@@ -47,9 +47,9 @@
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Consent period</span>
               <% if session.close_consent_at.past? %>
-                <%= "Closed #{session.close_consent_at.strftime('%-d %b')}" %>
+                <%= "Closed #{session.close_consent_at.strftime("%-d %b")}" %>
               <% else %>
-                <%= "Open until #{session.close_consent_at.strftime('%-d %b')}" %>
+                <%= "Open until #{session.close_consent_at.strftime("%-d %b")}" %>
               <% end %>
             <% end %>
             <% row.with_cell(numeric: true) do %>

--- a/app/views/cohort_lists/errors.html.erb
+++ b/app/views/cohort_lists/errors.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: new_pilot_cohort_path,
-    name: "cohort upload page"
-  ) %>
+        href: new_pilot_cohort_path,
+        name: "cohort upload page",
+      ) %>
 <% end %>
 
 <%= h1 "The cohort list could not be added" %>

--- a/app/views/cohort_lists/new.html.erb
+++ b/app/views/cohort_lists/new.html.erb
@@ -3,17 +3,17 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Manage pilot', href: manage_pilot_path },
-    { text: page_title }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Manage pilot", href: manage_pilot_path },
+                                          { text: page_title },
+                                        ]) %>
 <% end %>
 
 <%= form_for @cohort_list, url: pilot_cohort_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :csv,
-    label: { text: page_title, tag: 'h1', size: 'l' } %>
+                         label: { text: page_title, tag: "h1", size: "l" } %>
 
-  <%= f.govuk_submit 'Upload the cohort list' %>
+  <%= f.govuk_submit "Upload the cohort list" %>
 <% end %>

--- a/app/views/consent_forms/review_match.html.erb
+++ b/app/views/consent_forms/review_match.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: consent_form_path(@consent_form),
-    name: "search for a child record"
-  ) %>
+        href: consent_form_path(@consent_form),
+        name: "search for a child record",
+      ) %>
 <% end %>
 
 <% page_title = "Link consent response with child record?" %>
@@ -18,26 +18,27 @@
     <%= render AppCompareConsentFormAndPatientComponent.new(
           heading: "Compare details",
           consent_form: @consent_form,
-          patient: @patient_session.patient) %>
+          patient: @patient_session.patient,
+        ) %>
 
     <%= render AppCardComponent.new(heading: "Consent response") do
-      render AppConsentSummaryComponent.new(
-        name: @consent_form.parent_name,
-        relationship: @consent_form.who_responded,
-        contact: {
-          phone: @consent_form.parent_phone,
-          email: @consent_form.parent_email
-        },
-        response: {
-          text: @consent_form.summary_with_route,
-          timestamp: @consent_form.recorded_at
-        },
-        refusal_reason: {
-          reason: @consent_form.human_enum_name(:reason).presence,
-          notes: @consent_form.reason_notes
-        }
-      )
-    end %>
+          render AppConsentSummaryComponent.new(
+            name: @consent_form.parent_name,
+            relationship: @consent_form.who_responded,
+            contact: {
+              phone: @consent_form.parent_phone,
+              email: @consent_form.parent_email,
+            },
+            response: {
+              text: @consent_form.summary_with_route,
+              timestamp: @consent_form.recorded_at,
+            },
+            refusal_reason: {
+              reason: @consent_form.human_enum_name(:reason).presence,
+              notes: @consent_form.reason_notes,
+            },
+          )
+        end %>
 
     <%= form_tag match_consent_form_path(@consent_form.id, patient_session_id: @patient_session.id) do %>
       <%= submit_tag "Link response with record", class: "nhsuk-button" %>

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_consents_unmatched_responses_path(@consent_form.session.id),
-    name: "school page"
-  ) %>
+        href: session_consents_unmatched_responses_path(@consent_form.session.id),
+        name: "school page",
+      ) %>
 <% end %>
 
 <% page_title = "Search for a child record" %>
@@ -18,14 +18,14 @@
 <% end %>
 
 <%= render AppCardComponent.new(heading: "Children in this cohort") do
-  if @patient_sessions.count > 0
-    render AppPatientTableComponent.new(
-      patient_sessions: @patient_sessions,
-      columns: %i[name postcode dob select_for_matching],
-      section: :matching,
-      consent_form: @consent_form
-    )
-  else
-    render AppEmptyListComponent.new
-  end
-end %>
+      if @patient_sessions.count > 0
+        render AppPatientTableComponent.new(
+          patient_sessions: @patient_sessions,
+          columns: %i[name postcode dob select_for_matching],
+          section: :matching,
+          consent_form: @consent_form,
+        )
+      else
+        render AppEmptyListComponent.new
+      end
+    end %>

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -3,34 +3,34 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
-    { text: "Check consent responses", href: session_consents_path(@session) },
-    { text: page_title }
-  ]) %>
+                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                          { text: "Check consent responses", href: session_consents_path(@session) },
+                                          { text: page_title },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title %>
 
 <%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m", card_classes: "app-card--empty-list") do
-  govuk_table(classes: "app-table--dense  nhsuk-u-margin-0") do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(text: "Responded", html_attributes: { "data-col": "date" })
-        row.with_cell(text: "Child", html_attributes: { "data-col": "child" })
-        row.with_cell(text: "Parent or guardian", html_attributes: { "data-col": "parent" })
-        row.with_cell(text: "Action", html_attributes: { "no-sort": true })
-      end
-    end
-
-    table.with_body do |body|
-      @unmatched_consent_responses.each do |consent_form|
-        body.with_row do |row|
-          row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
-          row.with_cell(text: consent_form.full_name)
-          row.with_cell(text: consent_form.parent_name)
-          row.with_cell(text: govuk_link_to('Find match', consent_form))
+      govuk_table(classes: "app-table--dense  nhsuk-u-margin-0") do |table|
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(text: "Responded", html_attributes: { "data-col": "date" })
+            row.with_cell(text: "Child", html_attributes: { "data-col": "child" })
+            row.with_cell(text: "Parent or guardian", html_attributes: { "data-col": "parent" })
+            row.with_cell(text: "Action", html_attributes: { "no-sort": true })
+          end
+        end
+    
+        table.with_body do |body|
+          @unmatched_consent_responses.each do |consent_form|
+            body.with_row do |row|
+              row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
+              row.with_cell(text: consent_form.full_name)
+              row.with_cell(text: consent_form.parent_name)
+              row.with_cell(text: govuk_link_to("Find match", consent_form))
+            end
+          end
         end
       end
-    end
-  end
-end %>
+    end %>

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -2,10 +2,10 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Today’s sessions', href: sessions_path },
-    { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Today’s sessions", href: sessions_path },
+                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title, page_title: %>
@@ -14,32 +14,33 @@
   <%= govuk_inset_text html_attributes: { class: "nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-4" } do %>
     <span class="nhsuk-visually-hidden">Information: </span>
 
-    <p><%=
-      responses = pluralize(@unmatched_record_counts, 'response')
-      need = @unmatched_record_counts == 1 ? 'needs' : 'need'
-      link_to(
-        "#{responses} #{need} matching with records in the cohort",
-        session_consents_unmatched_responses_path(@session)
-      )
-    %></p>
+    <p><%= responses = pluralize(@unmatched_record_counts, "response")
+           need = @unmatched_record_counts == 1 ? "needs" : "need"
+           link_to(
+             "#{responses} #{need} matching with records in the cohort",
+             session_consents_unmatched_responses_path(@session)
+           ) %></p>
   <% end %>
 <% end %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-  TAB_PATHS[:consents].each do |tab, state|
-    nav.with_item(selected: @current_tab == state,
-      href: session_consents_tab_path(@session, tab:)) do %>
+      TAB_PATHS[:consents].each do |tab, state|
+        nav.with_item(selected: @current_tab == state,
+                      href: session_consents_tab_path(@session, tab:)) do
+        end
+      end
+    end %>
       <%= t("patients_table.#{state}.label") %>
       <%= render AppCountComponent.new(count: @tab_counts[state]) %>
     <% end
-  end
-end %>
+         end
+       end %>
 
 <%= render AppPatientTableComponent.new(
-  patient_sessions: @patient_sessions,
-  caption: t("patients_table.#{@current_tab}.caption",
-             children: pluralize_child(@patient_sessions.count)),
-  columns: @current_tab == :consent_refused ? %i[name dob reason] : %i[name dob],
-  section: :consents,
-  params:,
-) %>
+      patient_sessions: @patient_sessions,
+      caption: t("patients_table.#{@current_tab}.caption",
+                 children: pluralize_child(@patient_sessions.count)),
+      columns: @current_tab == :consent_refused ? %i[name dob reason] : %i[name dob],
+      section: :consents,
+      params:,
+    ) %>

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -23,18 +23,15 @@
   <% end %>
 <% end %>
 
-<%= render AppSecondaryNavigationComponent.new do |nav|
-      TAB_PATHS[:consents].each do |tab, state|
-        nav.with_item(selected: @current_tab == state,
-                      href: session_consents_tab_path(@session, tab:)) do
-        end
-      end
-    end %>
+<%= render AppSecondaryNavigationComponent.new do |nav| %>
+  <% TAB_PATHS[:consents].each do |tab, state| %>
+    <% nav.with_item(selected: @current_tab == state,
+                     href: session_consents_tab_path(@session, tab:)) do %>
       <%= t("patients_table.#{state}.label") %>
       <%= render AppCountComponent.new(count: @tab_counts[state]) %>
-    <% end
-         end
-       end %>
+    <% end %>
+  <% end %>
+<% end %>
 
 <%= render AppPatientTableComponent.new(
       patient_sessions: @patient_sessions,

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -1,116 +1,116 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_patient_path(id: @consent.patient.id),
-    name: "patient page",
-  ) %>
+        href: session_patient_path(id: @consent.patient.id),
+        name: "patient page",
+      ) %>
 <% end %>
 
 <%= h1 "Consent response from #{@consent.name}" %>
 
 <%= render AppCardComponent.new(heading: "Consent") do %>
   <%= govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "Response date" }
-      row.with_value { @consent.recorded_at.to_fs(:app_date_time) }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Decision" }
-      row.with_value { @consent.human_enum_name(:response).humanize }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Response method" }
-      row.with_value { @consent.human_enum_name(:route).humanize }
-    end
-
-    if @consent.reason_for_refusal.present?
-      summary_list.with_row do |row|
-        row.with_key { "Reason for refusal" }
-        row.with_value { @consent.human_enum_name(:reason_for_refusal) }
-      end
-    end
-
-    if @consent.reason_for_refusal_notes.present?
-      summary_list.with_row do |row|
-        row.with_key { "Refusal details" }
-        row.with_value { @consent.reason_for_refusal_notes }
-      end
-    end
-  end %>
+        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
+      ) do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Response date" }
+          row.with_value { @consent.recorded_at.to_fs(:app_date_time) }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Decision" }
+          row.with_value { @consent.human_enum_name(:response).humanize }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Response method" }
+          row.with_value { @consent.human_enum_name(:route).humanize }
+        end
+      
+        if @consent.reason_for_refusal.present?
+          summary_list.with_row do |row|
+            row.with_key { "Reason for refusal" }
+            row.with_value { @consent.human_enum_name(:reason_for_refusal) }
+          end
+        end
+      
+        if @consent.reason_for_refusal_notes.present?
+          summary_list.with_row do |row|
+            row.with_key { "Refusal details" }
+            row.with_value { @consent.reason_for_refusal_notes }
+          end
+        end
+      end %>
 <% end %>
 
 <%= render AppCardComponent.new(heading: "Child") do %>
   <%= govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "Full name" }
-      row.with_value { @consent.patient.full_name }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Date of birth" }
-      row.with_value { @consent.patient.date_of_birth.to_fs(:nhsuk_date) }
-    end
-
-    if @consent.consent_form.present?
-      summary_list.with_row do |row|
-        row.with_key { "GP surgery" }
-        row.with_value {
-          if @consent.consent_form.gp_response_yes?
-            @consent.consent_form.gp_name
-          elsif @consent.consent_form.gp_response_no?
-            "Not registered"
-          elsif @consent.consent_form.gp_response_dont_know?
-            "Not known"
+        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
+      ) do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Full name" }
+          row.with_value { @consent.patient.full_name }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Date of birth" }
+          row.with_value { @consent.patient.date_of_birth.to_fs(:nhsuk_date) }
+        end
+      
+        if @consent.consent_form.present?
+          summary_list.with_row do |row|
+            row.with_key { "GP surgery" }
+            row.with_value {
+              if @consent.consent_form.gp_response_yes?
+                @consent.consent_form.gp_name
+              elsif @consent.consent_form.gp_response_no?
+                "Not registered"
+              elsif @consent.consent_form.gp_response_dont_know?
+                "Not known"
+              end
+            }
           end
-        }
-      end
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "School" }
-      row.with_value { @consent.patient.location.name }
-    end
-  end %>
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "School" }
+          row.with_value { @consent.patient.location.name }
+        end
+      end %>
 <% end %>
 
 <%= render AppCardComponent.new(heading: "Parent or guardian") do %>
   <%= govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "Name" }
-      row.with_value { @consent.parent_name }
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Relationship" }
-      row.with_value { @consent.who_responded.humanize }
-    end
-
-    if @consent.parent_email.present?
-      summary_list.with_row do |row|
-        row.with_key { "Email address" }
-        row.with_value { @consent.parent_email }
-      end
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Phone number" }
-      row.with_value { @consent.parent_phone.presence || "Not provided" }
-    end
-
-    if @consent.parent_contact_method.present?
-      summary_list.with_row do |row|
-        row.with_key { "Phone contact method" }
-        row.with_value { @consent.phone_contact_method_description }
-      end
-    end
-  end %>
+        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
+      ) do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Name" }
+          row.with_value { @consent.parent_name }
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Relationship" }
+          row.with_value { @consent.who_responded.humanize }
+        end
+      
+        if @consent.parent_email.present?
+          summary_list.with_row do |row|
+            row.with_key { "Email address" }
+            row.with_value { @consent.parent_email }
+          end
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Phone number" }
+          row.with_value { @consent.parent_phone.presence || "Not provided" }
+        end
+      
+        if @consent.parent_contact_method.present?
+          summary_list.with_row do |row|
+            row.with_key { "Phone contact method" }
+            row.with_value { @consent.phone_contact_method_description }
+          end
+        end
+      end %>
 <% end %>
 
 <% if @consent.response_given? %>

--- a/app/views/edit_sessions/cohort.html.erb
+++ b/app/views/edit_sessions/cohort.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
-    name: "#{@previous_step} page of session creation",
-  ) %>
+        href: previous_wizard_path,
+        name: "#{@previous_step} page of session creation",
+      ) %>
 <% end %>
 
 <%= form_for @session, url: wizard_path, method: :put do |f| %>
@@ -10,51 +10,50 @@
   <%= h1 "Choose cohort for this session" %>
 
   <%= govuk_table(classes: "app-table--select-cohort",
-                  html_attributes: { data: { module: "check-all" }}) do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell do
-          tag.div class: "nhsuk-checkboxes",
-                  hidden: true,
-                  data: { "check-all-target": "checkAll" } do
-            f.govuk_check_box(
-              "all_patients",
-              1,
-              checked: @session.patients.empty?,
-              label: { text: "Select all patients", hidden: true },
-            )
+                  html_attributes: { data: { module: "check-all" } }) do |table|
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell do
+              tag.div class: "nhsuk-checkboxes",
+                      hidden: true,
+                      data: { "check-all-target": "checkAll" } do
+                f.govuk_check_box(
+                  "all_patients",
+                  1,
+                  checked: @session.patients.empty?,
+                  label: { text: "Select all patients", hidden: true },
+                )
+              end
+            end
+            row.with_cell(text: "Name")
+            row.with_cell(text: "Date of birth")
+            row.with_cell(text: "Year group")
           end
         end
-        row.with_cell(text: 'Name')
-        row.with_cell(text: 'Date of birth')
-        row.with_cell(text: 'Year group')
-      end
-    end
-
-    table.with_body do |body|
-      @patients.each do |patient|
-        body.with_row do |row|
-          row.with_cell do
-            tag.div class: "nhsuk-checkboxes" do
-              f.govuk_check_box(
-                "patient_ids",
-                patient.id,
-                checked: @session.patients.empty? || patient.in?(@session.patients),
-                label: { text: "Select #{patient.full_name}", hidden: true },
-                data: { "check-all-target": "item" }
+      
+        table.with_body do |body|
+          @patients.each do |patient|
+            body.with_row do |row|
+              row.with_cell do
+                tag.div class: "nhsuk-checkboxes" do
+                  f.govuk_check_box(
+                    "patient_ids",
+                    patient.id,
+                    checked: @session.patients.empty? || patient.in?(@session.patients),
+                    label: { text: "Select #{patient.full_name}", hidden: true },
+                    data: { "check-all-target": "item" },
+                  )
+                end
+              end
+              row.with_cell(text: patient.full_name)
+              row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date_short_month))
+              row.with_cell(
+                text: t("activerecord.attributes.patient.year_group.#{patient.year_group}"),
               )
             end
           end
-          row.with_cell(text: patient.full_name)
-          row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date_short_month))
-          row.with_cell(
-            text:
-            t("activerecord.attributes.patient.year_group.#{patient.year_group}")
-          )
         end
-      end
-    end
-  end %>
+      end %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/edit_sessions/confirm.html.erb
+++ b/app/views/edit_sessions/confirm.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
-    name: "#{@previous_step} page of session creation",
-  ) %>
+        href: previous_wizard_path,
+        name: "#{@previous_step} page of session creation",
+      ) %>
 <% end %>
 
 <% page_title = "Check and confirm details" %>

--- a/app/views/edit_sessions/location.html.erb
+++ b/app/views/edit_sessions/location.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: sessions_path,
-    name: "school session"
-  ) %>
+        href: sessions_path,
+        name: "school session",
+      ) %>
 <% end %>
 
 <%= form_for @session, url: wizard_path, method: :put do |f| %>
@@ -10,12 +10,12 @@
   <%= h1 "Which school is it at?" %>
 
   <%= f.govuk_collection_radio_buttons(
-    :location_id,
-    @locations,
-    :id,
-    :name,
-    legend: nil
-  ) %>
+        :location_id,
+        @locations,
+        :id,
+        :name,
+        legend: nil,
+      ) %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/edit_sessions/timeline.html.erb
+++ b/app/views/edit_sessions/timeline.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
-    name: "#{@previous_step} page of session creation",
-  ) %>
+        href: previous_wizard_path,
+        name: "#{@previous_step} page of session creation",
+      ) %>
 <% end %>
 
 <%= form_for @session, url: wizard_path, method: :put do |f| %>
@@ -18,34 +18,34 @@
   <% end %>
 
   <%= f.govuk_date_field :send_consent_at,
-    legend: { size: 'm', text: 'Consent requests' },
-    hint: { text: 'When should parents get a request for consent?' } %>
+                         legend: { size: "m", text: "Consent requests" },
+                         hint: { text: "When should parents get a request for consent?" } %>
 
   <%= f.govuk_radio_buttons_fieldset :reminder_days_after,
-    legend: { size: 'm', text: 'Reminders' },
-    hint: { text: 'When should parents who haven’t responded get a reminder?' } do %>
+                                     legend: { size: "m", text: "Reminders" },
+                                     hint: { text: "When should parents who haven’t responded get a reminder?" } do %>
     <%= f.govuk_radio_button :reminder_days_after, :default,
-      label: { text: "#{pluralize(Session::DEFAULT_DAYS_FOR_REMINDER, 'day')} after the first consent request" },
-      link_errors: true %>
+                             label: { text: "#{pluralize(Session::DEFAULT_DAYS_FOR_REMINDER, "day")} after the first consent request" },
+                             link_errors: true %>
     <%= f.govuk_radio_button :reminder_days_after, :custom,
-      label: { text: 'Choose your own date' } do %>
+                             label: { text: "Choose your own date" } do %>
       <%= f.govuk_text_field :reminder_days_after_custom,
-        label: { text: 'Days after the first consent request', size: 's' },
-        width: 2,
-        suffix_text: "days" %>
+                             label: { text: "Days after the first consent request", size: "s" },
+                             width: 2,
+                             suffix_text: "days" %>
     <% end %>
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :close_consent_on,
-    legend: { size: 'm', text: 'Deadline for responses' } do %>
+                                     legend: { size: "m", text: "Deadline for responses" } do %>
     <%= f.govuk_radio_button :close_consent_on, :default,
-      label: { text: 'Allow responses until the day of the session' },
-      link_errors: true %>
+                             label: { text: "Allow responses until the day of the session" },
+                             link_errors: true %>
     <%= f.govuk_radio_button :close_consent_on, :custom,
-      label: { text: 'Choose your own deadline' } do %>
+                             label: { text: "Choose your own deadline" } do %>
       <%= f.govuk_date_field :close_consent_at,
-        legend: { text: 'Deadline for consent responses', size: 's' },
-        hint: { text: 'For example, 27 3 2023' } %>
+                             legend: { text: "Deadline for consent responses", size: "s" },
+                             hint: { text: "For example, 27 3 2023" } %>
     <% end %>
   <% end %>
 

--- a/app/views/edit_sessions/when.html.erb
+++ b/app/views/edit_sessions/when.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
-    name: "#{@previous_step} page of session creation",
-  ) %>
+        href: previous_wizard_path,
+        name: "#{@previous_step} page of session creation",
+      ) %>
 <% end %>
 
 <%= form_for @session, url: wizard_path, method: :put do |f| %>
@@ -11,20 +11,20 @@
 
   <%= f.govuk_date_field :date,
                          legend: { text: "Date" },
-                         hint: { text: 'For example, 27 3 2017' },
+                         hint: { text: "For example, 27 3 2017" },
                          link_errors: true %>
 
   <%= f.govuk_collection_radio_buttons(
-    :time_of_day,
-    Session.time_of_days.keys.map do
-      [_1, Session.human_enum_name("time_of_days", _1)]
-    end,
-    :first,
-    :second,
-    legend: {
-      text: "Time",
-    }
-  ) %>
+        :time_of_day,
+        Session.time_of_days.keys.map do
+          [_1, Session.human_enum_name("time_of_days", _1)]
+        end,
+        :first,
+        :second,
+        legend: {
+          text: "Time",
+        },
+      ) %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -8,6 +8,6 @@
 </p>
 <p class="nhsuk-body">
   If you have any questions, please email us at
-  <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
-  <%= t('service.email') %></a>.
+  <a class="nhsuk-link" href="mailto:<%= t("service.email") %>">
+  <%= t("service.email") %></a>.
 </p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -8,6 +8,6 @@
 </p>
 <p class="nhsuk-body">
   If the web address is correct and you need to speak to someone about this
-  problem, contact <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
-  <%= t('service.email') %></a>.
+  problem, contact <a class="nhsuk-link" href="mailto:<%= t("service.email") %>">
+  <%= t("service.email") %></a>.
 </p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -4,6 +4,6 @@
 
 <p class="nhsuk-body">
   If you continue to see this error contact the <%= @service_name %>
-  team: <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
-  <%= t('service.email') %></a>.
+  team: <a class="nhsuk-link" href="mailto:<%= t("service.email") %>">
+  <%= t("service.email") %></a>.
 </p>

--- a/app/views/manage_consents/agree.html.erb
+++ b/app/views/manage_consents/agree.html.erb
@@ -1,11 +1,11 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: back_link_path,
-    name: "contact details page",
-  ) %>
+        href: back_link_path,
+        name: "contact details page",
+      ) %>
 <% end %>
 
-<% title = t("consents.edit_consent.title.#{ @session.type.downcase }") %>
+<% title = t("consents.edit_consent.title.#{@session.type.downcase}") %>
 <% content_for :page_title, title %>
 
 <%= form_for @consent, url: form_path_for(@consent), method: form_method_for(@consent) do |f| %>
@@ -15,18 +15,18 @@
     <%= hidden_field_tag :step, "agree" %>
   <% end %>
   <%= f.govuk_radio_buttons_fieldset(:response,
-    caption: { size: 'l',
-               text: @patient.full_name },
-    legend: { size: 'l',
-              tag: 'h1',
-              text: title }) do %>
+                                     caption: { size: "l",
+                                                text: @patient.full_name },
+                                     legend: { size: "l",
+                                               tag: "h1",
+                                               text: title }) do %>
     <%= f.govuk_radio_button :response, "given",
-      label: { text: 'Yes, they agree' }, link_errors: true %>
+                             label: { text: "Yes, they agree" }, link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",
-      label: { text: "No, they do not agree" } %>
+                             label: { text: "No, they do not agree" } %>
     <% unless @consent.via_self_consent? %>
       <%= f.govuk_radio_button :response, "not_provided",
-        label: { text: 'No response' } %>
+                               label: { text: "No response" } %>
     <% end %>
   <% end %>
 

--- a/app/views/manage_consents/assessing_gillick.html.erb
+++ b/app/views/manage_consents/assessing_gillick.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_patient_path(id: @patient.id),
-    name: "patient page",
-  ) %>
+        href: session_patient_path(id: @patient.id),
+        name: "patient page",
+      ) %>
 <% end %>
 
 <% page_title = "Assessing Gillick competence" %>
@@ -29,4 +29,4 @@ to ask questions.</p>
 
 
 <%= govuk_button_to "Give your assessment", wizard_path, method: :put,
-  class: "nhsuk-u-margin-top-6" %>
+                                                         class: "nhsuk-u-margin-top-6" %>

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: back_link_path,
-    name: "previous page",
-  ) %>
+        href: back_link_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% page_title = "Check and confirm answers" %>
@@ -16,42 +16,41 @@
 
 <% if @consent.via_self_consent? %>
   <%= render AppGillickCardComponent.new(
-    consent: @consent,
-    patient_session: @patient_session) %>
+        consent: @consent,
+        patient_session: @patient_session,
+      ) %>
 <% else %>
-  <%=
-    # BUG: this code was originally written with the assumption that it is called
-    # when the user is contacting a refusing parent (that assumption is baked into the microcopy)
-    # However, this code is also invoked when a user is recording the first verbal consent,
-    # and in that case, it doesn't quite display the right thing:
-    #
-    #   Consent updated to given...
-    #
-    # (it's not actually being updated as there wasn't consent there before)
-    # The code really needs awareness of whether there was a previous consent or not, and
-    # if there was one, what the response was. i.e. the previous_response needs to be dynamic.
-
-    heading = @consent.summary_with_consenter(previous_response: "refused")
-    render AppCardComponent.new(heading:) do
-      render AppConsentSummaryComponent.new(
-               name: @consent.parent_name,
-               relationship: @consent.who_responded,
-               contact: {
-                 phone: @consent.parent_phone,
-                 email: @consent.parent_email
-               },
-               response: {
-                 text:
-                   @consent.summary_with_route(previous_response: "refused"),
-                 timestamp: @consent.recorded_at,
-                 recorded_by: @consent.recorded_by
-               },
-               refusal_reason: {
-                 reason: @consent.human_enum_name(:reason_for_refusal).presence,
-                 notes: @consent.reason_for_refusal_notes
-               }
-             )
-    end %>
+  <%= # BUG: this code was originally written with the assumption that it is called
+      # when the user is contacting a refusing parent (that assumption is baked into the microcopy)
+      # However, this code is also invoked when a user is recording the first verbal consent,
+      # and in that case, it doesn't quite display the right thing:
+      #
+      #   Consent updated to given...
+      #
+      # (it's not actually being updated as there wasn't consent there before)
+      # The code really needs awareness of whether there was a previous consent or not, and
+      # if there was one, what the response was. i.e. the previous_response needs to be dynamic.
+      
+      heading = @consent.summary_with_consenter(previous_response: "refused")
+      render AppCardComponent.new(heading:) do
+        render AppConsentSummaryComponent.new(
+          name: @consent.parent_name,
+          relationship: @consent.who_responded,
+          contact: {
+            phone: @consent.parent_phone,
+            email: @consent.parent_email,
+          },
+          response: {
+            text: @consent.summary_with_route(previous_response: "refused"),
+            timestamp: @consent.recorded_at,
+            recorded_by: @consent.recorded_by,
+          },
+          refusal_reason: {
+            reason: @consent.human_enum_name(:reason_for_refusal).presence,
+            notes: @consent.reason_for_refusal_notes,
+          },
+        )
+      end %>
 <% end %>
 
 <% if @consent.response_given? %>
@@ -62,17 +61,17 @@
 
 <% if @consent.response_given? && @triage.status.present? %>
   <%= render AppCardComponent.new(heading: "Triage") do %>
-    <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { "Status" }
-        row.with_value { @triage.status.humanize }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { "Triage notes" }
-        row.with_value { @triage.notes.presence || "No notes" }
-      end
-    end %>
+    <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { "Status" }
+            row.with_value { @triage.status.humanize }
+          end
+        
+          summary_list.with_row do |row|
+            row.with_key { "Triage notes" }
+            row.with_value { @triage.notes.presence || "No notes" }
+          end
+        end %>
   <% end %>
 <% end %>
 

--- a/app/views/manage_consents/gillick.html.erb
+++ b/app/views/manage_consents/gillick.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: back_link_path,
-    name: "consent page",
-  ) %>
+        href: back_link_path,
+        name: "consent page",
+      ) %>
 <% end %>
 
 <% content_for :page_title, "Are they Gillick competent?" %>
@@ -10,20 +10,20 @@
 <%= form_for @patient_session, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_radio_buttons_fieldset(:gillick_competent,
-    caption: { size: 'l',
-               text: @patient.full_name },
-    legend: { size: 'l',
-              tag: 'h1',
-              text: 'Are they Gillick competent?' }) do %>
+                                     caption: { size: "l",
+                                                text: @patient.full_name },
+                                     legend: { size: "l",
+                                               tag: "h1",
+                                               text: "Are they Gillick competent?" }) do %>
     <%= f.govuk_radio_button :gillick_competent, true,
-      label: { text: 'Yes, they are Gillick competent' }, link_errors: true %>
+                             label: { text: "Yes, they are Gillick competent" }, link_errors: true %>
     <%= f.govuk_radio_button :gillick_competent, false,
-      label: { text: "No" } %>
+                             label: { text: "No" } %>
   <% end %>
 
   <%= f.govuk_text_area :gillick_competence_notes,
-    label: { text: 'Give details of your assessment' },
-    rows: 10 %>
+                        label: { text: "Give details of your assessment" },
+                        rows: 10 %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/manage_consents/questions.html.erb
+++ b/app/views/manage_consents/questions.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: back_link_path,
-    name: "consent page",
-  ) %>
+        href: back_link_path,
+        name: "consent page",
+      ) %>
 <% end %>
 
 <% page_title = "Health questions" %>
@@ -20,16 +20,16 @@
   <% @consent.health_answers.each_with_index do |health_answer, index| %>
     <%= f.fields_for "question_#{index}", health_answer do |ff| %>
       <%= ff.govuk_radio_buttons_fieldset(:question,
-        legend: { size: 's', text: health_answer.question },
-        hint: { text: health_answer.hint }) do %>
-        <%= ff.govuk_radio_button :response, 'yes',
-          label: { text: 'Yes' },
-          link_errors: true do %>
+                                          legend: { size: "s", text: health_answer.question },
+                                          hint: { text: health_answer.hint }) do %>
+        <%= ff.govuk_radio_button :response, "yes",
+                                  label: { text: "Yes" },
+                                  link_errors: true do %>
           <%= ff.govuk_text_area :notes,
-            label: { text: 'Give details' } %>
+                                 label: { text: "Give details" } %>
         <% end %>
-        <%= ff.govuk_radio_button :response, 'no',
-          label: { text: 'No' } %>
+        <%= ff.govuk_radio_button :response, "no",
+                                  label: { text: "No" } %>
       <% end %>
     <% end %>
   <% end %>
@@ -38,12 +38,12 @@
 
   <%= f.fields_for @triage do |ff| %>
     <%= ff.govuk_collection_radio_buttons :status,
-     triage_form_status_options,
-     :first,
-     :second,
-     legend: { text: "Is it safe to vaccinate #{@patient.full_name}?" } %>
+                                          triage_form_status_options,
+                                          :first,
+                                          :second,
+                                          legend: { text: "Is it safe to vaccinate #{@patient.full_name}?" } %>
 
-    <%= ff.govuk_text_area :notes, label: { text: 'Triage notes (optional)' },
+    <%= ff.govuk_text_area :notes, label: { text: "Triage notes (optional)" },
                                    rows: 5 %>
   <% end %>
 

--- a/app/views/manage_consents/reason.html.erb
+++ b/app/views/manage_consents/reason.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: back_link_path,
-    name: "consent page",
-  ) %>
+        href: back_link_path,
+        name: "consent page",
+      ) %>
 <% end %>
 
 <% title = "Why are they refusing to give consent?" %>
@@ -11,22 +11,22 @@
 <%= form_for @consent, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_radio_buttons_fieldset(:reason_for_refusal,
-    caption: { size: 'l',
-               text: @patient.full_name },
-    legend: { size: 'l',
-              tag: 'h1',
-              text: title }) do %>
+                                     caption: { size: "l",
+                                                text: @patient.full_name },
+                                     legend: { size: "l",
+                                               tag: "h1",
+                                               text: title }) do %>
     <%= f.govuk_radio_button :reason_for_refusal, "already_vaccinated",
-      label: { text: 'Vaccine already received' }, link_errors: true %>
+                             label: { text: "Vaccine already received" }, link_errors: true %>
     <%= f.govuk_radio_button :reason_for_refusal, "will_be_vaccinated_elsewhere",
-      label: { text: "Vaccine will be given elsewhere" } %>
+                             label: { text: "Vaccine will be given elsewhere" } %>
     <%= f.govuk_radio_button :reason_for_refusal, "medical_reasons",
-      label: { text: 'Medical reasons' } %>
+                             label: { text: "Medical reasons" } %>
     <%= f.govuk_radio_button :reason_for_refusal, "personal_choice",
-      label: { text: 'Personal choice' } %>
+                             label: { text: "Personal choice" } %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :reason_for_refusal, "other",
-      label: { text: 'Other' } %>
+                             label: { text: "Other" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/manage_consents/reason_notes.html.erb
+++ b/app/views/manage_consents/reason_notes.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% title = t("consents.reason_for_refusal_notes.title.#{@consent.reason_for_refusal}") %>
@@ -14,9 +14,9 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_text_area :reason_for_refusal_notes,
-    label: { text: 'Give details' + (@consent.reason_notes_required? ?
-                                        '' :
-                                        ' (optional)') } %>
+                        label: { text: "Give details" + (@consent.reason_notes_required? ?
+                          "" :
+                          " (optional)") } %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: back_link_path,
-    name: "patient page",
-  ) %>
+        href: back_link_path,
+        name: "patient page",
+      ) %>
 <% end %>
 
 <% page_title = "Who are you trying to get consent from?" %>
@@ -17,25 +17,25 @@
 <%= form_for @consent, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_text_field :parent_name, label: { text: 'Full name' } %>
+  <%= f.govuk_text_field :parent_name, label: { text: "Full name" } %>
 
-  <%= f.govuk_text_field :parent_phone, label: { text: 'Phone number' } %>
+  <%= f.govuk_text_field :parent_phone, label: { text: "Phone number" } %>
 
   <%= f.govuk_radio_buttons_fieldset(:parent_relationship,
-    legend: { size: 's',
-              text: 'Relationship to the child' }) do %>
+                                     legend: { size: "s",
+                                               text: "Relationship to the child" }) do %>
     <%= f.govuk_radio_button :parent_relationship, "mother",
-      label: { text: 'Mum' }, link_errors: true %>
+                             label: { text: "Mum" }, link_errors: true %>
     <%= f.govuk_radio_button :parent_relationship, "father",
-      label: { text: "Dad" } %>
+                             label: { text: "Dad" } %>
     <%= f.govuk_radio_button :parent_relationship, "guardian",
-      label: { text: 'Guardian' } %>
+                             label: { text: "Guardian" } %>
     <%= f.govuk_radio_button :parent_relationship, "other",
-      label: { text: 'Other' } do %>
+                             label: { text: "Other" } do %>
       <p>They need parental responsibility to give consent.</p>
       <%= f.govuk_text_field :parent_relationship_other,
-        label: { text: 'Relationship to the child' },
-        hint: { text: 'For example, carer' } %>
+                             label: { text: "Relationship to the child" },
+                             hint: { text: "For example, carer" } %>
     <% end %>
   <% end %>
 

--- a/app/views/offline_passwords/new.html.erb
+++ b/app/views/offline_passwords/new.html.erb
@@ -25,27 +25,25 @@
       <%= f.hidden_field :assets_js, value: asset_path("application.js") %>
 
       <%= f.govuk_password_field :password,
-        label: {
-          text: "Offline password",
-          size: 's'
-        },
-        hint: {
-          text: "Your password must be at least 12 characters long",
-        },
-        width: 20,
-        autocomplete: 'new-password',
-        data: { testid: "password" }
-      %>
+                                 label: {
+                                   text: "Offline password",
+                                   size: "s",
+                                 },
+                                 hint: {
+                                   text: "Your password must be at least 12 characters long",
+                                 },
+                                 width: 20,
+                                 autocomplete: "new-password",
+                                 data: { testid: "password" } %>
 
       <%= f.govuk_password_field :password_confirmation,
-        label: {
-          text: "Confirm offline password",
-          size: 's'
-        },
-        width: 20,
-        autocomplete: 'new-password',
-        data: { testid: "password-confirmation" }
-      %>
+                                 label: {
+                                   text: "Confirm offline password",
+                                   size: "s",
+                                 },
+                                 width: 20,
+                                 autocomplete: "new-password",
+                                 data: { testid: "password-confirmation" } %>
 
       <%= f.govuk_submit "Save password", data: { testid: "submit" } %>
     <% end %>

--- a/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
@@ -1,7 +1,6 @@
-<% title = t("consent_forms.confirmation_agreed.title.#{ @session.type.downcase }",
-  full_name: @consent_form.full_name,
-  date: @session.date.to_fs(:nhsuk_date)
-) %>
+<% title = t("consent_forms.confirmation_agreed.title.#{@session.type.downcase}",
+            full_name: @consent_form.full_name,
+            date: @session.date.to_fs(:nhsuk_date)) %>
 <% content_for :page_title, title %>
 
 <%= govuk_panel(title_text: title, classes: "app-panel nhsuk-u-margin-bottom-6") %>

--- a/app/views/parent_interface/consent_forms/_confirmation_injection.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_injection.html.erb
@@ -1,3 +1,3 @@
-<%= h1 t("consent_forms.confirmation_injection.title.#{ @session.type.downcase }") %>
+<%= h1 t("consent_forms.confirmation_injection.title.#{@session.type.downcase}") %>
 
 <p>Someone will be in touch to discuss them having an injection instead.</p>

--- a/app/views/parent_interface/consent_forms/_confirmation_needs_triage.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_needs_triage.html.erb
@@ -1,4 +1,4 @@
-<%= h1 t("consent_forms.confirmation_needs_triage.title.#{ @session.type.downcase }") %>
+<%= h1 t("consent_forms.confirmation_needs_triage.title.#{@session.type.downcase}") %>
 
 <p>
   As you answered ‘yes’ to some of the health questions, we need to check the

--- a/app/views/parent_interface/consent_forms/_confirmation_refused.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_refused.html.erb
@@ -1,1 +1,1 @@
-<%= h1 t("consent_forms.confirmation_refused.title.#{ @session.type.downcase }") %>
+<%= h1 t("consent_forms.confirmation_refused.title.#{@session.type.downcase}") %>

--- a/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :parent),
-    name: "edit your details page"
-  ) %>
+        href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :parent),
+        name: "edit your details page",
+      ) %>
 <% end %>
 
 <%= h1 "You cannot give or refuse consent through this service" %>

--- a/app/views/parent_interface/consent_forms/cannot_consent_school.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_school.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :school),
-    name: "edit school page"
-  ) %>
+        href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :school),
+        name: "edit school page",
+      ) %>
 <% end %>
 
 <%= h1 "You cannot give or refuse consent through this service" %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -1,210 +1,216 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :consent),
-    name: "edit consent page",
-  ) %>
+        href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :consent),
+        name: "edit consent page",
+      ) %>
 <% end %>
 
 <% change_link = Proc.new do |attr, params = {}|
-  options = attr.in?(%i[consent reason]) ? {} : { skip_to_confirm: true }
-  session_parent_interface_consent_form_edit_path(
-    @session,
-    @consent_form,
-    attr.to_s.dasherize,
-    options.merge(params)
-  )
-end %>
+     options = attr.in?(%i[consent reason]) ? {} : { skip_to_confirm: true }
+     session_parent_interface_consent_form_edit_path(
+       @session,
+       @consent_form,
+       attr.to_s.dasherize,
+       options.merge(params)
+     )
+   end %>
 
 <%= h1 "Check your answers and confirm" %>
 
-<%= render AppCardComponent.new(heading: t("consent_forms.confirm.consent_card_title.#{ @consent_form.session.type.downcase }")) do %>
-  <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "Do you agree?" }
-      row.with_value { @consent_form.consent_given? ?
-                        t("consent_forms.confirm.i_agree.#{ @consent_form.session.type.downcase }") :
-                        "No" }
-      row.with_action(text: "Change",
-        href: change_link[:consent],
-        visually_hidden_text: "consent")
-    end
-
-    reason_notes = @consent_form.reason_notes.present? ? "<br>".html_safe + @consent_form.reason_notes : ""
-    reason_for_refusal_text = @consent_form.human_enum_name(:reason) + reason_notes
-
-    if @consent_form.consent_refused?
-      summary_list.with_row do |row|
-        row.with_key { "Reason" }
-        row.with_value { reason_for_refusal_text.html_safe }
-        row.with_action(text: "Change",
-          href: change_link[:reason],
-          visually_hidden_text: "reason for refusal")
-      end
-
-      if !@consent_form.contact_injection.nil?
+<%= render AppCardComponent.new(heading: t("consent_forms.confirm.consent_card_title.#{@consent_form.session.type.downcase}")) do %>
+  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
         summary_list.with_row do |row|
-          row.with_key { "Alternative option" }
-          row.with_value { @consent_form.contact_injection? ?
-                            "Someone can contact me about an injection" :
-                            "No" }
+          row.with_key { "Do you agree?" }
+          row.with_value {
+            @consent_form.consent_given? ?
+              t("consent_forms.confirm.i_agree.#{@consent_form.session.type.downcase}") :
+              "No"
+          }
           row.with_action(text: "Change",
-            href: change_link[:injection],
-            visually_hidden_text: "alternative option")
+                          href: change_link[:consent],
+                          visually_hidden_text: "consent")
         end
-      end
-    end
-  end %>
+      
+        reason_notes = @consent_form.reason_notes.present? ? "<br>".html_safe + @consent_form.reason_notes : ""
+        reason_for_refusal_text = @consent_form.human_enum_name(:reason) + reason_notes
+      
+        if @consent_form.consent_refused?
+          summary_list.with_row do |row|
+            row.with_key { "Reason" }
+            row.with_value { reason_for_refusal_text.html_safe }
+            row.with_action(text: "Change",
+                            href: change_link[:reason],
+                            visually_hidden_text: "reason for refusal")
+          end
+      
+          if !@consent_form.contact_injection.nil?
+            summary_list.with_row do |row|
+              row.with_key { "Alternative option" }
+              row.with_value {
+                @consent_form.contact_injection? ?
+                  "Someone can contact me about an injection" :
+                  "No"
+              }
+              row.with_action(text: "Change",
+                              href: change_link[:injection],
+                              visually_hidden_text: "alternative option")
+            end
+          end
+        end
+      end %>
 <% end %>
 
 <%= render AppCardComponent.new(heading: "About your child") do %>
-  <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "Child’s name" }
-      row.with_value { @consent_form.full_name }
-      row.with_action(text: "Change",
-        href: change_link[:name],
-        visually_hidden_text: "child’s name")
-    end
-
-    if @consent_form.use_common_name
-      summary_list.with_row do |row|
-        row.with_key { "Also known as" }
-        row.with_value { @consent_form.common_name }
-        row.with_action(text: "Change",
-          href: change_link[:name],
-          visually_hidden_text: "common name")
-      end
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Date of birth" }
-      row.with_value { @consent_form.date_of_birth.to_fs(:nhsuk_date) }
-      row.with_action(
-        text: "Change",
-        href: change_link[:date_of_birth],
-        visually_hidden_text: "date of birth"
-      )
-    end
-
-    if @consent_form.consent_given?
-      summary_list.with_row do |row|
-        row.with_key { "Address" }
-        row.with_value { format_address(@consent_form) }
-        row.with_action(
-          text: "Change",
-          href: change_link[:address],
-          visually_hidden_text: "address"
-        )
-      end
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "School" }
-      row.with_value { @consent_form.session.location.name }
-      row.with_action(
-        text: "Change",
-        href: change_link[:school],
-        visually_hidden_text: "school"
-      )
-    end
-
-    if @consent_form.gp_response_yes?
-      summary_list.with_row do |row|
-        row.with_key { "GP Surgery" }
-        row.with_value { @consent_form.gp_name }
-        row.with_action(
-          text: "Change",
-          href: change_link[:gp],
-          visually_hidden_text: "GP"
-        )
-      end
-    end
-
-    if @consent_form.gp_response_no? || @consent_form.gp_response_dont_know?
-      summary_list.with_row do |row|
-        row.with_key { "Registered with a GP" }
-        row.with_value { @consent_form.gp_response_no? ? "No" : "I don’t know" }
-        row.with_action(
-          text: "Change",
-          href: change_link[:gp],
-          visually_hidden_text: "GP"
-        )
-      end
-    end
-  end %>
+  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Child’s name" }
+          row.with_value { @consent_form.full_name }
+          row.with_action(text: "Change",
+                          href: change_link[:name],
+                          visually_hidden_text: "child’s name")
+        end
+      
+        if @consent_form.use_common_name
+          summary_list.with_row do |row|
+            row.with_key { "Also known as" }
+            row.with_value { @consent_form.common_name }
+            row.with_action(text: "Change",
+                            href: change_link[:name],
+                            visually_hidden_text: "common name")
+          end
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Date of birth" }
+          row.with_value { @consent_form.date_of_birth.to_fs(:nhsuk_date) }
+          row.with_action(
+            text: "Change",
+            href: change_link[:date_of_birth],
+            visually_hidden_text: "date of birth",
+          )
+        end
+      
+        if @consent_form.consent_given?
+          summary_list.with_row do |row|
+            row.with_key { "Address" }
+            row.with_value { format_address(@consent_form) }
+            row.with_action(
+              text: "Change",
+              href: change_link[:address],
+              visually_hidden_text: "address",
+            )
+          end
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "School" }
+          row.with_value { @consent_form.session.location.name }
+          row.with_action(
+            text: "Change",
+            href: change_link[:school],
+            visually_hidden_text: "school",
+          )
+        end
+      
+        if @consent_form.gp_response_yes?
+          summary_list.with_row do |row|
+            row.with_key { "GP Surgery" }
+            row.with_value { @consent_form.gp_name }
+            row.with_action(
+              text: "Change",
+              href: change_link[:gp],
+              visually_hidden_text: "GP",
+            )
+          end
+        end
+      
+        if @consent_form.gp_response_no? || @consent_form.gp_response_dont_know?
+          summary_list.with_row do |row|
+            row.with_key { "Registered with a GP" }
+            row.with_value { @consent_form.gp_response_no? ? "No" : "I don’t know" }
+            row.with_action(
+              text: "Change",
+              href: change_link[:gp],
+              visually_hidden_text: "GP",
+            )
+          end
+        end
+      end %>
 <% end %>
 
 <%= render AppCardComponent.new(heading: "About you") do %>
-  <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
-    summary_list.with_row do |row|
-      row.with_key { "Your name" }
-      row.with_value { @consent_form.parent_name }
-      row.with_action(text: "Change",
-        href: change_link[:parent],
-        visually_hidden_text: "your name")
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Relationship" }
-      row.with_value { @consent_form
-        .human_enum_name(:parent_relationship)
-        .capitalize }
-      row.with_action(text: "Change",
-        href: change_link[:parent],
-        visually_hidden_text: "your relationship")
-    end
-
-    summary_list.with_row do |row|
-      row.with_key { "Email address" }
-      row.with_value { @consent_form.parent_email }
-      row.with_action(text: "Change",
-        href: change_link[:parent],
-        visually_hidden_text: "your email")
-    end
-
-    if @consent_form.parent_phone.present?
-      summary_list.with_row do |row|
-        row.with_key { "Phone number" }
-        row.with_value { @consent_form.parent_phone }
-        row.with_action(text: "Change",
-          href: change_link[:parent],
-          visually_hidden_text: "your phone")
-      end
-
-      if @consent_form.contact_method.present?
+  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
         summary_list.with_row do |row|
-          row.with_key { "Phone contact method" }
-          row.with_value { contact_method_for(@consent_form) }
+          row.with_key { "Your name" }
+          row.with_value { @consent_form.parent_name }
           row.with_action(text: "Change",
-            href: change_link[:contact_method],
-            visually_hidden_text: "your phone contact method")
+                          href: change_link[:parent],
+                          visually_hidden_text: "your name")
         end
-      end
-    else
-      summary_list.with_row do |row|
-        row.with_key { "Phone number" }
-        row.with_value { "Not provided" }
-        row.with_action(text: "Change",
-          href: change_link[:parent],
-          visually_hidden_text: "your phone")
-      end
-    end
-  end %>
+      
+        summary_list.with_row do |row|
+          row.with_key { "Relationship" }
+          row.with_value {
+            @consent_form
+              .human_enum_name(:parent_relationship)
+              .capitalize
+          }
+          row.with_action(text: "Change",
+                          href: change_link[:parent],
+                          visually_hidden_text: "your relationship")
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Email address" }
+          row.with_value { @consent_form.parent_email }
+          row.with_action(text: "Change",
+                          href: change_link[:parent],
+                          visually_hidden_text: "your email")
+        end
+      
+        if @consent_form.parent_phone.present?
+          summary_list.with_row do |row|
+            row.with_key { "Phone number" }
+            row.with_value { @consent_form.parent_phone }
+            row.with_action(text: "Change",
+                            href: change_link[:parent],
+                            visually_hidden_text: "your phone")
+          end
+      
+          if @consent_form.contact_method.present?
+            summary_list.with_row do |row|
+              row.with_key { "Phone contact method" }
+              row.with_value { contact_method_for(@consent_form) }
+              row.with_action(text: "Change",
+                              href: change_link[:contact_method],
+                              visually_hidden_text: "your phone contact method")
+            end
+          end
+        else
+          summary_list.with_row do |row|
+            row.with_key { "Phone number" }
+            row.with_value { "Not provided" }
+            row.with_action(text: "Change",
+                            href: change_link[:parent],
+                            visually_hidden_text: "your phone")
+          end
+        end
+      end %>
 <% end %>
 
 <% if @consent_form.consent_given? %>
   <%= render AppCardComponent.new(heading: "Health questions") do %>
-    <%= govuk_summary_list classes: 'app-summary-list--full-width' do |summary_list|
-      @consent_form.each_health_answer do |ha|
-        summary_list.with_row do |row|
-          row.with_key { ha.question }
-          row.with_value { health_answer_response(ha) }
-          row.with_action(text: "Change",
-            href: change_link[:health_question, question_number: ha.id],
-            visually_hidden_text: "your answer to health question #{ha.id + 1}")
-        end
-      end
-    end %>
+    <%= govuk_summary_list classes: "app-summary-list--full-width" do |summary_list|
+          @consent_form.each_health_answer do |ha|
+            summary_list.with_row do |row|
+              row.with_key { ha.question }
+              row.with_value { health_answer_response(ha) }
+              row.with_action(text: "Change",
+                              href: change_link[:health_question, question_number: ha.id],
+                              visually_hidden_text: "your answer to health question #{ha.id + 1}")
+            end
+          end
+        end %>
   <% end %>
 <% end %>
 

--- a/app/views/parent_interface/consent_forms/edit/address.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/address.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <%= h1 "Home address" %>
@@ -11,17 +11,17 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_text_field :address_line_1,
-    label: { text: 'Address line 1' } %>
+                         label: { text: "Address line 1" } %>
 
   <%= f.govuk_text_field :address_line_2,
-    label: { text: 'Address line 2 (optional)' } %>
+                         label: { text: "Address line 2 (optional)" } %>
 
   <%= f.govuk_text_field :address_town,
-    label: { text: 'Town or city' } %>
+                         label: { text: "Town or city" } %>
 
   <%= f.govuk_text_field :address_postcode,
-    label: { text: 'Postcode' },
-    class: 'nhsuk-input--width-10' %>
+                         label: { text: "Postcode" },
+                         class: "nhsuk-input--width-10" %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/parent_interface/consent_forms/edit/consent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/consent.html.erb
@@ -1,25 +1,24 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
-<% title = t("consent_forms.consent.title.#{ @session.type.downcase }") %>
+<% title = t("consent_forms.consent.title.#{@session.type.downcase}") %>
 <% content_for :page_title, title %>
 
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:response,
-    legend: { size: 'l', text: title, tag: 'h1' },
-    hint: { text: t("consent_forms.consent.hint.#{ @session.type.downcase }") }
-  ) do %>
+                                     legend: { size: "l", text: title, tag: "h1" },
+                                     hint: { text: t("consent_forms.consent.hint.#{@session.type.downcase}") }) do %>
     <%= f.govuk_radio_button :response, "given",
-      label: { text: t("consent_forms.consent.i_agree.#{ @session.type.downcase }") },
-      link_errors: true %>
+                             label: { text: t("consent_forms.consent.i_agree.#{@session.type.downcase}") },
+                             link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",
-      label: { text: 'No' } %>
+                             label: { text: "No" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/contact_method.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/contact_method.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% title = "Phone contact method" %>
@@ -12,22 +12,21 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:contact_method,
-    legend: { size: 'l', text: title, tag: 'h1' },
-    hint: { text: "Tell us if you have specific needs" }
-  ) do %>
+                                     legend: { size: "l", text: title, tag: "h1" },
+                                     hint: { text: "Tell us if you have specific needs" }) do %>
     <%= f.govuk_radio_button :contact_method, "text",
-      label: { text: 'I can only receive text messages' },
-      link_errors: true %>
+                             label: { text: "I can only receive text messages" },
+                             link_errors: true %>
     <%= f.govuk_radio_button :contact_method, "voice",
-      label: { text: 'I can only receive voice calls' } %>
+                             label: { text: "I can only receive voice calls" } %>
     <%= f.govuk_radio_button :contact_method, "other",
-      label: { text: 'Other' } do %>
+                             label: { text: "Other" } do %>
       <%= f.govuk_text_area :contact_method_other,
-        label: { text: 'Give details' } %>
+                            label: { text: "Give details" } %>
     <% end %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :contact_method, "any",
-      label: { text: 'I do not have specific needs' } %>
+                             label: { text: "I do not have specific needs" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/date_of_birth.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/date_of_birth.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% content_for(:page_title, "What is your child’s date of birth?") %>
@@ -13,11 +13,11 @@
   <%= f.govuk_date_field :date_of_birth,
                          date_of_birth: true,
                          legend: {
-                             tag: "h1",
-                             text: "What is your child’s date of birth?",
-                             size: "l"
+                           tag: "h1",
+                           text: "What is your child’s date of birth?",
+                           size: "l",
                          },
-                         hint: { text: 'For example, 27 3 2017' },
+                         hint: { text: "For example, 27 3 2017" },
                          link_errors: true %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/gp.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/gp.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% title = "Is your child registered with a GP?" %>
@@ -12,18 +12,17 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:gp_response,
-    legend: { size: 'l', text: title, tag: 'h1' }
-  ) do %>
+                                     legend: { size: "l", text: title, tag: "h1" }) do %>
     <%= f.govuk_radio_button :gp_response, "yes",
-      label: { text: 'Yes, they are registered with a GP' },
-      link_errors: true do %>
+                             label: { text: "Yes, they are registered with a GP" },
+                             link_errors: true do %>
       <%= f.govuk_text_field :gp_name,
-        label: { text: 'Name of GP surgery' } %>
+                             label: { text: "Name of GP surgery" } %>
     <% end %>
     <%= f.govuk_radio_button :gp_response, "no",
-      label: { text: 'No, they are not registered with a GP' } %>
+                             label: { text: "No, they are not registered with a GP" } %>
     <%= f.govuk_radio_button :gp_response, "dont_know",
-      label: { text: 'I don’t know' } %>
+                             label: { text: "I don’t know" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/health_question.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/health_question.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: health_question_backlink_path(@consent_form, @health_answer),
-      name: "previous page"
-  ) %>
+        href: health_question_backlink_path(@consent_form, @health_answer),
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% title = @health_answer.question %>
@@ -13,17 +13,16 @@
   <%= hidden_field_tag "question_number", @question_number %>
 
   <%= f.govuk_radio_buttons_fieldset(:response,
-   legend: { size: 'l', text: title, tag: 'h1' },
-   hint: { text: @health_answer.hint }
-  ) do %>
+                                     legend: { size: "l", text: title, tag: "h1" },
+                                     hint: { text: @health_answer.hint }) do %>
     <%= f.govuk_radio_button :response, "yes",
-      label: { text: 'Yes' },
-      link_errors: true do %>
+                             label: { text: "Yes" },
+                             link_errors: true do %>
       <%= f.govuk_text_area :notes,
-        label: { text: 'Give details' } %>
+                            label: { text: "Give details" } %>
     <% end %>
     <%= f.govuk_radio_button :response, "no",
-      label: { text: 'No' } %>
+                             label: { text: "No" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/injection.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/injection.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <%= h1 "Your child may be able to have an injection instead" %>
@@ -16,14 +16,13 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:contact_injection,
-    legend: { size: 's',
-              text: 'Would you like someone to contact you about this option?' }
-  ) do %>
+                                     legend: { size: "s",
+                                               text: "Would you like someone to contact you about this option?" }) do %>
     <%= f.govuk_radio_button :contact_injection, true,
-      label: { text: 'Yes, I am happy for someone to contact me' },
-      link_errors: true %>
+                             label: { text: "Yes, I am happy for someone to contact me" },
+                             link_errors: true %>
     <%= f.govuk_radio_button :contact_injection, false,
-      label: { text: 'No' } %>
+                             label: { text: "No" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: start_session_parent_interface_consent_forms_path(@session),
-      name: "start consent page"
-  ) %>
+        href: start_session_parent_interface_consent_forms_path(@session),
+        name: "start consent page",
+      ) %>
 <% end %>
 
 <%= h1 "What is your child’s name?" %>
@@ -15,19 +15,19 @@
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
-  <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
+  <%= f.govuk_text_field :first_name, label: { text: "First name" } %>
+  <%= f.govuk_text_field :last_name, label: { text: "Last name" } %>
   <%= f.govuk_radio_buttons_fieldset(:use_common_name,
-    bold_labels: false,
-    legend: { size: 's',
-              text: 'Do they use a different name in school?' }) do %>
+                                     bold_labels: false,
+                                     legend: { size: "s",
+                                               text: "Do they use a different name in school?" }) do %>
     <%= f.govuk_radio_button :use_common_name,
                              true,
-                             label: { text: 'Yes' },
+                             label: { text: "Yes" },
                              link_errors: true do %>
-      <%= f.govuk_text_field :common_name, label: { text: 'Known as' } %>
+      <%= f.govuk_text_field :common_name, label: { text: "Known as" } %>
     <% end %>
-    <%= f.govuk_radio_button :use_common_name, false, label: { text: 'No' } %>
+    <%= f.govuk_radio_button :use_common_name, false, label: { text: "No" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/parent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/parent.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <%= h1 "About you" %>
@@ -10,43 +10,43 @@
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_text_field :parent_name, label: { text: 'Your name' } %>
+  <%= f.govuk_text_field :parent_name, label: { text: "Your name" } %>
 
   <%= f.govuk_radio_buttons_fieldset(:parent_relationship,
-    legend: { size: 's',
-              text: 'Your relationship to the child' }) do %>
+                                     legend: { size: "s",
+                                               text: "Your relationship to the child" }) do %>
     <%= f.govuk_radio_button :parent_relationship, "mother",
-      label: { text: 'Mum' }, link_errors: true %>
+                             label: { text: "Mum" }, link_errors: true %>
     <%= f.govuk_radio_button :parent_relationship, "father",
-      label: { text: "Dad" } %>
+                             label: { text: "Dad" } %>
     <%= f.govuk_radio_button :parent_relationship, "guardian",
-      label: { text: 'Guardian' } %>
+                             label: { text: "Guardian" } %>
     <%= f.govuk_radio_button :parent_relationship, "other",
-      label: { text: 'Other' } do %>
+                             label: { text: "Other" } do %>
       <%= f.govuk_text_field :parent_relationship_other,
-        # The radio button already has a consent-form-parent-relationship-other
-        # id, so we need to use a different one here.
-        label: { text: 'Relationship to the child',
-                 for: "parent-relationship-other" },
-        hint: { text: 'For example, carer' },
-        id: "parent-relationship-other" %>
+                             # The radio button already has a consent-form-parent-relationship-other
+                             # id, so we need to use a different one here.
+                             label: { text: "Relationship to the child",
+                                      for: "parent-relationship-other" },
+                             hint: { text: "For example, carer" },
+                             id: "parent-relationship-other" %>
       <%= f.govuk_radio_buttons_fieldset(:parental_responsibility,
-        legend: { size: "s",
-                  text: "Do you have parental responsibility?" },
-        hint: { text: "This means you have legal rights and duties relating to the child" }) do %>
+                                         legend: { size: "s",
+                                                   text: "Do you have parental responsibility?" },
+                                         hint: { text: "This means you have legal rights and duties relating to the child" }) do %>
         <%= f.govuk_radio_button :parental_responsibility, "yes",
-          label: { text: "Yes" }, link_errors: true %>
+                                 label: { text: "Yes" }, link_errors: true %>
         <%= f.govuk_radio_button :parental_responsibility, "no",
-          label: { text: "No" } %>
+                                 label: { text: "No" } %>
       <% end %>
     <% end %>
   <% end %>
 
-  <%= f.govuk_text_field :parent_email, label: { text: 'Email address' } %>
+  <%= f.govuk_text_field :parent_email, label: { text: "Email address" } %>
 
   <%= f.govuk_text_field :parent_phone,
-    label: { text: 'Phone number (optional)' },
-    hint: { text: 'Someone might call you about your child’s vaccination' } %>
+                         label: { text: "Phone number (optional)" },
+                         hint: { text: "Someone might call you about your child’s vaccination" } %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% title = "Why are you refusing to give consent?" %>
@@ -12,24 +12,23 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:reason,
-    legend: { size: 'l', text: title, tag: 'h1' }
-  ) do %>
+                                     legend: { size: "l", text: title, tag: "h1" }) do %>
     <% if @consent_form.gelatine_content_status_in_vaccines.in? [true, :maybe] %>
       <%= f.govuk_radio_button :reason, "contains_gelatine",
-        label: { text: 'Vaccine contains gelatine from pigs' },
-        link_errors: true %>
+                               label: { text: "Vaccine contains gelatine from pigs" },
+                               link_errors: true %>
     <% end %>
     <%= f.govuk_radio_button :reason, "already_vaccinated",
-      label: { text: 'Vaccine already received' } %>
+                             label: { text: "Vaccine already received" } %>
     <%= f.govuk_radio_button :reason, "will_be_vaccinated_elsewhere",
-      label: { text: 'Vaccine will be given elsewhere' } %>
+                             label: { text: "Vaccine will be given elsewhere" } %>
     <%= f.govuk_radio_button :reason, "medical_reasons",
-      label: { text: 'Medical reasons' } %>
+                             label: { text: "Medical reasons" } %>
     <%= f.govuk_radio_button :reason, "personal_choice",
-      label: { text: 'Personal choice' } %>
+                             label: { text: "Personal choice" } %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :reason, "other",
-      label: { text: 'Other' } %>
+                             label: { text: "Other" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <% title = t("consent_forms.reason_notes.title.#{@consent_form.reason}") %>
@@ -14,7 +14,7 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_text_area :reason_notes,
-    label: { text: 'Give details' + (@consent_form.reason_notes_must_be_provided? ? '' : ' (optional)') } %>
+                        label: { text: "Give details" + (@consent_form.reason_notes_must_be_provided? ? "" : " (optional)") } %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: backlink_path,
-      name: "previous page"
-  ) %>
+        href: backlink_path,
+        name: "previous page",
+      ) %>
 <% end %>
 
 <%= h1 "Confirm your child’s school" %>
@@ -20,12 +20,12 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:is_this_their_school,
-    legend: { size: 's', text: 'Is this their school?' }) do %>
+                                     legend: { size: "s", text: "Is this their school?" }) do %>
     <%= f.govuk_radio_button :is_this_their_school, "yes",
-      link_errors: true,
-      label: { text: 'Yes, they go to this school' } %>
+                             link_errors: true,
+                             label: { text: "Yes, they go to this school" } %>
     <%= f.govuk_radio_button :is_this_their_school, "no",
-      label: { text: 'No, they go to a different school' } %>
+                             label: { text: "No, they go to a different school" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/start.html.erb
+++ b/app/views/parent_interface/consent_forms/start.html.erb
@@ -1,6 +1,6 @@
-<%= h1 t("consent_forms.start.title.#{ @session.type.downcase }") %>
+<%= h1 t("consent_forms.start.title.#{@session.type.downcase}") %>
 
-<% t("consent_forms.start.paragraphs.#{ @session.type.downcase }").each do |paragraph| %>
+<% t("consent_forms.start.paragraphs.#{@session.type.downcase}").each do |paragraph| %>
   <p class="nhsuk-u-margin-bottom-6">
     <%= paragraph %>
   </p>

--- a/app/views/pilot/manage.html.erb
+++ b/app/views/pilot/manage.html.erb
@@ -2,9 +2,9 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: page_title },
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: page_title },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title, size: "xl" %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -4,9 +4,9 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: page_title },
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: page_title },
+                                        ]) %>
 <% end %>
 
 <h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-4">

--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -12,10 +12,10 @@
     <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
       <% if session.in_progress? %>
         <%= govuk_tag(
-          classes: "nhsuk-u-margin-bottom-2",
-          text: "Session in progress",
-          colour: "blue"
-        ) %><br>
+              classes: "nhsuk-u-margin-bottom-2",
+              text: "Session in progress",
+              colour: "blue",
+            ) %><br>
       <% end %>
       <%= link_to session.location.name, edit_session_path(session), "data-testid": "session-link" %><br>
       <%= session.location.town %>, <%= session.location.postcode %>

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -2,10 +2,10 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Today’s sessions', href: sessions_path },
-    { text: @session.name, active: true }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Today’s sessions", href: sessions_path },
+                                          { text: @session.name, active: true },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -15,9 +15,9 @@
     <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
-          <% row.with_cell(text: 'Time', html_attributes: { style: "width: 20%" }) %>
-          <% row.with_cell(text: 'Location') %>
-          <% row.with_cell(text: 'Cohort') %>
+          <% row.with_cell(text: "Time", html_attributes: { style: "width: 20%" }) %>
+          <% row.with_cell(text: "Location") %>
+          <% row.with_cell(text: "Cohort") %>
         <% end %>
       <% end %>
 

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -2,17 +2,17 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Campaigns', href: campaigns_path },
-    { text: @session.campaign.name, href: campaign_path(@session.campaign) }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Campaigns", href: campaigns_path },
+                                          { text: @session.campaign.name, href: campaign_path(@session.campaign) },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title: do %>
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @session.date.to_fs(:nhsuk_date) %> (<%= @session.human_enum_name(:time_of_day) %>) ·
-    <%= pluralize(@patient_sessions.size, 'child') %> in cohort
+    <%= pluralize(@patient_sessions.size, "child") %> in cohort
   </span>
 <% end %>
 
@@ -24,17 +24,17 @@
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     <%= render AppCardComponent.new(
-      heading: "Register attendance",
-      link_to: "#"
-    ) do %>
+          heading: "Register attendance",
+          link_to: "#",
+        ) do %>
       <%= pluralize_child(@patient_sessions.size) %> still to register
     <% end %>
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     <%= render AppCardComponent.new(
-      heading: "Record vaccinations",
-      link_to: session_vaccinations_path(@session)
-    ) do %>
+          heading: "Record vaccinations",
+          link_to: session_vaccinations_path(@session),
+        ) do %>
       <%= pluralize_child(@counts[:vaccinate]) %> to vaccinate<br>
       <%= pluralize_child(@counts[:vaccinated]) %> vaccinated<br>
       <%= pluralize_child(@counts[:could_not_vaccinate]) %> could not be vaccinated
@@ -42,9 +42,9 @@
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     <%= render AppCardComponent.new(
-      heading: "Check consent responses",
-      link_to: session_consents_path(@session)
-    ) do %>
+          heading: "Check consent responses",
+          link_to: session_consents_path(@session),
+        ) do %>
       <%= pluralize_child(@counts[:without_a_response]) %> without a response<br>
       <%= pluralize_child(@counts[:with_consent_given]) %> with consent given<br>
       <%= pluralize_child(@counts[:with_consent_refused]) %> with consent refused<br>
@@ -53,9 +53,9 @@
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
     <%= render AppCardComponent.new(
-      heading: "Triage health questions",
-      link_to: session_triage_path(@session)
-    ) do %>
+          heading: "Triage health questions",
+          link_to: session_triage_path(@session),
+        ) do %>
       <%= pluralize_child(@counts[:needing_triage]) %> needing triage
     <% end %>
   </li>
@@ -68,12 +68,12 @@
         Vaccinations can only be recorded if a session is in progress. If you want to test vaccination recording, you can set this session as in progress for today.
       </p>
       <%= govuk_button_to(
-        "Set session in progress for today",
-        make_in_progress_session_path,
-        method: :put,
-        secondary: true,
-        prevent_double_click: true
-      ) %>
+            "Set session in progress for today",
+            make_in_progress_session_path,
+            method: :put,
+            secondary: true,
+            prevent_double_click: true,
+          ) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/triage/_patient_triage_card.html.erb
+++ b/app/views/triage/_patient_triage_card.html.erb
@@ -6,18 +6,18 @@
 
     <%= form_for triage,
                  url: session_patient_triage_path(
-                    session, patient, triage
+                   session, patient, triage
                  ) do |f| %>
 
       <% content_for(:before_content) { f.govuk_error_summary } %>
 
-      <%= f.govuk_text_area :notes, label: { text: 'Triage notes (optional)' },
+      <%= f.govuk_text_area :notes, label: { text: "Triage notes (optional)" },
                                     rows: 5 %>
       <%= f.govuk_collection_radio_buttons :status,
                                            triage_form_status_options,
                                            :first,
                                            :second,
-                                           legend: { text: 'Triage status' } %>
+                                           legend: { text: "Triage status" } %>
 
       <%= f.submit "Save triage", class: "nhsuk-button" %>
     <% end %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -10,18 +10,15 @@
 
 <%= h1 page_title, page_title: %>
 
-<%= render AppSecondaryNavigationComponent.new do |nav|
-      TAB_PATHS[:triage].each do |tab, state|
-        nav.with_item(selected: @current_tab == state,
-                      href: session_triage_tab_path(@session, tab:)) do
-        end
-      end
-    end %>
+<%= render AppSecondaryNavigationComponent.new do |nav| %>
+  <% TAB_PATHS[:triage].each do |tab, state| %>
+    <% nav.with_item(selected: @current_tab == state,
+                     href: session_triage_tab_path(@session, tab:)) do %>
       <%= t("patients_table.#{state}.label") %>
       <%= render AppCountComponent.new(count: @tab_counts[state]) %>
-    <% end
-         end
-       end %>
+    <% end %>
+  <% end %>
+<% end %>
 
 <%= render AppPatientTableComponent.new(
       patient_sessions: @patient_sessions,

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -2,29 +2,32 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Today’s sessions', href: sessions_path },
-    { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Today’s sessions", href: sessions_path },
+                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title, page_title: %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-  TAB_PATHS[:triage].each do |tab, state|
-    nav.with_item(selected: @current_tab == state,
-      href: session_triage_tab_path(@session, tab:)) do %>
+      TAB_PATHS[:triage].each do |tab, state|
+        nav.with_item(selected: @current_tab == state,
+                      href: session_triage_tab_path(@session, tab:)) do
+        end
+      end
+    end %>
       <%= t("patients_table.#{state}.label") %>
       <%= render AppCountComponent.new(count: @tab_counts[state]) %>
     <% end
-  end
-end %>
+         end
+       end %>
 
 <%= render AppPatientTableComponent.new(
-  patient_sessions: @patient_sessions,
-  caption: t("patients_table.#{@current_tab}.caption",
-             children: pluralize_child(@patient_sessions.count)),
-  columns: %i[name dob],
-  section: :triage,
-  params:
-) %>
+      patient_sessions: @patient_sessions,
+      caption: t("patients_table.#{@current_tab}.caption",
+                 children: pluralize_child(@patient_sessions.count)),
+      columns: %i[name dob],
+      section: :triage,
+      params:,
+    ) %>

--- a/app/views/users/accounts/show.html.erb
+++ b/app/views/users/accounts/show.html.erb
@@ -6,9 +6,9 @@
   <%= f.govuk_text_field :full_name, label: { text: "Full name" } %>
   <%= f.govuk_text_field :email, label: { text: "Email address" } %>
   <%= f.govuk_text_field :registration,
-    width: 10,
-    label: { text: "Registration number" },
-    hint: { text: "Also known as a GMC number or nurse’s pin number" } %>
+                         width: 10,
+                         label: { text: "Registration number" },
+                         hint: { text: "Also known as a GMC number or nurse’s pin number" } %>
 
   <%= f.govuk_submit "Save changes" %>
 <% end %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -6,9 +6,9 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_password_field :password, autocomplete: "new-password",
-    label: { text: "New password" } %>
+                                        label: { text: "New password" } %>
   <%= f.govuk_password_field :password_confirmation, autocomplete: "new-password",
-    label: { text: "Confirm new password" } %>
+                                                     label: { text: "Confirm new password" } %>
 
   <%= f.govuk_submit "Change password" %>
 <% end %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: new_user_session_path,
-    name: "sign in",
-  ) %>
+        href: new_user_session_path,
+        name: "sign in",
+      ) %>
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name),

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -2,9 +2,8 @@
   <div id="error_explanation" data-turbo-cache="false">
     <h2>
       <%= t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
+            count: resource.errors.count,
+            resource: resource.class.model_name.human.downcase) %>
     </h2>
     <ul>
       <% resource.errors.full_messages.each do |message| %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,25 +1,25 @@
-<%- if controller_name != 'sessions' %>
+<% -if controller_name != "sessions" %>
   <p><%= link_to "Log in", new_session_path(resource_name) %></p>
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+<% -if devise_mapping.registerable? && controller_name != "registrations" %>
   <p><%= link_to "Sign up", new_school_registration_path(resource_name) %></p>
 <% end %>
 
-<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+<% -if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
   <p><%= link_to "I’ve forgotten my password", new_password_path(resource_name) %></p>
 <% end %>
 
-<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+<% -if devise_mapping.confirmable? && controller_name != "confirmations" %>
   <p><%= link_to "Didn’t receive confirmation instructions?", new_confirmation_path(resource_name) %></p>
 <% end %>
 
-<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+<% -if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
   <p><%= link_to "Didn’t receive unlock instructions?", new_unlock_path(resource_name) %></p>
 <% end %>
 
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
+<% -if devise_mapping.omniauthable? %>
+  <% -resource_class.omniauth_providers.each do |provider| %>
     <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %>
   <% end %>
 <% end %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,24 +1,24 @@
-<% -if controller_name != "sessions" %>
+<% if controller_name != "sessions" %>
   <p><%= link_to "Log in", new_session_path(resource_name) %></p>
 <% end %>
 
-<% -if devise_mapping.registerable? && controller_name != "registrations" %>
+<% if devise_mapping.registerable? && controller_name != "registrations" %>
   <p><%= link_to "Sign up", new_school_registration_path(resource_name) %></p>
 <% end %>
 
-<% -if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
+<% if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations" %>
   <p><%= link_to "I’ve forgotten my password", new_password_path(resource_name) %></p>
 <% end %>
 
-<% -if devise_mapping.confirmable? && controller_name != "confirmations" %>
+<% if devise_mapping.confirmable? && controller_name != "confirmations" %>
   <p><%= link_to "Didn’t receive confirmation instructions?", new_confirmation_path(resource_name) %></p>
 <% end %>
 
-<% -if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
+<% if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != "unlocks" %>
   <p><%= link_to "Didn’t receive unlock instructions?", new_unlock_path(resource_name) %></p>
 <% end %>
 
-<% -if devise_mapping.omniauthable? %>
+<% if devise_mapping.omniauthable? %>
   <% -resource_class.omniauth_providers.each do |provider| %>
     <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %>
   <% end %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: new_user_session_path,
-    name: "sign in",
-  ) %>
+        href: new_user_session_path,
+        name: "sign in",
+      ) %>
 <% end %>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/vaccinations/_form.html.erb
+++ b/app/views/vaccinations/_form.html.erb
@@ -1,32 +1,31 @@
 <%= form_with model: @draft_vaccination_record,
-              url: session_patient_vaccinations_path(
-                session_id: @session.id,
-                id: @patient.id,
-              ),
-              method: :post do |f| %>
+             url: session_patient_vaccinations_path(
+               session_id: @session.id,
+               id: @patient.id,
+             ),
+             method: :post do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:administered,
-    caption: { text: @patient.full_name, size: 'l' },
-    legend: { text: 'Did they get the vaccine?' }
-      .merge(embedded ? { size: 'm' } : { size: 'l', tag: 'h1' })
-  ) do %>
+                                     caption: { text: @patient.full_name, size: "l" },
+                                     legend: { text: "Did they get the vaccine?" }
+                                       .merge(embedded ? { size: "m" } : { size: "l", tag: "h1" })) do %>
     <%= f.govuk_radio_button :administered, true,
-      label: { text: t("vaccinations.form.label.#{ @session.type.downcase }") },
-      link_errors: true do %>
+                             label: { text: t("vaccinations.form.label.#{@session.type.downcase}") },
+                             link_errors: true do %>
       <%= f.govuk_collection_radio_buttons :delivery_site,
-        vaccination_initial_delivery_sites,
-        :to_s,
-        :humanize,
-        inline: true,
-        legend: {
-          text: 'Where did they get it?',
-          hidden: true
-        },
-        bold_labels: false %>
+                                           vaccination_initial_delivery_sites,
+                                           :to_s,
+                                           :humanize,
+                                           inline: true,
+                                           legend: {
+                                             text: "Where did they get it?",
+                                             hidden: true,
+                                           },
+                                           bold_labels: false %>
     <% end %>
     <%= f.govuk_radio_button :administered, false,
-      label: { text: 'No, they did not get it' } %>
+                             label: { text: "No, they did not get it" } %>
   <% end %>
 
   <%= f.hidden_field :delivery_method, value: :intramuscular %>

--- a/app/views/vaccinations/batches/edit.html.erb
+++ b/app/views/vaccinations/batches/edit.html.erb
@@ -1,25 +1,25 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: session_patient_path(@session.id, id: @patient.id),
-    name: "vaccination page"
-  ) %>
+        href: session_patient_path(@session.id, id: @patient.id),
+        name: "vaccination page",
+      ) %>
 <% end %>
 
 <% content_for :page_title, "Which batch did you use?" %>
 
 <%= form_with model: @draft_vaccination_record,
-   url: session_patient_vaccinations_batch_path(
-       session_id: @session.id,
-       patient_id: @patient.id,
-   ),
- method: :put do |f| %>
+              url: session_patient_vaccinations_batch_path(
+                session_id: @session.id,
+                patient_id: @patient.id,
+              ),
+              method: :put do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:batch_id,
-    caption: { text: @patient.full_name, size: 'l' },
-    legend: { size: 'l', tag: 'h1', text: 'Which batch did you use?' }) do %>
+                                     caption: { text: @patient.full_name, size: "l" },
+                                     legend: { size: "l", tag: "h1", text: "Which batch did you use?" }) do %>
     <% @batches.each do |batch| %>
       <%= f.govuk_radio_button :batch_id,
-       batch.id,
-       label: { text: "#{batch.name} (expires #{batch.expiry.to_fs(:nhsuk_date)})" } do %>
+                               batch.id,
+                               label: { text: "#{batch.name} (expires #{batch.expiry.to_fs(:nhsuk_date)})" } do %>
        <%= f.govuk_check_box :todays_batch, batch.id, label: { text: "Default to this batch for today" } %>
       <% end %>
     <% end %>

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -1,15 +1,13 @@
 <% content_for :before_main do %>
-  <%
-  back_url = if @draft_vaccination_record.administered?
-    edit_session_patient_vaccinations_batch_path(@session, patient_id: @patient.id)
-  else
-    edit_reason_session_patient_vaccinations_path(@session, patient_id: @patient.id)
-  end
-  %>
+  <% back_url = if @draft_vaccination_record.administered?
+         edit_session_patient_vaccinations_batch_path(@session, patient_id: @patient.id)
+       else
+         edit_reason_session_patient_vaccinations_path(@session, patient_id: @patient.id)
+       end %>
   <%= render AppBacklinkComponent.new(
-    href: back_url,
-    name: "vaccination page"
-  ) %>
+        href: back_url,
+        name: "vaccination page",
+      ) %>
 <% end %>
 
 <% page_title = "Check and confirm" %>
@@ -21,96 +19,96 @@
 <div class="nhsuk-card">
   <div class="nhsuk-card__content">
     <%= govuk_summary_list(
-      actions: false,
-      classes: 'app-summary-list--no-bottom-border'
-    ) do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { 'Child' }
-        row.with_value { @patient.full_name }
-      end
-
-      if @draft_vaccination_record.administered?
-        summary_list.with_row do |row|
-          row.with_key { 'Vaccine' }
-          row.with_value { @session.type }
-        end
-
-        summary_list.with_row do |row|
-          row.with_key { 'Brand' }
-          row.with_value do
-            vaccine = @draft_vaccination_record.vaccine
-            "#{vaccine.brand} (#{vaccine.method})"
+          actions: false,
+          classes: "app-summary-list--no-bottom-border",
+        ) do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { "Child" }
+            row.with_value { @patient.full_name }
           end
-        end
-
-        summary_list.with_row do |row|
-          row.with_key { 'Batch' }
-          row.with_value do
-            batch = @draft_vaccination_record.batch
-            "#{batch.name} (expires #{batch.expiry.to_fs(:nhsuk_date)})"
+        
+          if @draft_vaccination_record.administered?
+            summary_list.with_row do |row|
+              row.with_key { "Vaccine" }
+              row.with_value { @session.type }
+            end
+        
+            summary_list.with_row do |row|
+              row.with_key { "Brand" }
+              row.with_value do
+                vaccine = @draft_vaccination_record.vaccine
+                "#{vaccine.brand} (#{vaccine.method})"
+              end
+            end
+        
+            summary_list.with_row do |row|
+              row.with_key { "Batch" }
+              row.with_value do
+                batch = @draft_vaccination_record.batch
+                "#{batch.name} (expires #{batch.expiry.to_fs(:nhsuk_date)})"
+              end
+            end
+        
+            summary_list.with_row do |row|
+              row.with_key { "Site" }
+              row.with_value { @draft_vaccination_record.human_enum_name(:delivery_site) }
+            end
+        
+            summary_list.with_row do |row|
+              row.with_key { "Outcome" }
+              row.with_value { "Vaccinated" }
+            end
+          else
+            summary_list.with_row do |row|
+              row.with_key { "Outcome" }
+              row.with_value { @draft_vaccination_record.human_enum_name(:reason) }
+            end
           end
-        end
-
-        summary_list.with_row do |row|
-          row.with_key { 'Site' }
-          row.with_value { @draft_vaccination_record.human_enum_name(:delivery_site) }
-        end
-
-        summary_list.with_row do |row|
-          row.with_key { 'Outcome' }
-          row.with_value { 'Vaccinated' }
-        end
-      else
-        summary_list.with_row do |row|
-          row.with_key { 'Outcome' }
-          row.with_value { @draft_vaccination_record.human_enum_name(:reason) }
-        end
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { 'Date' }
-        row.with_value { "Today (#{Time.zone.now.to_fs(:nhsuk_date)})" }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { 'Time' }
-        row.with_value { Time.zone.now.to_fs(:time) }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { 'Location' }
-        row.with_value { @session.location.name }
-      end
-
-      summary_list.with_row do |row|
-        row.with_key { 'Vaccinator' }
-        row.with_value { "You (#{@draft_vaccination_record.user.full_name})" }
-      end
-    end %>
+        
+          summary_list.with_row do |row|
+            row.with_key { "Date" }
+            row.with_value { "Today (#{Time.zone.now.to_fs(:nhsuk_date)})" }
+          end
+        
+          summary_list.with_row do |row|
+            row.with_key { "Time" }
+            row.with_value { Time.zone.now.to_fs(:time) }
+          end
+        
+          summary_list.with_row do |row|
+            row.with_key { "Location" }
+            row.with_value { @session.location.name }
+          end
+        
+          summary_list.with_row do |row|
+            row.with_key { "Vaccinator" }
+            row.with_value { "You (#{@draft_vaccination_record.user.full_name})" }
+          end
+        end %>
   </div>
 </div>
 
 <%= form_with model: @draft_vaccination_record,
-    url: record_session_patient_vaccinations_path(
-      session_id: @session.id,
-      patient_id: @patient.id,
-    ),
- method: :put do |f| %>
+              url: record_session_patient_vaccinations_path(
+                session_id: @session.id,
+                patient_id: @patient.id,
+              ),
+              method: :put do |f| %>
 
     <% content_for(:before_content) { f.govuk_error_summary } %>
 
     <div class="nhsuk-card">
       <div class="nhsuk-card__content">
         <%= f.govuk_text_area :notes,
-          label: {
-            text: 'Add notes',
-            size: 'm',
-            class: 'nhsuk-u-margin-bottom-3'
-          },
-          hint: {
-            text: 'For example, if the child had a reaction to the vaccine'
-          },
-          rows: 5 %>
+                              label: {
+                                text: "Add notes",
+                                size: "m",
+                                class: "nhsuk-u-margin-bottom-3",
+                              },
+                              hint: {
+                                text: "For example, if the child had a reaction to the vaccine",
+                              },
+                              rows: 5 %>
       </div>
     </div>
   <%= f.submit "Confirm", class: "nhsuk-button" %>

--- a/app/views/vaccinations/delivery_site/edit.html.erb
+++ b/app/views/vaccinations/delivery_site/edit.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: session_patient_vaccinations_path(@session, @patient),
-      name: "vaccination page"
-  ) %>
+        href: session_patient_vaccinations_path(@session, @patient),
+        name: "vaccination page",
+      ) %>
 <% end %>
 
 <% page_title = "Tell us how the vaccination was given" %>
@@ -15,30 +15,30 @@
 <% end %>
 
 <%= form_with model: @draft_vaccination_record,
-   url: session_patient_vaccinations_delivery_site_path(
-       session_id: @session.id,
-       id: @patient.id,
-   ),
- method: :put do |f| %>
+              url: session_patient_vaccinations_delivery_site_path(
+                session_id: @session.id,
+                id: @patient.id,
+              ),
+              method: :put do |f| %>
   <%= f.govuk_collection_radio_buttons(
-      :delivery_method,
-      vaccination_delivery_methods,
-      :first,
-      :second,
-      legend: {
-          text: 'How was the vaccination given?',
-      },
-      bold_labels: false
-  ) %>
+        :delivery_method,
+        vaccination_delivery_methods,
+        :first,
+        :second,
+        legend: {
+          text: "How was the vaccination given?",
+        },
+        bold_labels: false,
+      ) %>
   <%= f.govuk_collection_radio_buttons(
         :delivery_site,
         vaccination_delivery_sites,
         :first,
         :second,
         legend: {
-            text: 'Site',
+          text: "Site",
         },
-        bold_labels: false
-        ) %>
+        bold_labels: false,
+      ) %>
   <%= f.submit "Continue", class: "nhsuk-button" %>
 <% end %>

--- a/app/views/vaccinations/edit_reason.html.erb
+++ b/app/views/vaccinations/edit_reason.html.erb
@@ -1,11 +1,11 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-               href: session_patient_vaccinations_path(@session, id: @patient.id),
-               name: "vaccination page"
-             ) %>
+        href: session_patient_vaccinations_path(@session, id: @patient.id),
+        name: "vaccination page",
+      ) %>
 <% end %>
 
-<% title = t("vaccinations.edit_reason.title.#{ @session.type.downcase }") %>
+<% title = t("vaccinations.edit_reason.title.#{@session.type.downcase}") %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record,
@@ -17,22 +17,22 @@
     <%= f.govuk_error_summary %>
 
     <%= f.govuk_radio_buttons_fieldset(:reason,
-      caption: { text: @patient.full_name, size: 'l' },
-      legend: { size: 'l', tag: 'h1',
-                text: title }) do %>
+                                       caption: { text: @patient.full_name, size: "l" },
+                                       legend: { size: "l", tag: "h1",
+                                                 text: title }) do %>
 
       <%= f.govuk_radio_button :reason, "refused",
-        label: { text: 'They refused it' } %>
+                               label: { text: "They refused it" } %>
       <%= f.govuk_radio_button :reason, "not_well",
-        label: { text: 'They were not well enough' } %>
+                               label: { text: "They were not well enough" } %>
       <%= f.govuk_radio_button :reason, "contraindications",
-        label: { text: 'They had contraindications' } %>
+                               label: { text: "They had contraindications" } %>
       <%= f.govuk_radio_button :reason, "already_had",
-        label: { text: 'They have already had the vaccine' } %>
+                               label: { text: "They have already had the vaccine" } %>
       <%= f.govuk_radio_button :reason, "absent_from_school",
-        label: { text: 'They were absent from school' } %>
+                               label: { text: "They were absent from school" } %>
       <%= f.govuk_radio_button :reason, "absent_from_session",
-        label: { text: 'They were absent from the session' } %>
+                               label: { text: "They were absent from the session" } %>
     <% end %>
   <%= f.submit "Continue", class: "nhsuk-button" %>
 <% end %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -10,18 +10,15 @@
 
 <%= h1 page_title, page_title: %>
 
-<%= render AppSecondaryNavigationComponent.new do |nav|
-      TAB_PATHS[:vaccinations].each do |tab, state|
-        nav.with_item(selected: @current_tab == state,
-                      href: session_vaccinations_tab_path(@session, tab:)) do
-        end
-      end
-    end %>
+<%= render AppSecondaryNavigationComponent.new do |nav| %>
+  <% TAB_PATHS[:vaccinations].each do |tab, state| %>
+    <% nav.with_item(selected: @current_tab == state,
+                     href: session_vaccinations_tab_path(@session, tab:)) do %>
       <%= t("patients_table.#{state}.label") %>
       <%= render AppCountComponent.new(count: @tab_counts[state]) %>
-    <% end
-         end
-       end %>
+    <% end %>
+  <% end %>
+<% end %>
 
 <%= render AppPatientTableComponent.new(
       patient_sessions: @patient_sessions,

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -2,31 +2,34 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Today’s sessions', href: sessions_path },
-    { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) }
-  ]) %>
+                                          { text: "Home", href: dashboard_path },
+                                          { text: "Today’s sessions", href: sessions_path },
+                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                        ]) %>
 <% end %>
 
 <%= h1 page_title, page_title: %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-  TAB_PATHS[:vaccinations].each do |tab, state|
-    nav.with_item(selected: @current_tab == state,
-      href: session_vaccinations_tab_path(@session, tab:)) do %>
+      TAB_PATHS[:vaccinations].each do |tab, state|
+        nav.with_item(selected: @current_tab == state,
+                      href: session_vaccinations_tab_path(@session, tab:)) do
+        end
+      end
+    end %>
       <%= t("patients_table.#{state}.label") %>
       <%= render AppCountComponent.new(count: @tab_counts[state]) %>
     <% end
-  end
-end %>
+         end
+       end %>
 
 <%= render AppPatientTableComponent.new(
-  patient_sessions: @patient_sessions,
-  caption: t("patients_table.#{@current_tab}.caption",
-             children: pluralize_child(@patient_sessions.count)),
-  columns: @current_tab == :vaccinate ?
-    %i[name dob action] :
-    %i[name dob outcome],
-  section: :vaccinations,
-  params:
-) %>
+      patient_sessions: @patient_sessions,
+      caption: t("patients_table.#{@current_tab}.caption",
+                 children: pluralize_child(@patient_sessions.count)),
+      columns: @current_tab == :vaccinate ?
+        %i[name dob action] :
+        %i[name dob outcome],
+      section: :vaccinations,
+      params:,
+    ) %>

--- a/app/views/vaccinations/new.html.erb
+++ b/app/views/vaccinations/new.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-               href: session_patient_vaccinations_path(@session, @patient),
-               name: "vaccination page"
-             ) %>
+        href: session_patient_vaccinations_path(@session, @patient),
+        name: "vaccination page",
+      ) %>
 <% end %>
 
 <% content_for :page_title, "Did they get the vaccine?" %>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: vaccines_path,
-    name: "vaccines page"
-  ) %>
+        href: vaccines_path,
+        name: "vaccines page",
+      ) %>
 <% end %>
 
 <%= h1 vaccine_heading(@vaccine), size: "l" %>

--- a/bin/lint
+++ b/bin/lint
@@ -2,6 +2,7 @@
 
 bin/bundle exec rubocop --autocorrect-all $*
 yarn prettier --write --list-different --ignore-unknown ${*:-'**/*'}
+bin/bundle exec rufo --check ${*:-app}
 if [ -z "$*" ]
 then
    bin/bundle exec brakeman --quiet --no-summary --no-pager


### PR DESCRIPTION
We already use `prettier` for Ruby, JS/TS, (S)CSS, plain HTML, markdown, and yml, but unfortunately it doesn't support `.erb` which is a significant portion of our codebase.

[`rufo`](https://github.com/ruby-formatter/rufo) does however and it has good editor support.

It's not as deterministic as `prettier` and there are some edge cases where it "changes its mind" and formats identical input in two different ways. But for the most part it seems to work well enough.

Second commit is really long, probably not worth reviewing. We can always manually tweak awkward styling in follow-up PRs.