### PR TITLE
Bugfix: on the consent details page, hide parent section for self-consent

### DIFF
--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -78,39 +78,41 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Parent or guardian") do %>
-  <%= govuk_summary_list(
-        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
-      ) do |summary_list|
-        summary_list.with_row do |row|
-          row.with_key { "Name" }
-          row.with_value { @consent.parent_name }
-        end
-      
-        summary_list.with_row do |row|
-          row.with_key { "Relationship" }
-          row.with_value { @consent.who_responded.humanize }
-        end
-      
-        if @consent.parent_email.present?
+<% unless @consent.via_self_consent? %>
+  <%= render AppCardComponent.new(heading: "Parent or guardian") do %>
+    <%= govuk_summary_list(
+          classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
+        ) do |summary_list|
           summary_list.with_row do |row|
-            row.with_key { "Email address" }
-            row.with_value { @consent.parent_email }
+            row.with_key { "Name" }
+            row.with_value { @consent.parent_name }
           end
-        end
-      
-        summary_list.with_row do |row|
-          row.with_key { "Phone number" }
-          row.with_value { @consent.parent_phone.presence || "Not provided" }
-        end
-      
-        if @consent.parent_contact_method.present?
+        
           summary_list.with_row do |row|
-            row.with_key { "Phone contact method" }
-            row.with_value { @consent.phone_contact_method_description }
+            row.with_key { "Relationship" }
+            row.with_value { @consent.who_responded.humanize }
           end
-        end
-      end %>
+        
+          if @consent.parent_email.present?
+            summary_list.with_row do |row|
+              row.with_key { "Email address" }
+              row.with_value { @consent.parent_email }
+            end
+          end
+        
+          summary_list.with_row do |row|
+            row.with_key { "Phone number" }
+            row.with_value { @consent.parent_phone.presence || "Not provided" }
+          end
+        
+          if @consent.parent_contact_method.present?
+            summary_list.with_row do |row|
+              row.with_key { "Phone contact method" }
+              row.with_value { @consent.phone_contact_method_description }
+            end
+          end
+        end %>
+  <% end %>
 <% end %>
 
 <% if @consent.response_given? %>

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -128,6 +128,10 @@ RSpec.describe "Self-consent" do
     expect(page).to have_content(
       "They understand the benefits and risks of the vaccine"
     )
+
+    click_on @child.full_name
+    expect(page).not_to have_content("Parent or guardian")
+    click_on "Back to patient page"
   end
 
   def and_the_child_should_be_safe_to_vaccinate


### PR DESCRIPTION
![consent-details](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/c832dd21-3d4e-4ffd-a71e-cfa0757cf91d)
