### PR TITLE
Allow users to update a triage outcome

### DIFF
--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -2,15 +2,17 @@ class AppCardComponent < ViewComponent::Base
   erb_template <<-ERB
     <div class="<%= card_classes %>">
       <div class="<%= content_classes %>">
-        <h2 class="<%= heading_classes %>">
-          <% if @link_to.present? %>
-            <%= link_to @link_to, class: "nhsuk-card__link" do %>
+        <% if @heading.present? %>
+          <h2 class="<%= heading_classes %>">
+            <% if @link_to.present? %>
+              <%= link_to @link_to, class: "nhsuk-card__link" do %>
+                <%= @heading %>
+              <% end %>
+            <% else %>
               <%= @heading %>
             <% end %>
-          <% else %>
-            <%= @heading %>
-          <% end %>
-        </h2>
+          </h2>
+        <% end %>
 
         <%= content %>
       </div>
@@ -18,7 +20,7 @@ class AppCardComponent < ViewComponent::Base
   ERB
 
   def initialize(
-    heading:,
+    heading: nil,
     heading_size: "m",
     feature: false,
     colour: nil,

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -1,6 +1,5 @@
 <%= if patient_session.state.in? %w[
                                   vaccinated
-                                  triaged_do_not_vaccinate
                                   unable_to_vaccinate
                                 ]
      render AppOutcomeBannerComponent.new(

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -64,12 +64,16 @@
   <%= render AppTriageNotesComponent.new(patient_session:) %>
 <% end %>
 
-<%= render AppTriageFormComponent.new(
-      patient_session:,
-      triage: @triage,
-      section:,
-      tab:,
-    ) %>
+<% if @patient_session.next_step == :triage %>
+  <%= render AppCardComponent.new do %>
+    <%= render AppTriageFormComponent.new(
+          patient_session:,
+          triage: @triage,
+          section:,
+          tab:,
+        ) %>
+  <% end %>
+<% end %>
 
 <%= render AppVaccinateFormComponent.new(
       patient_session:,

--- a/app/components/app_simple_status_banner_component.html.erb
+++ b/app/components/app_simple_status_banner_component.html.erb
@@ -1,0 +1,14 @@
+<%= render AppCardComponent.new(heading:, feature: true, colour:) do %>
+  <p><%= I18n.t("patient_session_statuses.#{state}.banner_explanation",
+                default: "", full_name:, nurse:, who_refused:) %></p>
+  <% if state.in? %w[delay_vaccination
+                     triaged_ready_to_vaccinate
+                     triaged_do_not_vaccinate] %>
+    <p>
+      <%= link_to "Update triage outcome", new_session_patient_triage_path(
+            session_id: @patient_session.session.id,
+            patient_id: @patient_session.patient.id,
+          ) %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -7,27 +7,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
     @patient_session = patient_session
   end
 
-  def call
-    render AppCardComponent.new(heading:, feature: true, colour:) do
-      tag.p do
-        I18n.t(
-          "patient_session_statuses.#{state}.banner_explanation",
-          default: "",
-          full_name:,
-          nurse:,
-          who_responded:,
-          who_refused:
-        )
-      end
-    end
-  end
-
   private
-
-  def consent
-    # HACK: Component needs to be updated to work with multiple consents.
-    @consent ||= @patient_session.consents.first
-  end
 
   def most_recent_triage
     @most_recent_triage ||= @patient_session.triage.order(:created_at).last
@@ -36,10 +16,6 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   def most_recent_vaccination
     @most_recent_vaccination ||=
       @patient_session.vaccination_records.order(:created_at).last
-  end
-
-  def who_responded
-    consent&.who_responded&.downcase
   end
 
   def who_refused

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -1,16 +1,16 @@
 <%= form_with(
      model: @triage,
      url:,
-     class: "nhsuk-card",
      method: :post,
      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
    ) do |f| %>
-  <div class="nhsuk-card__content">
-    <h2 class="nhsuk-card__heading nhsuk-heading-m">
-      Is it safe to vaccinate <%= patient.first_name %>?
-    </h2>
-    <% content_for(:before_content) { f.govuk_error_summary } %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
 
+  <%= f.govuk_fieldset legend: {
+                         text: "Is it safe to vaccinate \
+                                     #{@patient_session.patient.first_name}?",
+                         tag: :h2,
+                       } do %>
     <%= f.govuk_collection_radio_buttons(
           :status,
           triage_status_options,
@@ -26,5 +26,5 @@
         ) %>
 
     <%= f.submit "Save triage", class: "nhsuk-button" %>
-  </div>
+  <% end %>
 <% end %>

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -24,10 +24,6 @@ class AppTriageFormComponent < ViewComponent::Base
     )
   end
 
-  def render?
-    @patient_session.next_step == :triage
-  end
-
   private
 
   def patient

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -3,12 +3,12 @@ class TriageController < ApplicationController
   include PatientTabsConcern
   include PatientSortingConcern
 
-  before_action :set_session, only: %i[index create]
-  before_action :set_patient, only: %i[create]
-  before_action :set_patient_session, only: %i[create]
-  before_action :set_section_and_tab, only: %i[create]
+  before_action :set_session, only: %i[index create new]
+  before_action :set_patient, only: %i[create new]
+  before_action :set_patient_session, only: %i[create new]
+  before_action :set_section_and_tab, only: %i[create new]
 
-  after_action :verify_policy_scoped, only: %i[index create]
+  after_action :verify_policy_scoped, only: %i[index create new]
 
   layout "two_thirds", except: %i[index]
 
@@ -36,6 +36,10 @@ class TriageController < ApplicationController
     sort_and_filter_patients!(@patient_sessions)
 
     session[:current_section] = "triage"
+  end
+
+  def new
+    @triage = @patient_session.triage.new
   end
 
   def create

--- a/app/views/triage/new.html.erb
+++ b/app/views/triage/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: session_patient_path(id: @patient.id),
+        name: "patient page",
+      ) %>
+<% end %>
+
+<%= h1 page_title: "Update triage outcome" do %>
+  <span class="nhsuk-caption-l"><%= @patient.full_name %></span>
+  Update triage outcome
+<% end %>
+
+<%= render AppTriageFormComponent.new(
+      patient_session: @patient_session,
+      triage: @triage,
+      section: @section,
+      tab: @tab,
+    ) %>

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -34,6 +34,7 @@ en:
       colour: red
       text: Do not vaccinate
       banner_title: Could not vaccinate
+      banner_explanation: "%{nurse} decided that %{full_name} should not be vaccinated"
     triaged_kept_in_triage:
       colour: blue
       text: Triage started

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -159,7 +159,7 @@ Rails.application.routes.draw do
                  path: "gillick-assessment/:id",
                  only: %i[show update]
 
-        resource :triage, only: %i[create]
+        resource :triage, only: %i[new create]
 
         resource :vaccinations, only: %i[new create update] do
           resource "batch",

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.describe AppPatientPageComponent, type: :component do
+  before do
+    allow_any_instance_of(AppSimpleStatusBannerComponent).to receive(
+      :new_session_patient_triage_path
+    ).and_return("/session/patient/triage/new")
+  end
+
   let(:component) do
     described_class.new(
       patient_session:,
@@ -26,7 +32,7 @@ RSpec.describe AppPatientPageComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should_not have_css(".nhsuk-card__heading", text: "Triage notes") }
     it "shows the triage form" do
-      should have_css(".nhsuk-card__heading", text: "Is it safe to vaccinate")
+      should have_selector(:heading, text: "Is it safe to vaccinate")
     end
     it "does not show the vaccination form" do
       should_not have_css(".nhsuk-card", text: "Did they get the HPV vaccine?")

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -1,6 +1,11 @@
 require "rails_helper"
 
 RSpec.describe AppSimpleStatusBannerComponent, type: :component do
+  before do
+    allow(component).to receive(:new_session_patient_triage_path).and_return(
+      "/session/patient/triage/new"
+    )
+  end
   let(:user) { create :user }
   let(:patient_session) { create :patient_session, user: }
   let(:component) { described_class.new(patient_session:) }

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe AppSimpleStatusBannerComponent, type: :component do
                "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
              )
     end
