### PR TITLE
Manage consents: show error summary on triage step

### DIFF
--- a/app/views/manage_consents/triage.html.erb
+++ b/app/views/manage_consents/triage.html.erb
@@ -7,14 +7,16 @@
 
 <% page_title = "Is it safe to vaccinate?" %>
 
-<%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    <%= @patient.full_name %>
-  </span>
-  <%= page_title %>
-<% end %>
-
 <%= form_for @triage, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= h1 page_title: do %>
+    <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+      <%= @patient.full_name %>
+    </span>
+    <%= page_title %>
+  <% end %>
+
   <%= f.govuk_collection_radio_buttons :status,
                                        triage_form_status_options,
                                        :first,


### PR DESCRIPTION
#1388 left a bug, whereby the error summary wasn't being displayed.

## Before

<img width="796" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/92e9a41f-06f2-498d-be73-aa12f233d11b">

## After

<img width="824" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/156aa4d8-c41e-4e6a-ace2-1e0163595e03">
