### PR TITLE
Ensure initial seeds are audited to Nurse Joy

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,11 +20,15 @@ user =
       email: "nurse.joy@example.com",
       password: "nurse.joy@example.com"
     )
-FactoryBot.create(
-  :example_campaign,
-  :in_progress,
-  :in_past,
-  :in_future,
-  :hpv,
-  user:
-)
+Audited
+  .audit_class
+  .as_user(user) do
+    FactoryBot.create(
+      :example_campaign,
+      :in_progress,
+      :in_past,
+      :in_future,
+      :hpv,
+      user:
+    )
+  end


### PR DESCRIPTION
Without this, `audits` for creating sessions/patient_sessions are attributed to `nil` which isn't realistic.