### PR TITLE
Add heading and description slots to AppCardComponent

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -22,8 +22,4 @@
       background-color: $color_nhsuk-red;
     }
   }
-
-  &__content > *:last-child {
-    margin-bottom: 0;
-  }
 }

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -2,16 +2,20 @@ class AppCardComponent < ViewComponent::Base
   erb_template <<-ERB
     <div class="<%= card_classes %>">
       <div class="<%= content_classes %>">
-        <% if @heading.present? %>
+        <% if heading.present? %>
           <h2 class="<%= heading_classes %>">
             <% if @link_to.present? %>
               <%= link_to @link_to, class: "nhsuk-card__link" do %>
-                <%= @heading %>
+                <%= heading %>
               <% end %>
             <% else %>
-              <%= @heading %>
+              <%= heading %>
             <% end %>
           </h2>
+        <% end %>
+
+        <% if description.present? %>
+          <p class="nhsuk-card__description"><%= description %></p>
         <% end %>
 
         <%= content %>
@@ -19,17 +23,14 @@ class AppCardComponent < ViewComponent::Base
     </div>
   ERB
 
-  def initialize(heading: nil, feature: false, colour: nil, link_to: nil)
+  renders_one :heading
+  renders_one :description
+
+  def initialize(colour: nil, link_to: nil)
     super
 
-    @heading = heading
-    @feature = feature
     @link_to = link_to
     @colour = colour
-  end
-
-  def render?
-    content.present?
   end
 
   private
@@ -38,7 +39,7 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card",
       "app-card",
-      ("nhsuk-card--feature" if @feature),
+      ("nhsuk-card--feature" if @colour.present?),
       ("app-card--#{@colour}" if @colour.present?),
       ("nhsuk-card--clickable" if @link_to.present?)
     ].compact.join(" ")
@@ -48,7 +49,7 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card__content",
       "app-card__content",
-      ("nhsuk-card__content--feature" if @feature)
+      ("nhsuk-card__content--feature" if @colour.present?)
     ].compact.join(" ")
   end
 
@@ -56,7 +57,7 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card__heading",
       "nhsuk-heading-m",
-      ("nhsuk-card__heading--feature" if @feature)
+      ("nhsuk-card__heading--feature" if @colour.present?)
     ].compact.join(" ")
   end
 end

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -24,7 +24,6 @@ class AppCardComponent < ViewComponent::Base
     heading_size: "m",
     feature: false,
     colour: nil,
-    card_classes: nil,
     link_to: nil
   )
     super
@@ -32,9 +31,7 @@ class AppCardComponent < ViewComponent::Base
     @heading = heading
     @heading_size = heading_size
     @feature = feature
-    @card_classes = card_classes
     @link_to = link_to
-
     @colour = colour
   end
 
@@ -50,8 +47,7 @@ class AppCardComponent < ViewComponent::Base
       "app-card",
       ("nhsuk-card--feature" if @feature),
       ("app-card--#{@colour}" if @colour.present?),
-      ("nhsuk-card--clickable" if @link_to.present?),
-      @card_classes
+      ("nhsuk-card--clickable" if @link_to.present?)
     ].compact.join(" ")
   end
 

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -19,17 +19,10 @@ class AppCardComponent < ViewComponent::Base
     </div>
   ERB
 
-  def initialize(
-    heading: nil,
-    heading_size: "m",
-    feature: false,
-    colour: nil,
-    link_to: nil
-  )
+  def initialize(heading: nil, feature: false, colour: nil, link_to: nil)
     super
 
     @heading = heading
-    @heading_size = heading_size
     @feature = feature
     @link_to = link_to
     @colour = colour
@@ -62,8 +55,8 @@ class AppCardComponent < ViewComponent::Base
   def heading_classes
     [
       "nhsuk-card__heading",
-      ("nhsuk-card__heading--feature" if @feature),
-      ("nhsuk-heading-#{@heading_size}" if @heading_size)
+      "nhsuk-heading-m",
+      ("nhsuk-card__heading--feature" if @feature)
     ].compact.join(" ")
   end
 end

