### PR TITLE
Properly remove obselete ConsentFrom.parent_* fields

### DIFF
--- a/app/components/app_matching_criteria_component.rb
+++ b/app/components/app_matching_criteria_component.rb
@@ -1,10 +1,14 @@
 class AppMatchingCriteriaComponent < ViewComponent::Base
-  delegate :common_name, :date_of_birth, :age, :parent_name, to: :@consent_form
+  delegate :common_name, :date_of_birth, :age, to: :@consent_form
 
   def initialize(consent_form:)
     super
 
     @consent_form = consent_form
+  end
+
+  def parent_name
+    @consent_form.parent.name
   end
 
   def child_full_name

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -51,13 +51,7 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def parent_name
-    if @patient.is_a?(Patient)
-      @patient.parent.name
-    elsif @patient.is_a?(ConsentForm)
-      @patient.parent_name
-    else
-      raise ArgumentError, "Unknown patient type"
-    end
+    @patient.parent.name
   end
 
   def location_name

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -80,29 +80,19 @@ class ConsentForm < ApplicationRecord
            :address_postcode,
            :address_town,
            :common_name,
-           :contact_method_other,
            :first_name,
            :gp_name,
            :health_answers,
            :last_name,
-           :parent_email,
-           :parent_name,
-           :parent_phone,
-           :parent_relationship_other,
            :reason_notes
 
   validates :address_line_1,
             :address_line_2,
             :address_town,
             :common_name,
-            :contact_method_other,
             :first_name,
             :gp_name,
             :last_name,
-            :parent_email,
-            :parent_name,
-            :parent_phone,
-            :parent_relationship_other,
             length: {
               maximum: 300
             }

--- a/app/views/consent_forms/review_match.html.erb
+++ b/app/views/consent_forms/review_match.html.erb
@@ -10,7 +10,7 @@
   <div class="nhsuk-grid-column-two-thirds">
     <%= h1 page_title: do %>
       <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-        Consent response from <%= @consent_form.parent_name %>
+        Consent response from <%= @consent_form.parent.name %>
       </span>
       <%= page_title %>
     <% end %>
@@ -24,11 +24,11 @@
     <%= render AppCardComponent.new do |c|
           c.with_heading { "Consent response" }
           render AppConsentSummaryComponent.new(
-            name: @consent_form.parent_name,
+            name: @consent_form.parent.name,
             relationship: @consent_form.who_responded,
             contact: {
-              phone: @consent_form.parent_phone,
-              email: @consent_form.parent_email,
+              phone: @consent_form.parent.phone,
+              email: @consent_form.parent.email,
             },
             response: {
               text: @consent_form.summary_with_route,

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -8,7 +8,7 @@
 <% page_title = "Search for a child record" %>
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    Consent response from <%= @consent_form.parent_name %>
+    Consent response from <%= @consent_form.parent.name %>
   </span>
   <%= page_title %>
 <% end %>

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -28,7 +28,7 @@
             body.with_row do |row|
               row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
               row.with_cell(text: consent_form.full_name)
-              row.with_cell(text: consent_form.parent_name)
+              row.with_cell(text: consent_form.parent.name)
               row.with_cell(text: govuk_link_to("Find match", consent_form))
             end
           end

--- a/app/views/parent_interface/consent_forms/record.html.erb
+++ b/app/views/parent_interface/consent_forms/record.html.erb
@@ -8,4 +8,4 @@
   <%= render "confirmation_agreed" %>
 <% end %>
 
-<p>We’ve sent a confirmation to <%= @consent_form.parent_email %>.</p>
+<p>We’ve sent a confirmation to <%= @consent_form.parent.email %>.</p>


### PR DESCRIPTION
This PR cleans up some stuff left broken after #1407.

As the obsolete fields were still being mentioned in the `encrypts` invocation on ConsentForm, the model still had getters for them, which returned nulls.

After cleaning up those invocations, a bunch of templates, which were not properly ported across to the `Parent` model, broke.

Clearly our feature specs could be more thorough in asserting on the strings like the parent's name, otherwise this would have been picked up earlier.

