### PR TITLE
Fix flakey test

### DIFF
--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -54,7 +54,7 @@ FactoryBot.define do
     parent_relationship do
       ConsentForm.parent_relationships.keys.first(2).sample(random:)
     end
-    parent_email { Faker::Internet.email name: parent_name }
+    parent_email { Faker::Internet.email name: parent_name.gsub(".", "") }
     parent_phone { "07700900#{random.rand(0..999).to_s.rjust(3, "0")}" }
     contact_method { "any" }
     response { "given" }


### PR DESCRIPTION
The consent_form factory autogenerates an email for the parent based on a faked name. Sometimes the name is something like "Sen. Star Hickle" which contains a period and gets email-ified to "sen..star.hickle@stamm.test" or similar. The double period doesn't pass our email RegExp validation.