### PR TITLE
Show validation error when user doesn't choose a triage status

### DIFF
--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -37,3 +37,8 @@
 .nhsuk-table-responsive {
   @include nhsuk-responsive-margin(7, "bottom");
 }
+
+// Don't show a grey background when hovering over table rows.
+.nhsuk-table__row:hover {
+  background: none;
+}

--- a/app/components/app_breadcrumb_component.html.erb
+++ b/app/components/app_breadcrumb_component.html.erb
@@ -7,10 +7,9 @@
         <li class="nhsuk-breadcrumb__item">
           <%= item[:href].nil? ?
                 item[:text] :
-                govuk_link_to(item[:text], item[:href],
-                              class: "nhsuk-breadcrumb__link",
-                              attributes: item[:attributes]) %>
-        </li>
+                link_to(item[:text], item[:href],
+                        class: "nhsuk-breadcrumb__link",
+                        attributes: item[:attributes]) %></li>
       <% end %>
     </ol>
     <p class="nhsuk-breadcrumb__back">

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -7,7 +7,7 @@
    ) do |f| %>
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
-      Is it safe to vaccinate <%= patient.full_name %>?
+      Is it safe to vaccinate <%= patient.first_name %>?
     </h2>
     <% content_for(:before_content) { f.govuk_error_summary } %>
 

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -41,34 +41,12 @@ class TriageController < ApplicationController
 
   def create
     @triage = @patient_session.triage.new
-    @triage.assign_attributes triage_params.merge(user: current_user)
-    if @triage.save(context: :consent)
-      @patient_session.do_triage!
-      send_triage_mail(@patient_session, @consent)
-      success_flash_after_patient_update(
-        patient: @patient,
-        view_record_link: session_patient_path(@session, id: @patient.id)
-      )
-      redirect_to redirect_path
-    else
-      render "patients/show", status: :unprocessable_entity
-    end
+    process_triage
   end
 
   def update
     @triage = @patient_session.triage.last
-    @triage.assign_attributes triage_params
-    if @triage.save(context: :consent)
-      @patient_session.do_triage!
-      send_triage_mail(@patient_session, @consent)
-      success_flash_after_patient_update(
-        patient: @patient,
-        view_record_link: session_patient_path(@session, id: @patient.id)
-      )
-      redirect_to redirect_path
-    else
-      render "patients/show", status: :unprocessable_entity
-    end
+    process_triage
   end
 
   private
@@ -109,6 +87,21 @@ class TriageController < ApplicationController
       session_consents_tab_path(@session, tab: params[:tab])
     else # if current_section is triage or anything else
       session_triage_path(@session)
+    end
+  end
+
+  def process_triage
+    @triage.assign_attributes triage_params.merge(user: current_user)
+    if @triage.save(context: :consent)
+      @patient_session.do_triage!
+      send_triage_mail(@patient_session, @consent)
+      success_flash_after_patient_update(
+        patient: @patient,
+        view_record_link: session_patient_path(@session, id: @patient.id)
+      )
+      redirect_to redirect_path
+    else
+      render "patients/show", status: :unprocessable_entity
     end
   end
 end

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -11,12 +11,13 @@
 <% end %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(href: session_patient_path, selected: true) {
-        "Child record"
-      }
-      nav.with_item(href: session_patient_log_path(patient_id: @patient.id)) {
-        "Activity log"
-      }
+      nav.with_item(
+        href: session_patient_path(id: @patient.id),
+        selected: true,
+      ) { "Child record" }
+      nav.with_item(
+        href: session_patient_log_path(patient_id: @patient.id),
+      ) { "Activity log" }
     end %>
 
 <%= render AppPatientPageComponent.new(

--- a/spec/features/triage_during_consent_spec.rb
+++ b/spec/features/triage_during_consent_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe "Triage" do
     and_a_patient_needing_triage
     and_i_am_signed_in
 
-    when_i_go_to_the_given_tab_of_the_consents_page
-    and_i_go_to_the_patient_that_needs_triage
-    and_i_record_that_they_are_safe_to_vaccinate
+    when_i_go_to_the_patient_that_needs_triage
+    then_i_see_the_triage_options
+
+    when_i_save_the_triage_without_choosing_an_option
+    then_i_see_a_validation_error
+
+    when_i_record_that_they_are_safe_to_vaccinate
     then_i_see_the_consents_page
+    and_an_email_is_sent_to_the_parent
   end
 
   def given_a_campaign_with_a_running_session
@@ -35,20 +40,34 @@ RSpec.describe "Triage" do
     sign_in @team.users.first
   end
 
-  def when_i_go_to_the_given_tab_of_the_consents_page
+  def when_i_go_to_the_patient_that_needs_triage
     visit session_consents_tab_path(@session, tab: "given")
-  end
-
-  def and_i_go_to_the_patient_that_needs_triage
     click_link @patient.full_name
   end
 
-  def and_i_record_that_they_are_safe_to_vaccinate
+  def when_i_record_that_they_are_safe_to_vaccinate
     choose "Yes, it’s safe to vaccinate"
     click_button "Save triage"
   end
 
   def then_i_see_the_consents_page
     expect(page).to have_content("Check consent responses")
+  end
+
+  def then_i_see_the_triage_options
+    expect(page).to have_selector :heading, "Is it safe to vaccinate"
+  end
+
+  def when_i_save_the_triage_without_choosing_an_option
+    click_button "Save triage"
+  end
+
+  def then_i_see_a_validation_error
+    expect(page).to have_selector :heading, "There is a problem"
+  end
+
+  def and_an_email_is_sent_to_the_parent
+    expect_email_to @patient.consents.first.parent_email,
+                    EMAILS[:triage_vaccination_will_happen]
   end
 end


### PR DESCRIPTION
This functionality was broken when we added the secondary navigation menu to allow users to get to the Activity Log. This updates the test coverage and fixes the bug.

Also a couple of small but unrelated commits to the CSS.