### PR TITLE
Gillick assessment recording: redesign

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -36,17 +36,15 @@
         <% end %>
       <% end %>
     <% else %>
-      <%= govuk_button_to(
-            "Assess Gillick competence",
-            session_patient_manage_consents_path(
-              session, patient_id: patient.id,
-                       section: @section,
-                       tab: @tab,
-            ),
-            secondary: true,
-            name: "consent", value: "self_consent",
-            prevent_double_click: true,
-          ) %>
+      <p class="nhsuk-body">
+        <%= govuk_link_to("Give your assessment",
+                          new_session_patient_gillick_assessment_path(
+              session_id: session.id,
+              patient_id: patient.id,
+              section: @section,
+              tab: @tab,
+            )) %>
+      </p>
     <% end %>
   <% end %>
 <% end %>

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -1,0 +1,70 @@
+class GillickAssessmentsController < ApplicationController
+  include Wicked::Wizard
+
+  layout "two_thirds"
+
+  before_action :set_patient
+  before_action :set_session
+  before_action :set_patient_session
+  before_action :set_assessment, only: %i[show update]
+
+  steps :gillick, :confirm
+
+  def new
+  end
+
+  def create
+    @patient_session.create_gillick_assessment!(assessor: current_user)
+
+    redirect_to wizard_path(steps.first)
+  end
+
+  def show
+    render_wizard
+  end
+
+  def update
+    case current_step
+    when :gillick
+      @assessment.assign_attributes(gillick_params)
+    when :confirm
+      @assessment.assign_attributes(recorded_at: Time.zone.now)
+    end
+
+    render_wizard @assessment
+  end
+
+  private
+
+  def set_patient
+    @patient = policy_scope(Patient).find(params[:patient_id])
+  end
+
+  def set_session
+    @session = policy_scope(Session).find(params[:session_id])
+  end
+
+  def set_patient_session
+    @patient_session =
+      policy_scope(PatientSession).find_by(
+        session_id: params[:session_id],
+        patient_id: params[:patient_id],
+      )
+  end
+
+  def set_assessment
+    @assessment = @patient_session.draft_gillick_assessment
+  end
+
+  def finish_wizard_path
+    session_patient_path(id: @patient.id)
+  end
+
+  def current_step
+    @current_step ||= wizard_value(step).to_sym
+  end
+
+  def gillick_params
+    params.fetch(:gillick_assessment, {}).permit(:gillick_competent, :notes)
+  end
+end

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -25,7 +25,7 @@ class GillickAssessmentsController < ApplicationController
 
   def update
     case current_step
-    when :gillick
+    when :gillick, :notes
       @assessment.assign_attributes(
         gillick_params.merge(form_step: current_step)
       )

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -11,11 +11,7 @@ class ManageConsentsController < ApplicationController
   before_action :set_consent, except: %i[create]
   before_action :set_steps, except: %i[create]
   before_action :setup_wizard_translated, except: %i[create]
-  before_action :set_patient_session,
-                except: %i[create],
-                if: -> do
-                  step.in?(%w[assessing-gillick gillick questions confirm])
-                end
+  before_action :set_patient_session
   before_action :set_triage,
                 except: %i[create],
                 if: -> { step.in?(%w[questions confirm]) }
@@ -44,10 +40,6 @@ class ManageConsentsController < ApplicationController
       handle_questions
     when :agree
       handle_agree
-    when :assessing_gillick
-      handle_assessing_gillick
-    when :gillick
-      handle_gillick
     else
       @consent.assign_attributes(update_params)
     end
@@ -95,12 +87,6 @@ class ManageConsentsController < ApplicationController
 
   def handle_confirm
     ActiveRecord::Base.transaction do
-      if @patient_session.draft_gillick_assessment.present?
-        @patient_session.draft_gillick_assessment.update!(
-          recorded_at: Time.zone.now
-        )
-      end
-
       @consent.recorded_at = Time.zone.now
       @consent.save!
 
@@ -146,22 +132,6 @@ class ManageConsentsController < ApplicationController
     end
   end
 
-  def handle_assessing_gillick
-    @patient_session.create_gillick_assessment!(assessor: current_user)
-    @consent.assign_attributes(
-      gillick_assessment: @patient_session.reload.draft_gillick_assessment,
-      form_step: current_step
-    )
-  end
-
-  def handle_gillick
-    @patient_session.draft_gillick_assessment.update!(gillick_params)
-    @consent.assign_attributes(
-      gillick_assessment: @patient_session.reload.draft_gillick_assessment,
-      form_step: current_step
-    )
-  end
-
   def set_route
     @section = params[:section]
   end
@@ -190,7 +160,12 @@ class ManageConsentsController < ApplicationController
   end
 
   def create_params