+    it { should have_link("Update triage") }
+  end
+
+  context "state is triaged_do_not_vaccinate" do
+    let(:patient_session) { create :patient_session, :triaged_do_not_vaccinate }
+
+    it { should have_css(".app-card--red") }
+    it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
+    it do
+      should have_text(
+               "#{triage_nurse_name} decided that #{patient_name} should not be vaccinated"
+             )
+    end
+    it { should have_link("Update triage") }
   end
 
   context "state is delay_vaccination" do
@@ -83,5 +97,6 @@ RSpec.describe AppSimpleStatusBannerComponent, type: :component do
                "#{vaccination_nurse_name} decided that #{patient_name}’s vaccination should be delayed"
              )
     end
+    it { should have_link("Update triage") }
   end
 end

--- a/spec/components/previews/app_simple_status_banner_component_preview.rb
+++ b/spec/components/previews/app_simple_status_banner_component_preview.rb
@@ -38,6 +38,13 @@ class AppSimpleStatusBannerComponentPreview < ViewComponent::Preview
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
+  def triaged_do_not_vaccinate
+    patient_session =
+      FactoryBot.create(:patient_session, :triaged_do_not_vaccinate)
+
+    render AppSimpleStatusBannerComponent.new(patient_session:)
+  end
+
   def triaged_ready_to_vaccinate
     patient_session =
       FactoryBot.create(:patient_session, :triaged_ready_to_vaccinate)

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -13,7 +13,19 @@ RSpec.describe "Triage" do
 
     when_i_record_that_they_need_triage
     then_i_see_the_triage_page