--- a/app/components/app_compare_consent_form_and_patient_component.html.erb
+++ b/app/components/app_compare_consent_form_and_patient_component.html.erb
@@ -1,4 +1,5 @@
-<%= render AppCardComponent.new(heading:) do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { heading } %>
   <%= govuk_table do |table| %>
     <%= table.with_head do |head| %>
       <%= head.with_row do |row| %>

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -9,7 +9,8 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def call
-    render AppCardComponent.new(heading:, feature: true, colour:) do
+    render AppCardComponent.new(colour:) do |c|
+      c.with_heading { heading }
       govuk_summary_list(classes: "app-summary-list--no-bottom-border", rows:)
     end
   end

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -10,12 +10,14 @@
      render AppSimpleStatusBannerComponent.new(patient_session:)
    end %>
 
-<%= render AppCardComponent.new(heading: "Child details") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Child details" } %>
   <%= render AppPatientDetailsComponent.new(patient:, session:) %>
 <% end %>
 
 <% if gillick_assessment_applicable? %>
-  <%= render AppCardComponent.new(heading: "Gillick assessment") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Gillick assessment" } %>
     <% if gillick_assessment_recorded? %>
       <%= govuk_summary_list(
             classes: %w[app-summary-list--no-bottom-border
@@ -48,20 +50,25 @@
   <% end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Consent") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Consent" } %>
   <%= render AppConsentComponent.new(patient_session:, section:, tab:) %>
 <% end %>
 
 <% if display_health_questions? %>
-  <%= render AppCardComponent.new(heading: "All answers to health questions") do
-        render AppHealthQuestionsComponent.new(
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "All answers to health questions" } %>
+    <%= render AppHealthQuestionsComponent.new(
           consents: @patient_session.consents,
-        )
-      end %>
+        ) %>
+  <% end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Triage notes") do %>
-  <%= render AppTriageNotesComponent.new(patient_session:) %>
+<% if @patient_session.triage.any? %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Triage notes" } %>
+    <%= render AppTriageNotesComponent.new(patient_session:) %>
+  <% end %>
 <% end %>
 
 <% if @patient_session.next_step == :triage %>

--- a/app/components/app_session_details_component.html.erb
+++ b/app/components/app_session_details_component.html.erb
@@ -1,4 +1,5 @@
-<%= render AppCardComponent.new(heading: "Session") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Session" } %>
   <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "School" }

--- a/app/components/app_simple_status_banner_component.html.erb
+++ b/app/components/app_simple_status_banner_component.html.erb
@@ -1,4 +1,5 @@
-<%= render AppCardComponent.new(heading:, feature: true, colour:) do %>
+<%= render AppCardComponent.new(colour:) do |c| %>
+  <% c.with_heading { heading } %>
   <p><%= I18n.t("patient_session_statuses.#{state}.banner_explanation",
                 default: "", full_name:, nurse:, who_refused:) %></p>
   <% if state.in? %w[delay_vaccination

--- a/app/views/consent_forms/review_match.html.erb
+++ b/app/views/consent_forms/review_match.html.erb
@@ -21,7 +21,8 @@
           patient: @patient_session.patient,
         ) %>
 