-    route = params.permit(:consent)[:consent]
+    route =
+      if @patient_session.gillick_competent?
+        :self_consent
+      else
+        params.permit(:consent)[:consent]
+      end
 
     attrs = { patient: @patient, campaign: @session.campaign, route: }
 
@@ -233,10 +208,6 @@ class ManageConsentsController < ApplicationController
       .fetch(:consent, {})
       .permit(permitted_attributes)
       .merge(form_step: current_step)
-  end
-
-  def gillick_params
-    params.fetch(:gillick_assessment, {}).permit(:gillick_competent, :notes)
   end
 
   # Returns:

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -94,10 +94,6 @@ class Consent < ApplicationRecord
 
   validates :reason_for_refusal_notes, length: { maximum: 1000 }
 
-  on_wizard_step :gillick, exact: true do
-    validate :gillick_assessment_valid?
-  end
-
   on_wizard_step :who do
     validates :parent_name, presence: true
     validates :parent_phone, presence: true
@@ -142,8 +138,6 @@ class Consent < ApplicationRecord
 
   def form_steps
     [
-      (:assessing_gillick if via_self_consent?),
-      (:gillick if via_self_consent?),
       (:who if via_phone?),
       :agree,
       (:questions if response_given?),
@@ -265,16 +259,6 @@ class Consent < ApplicationRecord
         end
       end
     end
-  end
-
-  def gillick_assessment_valid?
-    return if gillick_assessment.valid?(:edit_gillick)
-
-    errors.add(
-      :gillick_competent,
-      gillick_assessment.errors.messages[:gillick_competent].first
-    )
-    errors.add(:notes, gillick_assessment.errors.messages[:notes].first)
   end
 
   def triage_valid?

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -22,6 +22,7 @@
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #
 class GillickAssessment < ApplicationRecord
+  include WizardFormConcern
   audited
 
   belongs_to :patient_session
@@ -33,7 +34,20 @@ class GillickAssessment < ApplicationRecord
   scope :recorded, -> { where.not(recorded_at: nil) }
   default_scope { recorded }
 
+  on_wizard_step :gillick do
+    validates :gillick_competent, inclusion: { in: [true, false] }
+    validates :notes, length: { maximum: 1000 }, presence: true
+  end
+
   def draft?
     recorded_at.nil?
+  end
+
+  def self.form_steps
+    %i[gillick confirm]
+  end
+
+  def form_steps
+    self.class.form_steps
   end
 end

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -36,6 +36,9 @@ class GillickAssessment < ApplicationRecord
 
   on_wizard_step :gillick do
     validates :gillick_competent, inclusion: { in: [true, false] }
+  end
+
+  on_wizard_step :notes do
     validates :notes, length: { maximum: 1000 }, presence: true
   end
 
@@ -44,7 +47,7 @@ class GillickAssessment < ApplicationRecord
   end
 
   def self.form_steps
-    %i[gillick confirm]
+    %i[gillick notes confirm]
   end
 
   def form_steps

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -40,6 +40,10 @@ class PatientSession < ApplicationRecord
     vaccination_records.last
   end
 
+  def gillick_competent?
+    gillick_assessment&.gillick_competent?
+  end
+
   def able_to_vaccinate?
     !unable_to_vaccinate? && !unable_to_vaccinate_not_gillick_competent?
   end

--- a/app/views/gillick_assessments/confirm.html.erb
+++ b/app/views/gillick_assessments/confirm.html.erb
@@ -1,0 +1,31 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: previous_wizard_path,
+        name: "previous page",
+      ) %>
+<% end %>
+
+<% page_title = "Check and confirm" %>
+
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<%= render AppCardComponent.new(heading: "Gillick assessment details") do %>
+  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border nhsuk-u-margin-0" do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "Are they Gillick competent?" }
+          row.with_value { @assessment.gillick_competent ? "Yes, they are Gillick competent" : "No" }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Details of your assessment" }
+          row.with_value { @assessment.notes }
+        end
+      end %>
+<% end %>
+
+<%= govuk_button_to "Save changes", wizard_path, method: :put, prevent_double_click: true %>

--- a/app/views/gillick_assessments/gillick.html.erb
+++ b/app/views/gillick_assessments/gillick.html.erb
@@ -1,7 +1,12 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: previous_wizard_path,
-        name: "consent page",
+        href: new_session_patient_gillick_assessment_path(
+          session_id: @session.id,
+          patient_id: @patient.id,
+          section: params[:section],
+          tab: params[:tab],
+        ),
+        name: "Gillick assessment start page",
       ) %>
 <% end %>
 

--- a/app/views/gillick_assessments/gillick.html.erb
+++ b/app/views/gillick_assessments/gillick.html.erb
@@ -12,7 +12,7 @@
 
 <% content_for :page_title, "Are they Gillick competent?" %>
 
