### PR TITLE
PDS Integration

### DIFF
--- a/app/models/pds/patient.rb
+++ b/app/models/pds/patient.rb
@@ -1,0 +1,31 @@
+class PDS::Patient
+  include ActiveModel::Model
+
+  attr_accessor :nhs_number, :given_name, :family_name, :date_of_birth
+
+  class << self
+    def find(nhs_number)
+      response =
+        JSON.parse(
+          Net::HTTP.get(
+            URI(
+              "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/#{nhs_number}"
+            ),
+            "X-Request-ID": SecureRandom.uuid
+          )
+        )
+      from_pds_fhir_response(response)
+    end
+
+    private
+
+    def from_pds_fhir_response(response)
+      new(
+        nhs_number: response["id"],
+        given_name: response["name"][0]["given"][0],
+        family_name: response["name"][0]["family"],
+        date_of_birth: response["birthDate"]
+      )
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,5 +13,7 @@
 # These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "CSRF"
+  inflect.acronym "FHIR"
+  inflect.acronym "PDS"
   inflect.uncountable "triage"
 end

--- a/spec/models/pds/patient_spec.rb
+++ b/spec/models/pds/patient_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe PDS::Patient do
+  describe ".find" do
+    let(:json_response) do
+      File.read("spec/support/pds-get-patient-response.json")
+    end
+    let(:request_id) { "123e4567-e89b-12d3-a456-426614174000" }
+
+    before do
+      allow(SecureRandom).to receive(:uuid).and_return(request_id)
+      stub_request(
+        :get,
+        "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9000000009"
+      ).with(headers: { "X-Request-ID" => request_id }).to_return(
+        status: 200,
+        body: json_response
+      )
+    end
+
+    it "returns a patient with the correct attributes" do
+      patient = described_class.find("9000000009")
+
+      expect(patient.nhs_number).to eq("9000000009")
+      expect(patient.given_name).to eq("Jane")
+      expect(patient.family_name).to eq("Smith")
+      expect(patient.date_of_birth).to eq("2010-10-22")
+    end
+  end
+end