-    <%= render AppCardComponent.new(heading: "Consent response") do
+    <%= render AppCardComponent.new do |c|
+          c.with_heading { "Consent response" }
           render AppConsentSummaryComponent.new(
             name: @consent_form.parent_name,
             relationship: @consent_form.who_responded,

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -17,7 +17,8 @@
   <%= render AppMatchingCriteriaComponent.new(consent_form: @consent_form) %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Children in this cohort") do
+<%= render AppCardComponent.new do |c|
+      c.with_heading { "Children in this cohort" }
       if @patient_sessions.count > 0
         render AppPatientTableComponent.new(
           patient_sessions: @patient_sessions,

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -11,7 +11,7 @@
 
 <%= h1 page_title %>
 
-<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m") do
+<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses") do
       govuk_table(classes: "app-table--dense  nhsuk-u-margin-0") do |table|
         table.with_head do |head|
           head.with_row do |row|

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -11,7 +11,8 @@
 
 <%= h1 page_title %>
 
-<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses") do
+<%= render AppCardComponent.new do |c|
+      c.with_heading { "#{@unmatched_consent_responses.count} unmatched responses" }
       govuk_table(classes: "app-table--dense  nhsuk-u-margin-0") do |table|
         table.with_head do |head|
           head.with_row do |row|

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -11,7 +11,7 @@
 
 <%= h1 page_title %>
 
-<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m", card_classes: "app-card--empty-list") do
+<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m") do
       govuk_table(classes: "app-table--dense  nhsuk-u-margin-0") do |table|
         table.with_head do |head|
           head.with_row do |row|

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -7,7 +7,8 @@
 
 <%= h1 "Consent response from #{@consent.name}" %>
 
-<%= render AppCardComponent.new(heading: "Consent") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Consent" } %>
   <%= govuk_summary_list(
         classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
       ) do |summary_list|
@@ -42,7 +43,8 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Child") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Child" } %>
   <%= govuk_summary_list(
         classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
       ) do |summary_list|
@@ -79,7 +81,8 @@
 <% end %>
 
 <% if @consent.parent.present? %>
-  <%= render AppCardComponent.new(heading: "Parent or guardian") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Parent or guardian" } %>
     <%= govuk_summary_list(
           classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
         ) do |summary_list|
@@ -116,7 +119,8 @@
 <% end %>
 
 <% if @consent.response_given? %>
-  <%= render AppCardComponent.new(heading: "Answers to health questions") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Answers to health questions" } %>
     <%= render AppHealthQuestionsComponent.new(consents: [@consent]) %>
   <% end %>
 <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -2,23 +2,29 @@
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(heading: "Today’s sessions",
-                                    link_to: sessions_path) do %>
-      View all sessions taking place today.
+    <%= render AppCardComponent.new(link_to: sessions_path) do |c| %>
+      <% c.with_heading { "Today’s sessions" } %>
+      <% c.with_description do %>
+        View all sessions taking place today.
+      <% end %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(heading: "Campaigns",
-                                    link_to: campaigns_path) do %>
-      Create and manage vaccination campaigns.
+    <%= render AppCardComponent.new(link_to: campaigns_path) do |c| %>
+      <% c.with_heading { "Campaigns" } %>
+      <% c.with_description do %>
+        Create and manage vaccination campaigns.
+      <% end %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(heading: "Vaccines",
-                                    link_to: vaccines_path) do %>
-      Add or remove batches.
+    <%= render AppCardComponent.new(link_to: vaccines_path) do |c| %>
+      <% c.with_heading { "Vaccines" } %>
+      <% c.with_description do %>
+        Add or remove batches.
+      <% end %>
     <% end %>
   </li>
 </ul>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -2,30 +2,35 @@
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(heading: "Today’s sessions", link_to: sessions_path) do %>
+    <%= render AppCardComponent.new(heading: "Today’s sessions",
+                                    link_to: sessions_path) do %>
       View all sessions taking place today.
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(heading: "Campaigns", link_to: campaigns_path) do %>
+    <%= render AppCardComponent.new(heading: "Campaigns",
+                                    link_to: campaigns_path) do %>
       Create and manage vaccination campaigns.
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(heading: "Vaccines", link_to: vaccines_path) do %>
+    <%= render AppCardComponent.new(heading: "Vaccines",
+                                    link_to: vaccines_path) do %>
       Add or remove batches.
     <% end %>
   </li>
 </ul>
 
 <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
-  <%= link_to "Add a new session", sessions_path, class: "nhsuk-link--no-visited-state" %>
+  <%= link_to "Add a new session", sessions_path,
+              class: "nhsuk-link--no-visited-state" %>
 </h2>
 <p>Create a new session or clinic for a campaign.</p>
 
 <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
-  <%= link_to "Your account", users_account_path(current_user), class: "nhsuk-link--no-visited-state" %>
+  <%= link_to "Your account", users_account_path(current_user),
+              class: "nhsuk-link--no-visited-state" %>
 </h2>
 <p>Change your email address, name, or registration number.</p>

--- a/app/views/gillick_assessments/confirm.html.erb
+++ b/app/views/gillick_assessments/confirm.html.erb
@@ -14,7 +14,8 @@
   <%= page_title %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Gillick assessment details") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Gillick assessment details" } %>
   <%= govuk_summary_list classes: "app-summary-list--no-bottom-border nhsuk-u-margin-0" do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Are they Gillick competent?" }

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -14,7 +14,8 @@
   <%= page_title %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Consent") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Consent" } %>
   <%= govuk_summary_list(
         classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
       ) do |summary_list|
@@ -48,7 +49,8 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "Child") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Child" } %>
   <%= govuk_summary_list(
         classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
       ) do |summary_list|
@@ -85,7 +87,8 @@
 <% end %>
 
 <% if @consent.parent.present? %>
-  <%= render AppCardComponent.new(heading: "Parent or guardian") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Parent or guardian" } %>
     <%= govuk_summary_list(
           classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
         ) do |summary_list|
@@ -122,13 +125,15 @@
 <% end %>
 
 <% if @consent.response_given? %>