-<%= form_for @patient_session.draft_gillick_assessment, url: wizard_path, method: :put do |f| %>
+<%= form_for @assessment, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_radio_buttons_fieldset(:gillick_competent,
                                      caption: { size: "l",
@@ -25,10 +25,6 @@
     <%= f.govuk_radio_button :gillick_competent, false,
                              label: { text: "No" } %>
   <% end %>
-
-  <%= f.govuk_text_area :notes,
-                        label: { text: "Give details of your assessment" },
-                        rows: 10 %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/gillick_assessments/gillick.html.erb
+++ b/app/views/gillick_assessments/gillick.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: back_link_path,
+        href: previous_wizard_path,
         name: "consent page",
       ) %>
 <% end %>

--- a/app/views/gillick_assessments/new.html.erb
+++ b/app/views/gillick_assessments/new.html.erb
@@ -27,6 +27,9 @@
 <p>Before you make your assessment, you should give the young person a chance
 to ask questions.</p>
 
-
-<%= govuk_button_to "Give your assessment", wizard_path, method: :put,
-                                                         class: "nhsuk-u-margin-top-6" %>
+<%= govuk_button_to "Give your assessment", session_patient_gillick_assessment_path(
+      session_id: @session.id,
+      patient_id: @patient.id,
+      section: params[:section],
+      tab: params[:tab],
+    ), class: "nhsuk-u-margin-top-6" %>

--- a/app/views/gillick_assessments/notes.html.erb
+++ b/app/views/gillick_assessments/notes.html.erb
@@ -1,0 +1,22 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: previous_wizard_path,
+        name: "previous page",
+      ) %>
+<% end %>
+
+<% content_for :page_title, "Details of your assessment" %>
+
+<%= form_for @assessment, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_text_area :notes, caption: { size: "l",
+                                           text: @patient.full_name },
+                                label: { size: "l",
+                                         tag: "h1",
+                                         text: content_for(:page_title) },
+                                rows: 10 %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -353,6 +353,13 @@ en:
           nasal: Nasal spray
     errors:
       models:
+        gillick_assessment:
+          attributes:
+            gillick_competent:
+              inclusion: Choose if they are Gillick competent
+            notes:
+              blank: Enter details of your assessment
+              too_long: Enter details that are less than 1000 characters long
         offline_password:
           attributes:
             password:
@@ -377,13 +384,6 @@ en:
               blank: Choose a site
             reason:
               inclusion: Choose a reason
-        patient_session:
-          attributes:
-            gillick_competent:
-              inclusion: Choose if they are Gillick competent
-            gillick_competence_notes:
-              blank: Enter details of your assessment
-              too_long: Enter details that are less than 1000 characters long
         batch:
           attributes:
             name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,12 @@ Rails.application.routes.draw do
           get "details", on: :collection, to: "consents#show"
         end
 
+        resource :gillick_assessment, only: %i[new create]
+
+        resource :gillick_assessment,
+                 path: "gillick-assessment/:id",
+                 only: %i[show update]
+
         resource :triage, only: %i[create update]
 
         resource :vaccinations, only: %i[new create update] do

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AppPatientPageComponent, type: :component do
     it "does not show the vaccination form" do
       should_not have_css(".nhsuk-card", text: "Did they get the HPV vaccine?")
     end
-    it { should have_css("button", text: "Assess Gillick competence") }
+    it { should have_css("a", text: "Give your assessment") }
   end
 
   context "session in progress, patient ready to vaccinate" do

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe "Self-consent" do
     click_link "Give your assessment"
     click_button "Give your assessment"
 
+    # try submitting without filling in the form
+    click_on "Continue"
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Choose if they are Gillick competent")
+    expect(page).to have_content("Enter details of your assessment")
+
     choose "Yes, they are Gillick competent"
 
     fill_in "Give details of your assessment",

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -54,11 +54,15 @@ RSpec.describe "Self-consent" do
     click_on "Continue"
     expect(page).to have_content("There is a problem")
     expect(page).to have_content("Choose if they are Gillick competent")
-    expect(page).to have_content("Enter details of your assessment")
 
     choose "Yes, they are Gillick competent"
+    click_on "Continue"
 
-    fill_in "Give details of your assessment",
+    # try submitting without filling in the form
+    click_on "Continue"
+    expect(page).to have_content("Enter details of your assessment")
+
+    fill_in "Details of your assessment",
             with: "They understand the benefits and risks of the vaccine"
     click_on "Continue"
 

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -46,10 +46,20 @@ RSpec.describe "Self-consent" do
 
   def when_the_nurse_assesses_the_child_as_gillick_competent
     click_on @child.full_name
-
     click_link "Give your assessment"
-    click_button "Give your assessment"
 
