### PR TITLE
Rename sign in and sign out

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -31,9 +31,7 @@
           <%= link_to current_user.email, users_account_path(current_user), class: "nhsuk-header__navigation-link" %>
         </li>
         <li class="nhsuk-header__navigation-item">
-          <%= button_to destroy_user_session_path, class: "app-header__button-link", method: :delete do %>
-            Sign out
-          <% end %>
+          <%= button_to "Log out", destroy_user_session_path, class: "app-header__button-link", method: :delete %>
         </li>
       <% end %>
       <li class="nhsuk-mobile-menu-container">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "Sign in", size: "xl" %>
+<%= h1 "Log in", size: "xl" %>
 
 <%= form_for(resource, as: resource_name, url: user_session_path) do |f| %>
   <%= f.govuk_error_summary %>
@@ -14,9 +14,9 @@
 
   <%= render "users/shared/links" %>
 
-  <%= f.govuk_submit "Sign in" %>
+  <%= f.govuk_submit "Log in" %>
 <% end %>
 
 <% if Settings.cis2.present? %>
-  <%= govuk_button_to "Sign in with CIS2", user_cis2_omniauth_authorize_path, data: { turbo: false } %>
+  <%= govuk_button_to "Log in with CIS2", user_cis2_omniauth_authorize_path, data: { turbo: false } %>
 <% end %>

--- a/spec/features/user_authentication_spec.rb
+++ b/spec/features/user_authentication_spec.rb
@@ -29,13 +29,13 @@ describe "User authentication" do
   end
 
   def then_i_see_the_sign_in_form
-    expect(page).to have_content "Sign in"
+    expect(page).to have_content "Log in"
   end
 
   def when_i_sign_in
     fill_in "Email address", with: @user.email
     fill_in "Password", with: "rosebud123"
-    click_button "Sign in"
+    click_button "Log in"
   end
 
   def then_i_see_the_dashboard
@@ -44,7 +44,7 @@ describe "User authentication" do
   end
 
   def when_i_sign_out
-    click_button "Sign out"
+    click_button "Log out"
   end
 
   def then_i_see_the_start_page


### PR DESCRIPTION
In the designs these have been renamed to "Log in" and "Log out". I've decided internally to keep the naming "Sign X" as that matches our database column names and the naming convention that Devise uses.

Although I've changed the content on the log in page as well, this design is likely to change anyway as we integrate with CIS2.