### PR TITLE
Remove types from RemoveGillickFields migration 

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,5 +2,5 @@ nodejs 18.1.0
 postgres 13.5
 ruby 3.3.0
 yarn 1.22.19
-aws-copilot 1.33.2
+aws-copilot 1.33.4
 awscli 2.13.31

--- a/db/migrate/20240531213930_remove_gillick_fields_from_patient_session.rb
+++ b/db/migrate/20240531213930_remove_gillick_fields_from_patient_session.rb
@@ -1,9 +1,9 @@
 class RemoveGillickFieldsFromPatientSession < ActiveRecord::Migration[7.1]
   def up
     change_table :patient_sessions, bulk: true do |t|
-      t.remove :gillick_competence_assessor_user_id, :bigint
-      t.remove :gillick_competent, :boolean
-      t.remove :gillick_competence_notes, :text
+      t.remove :gillick_competence_assessor_user_id,
+               :gillick_competent,
+               :gillick_competence_notes
     end
   end
 


### PR DESCRIPTION
These are being interpreted as fields and breaking.

Also bump aws-copilot version.