### PR TITLE
Re-enable WebMock after each system test

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,8 @@ RSpec.configure do |config|
     driven_by(:cuprite_custom)
   end
 
+  config.after(:each, type: :system) { WebMock.enable! }
+
   config.include ActiveJob::TestHelper, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :system


### PR DESCRIPTION
## What's the issue

When pyjama coding 😬  on a train without internet, the build intermittently fails.

To reproduce:

```
% bundle exec rspec ./spec/features/patient_sorting_filtering_spec.rb:41 spec/models/pds/patient_spec.rb --seed 27063
Run options: include {:locations=>{"./spec/features/patient_sorting_filtering_spec.rb"=>[41]}}

Randomized with seed 27063
.F

Failures:

  1) PDS::Patient.find returns a patient with the correct attributes
     Failure/Error:
       Net::HTTP.get(
         URI(
           "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/#{nhs_number}"
         ),
         "X-Request-ID": SecureRandom.uuid
       )

     Socket::ResolutionError:
       Failed to open TCP connection to sandbox.api.service.nhs.uk:443 (getaddrinfo: nodename nor servname provided, or not known)
     # ./app/models/pds/patient.rb:10:in `find'
     # ./spec/models/pds/patient_spec.rb:22:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Socket::ResolutionError:
     #   getaddrinfo: nodename nor servname provided, or not known
     #   ./app/models/pds/patient.rb:10:in `find'

Finished in 1.95 seconds (files took 1.34 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/models/pds/patient_spec.rb:21 # PDS::Patient.find returns a patient with the correct attributes

Randomized with seed 27063
```

## Investigation

The issue happens when:

1. There is no network connectivity.
2. A system spec is run.
3. It is followed by a spec that uses WebMock

In `rails_helper.rb` WebMock is disabled before each system spec but never re-enabled again.

## The fix

Re-enable WebMock after each system spec.