--- a/spec/support/pds-get-patient-response.json
+++ b/spec/support/pds-get-patient-response.json
@@ -1,0 +1,387 @@
+{
+  "resourceType": "Patient",
+  "id": "9000000009",
+  "identifier": [
+    {
+      "system": "https://fhir.nhs.uk/Id/nhs-number",
+      "value": "9000000009",
+      "extension": [
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus",
+                "version": "1.0.0",
+                "code": "01",
+                "display": "Number present and verified"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "meta": {
+    "versionId": "2",
+    "security": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/v3-Confidentiality",
+        "code": "U",
+        "display": "unrestricted"
+      }
+    ]
+  },
+  "name": [
+    {
+      "id": "123",
+      "use": "usual",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      },
+      "given": ["Jane"],
+      "family": "Smith",
+      "prefix": ["Mrs"],
+      "suffix": ["MBE"]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "2010-10-22",
+  "multipleBirthInteger": 1,
+  "deceasedDateTime": "2010-10-22T00:00:00+00:00",
+  "generalPractitioner": [
+    {
+      "id": "254406A3",
+      "type": "Organization",
+      "identifier": {
+        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+        "value": "Y12345",
+        "period": {
+          "start": "2020-01-01",
+          "end": "2021-12-31"
+        }
+      }
+    }
+  ],
+  "managingOrganization": {
+    "type": "Organization",
+    "identifier": {
+      "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+      "value": "Y12345",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      }
+    }
+  },
+  "extension": [
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NominatedPharmacy",
+      "valueReference": {
+        "identifier": {
+          "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+          "value": "Y12345"
+        }
+      }
+    },
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-PreferredDispenserOrganization",
+      "valueReference": {
+        "identifier": {
+          "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+          "value": "Y23456"
+        }
+      }
+    },
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicalApplianceSupplier",
+      "valueReference": {
+        "identifier": {
+          "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+          "value": "Y34567"
+        }
+      }
+    },
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-DeathNotificationStatus",
+      "extension": [
+        {
+          "url": "deathNotificationStatus",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-DeathNotificationStatus",
+                "version": "1.0.0",
+                "code": "2",
+                "display": "Formal - death notice received from Registrar of Deaths"
+              }
+            ]
+          }
+        },
+        {
+          "url": "systemEffectiveDate",
+          "valueDateTime": "2010-10-22T00:00:00+00:00"
+        }
+      ]
+    },
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSCommunication",
+      "extension": [
+        {
+          "url": "language",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-HumanLanguage",
+                "version": "1.0.0",
+                "code": "fr",
+                "display": "French"
+              }
+            ]
+          }
+        },
+        {
+          "url": "interpreterRequired",
+          "valueBoolean": true
+        }
+      ]
+    },
+    {
+      "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-ContactPreference",
+      "extension": [
+        {
+          "url": "PreferredWrittenCommunicationFormat",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-PreferredWrittenCommunicationFormat",
+                "code": "12",
+                "display": "Braille"
+              }
+            ]
+          }
+        },
+        {
+          "url": "PreferredContactMethod",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-PreferredContactMethod",
+                "code": "1",
+                "display": "Letter"
+              }
+            ]
+          }
+        },
+        {
+          "url": "PreferredContactTimes",
+          "valueString": "Not after 7pm"
+        }
+      ]
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+      "valueAddress": {
+        "city": "Manchester",
+        "district": "Greater Manchester",
+        "country": "GBR"
+      }
+    },
+    {
+      "url": "https://fhir.nhs.uk/StructureDefinition/Extension-PDS-RemovalFromRegistration",
+      "extension": [
+        {
+          "url": "removalFromRegistrationCode",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.nhs.uk/CodeSystem/PDS-RemovalReasonExitCode",
+                "code": "SCT",
+                "display": "Transferred to Scotland"
+              }
+            ]
+          }
+        },
+        {
+          "url": "effectiveTime",
+          "valuePeriod": {
+            "start": "2020-01-01T00:00:00+00:00",
+            "end": "2021-12-31T00:00:00+00:00"
+          }
+        }
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "id": "789",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      },
+      "system": "phone",
+      "value": "01632960587",
+      "use": "home"
+    },
+    {
+      "id": "790",
+      "period": {
+        "start": "2019-01-01",
+        "end": "2022-12-31"
+      },
+      "system": "email",
+      "value": "jane.smith@example.com",
+      "use": "home"
+    },
+    {
+      "id": "OC789",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      },
+      "system": "other",
+      "value": "01632960587",
+      "use": "home",
+      "extension": [
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-OtherContactSystem",
+          "valueCoding": {
+            "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-OtherContactSystem",
+            "code": "textphone",
+            "display": "Minicom (Textphone)"
+          }
+        }
+      ]
+    }
+  ],
+  "contact": [
+    {
+      "id": "C123",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      },
+      "relationship": [
+        {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+              "code": "C",
+              "display": "Emergency Contact"
+            }
+          ]
+        }
+      ],
+      "telecom": [
+        {
+          "system": "phone",
+          "value": "01632960587"
+        }
+      ]
+    }
+  ],
+  "address": [
+    {
+      "id": "456",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      },
+      "use": "home",
+      "line": [
+        "1 Trevelyan Square",
+        "Boar Lane",
+        "City Centre",
+        "Leeds",
+        "West Yorkshire"
+      ],
+      "postalCode": "LS1 6AE",
+      "extension": [
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey",
+          "extension": [
+            {
+              "url": "type",
+              "valueCoding": {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType",
+                "code": "PAF"
+              }
+            },
+            {
+              "url": "value",
+              "valueString": "12345678"
+            }
+          ]
+        },
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey",
+          "extension": [
+            {
+              "url": "type",
+              "valueCoding": {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType",
+                "code": "UPRN"
+              }
+            },
+            {
+              "url": "value",
+              "valueString": "123456789012"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "T456",
+      "period": {
+        "start": "2020-01-01",
+        "end": "2021-12-31"
+      },
+      "use": "temp",
+      "text": "Student Accommodation",
+      "line": [
+        "1 Trevelyan Square",
+        "Boar Lane",
+        "City Centre",
+        "Leeds",
+        "West Yorkshire"
+      ],
+      "postalCode": "LS1 6AE",
+      "extension": [
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey",
+          "extension": [
+            {
+              "url": "type",
+              "valueCoding": {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType",
+                "code": "PAF"
+              }
+            },
+            {
+              "url": "value",
+              "valueString": "12345678"
+            }
+          ]
+        },
+        {
+          "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-AddressKey",
+          "extension": [
+            {
+              "url": "type",
+              "valueCoding": {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-AddressKeyType",
+                "code": "UPRN"
+              }
+            },
+            {
+              "url": "value",
+              "valueString": "123456789012"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is the simplest possible way of getting a patient from PDS. Wrapped up into a model so we can change the implementation later.

The model itself is also quite simple, whereas the FHIR model may potentially have multiple names (in case the patient has changed their name), etc. We need to better understand how Mavis uses this data before we expand our own model, so consider this a proof-of-concept.