-  <%= render AppCardComponent.new(heading: "Health questions") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Health questions" } %>
     <%= render AppHealthQuestionsComponent.new(consents: [@consent]) %>
   <% end %>
 <% end %>
 
 <% if @consent.response_given? && @triage.status.present? %>
-  <%= render AppCardComponent.new(heading: "Triage") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Triage" } %>
     <%= govuk_summary_list classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0" do |summary_list|
           summary_list.with_row do |row|
             row.with_key { "Status" }

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -17,7 +17,8 @@
 
 <%= h1 "Check your answers and confirm" %>
 
-<%= render AppCardComponent.new(heading: t("consent_forms.confirm.consent_card_title.#{@consent_form.session.type.downcase}")) do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { t("consent_forms.confirm.consent_card_title.#{@consent_form.session.type.downcase}") } %>
   <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Do you agree?" }
@@ -60,7 +61,8 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "About your child") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "About your child" } %>
   <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Child’s name" }
@@ -138,7 +140,8 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading: "About you") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "About you" } %>
   <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Your name" }
@@ -199,7 +202,8 @@
 <% end %>
 
 <% if @consent_form.consent_given? %>
-  <%= render AppCardComponent.new(heading: "Health questions") do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { "Health questions" } %>
     <%= govuk_summary_list classes: "app-summary-list--full-width" do |summary_list|
           @consent_form.each_health_answer do |ha|
             summary_list.with_row do |row|

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -23,40 +23,40 @@
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(
-          heading: "Register attendance",
-          link_to: "#",
-        ) do %>
-      <%= pluralize_child(@patient_sessions.size) %> still to register
+    <%= render AppCardComponent.new(link_to: "#") do |c| %>
+      <% c.with_heading { "Register attendance" } %>
+      <% c.with_description do %>
+        <%= pluralize_child(@patient_sessions.size) %> still to register
+      <% end %>
     <% end %>
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(
-          heading: "Record vaccinations",
-          link_to: session_vaccinations_path(@session),
-        ) do %>
-      <%= pluralize_child(@counts[:vaccinate]) %> to vaccinate<br>
-      <%= pluralize_child(@counts[:vaccinated]) %> vaccinated<br>
-      <%= pluralize_child(@counts[:could_not_vaccinate]) %> could not be vaccinated
+    <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
+      <% c.with_heading { "Record vaccinations" } %>
+      <% c.with_description do %>
+        <%= pluralize_child(@counts[:vaccinate]) %> to vaccinate<br>
+        <%= pluralize_child(@counts[:vaccinated]) %> vaccinated<br>
+        <%= pluralize_child(@counts[:could_not_vaccinate]) %> could not be vaccinated
+      <% end %>
     <% end %>
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(
-          heading: "Check consent responses",
-          link_to: session_consents_path(@session),
-        ) do %>
-      <%= pluralize_child(@counts[:without_a_response]) %> without a response<br>
-      <%= pluralize_child(@counts[:with_consent_given]) %> with consent given<br>
-      <%= pluralize_child(@counts[:with_consent_refused]) %> with consent refused<br>
-      <%= pluralize_child(@counts[:with_conflicting_consent]) %> with conflicting consent
+    <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
+      <% c.with_heading { "Check consent responses" } %>
+      <% c.with_description do %>
+        <%= pluralize_child(@counts[:without_a_response]) %> without a response<br>
+        <%= pluralize_child(@counts[:with_consent_given]) %> with consent given<br>
+        <%= pluralize_child(@counts[:with_consent_refused]) %> with consent refused<br>
+        <%= pluralize_child(@counts[:with_conflicting_consent]) %> with conflicting consent
+      <% end %>
     <% end %>
   </li>
   <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(
-          heading: "Triage health questions",
-          link_to: session_triage_path(@session),
-        ) do %>
-      <%= pluralize_child(@counts[:needing_triage]) %> needing triage
+    <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
+      <% c.with_heading { "Triage health questions" } %>
+      <% c.with_description do %>
+        <%= pluralize_child(@counts[:needing_triage]) %> needing triage
+      <% end %>
     <% end %>
   </li>
 </ul>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -1,7 +1,8 @@
 <%= h1 "Vaccines", size: "xl" %>
 
 <% @vaccines.each do |vaccine| %>
