### PR TITLE
Mavis consent: must confirm parental responsibility when 'other' parent

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -205,7 +205,8 @@ class ManageConsentsController < ApplicationController
       :name,
       :phone,
       :relationship,
-      :relationship_other
+      :relationship_other,
+      :parental_responsibility
     )
   end
 

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -18,6 +18,8 @@ class Parent < ApplicationRecord
 
   has_one :patient
 
+  attr_accessor :parental_responsibility
+
   enum :contact_method, %w[text voice other any], prefix: true
   enum :relationship, %w[mother father guardian other], prefix: true
 
@@ -31,10 +33,12 @@ class Parent < ApplicationRecord
               in: Parent.relationships.keys
             },
             presence: true
-  validates :relationship_other,
-            presence: true,
-            if: -> { relationship == "other" }
-
+  validates :relationship_other, presence: true, if: -> { relationship_other? }
+  validates :parental_responsibility,
+            inclusion: {
+              in: %w[yes]
+            },
+            if: -> { relationship_other? }
   validates :contact_method_other,
             :email,
             :name,

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -36,6 +36,16 @@
       <%= f.govuk_text_field :relationship_other,
                              label: { text: "Relationship to the child" },
                              hint: { text: "For example, carer" } %>
+      <%= f.govuk_radio_buttons_fieldset(:parental_responsibility,
+                                         legend: { size: "s",
+                                                   text: "Do they have parental responsibility?" },
+                                         hint: { text: "This means they have legal rights and duties relating to the child" }) do %>
+        <%= f.govuk_radio_button :parental_responsibility, "yes",
+                                 label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :parental_responsibility, "no",
+                                 label: { text: "No" } %>
+      <% end %>
+
     <% end %>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,6 +490,8 @@ en:
             relationship_other:
               blank: Enter a relationship
               too_long: Enter a relationship that is less than 300 characters long
+            parental_responsibility:
+              inclusion: Choose whether there is parental responsibility
         user:
           attributes:
             email:

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -136,6 +136,7 @@ FactoryBot.define do
           :parent,
           relationship: :other,
           relationship_other: "Granddad",
+          parental_responsibility: "yes",
           last_name: patient.last_name
         )
       end


### PR DESCRIPTION
This makes the Mavis interaction consistent with the parent consent forms.

## Extra field

![fields](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/8804b301-2362-4c65-94ad-5871019befc7)

## Error

![error](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/26d0a162-cdb9-407a-8b78-2dbbe3f412fa)