+    click_through_guidance
+    record_competence
+    record_details_of_assessment
+    check_and_confirm
+  end
+
+  def click_through_guidance
+    expect(page).to have_content("Assessing Gillick competence")
+    click_button "Give your assessment"
+  end
+
+  def record_competence
     # try submitting without filling in the form
     click_on "Continue"
     expect(page).to have_content("There is a problem")
@@ -57,7 +67,9 @@ RSpec.describe "Self-consent" do
 
     choose "Yes, they are Gillick competent"
     click_on "Continue"
+  end
 
+  def record_details_of_assessment
     # try submitting without filling in the form
     click_on "Continue"
     expect(page).to have_content("Enter details of your assessment")
@@ -65,7 +77,9 @@ RSpec.describe "Self-consent" do
     fill_in "Details of your assessment",
             with: "They understand the benefits and risks of the vaccine"
     click_on "Continue"
+  end
 
+  def check_and_confirm
     expect(page).to have_content("Check and confirm")
     expect(page).to have_content(
       ["Are they Gillick competent?", "Yes, they are Gillick competent"].join

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -47,17 +47,31 @@ RSpec.describe "Self-consent" do
   def when_the_nurse_assesses_the_child_as_gillick_competent
     click_on @child.full_name
 
-    click_on "Assess Gillick competence"
-    click_on "Give your assessment"
+    click_link "Give your assessment"
+    click_button "Give your assessment"
 
     choose "Yes, they are Gillick competent"
 
     fill_in "Give details of your assessment",
             with: "They understand the benefits and risks of the vaccine"
     click_on "Continue"
+
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content(
+      ["Are they Gillick competent?", "Yes, they are Gillick competent"].join
+    )
+    expect(page).to have_content(
+      [
+        "Details of your assessment",
+        "They understand the benefits and risks of the vaccine"
+      ].join
+    )
+    click_on "Save changes"
   end
 
   def then_the_child_can_give_their_own_consent_that_the_nurse_records
+    click_on "Get consent"
+
     # record consent
     choose "Yes, they agree"
     click_on "Continue"

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -46,8 +46,9 @@ RSpec.describe "Not Gillick competent" do
     click_button "Give your assessment"
 
     choose "No"
+    click_on "Continue"
 
-    fill_in "Give details of your assessment",
+    fill_in "Details of your assessment",
             with: "They didn't understand the benefits and risks of the vaccine"
     click_on "Continue"
 

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "Not Gillick competent" do
 
     when_the_nurse_assesses_the_child_as_not_being_gillick_competent
     then_the_child_cannot_give_their_own_consent
-    and_the_lack_of_gillick_competence_is_visible_to_the_nurse
   end
 
   def given_an_hpv_campaign_is_underway
@@ -43,23 +42,31 @@ RSpec.describe "Not Gillick competent" do
   def when_the_nurse_assesses_the_child_as_not_being_gillick_competent
     click_on @child.full_name
 
-    click_on "Assess Gillick competence"
-    click_on "Give your assessment"
+    click_link "Give your assessment"
+    click_button "Give your assessment"
 
     choose "No"
 
     fill_in "Give details of your assessment",
             with: "They didn't understand the benefits and risks of the vaccine"
     click_on "Continue"
+
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content(["Are they Gillick competent?", "No"].join)
+    expect(page).to have_content(
+      [
+        "Details of your assessment",
+        "They didn't understand the benefits and risks of the vaccine"
+      ].join
+    )
+    click_on "Save changes"
   end
 
   def then_the_child_cannot_give_their_own_consent
-    skip "BUG here: the child shouldn't be able to give their own consent, but can"
-  end
-
-  def and_the_lack_of_gillick_competence_is_visible_to_the_nurse
-    expect(page).to have_content(
-      "No-one responded to our requests for consent. When assessed, the child was not Gillick competent"
+    click_on "Get consent"
+    expect(page).to have_content("Who are you trying to get consent from?")
+    expect(page).not_to have_content(
+      "Do they agree to them having the HPV vaccination?"
     )
   end
 end


### PR DESCRIPTION
This PR:

* splits up the Gillick assessment steps into a stand-alone 4-step journey
* makes the "get consent" journey record self-consent if the child is Gillick competent
* splits the Gillick assessment recording across two screens, as per the new design
* re-enables validations for those two screens

## Patient page

<img width="876" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/2187b71a-e640-4630-b038-063144c9e50e">

## Guidance

<img width="781" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/79602ea0-1fe1-4811-a712-b9f04ac5d889">

## Are they Gillick competent?

<img width="474" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/468d84a3-e17d-440c-ab4f-e9e5e50a9bb8">

## Details

<img width="775" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/2ee9814f-e99c-4b26-98ae-c8384a6e95bf">

## Confirm

<img width="766" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/b89c1811-9ebd-40a9-9b0f-b0863f2e3b4b">

## Updated patient page

<img width="881" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/b189fc0e-8de8-4684-b4ba-55ae8e9014ca">