-  <%= render AppCardComponent.new(heading: link_to(vaccine_heading(vaccine), vaccine_path(vaccine))) do %>
+  <%= render AppCardComponent.new do |c| %>
+    <% c.with_heading { link_to(vaccine_heading(vaccine), vaccine_path(vaccine)) } %>
     <p class="nhsuk-body-s nhsuk-secondary-text-color">
       <%= vaccine.supplier %>,
       GTIN: <span class="app-u-monospace"><%= vaccine.gtin %></span>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -7,7 +7,8 @@
 
 <%= h1 vaccine_heading(@vaccine), size: "l" %>
 
-<%= render AppCardComponent.new(heading: "Vaccine details") do %>
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Vaccine details" } %>
   <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">
       <dt class="nhsuk-summary-list__key">

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -1,67 +1,37 @@
 require "rails_helper"
 
 RSpec.describe AppCardComponent, type: :component do
-  let(:heading) { "A Heading" }
-  let(:body) { "A Body" }
-  let(:component) { described_class.new(heading:) }
-
   subject { page }
 
-  before { render_inline(component) { body } }
+  context "with a title" do
+    before { render_inline(described_class.new) { _1.with_heading { "Test" } } }
 
-  it { should have_css(".nhsuk-card") }
-  it { should have_css("h2.nhsuk-card__heading", text: heading) }
-  it { should have_css(".nhsuk-card__content", text: "A Body") }
-
-  context "no content is provided" do
-    let(:body) { nil }
-
-    it { should_not have_css(".nhsuk-card__content") }
+    it { should have_css("h2.nhsuk-heading-m", text: "Test") }
   end
 
-  context "feature card" do
-    let(:component) { described_class.new(heading:, feature: true) }
-
-    describe "card_classes" do
-      subject { component.send(:card_classes) }
-
-      it { should include "nhsuk-card--feature" }
+  context "with a description" do
+    before do
+      render_inline(described_class.new) { _1.with_description { "Test" } }
     end
 
-    describe "content_classes" do
-      subject { component.send(:content_classes) }
-
-      it { should include "nhsuk-card__content--feature" }
-    end
-
-    describe "heading_classes" do
-      subject { component.send(:heading_classes) }
-
-      it { should include "nhsuk-card__heading--feature" }
-    end
+    it { should have_css("p.nhsuk-card__description", text: "Test") }
   end
 
-  context "coloured card" do
-    let(:component) { described_class.new(heading:, colour: "purple") }
-
-    describe "card_classes" do
-      subject { component.send(:card_classes) }
-
-      it { should include "app-card--purple" }
+  context "with a link" do
+    before do
+      render_inline(described_class.new(link_to: "foo")) do
+        _1.with_heading { "Test" }
+      end
     end
+
+    it { should have_css(".nhsuk-card--clickable") }
+    it { should have_link(href: "foo") }
   end
 
-  context "link_to is specified" do
-    let(:component) do
-      described_class.new(heading:, link_to: "http://example.com")
-    end
+  context "with a colour" do
+    before { render_inline(described_class.new(colour: "red")) }
 
-    describe "card_classes" do
-      subject { component.send(:card_classes) }
-
-      it { should include "nhsuk-card--clickable" }
-    end
-
-    it { is_expected.to have_link(href: "http://example.com") }
+    it { should have_css(".nhsuk-card--feature") }
+    it { should have_css(".app-card--red") }
   end
 end

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -19,14 +19,6 @@ RSpec.describe AppCardComponent, type: :component do
     it { should_not have_css(".nhsuk-card__content") }
   end
 
-  context "classes on container" do
-    let(:component) do
-      described_class.new(heading:, card_classes: "app-card--empty")
-    end
-
-    it { should have_css(".nhsuk-card.app-card--empty") }
-  end
-
   context "larger heading" do
     let(:component) { described_class.new(heading:, heading_size: "xl") }
 

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -19,12 +19,6 @@ RSpec.describe AppCardComponent, type: :component do
     it { should_not have_css(".nhsuk-card__content") }
   end
 
-  context "larger heading" do
-    let(:component) { described_class.new(heading:, heading_size: "xl") }
-
-    it { should have_css("h2.nhsuk-heading-xl", text: heading) }
-  end
-
   context "feature card" do
     let(:component) { described_class.new(heading:, feature: true) }
 


### PR DESCRIPTION
Also remove the `feature` option and make it implicit on receiving `colour`.

Like https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1403 but done in ViewComponent instead.

Plus a few other commits.

### After (correctly aligned card bodies on dashboard)

![image](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/c95de409-957b-4fcf-befb-d965a862fb5b)