-    and_emails_are_sent_to_both_parents
+    and_needs_triage_emails_are_sent_to_both_parents
+
+    when_i_go_to_the_patient
+    and_i_delay_the_vaccination
+    then_i_see_the_triage_page
+    and_vaccination_wont_happen_emails_are_sent_to_both_parents
+
+    when_i_go_to_the_patient
+    then_i_see_the_update_triage_link
+
+    when_i_record_that_they_are_safe_to_vaccinate
+    then_i_see_the_triage_page
+    and_vaccination_will_happen_emails_are_sent_to_both_parents
   end
 
   def given_a_campaign_with_a_running_session
@@ -44,13 +56,23 @@ RSpec.describe "Triage" do
     click_link @patient.full_name
   end
 
+  def when_i_go_to_the_patient
+    click_link @patient.full_name, match: :first
+  end
+
   def when_i_record_that_they_need_triage
     choose "No, keep in triage"
     click_button "Save triage"
   end
 
   def when_i_record_that_they_are_safe_to_vaccinate
+    click_link "Update triage"
     choose "Yes, it’s safe to vaccinate"
+    click_button "Save triage"
+  end
+
+  def and_i_delay_the_vaccination
+    choose "No, delay vaccination to a later date"
     click_button "Save triage"
   end
 
@@ -70,11 +92,34 @@ RSpec.describe "Triage" do
     expect(page).to have_selector :heading, "There is a problem"
   end
 
-  def and_emails_are_sent_to_both_parents
+  def then_i_see_the_update_triage_link
+    expect(page).to have_link "Update triage"
+  end
+
+  def and_needs_triage_emails_are_sent_to_both_parents
     expect_email_to @patient.consents.first.parent_email,
                     EMAILS[:parental_consent_confirmation_needs_triage]
     expect_email_to @patient.consents.second.parent_email,
                     EMAILS[:parental_consent_confirmation_needs_triage],
                     :second
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def and_vaccination_wont_happen_emails_are_sent_to_both_parents
+    expect_email_to @patient.consents.first.parent_email,
+                    EMAILS[:triage_vaccination_wont_happen]
+    expect_email_to @patient.consents.second.parent_email,
+                    EMAILS[:triage_vaccination_wont_happen],
+                    :second
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def and_vaccination_will_happen_emails_are_sent_to_both_parents
+    expect_email_to @patient.consents.first.parent_email,
+                    EMAILS[:triage_vaccination_will_happen]
+    expect_email_to @patient.consents.second.parent_email,
+                    EMAILS[:triage_vaccination_will_happen],
+                    :second
+    ActionMailer::Base.deliveries.clear
   end
 end

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Verbal consent" do
   end
 
   def then_i_see_that_the_status_is_do_not_vaccinate
-    expect(page).to have_content("Do not vaccinate")
+    expect(page).to have_content("Could not vaccinate")
   end
 
   def and_i_can_see_the_consent_response


### PR DESCRIPTION
This adds a `/triage/new` page.

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/ce529e43-d76a-4d9a-9e9c-8e21d4568a1e)
