### PR TITLE
Enable frozen string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,9 +10,16 @@ inherit_mode:
   merge:
     - Exclude
 
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+
 Lint/UnreachableLoop:
   Exclude:
     - spec/lib/health_answers_list_spec.rb
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always_true
 
 Style/NumericLiterals:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppActivityLogComponent < ViewComponent::Base
   def initialize(patient_session)
     super

--- a/app/components/app_backlink_component.rb
+++ b/app/components/app_backlink_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppBacklinkComponent < ViewComponent::Base
   def initialize(href:, name:, classes: nil, attributes: {})
     super

--- a/app/components/app_breadcrumb_component.rb
+++ b/app/components/app_breadcrumb_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppBreadcrumbComponent < ViewComponent::Base
   def initialize(items:, classes: nil, attributes: {})
     super

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppCardComponent < ViewComponent::Base
   erb_template <<-ERB
     <div class="<%= card_classes %>">

--- a/app/components/app_compare_consent_form_and_patient_component.rb
+++ b/app/components/app_compare_consent_form_and_patient_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
   attr_reader :heading, :consent_form, :patient
 

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppConsentComponent < ViewComponent::Base
   attr_reader :patient_session, :section, :tab
 

--- a/app/components/app_consent_status_component.rb
+++ b/app/components/app_consent_status_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppConsentStatusComponent < ViewComponent::Base
   def call
     if @patient_session.consent_given?

--- a/app/components/app_consent_summary_component.rb
+++ b/app/components/app_consent_summary_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppConsentSummaryComponent < ViewComponent::Base
   attr_reader :name, :relationship, :contact, :refusal_reason, :response
 

--- a/app/components/app_count_component.rb
+++ b/app/components/app_count_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppCountComponent < ViewComponent::Base
   erb_template <<-ERB
     <span class="app-count">

--- a/app/components/app_details_component.rb
+++ b/app/components/app_details_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppDetailsComponent < ViewComponent::Base
   erb_template <<-ERB
     <details class="nhsuk-details<%= expander_class %>"<%= open_attr %>>

--- a/app/components/app_dev_tools_component.rb
+++ b/app/components/app_dev_tools_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppDevToolsComponent < ViewComponent::Base
   erb_template <<-ERB
     <% unless Rails.env.production? %>

--- a/app/components/app_empty_list_component.rb
+++ b/app/components/app_empty_list_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppEmptyListComponent < ViewComponent::Base
   def initialize(text: "No results", title: nil)
     super

--- a/app/components/app_flash_message_component.rb
+++ b/app/components/app_flash_message_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppFlashMessageComponent < ViewComponent::Base
   attr_reader :body, :heading, :heading_link_text, :heading_link_href
 

--- a/app/components/app_health_questions_component.rb
+++ b/app/components/app_health_questions_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppHealthQuestionsComponent < ViewComponent::Base
   erb_template <<-ERB
     <dl class="nhsuk-summary-list app-summary-list--full-width nhsuk-u-margin-bottom-0">

--- a/app/components/app_matching_criteria_component.rb
+++ b/app/components/app_matching_criteria_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppMatchingCriteriaComponent < ViewComponent::Base
   delegate :common_name, :date_of_birth, :age, to: :@consent_form
 

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppOutcomeBannerComponent < ViewComponent::Base
   delegate :vaccination_record, :state, to: :@patient_session
 

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppPatientTableComponent < ViewComponent::Base
   attr_reader :params
 

--- a/app/components/app_secondary_navigation_component.rb
+++ b/app/components/app_secondary_navigation_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppSecondaryNavigationComponent < ViewComponent::Base
   renders_many :items, "Item"
 

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppSimpleStatusBannerComponent < ViewComponent::Base
   delegate :state, to: :@patient_session
 

--- a/app/components/app_tab_component.rb
+++ b/app/components/app_tab_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppTabComponent < GovukComponent::Base
   using HTMLAttributesUtils
 

--- a/app/components/app_timestamped_entry_component.rb
+++ b/app/components/app_timestamped_entry_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppTimestampedEntryComponent < ViewComponent::Base
   erb_template <<-ERB
     <p class="nhsuk-body">

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppTriageFormComponent < ViewComponent::Base
   def initialize(
     patient_session:,

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppTriageNotesComponent < ViewComponent::Base
   def call
     if triage_entries.size == 1

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppVaccinateFormComponent < ViewComponent::Base
   def initialize(patient_session:, section:, tab:, vaccination_record: nil)
     super

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   include Pundit::Authorization
 

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BatchesController < ApplicationController
   include TodaysBatchConcern
 

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CampaignsController < ApplicationController
   def index
     @campaigns = policy_scope(Campaign)

--- a/app/controllers/cohort_lists_controller.rb
+++ b/app/controllers/cohort_lists_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CohortListsController < ApplicationController
   layout "two_thirds"
 

--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ComponentPreviewsController < ApplicationController
   include ViewComponent::PreviewActions
   skip_before_action :authenticate_user!

--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConsentFormMailerConcern
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PatientSortingConcern
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PatientTabsConcern
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/todays_batch_concern.rb
+++ b/app/controllers/concerns/todays_batch_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TodaysBatchConcern
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TriageMailerConcern
   extend ActiveSupport::Concern
 

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VaccinationMailerConcern
   extend ActiveSupport::Concern
 

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentFormsController < ApplicationController
   before_action :set_consent_form, except: %i[unmatched_responses]
   skip_after_action :verify_policy_scoped

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentsController < ApplicationController
   include PatientTabsConcern
   include PatientSortingConcern

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContentController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped

--- a/app/controllers/csrf_controller.rb
+++ b/app/controllers/csrf_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CSRFController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DashboardController < ApplicationController
   skip_after_action :verify_policy_scoped, only: :index
 

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DevController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped

--- a/app/controllers/edit_sessions_controller.rb
+++ b/app/controllers/edit_sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class EditSessionsController < ApplicationController
   include Wicked::Wizard
   include Wicked::Wizard::Translated # For custom URLs, see en.yml wicked

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
   skip_before_action :authenticate_user!

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class GillickAssessmentsController < ApplicationController
   include Wicked::Wizard
 

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ManageConsentsController < ApplicationController
   include Wicked::Wizard
   include Wicked::Wizard::Translated # For custom URLs, see en.yml wicked

--- a/app/controllers/offline_passwords_controller.rb
+++ b/app/controllers/offline_passwords_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OfflinePasswordsController < ApplicationController
   def new
     @password = OfflinePassword.new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped, only: :start

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParentInterface
   class ConsentForms::BaseController < ApplicationController
     skip_before_action :authenticate_user!

--- a/app/controllers/parent_interface/consent_forms/edit_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/edit_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParentInterface
   class ConsentForms::EditController < ConsentForms::BaseController
     include Wicked::Wizard

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ParentInterface
   class ConsentFormsController < ConsentForms::BaseController
     include ConsentFormMailerConcern

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PatientsController < ApplicationController
   before_action :set_patient_session
   before_action :set_session

--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PilotController < ApplicationController
   skip_after_action :verify_policy_scoped
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReportsController < ApplicationController
   skip_after_action :verify_policy_scoped, only: %i[index]
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionsController < ApplicationController
   before_action :set_session, except: %i[index create]
   before_action :set_school, only: %i[show]

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TriageController < ApplicationController
   include TriageMailerConcern
   include PatientTabsConcern

--- a/app/controllers/users/accounts_controller.rb
+++ b/app/controllers/users/accounts_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Users
   class AccountsController < ApplicationController
     before_action :set_user

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Users
   class PasswordsController < Devise::PasswordsController
     skip_after_action :verify_policy_scoped

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Users
   class UnlocksController < Devise::UnlocksController
     skip_after_action :verify_policy_scoped

--- a/app/controllers/vaccinations/batches_controller.rb
+++ b/app/controllers/vaccinations/batches_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Vaccinations::BatchesController < ApplicationController
   include TodaysBatchConcern
 

--- a/app/controllers/vaccinations/delivery_site_controller.rb
+++ b/app/controllers/vaccinations/delivery_site_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Vaccinations::DeliverySiteController < ApplicationController
   before_action :set_session, only: %i[edit update]
   before_action :set_patient, only: %i[edit update]

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VaccinationsController < ApplicationController
   include TodaysBatchConcern
   include VaccinationMailerConcern

--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VaccinesController < ApplicationController
   include TodaysBatchConcern
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   def h1(text = nil, size: "l", **options, &block)
     title_text = options.delete(:page_title) { text }

--- a/app/helpers/consent_forms_helper.rb
+++ b/app/helpers/consent_forms_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ConsentFormsHelper
   def format_address(consent_form)
     safe_join(

--- a/app/helpers/manage_consents_helper.rb
+++ b/app/helpers/manage_consents_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ManageConsentsHelper
   def form_path_for(consent)
     consent.recorded? ? clone_session_patient_manage_consent_path : wizard_path

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SessionsHelper
   def pluralize_child(count)
     count.zero? ? "No children" : pluralize(count, "child")

--- a/app/helpers/triage_helper.rb
+++ b/app/helpers/triage_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TriageHelper
   def triage_status_colour(triage_status:)
     {

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VaccinationsHelper
   def vaccination_date(datetime)
     date = datetime.to_date

--- a/app/helpers/vaccines_helper.rb
+++ b/app/helpers/vaccines_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module VaccinesHelper
   def vaccine_heading(vaccine)
     sprintf("%s (%s)", vaccine.brand, t(vaccine.type, scope: "vaccines"))

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/app/jobs/consent_form_matching_job.rb
+++ b/app/jobs/consent_form_matching_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentFormMatchingJob < ApplicationJob
   queue_as :default
 

--- a/app/jobs/consent_reminders_job.rb
+++ b/app/jobs/consent_reminders_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This job triggers a job to send a batch of consent reminders for each sessions
 # that needs them sent today.
 

--- a/app/jobs/consent_reminders_session_batch_job.rb
+++ b/app/jobs/consent_reminders_session_batch_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This job sends consent reminders for a session.
 #
 # Each patient that hasn't been sent a consent reminder yet will be sent one.

--- a/app/jobs/consent_requests_job.rb
+++ b/app/jobs/consent_requests_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This job triggers a job to send a batch of consent requests for each sessions
 # that needs them sent today.
 

--- a/app/jobs/consent_requests_session_batch_job.rb
+++ b/app/jobs/consent_requests_session_batch_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This job sends consent requests for a session.
 #
 # Each patient that hasn't been sent a consent request yet will be sent one.

--- a/app/jobs/session_reminders_batch_job.rb
+++ b/app/jobs/session_reminders_batch_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionRemindersBatchJob < ApplicationJob
   queue_as :default
 

--- a/app/jobs/session_reminders_job.rb
+++ b/app/jobs/session_reminders_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This job triggers a job to send a batch of consent reminders for each sessions
 # that needs them sent today.
 

--- a/app/lib/date_params_validator.rb
+++ b/app/lib/date_params_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DateParamsValidator
   attr_reader :field_name, :object, :params
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < Mail::Notify::Mailer
   private
 

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentFormMailer < ApplicationMailer
   def confirmation(consent_form: nil, consent: nil, session: nil)
     template_mail(

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentRequestMailer < ApplicationMailer
   include Rails.application.routes.url_helpers
 

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeviseMailer < Devise::Mailer
   def reset_password_instructions(record, token, _opts = {})
     template_mail(

--- a/app/mailers/session_mailer.rb
+++ b/app/mailers/session_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionMailer < ApplicationMailer
   def session_reminder(session:, patient:)
     template_mail(

--- a/app/mailers/triage_mailer.rb
+++ b/app/mailers/triage_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TriageMailer < ApplicationMailer
   def vaccination_will_happen(patient_session, consent)
     @patient_session = patient_session

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VaccinationMailer < ApplicationMailer
   def hpv_vaccination_has_taken_place(vaccination_record:)
     template_mail(

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: batches

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: campaigns

--- a/app/models/cohort_list.rb
+++ b/app/models/cohort_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "csv"
 
 class CohortList

--- a/app/models/cohort_list_row.rb
+++ b/app/models/cohort_list_row.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CohortListRow
   include ActiveModel::Model
 

--- a/app/models/concerns/age_concern.rb
+++ b/app/models/concerns/age_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AgeConcern
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/human_enum_name_concern.rb
+++ b/app/models/concerns/human_enum_name_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HumanEnumNameConcern
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PatientSessionStateConcern
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/wizard_form_concern.rb
+++ b/app/models/concerns/wizard_form_concern.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module WizardFormConcern
   extend ActiveSupport::Concern
 

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: consents

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: consent_forms

--- a/app/models/consolidated_health_answers.rb
+++ b/app/models/consolidated_health_answers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsolidatedHealthAnswers
   def initialize
     @answers = {}

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: gillick_assessments

--- a/app/models/health_answer.rb
+++ b/app/models/health_answer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HealthAnswer
   include ActiveModel::Model
 

--- a/app/models/health_question.rb
+++ b/app/models/health_question.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: health_questions

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: locations

--- a/app/models/nivs_report.rb
+++ b/app/models/nivs_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "csv"
 
 class NivsReport

--- a/app/models/nivs_report_row.rb
+++ b/app/models/nivs_report_row.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NivsReportRow
   SITE_MAPPING = {
     "left_arm_upper_position" => "Left Upper Arm",

--- a/app/models/offline_password.rb
+++ b/app/models/offline_password.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: offline_passwords

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: parents

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: patients

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: patient_sessions

--- a/app/models/pds/patient.rb
+++ b/app/models/pds/patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PDS::Patient
   include ActiveModel::Model
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: sessions

--- a/app/models/session_stats.rb
+++ b/app/models/session_stats.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionStats
   def initialize(patient_sessions:, session:)
     @patient_sessions = patient_sessions

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: teams

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: triage

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: users

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: vaccination_records

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: vaccines

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class BatchPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/campaign_policy.rb
+++ b/app/policies/campaign_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CampaignPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/consent_form_policy.rb
+++ b/app/policies/consent_form_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentFormPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/consent_policy.rb
+++ b/app/policies/consent_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LocationPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PatientPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/patient_session_policy.rb
+++ b/app/policies/patient_session_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PatientSessionPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VaccinationRecordPolicy
   class Scope
     def initialize(user, scope)

--- a/app/policies/vaccine_policy.rb
+++ b/app/policies/vaccine_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class VaccinePolicy
   class Scope
     def initialize(user, scope)

--- a/app/validators/notify_safe_email_validator.rb
+++ b/app/validators/notify_safe_email_validator.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class NotifySafeEmailValidator < ActiveModel::EachValidator
-  VALID_LOCAL_CHARS = 'a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-'.freeze
+  VALID_LOCAL_CHARS = 'a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-'
   EMAIL_REGEX_PATTERN = /^[#{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+)$/
   HOSTNAME_PART = /^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$/i
   TLD_PART = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/i

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PostcodeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     ukpc = UKPostcode.parse(value.to_s)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative "application"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/audited.rb
+++ b/config/initializers/audited.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # See https://github.com/collectiveidea/audited/pull/694
 Audited.filter_encrypted_attributes = false
 

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Config.setup do |config|
   # Name of the constant exposing loaded settings
   config.const_name = "Settings"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy.

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
 Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y" # 5 Jan 2023

--- a/config/initializers/email_templates.rb
+++ b/config/initializers/email_templates.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 EMAILS = {
   hpv_session_consent_reminder: "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
   hpv_session_consent_request: "6aa04f0d-94c2-4a6b-af97-a7369a12f681",

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Rails.env.test?
   require "flipper/adapters/pstore"
   require "flipper"

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 GoodJob::Engine
   .middleware
   .use(Rack::Auth::Basic) do |username, password|

--- a/config/initializers/govuk_components.rb
+++ b/config/initializers/govuk_components.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 Govuk::Components.configure { |conf| conf.brand = "nhsuk" }

--- a/config/initializers/govuk_formbuilder.rb
+++ b/config/initializers/govuk_formbuilder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 GOVUKDesignSystemFormBuilder.configure do |config|
   # for more info see:
   #

--- a/config/initializers/govuk_markdown.rb
+++ b/config/initializers/govuk_markdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MarkdownTemplate
   def self.call(template, source)
     erb_handler = ActionView::Template.registered_template_handler(:erb)

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/log_public_assets.rb
+++ b/config/initializers/log_public_assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 return unless Rails.env.development?
 
 require Rails.root.join("lib/core_extensions/action_dispatch/file_handler.rb")

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 OkComputer.mount_at = "health"

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide HTTP permissions policy. For further

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Phonelib.default_country = "GB"
 
 if Settings.allow_dev_phone_numbers

--- a/config/initializers/precompile.rb
+++ b/config/initializers/precompile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 require "zlib"
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/parameter_filter"
 
 Sentry.init do |config|

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 Rails.application.config.session_store :cookie_store,
                                        secure: Rails.env.production?,
                                        expire_after: 2.hours

--- a/config/initializers/silencer.rb
+++ b/config/initializers/silencer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "silencer/rails/logger"
 
 Rails.application.configure do

--- a/config/initializers/tab_paths.rb
+++ b/config/initializers/tab_paths.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 TAB_PATHS = {
   consents: {

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
@@ -20,10 +22,10 @@ else
 end
 
 # Specifies the `environment` that Puma will run in.
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   devise_for :users,
              module: :users,

--- a/db/migrate/20221220145053_create_students.rb
+++ b/db/migrate/20221220145053_create_students.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateStudents < ActiveRecord::Migration[7.0]
   def change
     create_table :students do |t|

--- a/db/migrate/20230104174917_rename_students_to_children.rb
+++ b/db/migrate/20230104174917_rename_students_to_children.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameStudentsToChildren < ActiveRecord::Migration[7.0]
   def change
     rename_table :students, :children

--- a/db/migrate/20230114102057_create_schools.rb
+++ b/db/migrate/20230114102057_create_schools.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateSchools < ActiveRecord::Migration[7.0]
   def change
     create_table :schools do |t|

--- a/db/migrate/20230114102344_create_campaigns.rb
+++ b/db/migrate/20230114102344_create_campaigns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCampaigns < ActiveRecord::Migration[7.0]
   def change
     create_table :campaigns do |t|

--- a/db/migrate/20230115124728_create_campaign_children_join_table.rb
+++ b/db/migrate/20230115124728_create_campaign_children_join_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCampaignChildrenJoinTable < ActiveRecord::Migration[7.0]
   def change
     create_join_table :campaigns, :children do |t|

--- a/db/migrate/20230116181339_remove_title_from_campaigns.rb
+++ b/db/migrate/20230116181339_remove_title_from_campaigns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveTitleFromCampaigns < ActiveRecord::Migration[7.0]
   def change
     remove_column :campaigns, :title, :text

--- a/db/migrate/20230117000745_change_nhs_number_to_integer.rb
+++ b/db/migrate/20230117000745_change_nhs_number_to_integer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeNhsNumberToInteger < ActiveRecord::Migration[7.0]
   def up
     change_column :children, :nhs_number, :bigint

--- a/db/migrate/20230119214957_change_schools_urn_to_bigint_and_indexed.rb
+++ b/db/migrate/20230119214957_change_schools_urn_to_bigint_and_indexed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeSchoolsUrnToBigintAndIndexed < ActiveRecord::Migration[7.0]
   def up
     change_column :schools, :urn, :integer

--- a/db/migrate/20230119215218_add_index_to_children_nhs_number.rb
+++ b/db/migrate/20230119215218_add_index_to_children_nhs_number.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIndexToChildrenNhsNumber < ActiveRecord::Migration[7.0]
   def change
     add_index :children, :nhs_number, unique: true

--- a/db/migrate/20230503080550_create_offline_passwords.rb
+++ b/db/migrate/20230503080550_create_offline_passwords.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateOfflinePasswords < ActiveRecord::Migration[7.0]
   def change
     create_table :offline_passwords do |t|

--- a/db/migrate/20230605104145_refactor_campaigns_and_sessions.rb
+++ b/db/migrate/20230605104145_refactor_campaigns_and_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RefactorCampaignsAndSessions < ActiveRecord::Migration[7.0]
   def up
     rename_table :schools, :locations

--- a/db/migrate/20230607150942_rename_children_to_patients.rb
+++ b/db/migrate/20230607150942_rename_children_to_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameChildrenToPatients < ActiveRecord::Migration[7.0]
   def change
     change_table :children do |t|

--- a/db/migrate/20230607163717_create_triage.rb
+++ b/db/migrate/20230607163717_create_triage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTriage < ActiveRecord::Migration[7.0]
   def change
     create_table :triage do |t|

--- a/db/migrate/20230609153358_rename_table_patients_sessions_to_patient_sessions.rb
+++ b/db/migrate/20230609153358_rename_table_patients_sessions_to_patient_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameTablePatientsSessionsToPatientSessions < ActiveRecord::Migration[
   7.0
 ]

--- a/db/migrate/20230609155343_add_id_to_patient_sessions.rb
+++ b/db/migrate/20230609155343_add_id_to_patient_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIdToPatientSessions < ActiveRecord::Migration[7.0]
   def change
     add_column :patient_sessions, :id, :primary_key

--- a/db/migrate/20230609155513_create_vaccination_records.rb
+++ b/db/migrate/20230609155513_create_vaccination_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateVaccinationRecords < ActiveRecord::Migration[7.0]
   def change
     create_table :vaccination_records do |t|

--- a/db/migrate/20230616103904_create_consent_responses.rb
+++ b/db/migrate/20230616103904_create_consent_responses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateConsentResponses < ActiveRecord::Migration[7.0]
   def change
     create_table :consent_responses do |t|

--- a/db/migrate/20230628110504_create_vaccines.rb
+++ b/db/migrate/20230628110504_create_vaccines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateVaccines < ActiveRecord::Migration[7.0]
   def change
     create_table :vaccines do |t|

--- a/db/migrate/20230628110744_add_vaccine_id_to_campaign.rb
+++ b/db/migrate/20230628110744_add_vaccine_id_to_campaign.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddVaccineIdToCampaign < ActiveRecord::Migration[7.0]
   def up
     add_reference :campaigns, :vaccine, foreign_key: true

--- a/db/migrate/20230628114443_create_health_questions.rb
+++ b/db/migrate/20230628114443_create_health_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateHealthQuestions < ActiveRecord::Migration[7.0]
   def change
     create_table :health_questions do |t|

--- a/db/migrate/20230628144627_add_health_questions_to_consent_response.rb
+++ b/db/migrate/20230628144627_add_health_questions_to_consent_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddHealthQuestionsToConsentResponse < ActiveRecord::Migration[7.0]
   def change
     add_column :consent_responses, :health_questions, :jsonb

--- a/db/migrate/20230629110001_add_site_to_vaccination_record.rb
+++ b/db/migrate/20230629110001_add_site_to_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSiteToVaccinationRecord < ActiveRecord::Migration[7.0]
   def change
     add_column :vaccination_records, :site, :integer

--- a/db/migrate/20230629113823_add_administered_to_vaccination_record.rb
+++ b/db/migrate/20230629113823_add_administered_to_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAdministeredToVaccinationRecord < ActiveRecord::Migration[7.0]
   def change
     add_column :vaccination_records, :administered, :boolean

--- a/db/migrate/20230629115635_rename_administered_at_to_recorded_at_in_vaccination_record.rb
+++ b/db/migrate/20230629115635_rename_administered_at_to_recorded_at_in_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameAdministeredAtToRecordedAtInVaccinationRecord < ActiveRecord::Migration[
   7.0
 ]

--- a/db/migrate/20230630110334_remove_gp_field_from_patient.rb
+++ b/db/migrate/20230630110334_remove_gp_field_from_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveGpFieldFromPatient < ActiveRecord::Migration[7.0]
   def change
     remove_column :patients, :gp, :string

--- a/db/migrate/20230702121826_change_date_to_date_time_in_vaccination_record.rb
+++ b/db/migrate/20230702121826_change_date_to_date_time_in_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeDateToDateTimeInVaccinationRecord < ActiveRecord::Migration[7.0]
   def up
     change_column :vaccination_records, :recorded_at, :datetime

--- a/db/migrate/20230703141219_add_reason_to_vaccination_record.rb
+++ b/db/migrate/20230703141219_add_reason_to_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReasonToVaccinationRecord < ActiveRecord::Migration[7.0]
   def change
     add_column :vaccination_records, :reason, :integer

--- a/db/migrate/20230706141503_add_state_to_patient_sessions.rb
+++ b/db/migrate/20230706141503_add_state_to_patient_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStateToPatientSessions < ActiveRecord::Migration[7.0]
   def change
     add_column :patient_sessions, :state, :string

--- a/db/migrate/20230719135042_add_recorded_at_to_consent_response.rb
+++ b/db/migrate/20230719135042_add_recorded_at_to_consent_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRecordedAtToConsentResponse < ActiveRecord::Migration[7.0]
   def change
     add_column :consent_responses, :recorded_at, :datetime

--- a/db/migrate/20230721113157_update_vaccines.rb
+++ b/db/migrate/20230721113157_update_vaccines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateVaccines < ActiveRecord::Migration[7.0]
   def change
     change_table :vaccines, bulk: true do |t|

--- a/db/migrate/20230721120158_create_batches.rb
+++ b/db/migrate/20230721120158_create_batches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateBatches < ActiveRecord::Migration[7.0]
   def change
     create_table :batches do |t|

--- a/db/migrate/20230721120653_create_campaign_vaccines_join_table.rb
+++ b/db/migrate/20230721120653_create_campaign_vaccines_join_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCampaignVaccinesJoinTable < ActiveRecord::Migration[7.0]
   def up
     create_join_table :campaigns, :vaccines do |t|

--- a/db/migrate/20230721225536_add_batch_to_vaccination_record.rb
+++ b/db/migrate/20230721225536_add_batch_to_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddBatchToVaccinationRecord < ActiveRecord::Migration[7.0]
   def change
     add_reference :vaccination_records, :batch, foreign_key: true

--- a/db/migrate/20230724141314_add_parent_info_to_patient.rb
+++ b/db/migrate/20230724141314_add_parent_info_to_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddParentInfoToPatient < ActiveRecord::Migration[7.0]
   def change
     change_table :patients, bulk: true do |t|

--- a/db/migrate/20230725135855_add_gillick_competence_details_to_consent_response.rb
+++ b/db/migrate/20230725135855_add_gillick_competence_details_to_consent_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGillickCompetenceDetailsToConsentResponse < ActiveRecord::Migration[
   7.0
 ]

--- a/db/migrate/20230726074804_add_gillick_fields_to_patient_session.rb
+++ b/db/migrate/20230726074804_add_gillick_fields_to_patient_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGillickFieldsToPatientSession < ActiveRecord::Migration[7.0]
   def change
     change_table :patient_sessions, bulk: true do |t|

--- a/db/migrate/20230726085134_remove_gillick_competence_details_from_consent_response.rb
+++ b/db/migrate/20230726085134_remove_gillick_competence_details_from_consent_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveGillickCompetenceDetailsFromConsentResponse < ActiveRecord::Migration[
   7.0
 ]

--- a/db/migrate/20230726190539_rename_vaccination_records_site_to_delivery_site.rb
+++ b/db/migrate/20230726190539_rename_vaccination_records_site_to_delivery_site.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameVaccinationRecordsSiteToDeliverySite < ActiveRecord::Migration[7.0]
   def change
     rename_column :vaccination_records, :site, :delivery_site

--- a/db/migrate/20230726190647_add_delivery_method_to_vaccination_records.rb
+++ b/db/migrate/20230726190647_add_delivery_method_to_vaccination_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDeliveryMethodToVaccinationRecords < ActiveRecord::Migration[7.0]
   def change
     change_table :vaccination_records, bulk: true do |t|

--- a/db/migrate/20230731124441_add_patient_session_id_to_triage.rb
+++ b/db/migrate/20230731124441_add_patient_session_id_to_triage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPatientSessionIdToTriage < ActiveRecord::Migration[7.0]
   def change
     add_reference :triage, :patient_session, foreign_key: true

--- a/db/migrate/20230731124921_move_triage_to_patient_session.rb
+++ b/db/migrate/20230731124921_move_triage_to_patient_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MoveTriageToPatientSession < ActiveRecord::Migration[7.0]
   def up
     Triage.all.find_each do |triage|

--- a/db/migrate/20230731125846_remove_patient_campaign_from_triage.rb
+++ b/db/migrate/20230731125846_remove_patient_campaign_from_triage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemovePatientCampaignFromTriage < ActiveRecord::Migration[7.0]
   def change
     remove_reference :triage, :campaign

--- a/db/migrate/20230811072923_rename_consent_response_to_consent.rb
+++ b/db/migrate/20230811072923_rename_consent_response_to_consent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameConsentResponseToConsent < ActiveRecord::Migration[7.0]
   def change
     rename_table :consent_responses, :consents

--- a/db/migrate/20230811114758_rename_consent_consent_to_response.rb
+++ b/db/migrate/20230811114758_rename_consent_consent_to_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameConsentConsentToResponse < ActiveRecord::Migration[7.0]
   def change
     rename_column :consents, :consent, :response

--- a/db/migrate/20230823162539_create_consent_forms.rb
+++ b/db/migrate/20230823162539_create_consent_forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateConsentForms < ActiveRecord::Migration[7.0]
   def change
     create_table :consent_forms do |t|

--- a/db/migrate/20230824123840_add_name_to_consent_form.rb
+++ b/db/migrate/20230824123840_add_name_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNameToConsentForm < ActiveRecord::Migration[7.0]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20230825085229_add_date_of_birth_to_consent_form.rb
+++ b/db/migrate/20230825085229_add_date_of_birth_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDateOfBirthToConsentForm < ActiveRecord::Migration[7.0]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20230905115257_add_about_parent_fields_to_consent_form.rb
+++ b/db/migrate/20230905115257_add_about_parent_fields_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAboutParentFieldsToConsentForm < ActiveRecord::Migration[7.0]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20230906123147_add_response_to_consent_form.rb
+++ b/db/migrate/20230906123147_add_response_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddResponseToConsentForm < ActiveRecord::Migration[7.0]
   def change
     add_column :consent_forms, :response, :integer

--- a/db/migrate/20230908152505_add_reason_and_notes_to_consent_form.rb
+++ b/db/migrate/20230908152505_add_reason_and_notes_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReasonAndNotesToConsentForm < ActiveRecord::Migration[7.0]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20230911143431_add_contact_injection_to_consent_form.rb
+++ b/db/migrate/20230911143431_add_contact_injection_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddContactInjectionToConsentForm < ActiveRecord::Migration[7.0]
   def change
     add_column :consent_forms, :contact_injection, :boolean

--- a/db/migrate/20230912171418_add_full_name_to_users.rb
+++ b/db/migrate/20230912171418_add_full_name_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFullNameToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :full_name, :string

--- a/db/migrate/20230913110912_add_gp_fields_to_consent_form.rb
+++ b/db/migrate/20230913110912_add_gp_fields_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGpFieldsToConsentForm < ActiveRecord::Migration[7.0]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20230913135836_add_address_fields_to_consent_form.rb
+++ b/db/migrate/20230913135836_add_address_fields_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAddressFieldsToConsentForm < ActiveRecord::Migration[7.0]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20230913152019_add_questions_to_consent_form.rb
+++ b/db/migrate/20230913152019_add_questions_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddQuestionsToConsentForm < ActiveRecord::Migration[7.0]
   def change
     add_column :consent_forms, :health_answers, :jsonb, null: false, default: []

--- a/db/migrate/20230919000318_create_teams.rb
+++ b/db/migrate/20230919000318_create_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTeams < ActiveRecord::Migration[7.0]
   def change
     create_table :teams do |t|

--- a/db/migrate/20230919000737_add_team_id_to_campaigns.rb
+++ b/db/migrate/20230919000737_add_team_id_to_campaigns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTeamIdToCampaigns < ActiveRecord::Migration[7.0]
   def change
     add_column :campaigns, :team_id, :integer, null: true

--- a/db/migrate/20230919111724_create_teams_users_join_table.rb
+++ b/db/migrate/20230919111724_create_teams_users_join_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTeamsUsersJoinTable < ActiveRecord::Migration[7.0]
   def change
     create_join_table :teams, :users do |t|

--- a/db/migrate/20231006075420_add_hint_to_health_questions.rb
+++ b/db/migrate/20231006075420_add_hint_to_health_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddHintToHealthQuestions < ActiveRecord::Migration[7.0]
   def change
     add_column :health_questions, :hint, :string

--- a/db/migrate/20231012101034_add_reset_password_token_to_users.rb
+++ b/db/migrate/20231012101034_add_reset_password_token_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddResetPasswordTokenToUsers < ActiveRecord::Migration[6.0]
   def change
     change_table :users, bulk: true do |t|

--- a/db/migrate/20231012113819_add_metadata_to_health_questions.rb
+++ b/db/migrate/20231012113819_add_metadata_to_health_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMetadataToHealthQuestions < ActiveRecord::Migration[7.0]
   def change
     add_column :health_questions, :metadata, :jsonb, null: false, default: {}

--- a/db/migrate/20231019101317_add_service_name_to_active_storage_blobs.active_storage.rb
+++ b/db/migrate/20231019101317_add_service_name_to_active_storage_blobs.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20190112182829)
 class AddServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.0]
   def up

--- a/db/migrate/20231019101318_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20231019101318_create_active_storage_variant_records.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20191206030411)
 class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
   def change

--- a/db/migrate/20231019101319_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
+++ b/db/migrate/20231019101319_remove_not_null_on_active_storage_blobs_checksum.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20211119233751)
 class RemoveNotNullOnActiveStorageBlobsChecksum < ActiveRecord::Migration[6.0]
   def change

--- a/db/migrate/20231023145112_add_follow_up_question_to_health_questions.rb
+++ b/db/migrate/20231023145112_add_follow_up_question_to_health_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFollowUpQuestionToHealthQuestions < ActiveRecord::Migration[7.0]
   def change
     add_reference :health_questions,

--- a/db/migrate/20231023162558_add_next_question_to_health_questions.rb
+++ b/db/migrate/20231023162558_add_next_question_to_health_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNextQuestionToHealthQuestions < ActiveRecord::Migration[7.1]
   def change
     add_reference :health_questions,

--- a/db/migrate/20231203212837_add_user_to_triage.rb
+++ b/db/migrate/20231203212837_add_user_to_triage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserToTriage < ActiveRecord::Migration[7.1]
   def change
     add_reference :triage, :user, foreign_key: { to_table: :users }

--- a/db/migrate/20231211141707_add_user_id_to_vaccination_record.rb
+++ b/db/migrate/20231211141707_add_user_id_to_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUserIdToVaccinationRecord < ActiveRecord::Migration[7.1]
   def change
     add_reference :vaccination_records, :user, foreign_key: { to_table: :users }

--- a/db/migrate/20231211152827_add_notes_to_vaccination_record.rb
+++ b/db/migrate/20231211152827_add_notes_to_vaccination_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddNotesToVaccinationRecord < ActiveRecord::Migration[7.1]
   def change
     add_column :vaccination_records, :notes, :text

--- a/db/migrate/20231214105751_create_flipper_tables.rb
+++ b/db/migrate/20231214105751_create_flipper_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFlipperTables < ActiveRecord::Migration[7.1]
   def up
     create_table :flipper_features do |t|

--- a/db/migrate/20231220101659_add_health_answers_to_consent.rb
+++ b/db/migrate/20231220101659_add_health_answers_to_consent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddHealthAnswersToConsent < ActiveRecord::Migration[7.1]
   def change
     add_column :consents, :health_answers, :jsonb, null: false, default: []

--- a/db/migrate/20231228160517_add_consent_id_to_consent_form.rb
+++ b/db/migrate/20231228160517_add_consent_id_to_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConsentIdToConsentForm < ActiveRecord::Migration[7.1]
   def change
     add_reference :consent_forms, :consent, foreign_key: true

--- a/db/migrate/20231228174825_remove_not_null_on_consent_health_answers.rb
+++ b/db/migrate/20231228174825_remove_not_null_on_consent_health_answers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveNotNullOnConsentHealthAnswers < ActiveRecord::Migration[7.1]
   def change
     change_column_null :consents, :health_answers, true

--- a/db/migrate/20231229144634_remove_health_questions_on_consents.rb
+++ b/db/migrate/20231229144634_remove_health_questions_on_consents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveHealthQuestionsOnConsents < ActiveRecord::Migration[7.1]
   def change
     remove_column :consents, :health_questions, :jsonb

--- a/db/migrate/20240102140714_change_nhs_number_from_big_int_to_string.rb
+++ b/db/migrate/20240102140714_change_nhs_number_from_big_int_to_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeNhsNumberFromBigIntToString < ActiveRecord::Migration[7.1]
   def up
     change_column :patients, :nhs_number, :string

--- a/db/migrate/20240108112551_rename_consent_child_common_name.rb
+++ b/db/migrate/20240108112551_rename_consent_child_common_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameConsentChildCommonName < ActiveRecord::Migration[7.1]
   def change
     rename_column :consents, :childs_common_name, :common_name

--- a/db/migrate/20240108120307_remove_unused_consent_columns.rb
+++ b/db/migrate/20240108120307_remove_unused_consent_columns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveUnusedConsentColumns < ActiveRecord::Migration[7.1]
   def change
     change_table :consents, bulk: true do |t|

--- a/db/migrate/20240108131124_rename_patient_columns.rb
+++ b/db/migrate/20240108131124_rename_patient_columns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenamePatientColumns < ActiveRecord::Migration[7.1]
   def up
     change_table :patients, bulk: true do |t|

--- a/db/migrate/20240109222514_create_registrations.rb
+++ b/db/migrate/20240109222514_create_registrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateRegistrations < ActiveRecord::Migration[7.1]
   def change
     create_table :registrations do |t|

--- a/db/migrate/20240111113005_add_fields_to_registration_form.rb
+++ b/db/migrate/20240111113005_add_fields_to_registration_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFieldsToRegistrationForm < ActiveRecord::Migration[7.1]
   # rubocop:disable Rails/NotNullColumn
   def change

--- a/db/migrate/20240112143006_add_location_id_to_patients.rb
+++ b/db/migrate/20240112143006_add_location_id_to_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddLocationIdToPatients < ActiveRecord::Migration[7.1]
   def change
     add_reference :patients, :location, foreign_key: true

--- a/db/migrate/20240115094352_allow_null_parent_registration_fields.rb
+++ b/db/migrate/20240115094352_allow_null_parent_registration_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AllowNullParentRegistrationFields < ActiveRecord::Migration[7.1]
   def up
     change_table :registrations, bulk: true do |t|

--- a/db/migrate/20240115095617_add_child_fields_to_registration.rb
+++ b/db/migrate/20240115095617_add_child_fields_to_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddChildFieldsToRegistration < ActiveRecord::Migration[7.1]
   def change
     change_table :registrations, bulk: true do |t|

--- a/db/migrate/20240116100526_add_confirmation_to_registration.rb
+++ b/db/migrate/20240116100526_add_confirmation_to_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfirmationToRegistration < ActiveRecord::Migration[7.1]
   def change
     change_table :registrations, bulk: true do |t|

--- a/db/migrate/20240116150655_add_devise_lockable_to_users.rb
+++ b/db/migrate/20240116150655_add_devise_lockable_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDeviseLockableToUsers < ActiveRecord::Migration[7.1]
   def change
     change_table :users, bulk: true do |t|

--- a/db/migrate/20240117152336_remove_unused_fields_from_patient.rb
+++ b/db/migrate/20240117152336_remove_unused_fields_from_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveUnusedFieldsFromPatient < ActiveRecord::Migration[7.1]
   def up
     change_table :patients, bulk: true do |t|

--- a/db/migrate/20240118135419_add_team_id_to_locations.rb
+++ b/db/migrate/20240118135419_add_team_id_to_locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTeamIdToLocations < ActiveRecord::Migration[7.1]
   def change
     add_column :locations, :team_id, :integer, null: false # rubocop:disable Rails/NotNullColumn

--- a/db/migrate/20240122112154_add_draft_field_to_sessions.rb
+++ b/db/migrate/20240122112154_add_draft_field_to_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDraftFieldToSessions < ActiveRecord::Migration[7.1]
   def change
     add_column :sessions, :draft, :boolean, default: false

--- a/db/migrate/20240122120822_remove_session_name.rb
+++ b/db/migrate/20240122120822_remove_session_name.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveSessionName < ActiveRecord::Migration[7.1]
   def change
     remove_column :sessions, :name, :text

--- a/db/migrate/20240123175014_add_consent_timestamps_to_session.rb
+++ b/db/migrate/20240123175014_add_consent_timestamps_to_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConsentTimestampsToSession < ActiveRecord::Migration[7.1]
   def change
     change_table :sessions, bulk: true do |t|

--- a/db/migrate/20240125124827_add_registration_open_to_locations.rb
+++ b/db/migrate/20240125124827_add_registration_open_to_locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRegistrationOpenToLocations < ActiveRecord::Migration[7.1]
   def change
     add_column :locations, :registration_open, :boolean, default: false

--- a/db/migrate/20240129173744_add_emailto_teams.rb
+++ b/db/migrate/20240129173744_add_emailto_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddEmailtoTeams < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :email, :string

--- a/db/migrate/20240131003419_make_session_campaign_optional.rb
+++ b/db/migrate/20240131003419_make_session_campaign_optional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MakeSessionCampaignOptional < ActiveRecord::Migration[7.1]
   def change
     change_column_null :sessions, :campaign_id, true

--- a/db/migrate/20240131142726_add_privacy_policy_url_to_teams.rb
+++ b/db/migrate/20240131142726_add_privacy_policy_url_to_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPrivacyPolicyUrlToTeams < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :privacy_policy_url, :string

--- a/db/migrate/20240131231958_add_time_of_day_to_sessions.rb
+++ b/db/migrate/20240131231958_add_time_of_day_to_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTimeOfDayToSessions < ActiveRecord::Migration[7.1]
   def change
     add_column :sessions, :time_of_day, :integer

--- a/db/migrate/20240201120925_change_sessions_datetime_fields_to_date.rb
+++ b/db/migrate/20240201120925_change_sessions_datetime_fields_to_date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeSessionsDatetimeFieldsToDate < ActiveRecord::Migration[7.1]
   def up
     change_table :sessions, bulk: true do |t|

--- a/db/migrate/20240206155411_add_registration_to_user.rb
+++ b/db/migrate/20240206155411_add_registration_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRegistrationToUser < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :registration, :string

--- a/db/migrate/20240206160550_add_ods_code_to_team.rb
+++ b/db/migrate/20240206160550_add_ods_code_to_team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOdsCodeToTeam < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :ods_code, :string

--- a/db/migrate/20240206163847_add_urn_to_locations.rb
+++ b/db/migrate/20240206163847_add_urn_to_locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUrnToLocations < ActiveRecord::Migration[7.1]
   def change
     add_column :locations, :urn, :string

--- a/db/migrate/20240208122856_add_address_fields_to_patient.rb
+++ b/db/migrate/20240208122856_add_address_fields_to_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAddressFieldsToPatient < ActiveRecord::Migration[7.1]
   def change
     change_table :patients, bulk: true do |t|

--- a/db/migrate/20240208124647_add_registration_id_to_patient.rb
+++ b/db/migrate/20240208124647_add_registration_id_to_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRegistrationIdToPatient < ActiveRecord::Migration[7.1]
   def change
     add_reference :patients, :registration, foreign_key: true

--- a/db/migrate/20240212153242_remove_unique_constraint_on_vaccine_type.rb
+++ b/db/migrate/20240212153242_remove_unique_constraint_on_vaccine_type.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveUniqueConstraintOnVaccineType < ActiveRecord::Migration[7.1]
   def change
     remove_index :vaccines, :type, unique: true

--- a/db/migrate/20240214115829_add_reply_to_id_to_teams.rb
+++ b/db/migrate/20240214115829_add_reply_to_id_to_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReplyToIdToTeams < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :reply_to_id, :string

--- a/db/migrate/20240215121759_add_observed_session_agreed_field_to_registration.rb
+++ b/db/migrate/20240215121759_add_observed_session_agreed_field_to_registration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddObservedSessionAgreedFieldToRegistration < ActiveRecord::Migration[7.1]
   def change
     add_column :registrations, :user_research_observation_agreed, :boolean

--- a/db/migrate/20240215161923_add_permission_to_observe_required_to_location.rb
+++ b/db/migrate/20240215161923_add_permission_to_observe_required_to_location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPermissionToObserveRequiredToLocation < ActiveRecord::Migration[7.1]
   def change
     add_column :locations, :permission_to_observe_required, :boolean

--- a/db/migrate/20240220165801_add_sent_consent_at_to_patients.rb
+++ b/db/migrate/20240220165801_add_sent_consent_at_to_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSentConsentAtToPatients < ActiveRecord::Migration[7.1]
   def change
     add_column :patients, :sent_consent_at, :datetime

--- a/db/migrate/20240221130747_add_phone_to_team.rb
+++ b/db/migrate/20240221130747_add_phone_to_team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPhoneToTeam < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :phone, :string

--- a/db/migrate/20240226123956_re_encrypt_patients.rb
+++ b/db/migrate/20240226123956_re_encrypt_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReEncryptPatients < ActiveRecord::Migration[7.1]
   def up
     Patient.find_each(&:encrypt)

--- a/db/migrate/20240226162803_add_sent_reminder_at_to_patient.rb
+++ b/db/migrate/20240226162803_add_sent_reminder_at_to_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSentReminderAtToPatient < ActiveRecord::Migration[7.1]
   def change
     add_column :patients, :sent_reminder_at, :datetime

--- a/db/migrate/20240229120105_add_gillick_competency_assessor_user_id_to_patient_sessions.rb
+++ b/db/migrate/20240229120105_add_gillick_competency_assessor_user_id_to_patient_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGillickCompetencyAssessorUserIdToPatientSessions < ActiveRecord::Migration[
   7.1
 ]

--- a/db/migrate/20240229150456_rename_reason_for_refusal_other_to_reason_for_refusal_notes_on_consent.rb
+++ b/db/migrate/20240229150456_rename_reason_for_refusal_other_to_reason_for_refusal_notes_on_consent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameReasonForRefusalOtherToReasonForRefusalNotesOnConsent < ActiveRecord::Migration[
   7.1
 ]

--- a/db/migrate/20240301122902_add_recorded_by_to_consent.rb
+++ b/db/migrate/20240301122902_add_recorded_by_to_consent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRecordedByToConsent < ActiveRecord::Migration[7.1]
   def change
     add_reference :consents,

--- a/db/migrate/20240304163610_add_sessiion_reminder_sent_at_to_patients.rb
+++ b/db/migrate/20240304163610_add_sessiion_reminder_sent_at_to_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSessiionReminderSentAtToPatients < ActiveRecord::Migration[7.1]
   def change
     add_column :patients, :session_reminder_sent_at, :datetime

--- a/db/migrate/20240312151437_add_feedback_request_sent_at_to_consent_forms.rb
+++ b/db/migrate/20240312151437_add_feedback_request_sent_at_to_consent_forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFeedbackRequestSentAtToConsentForms < ActiveRecord::Migration[7.1]
   def change
     add_column :consent_forms, :feedback_request_sent_at, :datetime

--- a/db/migrate/20240314153941_remove_feedback_request_sent_at_from_consent_forms.rb
+++ b/db/migrate/20240314153941_remove_feedback_request_sent_at_from_consent_forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveFeedbackRequestSentAtFromConsentForms < ActiveRecord::Migration[7.1]
   def change
     remove_column :consent_forms, :feedback_request_sent_at, :datetime

--- a/db/migrate/20240512221431_remove_registration_open_from_location.rb
+++ b/db/migrate/20240512221431_remove_registration_open_from_location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveRegistrationOpenFromLocation < ActiveRecord::Migration[7.1]
   def change
     remove_column :locations, :registration_open, :boolean

--- a/db/migrate/20240513063547_remove_permission_to_observe_required_from_location.rb
+++ b/db/migrate/20240513063547_remove_permission_to_observe_required_from_location.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemovePermissionToObserveRequiredFromLocation < ActiveRecord::Migration[
   7.1
 ]

--- a/db/migrate/20240513160517_remove_registration_fk_from_patients.rb
+++ b/db/migrate/20240513160517_remove_registration_fk_from_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveRegistrationFkFromPatients < ActiveRecord::Migration[7.1]
   def change
     remove_foreign_key :patients, :registrations

--- a/db/migrate/20240513163410_remove_registration_id_from_patients.rb
+++ b/db/migrate/20240513163410_remove_registration_id_from_patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveRegistrationIdFromPatients < ActiveRecord::Migration[7.1]
   def change
     remove_column :patients, :registration_id, :string

--- a/db/migrate/20240513172932_remove_registrations.rb
+++ b/db/migrate/20240513172932_remove_registrations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveRegistrations < ActiveRecord::Migration[7.1]
   def up
     drop_table :registrations

--- a/db/migrate/20240522155355_add_supplier_to_vaccines.rb
+++ b/db/migrate/20240522155355_add_supplier_to_vaccines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSupplierToVaccines < ActiveRecord::Migration[7.1]
   def change
     change_table :vaccines do |t|

--- a/db/migrate/20240522222956_add_gtin_to_vaccines.rb
+++ b/db/migrate/20240522222956_add_gtin_to_vaccines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddGtinToVaccines < ActiveRecord::Migration[7.1]
   def change
     change_table :vaccines do |t|

--- a/db/migrate/20240531171121_create_gillick_assessments.rb
+++ b/db/migrate/20240531171121_create_gillick_assessments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGillickAssessments < ActiveRecord::Migration[7.1]
   def change
     create_table :gillick_assessments do |t|

--- a/db/migrate/20240531213930_remove_gillick_fields_from_patient_session.rb
+++ b/db/migrate/20240531213930_remove_gillick_fields_from_patient_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveGillickFieldsFromPatientSession < ActiveRecord::Migration[7.1]
   def up
     change_table :patient_sessions, bulk: true do |t|

--- a/db/migrate/20240603120457_add_omniauth_to_users.rb
+++ b/db/migrate/20240603120457_add_omniauth_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddOmniauthToUsers < ActiveRecord::Migration[7.1]
   def change
     change_table :users, bulk: true do |t|

--- a/db/migrate/20240604093030_add_provider_uid_index_to_user.rb
+++ b/db/migrate/20240604093030_add_provider_uid_index_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddProviderUidIndexToUser < ActiveRecord::Migration[7.1]
   def change
     add_index :users, %i[provider uid]

--- a/db/migrate/20240605082324_add_created_by_to_patient_session.rb
+++ b/db/migrate/20240605082324_add_created_by_to_patient_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCreatedByToPatientSession < ActiveRecord::Migration[7.1]
   def change
     add_reference :patient_sessions,

--- a/db/migrate/20240605082418_populate_created_by_on_patient_session.rb
+++ b/db/migrate/20240605082418_populate_created_by_on_patient_session.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PopulateCreatedByOnPatientSession < ActiveRecord::Migration[7.1]
   def up
     PatientSession.find_each do |ps|

--- a/db/migrate/20240607132153_make_consent_route_optional.rb
+++ b/db/migrate/20240607132153_make_consent_route_optional.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MakeConsentRouteOptional < ActiveRecord::Migration[7.1]
   def change
     change_column_null :consents, :route, true

--- a/db/migrate/20240607174955_create_parents.rb
+++ b/db/migrate/20240607174955_create_parents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateParents < ActiveRecord::Migration[7.1]
   def change
     create_table :parents do |t|

--- a/db/migrate/20240607210223_patient_belongs_to_parent.rb
+++ b/db/migrate/20240607210223_patient_belongs_to_parent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PatientBelongsToParent < ActiveRecord::Migration[7.1]
   def change
     add_reference :patients, :parent, null: true, foreign_key: true

--- a/db/migrate/20240608143120_remove_parent_fields_from_patient.rb
+++ b/db/migrate/20240608143120_remove_parent_fields_from_patient.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveParentFieldsFromPatient < ActiveRecord::Migration[7.1]
   def change
     change_table :patients, bulk: true do |t|

--- a/db/migrate/20240608165907_add_dose_to_vaccine.rb
+++ b/db/migrate/20240608165907_add_dose_to_vaccine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDoseToVaccine < ActiveRecord::Migration[7.1]
   def change
     add_column :vaccines, :dose, :decimal

--- a/db/migrate/20240609103407_consent_belongs_to_parent.rb
+++ b/db/migrate/20240609103407_consent_belongs_to_parent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentBelongsToParent < ActiveRecord::Migration[7.1]
   def change
     add_reference :consents, :parent, foreign_key: true

--- a/db/migrate/20240610082802_remove_parent_fields_from_consent.rb
+++ b/db/migrate/20240610082802_remove_parent_fields_from_consent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveParentFieldsFromConsent < ActiveRecord::Migration[7.1]
   def change
     change_table :consents, bulk: true do |t|

--- a/db/migrate/20240610182655_consent_form_belongs_to_parent.rb
+++ b/db/migrate/20240610182655_consent_form_belongs_to_parent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsentFormBelongsToParent < ActiveRecord::Migration[7.1]
   def change
     add_reference :consent_forms, :parent, foreign_key: true

--- a/db/migrate/20240616121453_remove_parent_fields_from_consent_form.rb
+++ b/db/migrate/20240616121453_remove_parent_fields_from_consent_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveParentFieldsFromConsentForm < ActiveRecord::Migration[7.1]
   def change
     change_table :consent_forms, bulk: true do |t|

--- a/db/migrate/20240622061956_add_recorded_at_to_parent.rb
+++ b/db/migrate/20240622061956_add_recorded_at_to_parent.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRecordedAtToParent < ActiveRecord::Migration[7.1]
   def change
     add_column :parents, :recorded_at, :datetime

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #

--- a/lib/core_extensions/action_dispatch/file_handler.rb
+++ b/lib/core_extensions/action_dispatch/file_handler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CoreExtensions
   module ActionDispatch
     module FileHandler

--- a/lib/task_helpers.rb
+++ b/lib/task_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "readline"
 
 module TaskHelpers

--- a/lib/tasks/add_health_questions.rake
+++ b/lib/tasks/add_health_questions.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../task_helpers"
 
 desc <<-DESC

--- a/lib/tasks/add_new_hpv_team.rake
+++ b/lib/tasks/add_new_hpv_team.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../task_helpers"
 
 desc <<-DESC

--- a/lib/tasks/add_new_location.rake
+++ b/lib/tasks/add_new_location.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../task_helpers"
 
 desc <<-DESC

--- a/lib/tasks/add_new_user.rake
+++ b/lib/tasks/add_new_user.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../task_helpers"
 
 desc <<-DESC

--- a/lib/tasks/add_new_user_securely.rake
+++ b/lib/tasks/add_new_user_securely.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "../task_helpers"
 
 desc <<-DESC

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # NOTE: only doing this in development as some production environments (Heroku)
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.

--- a/lib/tasks/auto_generate_diagram.rake
+++ b/lib/tasks/auto_generate_diagram.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # NOTE: only doing this in development as some production environments (Heroku)
 # NOTE: are sensitive to local FS writes, and besides -- it's just not proper
 # NOTE: to have a dev-mode tool do its thing in production.

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc "Get performance stats"
 task :performance, [] => :environment do |_task, _args|
   include ActionView::Helpers::TextHelper

--- a/lib/tasks/prepare_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/prepare_swallowing_concurrent_migration_exceptions.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :db do
   namespace :prepare do
     desc "Run db:prepare but ignore ActiveRecord::ConcurrentMigrationError errors"

--- a/lib/tasks/send_consent_reminders.rake
+++ b/lib/tasks/send_consent_reminders.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 desc <<-DESC
   Send consent reminders for a session to all patient's parents who've not returned consent yet
 DESC

--- a/lib/tasks/serviceworker_precompile.rake
+++ b/lib/tasks/serviceworker_precompile.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :serviceworker do
   desc "Precompile serviceworker JS"
   # Copy how the assets:precompile task depends on yarn being installed.

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 shared_examples "card" do |params|

--- a/spec/components/app_backlink_component_spec.rb
+++ b/spec/components/app_backlink_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppBacklinkComponent, type: :component do

--- a/spec/components/app_breadcrumb_component_spec.rb
+++ b/spec/components/app_breadcrumb_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppBreadcrumbComponent, type: :component do

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppCardComponent, type: :component do

--- a/spec/components/app_compare_consent_form_and_patient_component_spec.rb
+++ b/spec/components/app_compare_consent_form_and_patient_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppCompareConsentFormAndPatientComponent, type: :component do

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppConsentComponent, type: :component do

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppConsentStatusComponent, type: :component do

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppConsentSummaryComponent, type: :component do

--- a/spec/components/app_details_component_spec.rb
+++ b/spec/components/app_details_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppDetailsComponent, type: :component do

--- a/spec/components/app_dev_tools_component_spec.rb
+++ b/spec/components/app_dev_tools_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppDevToolsComponent, type: :component do

--- a/spec/components/app_empty_list_component_spec.rb
+++ b/spec/components/app_empty_list_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppEmptyListComponent, type: :component do

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppHealthQuestionsComponent, type: :component do

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppOutcomeBannerComponent, type: :component do

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppPatientDetailsComponent, type: :component do

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppPatientPageComponent, type: :component do

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "govuk_helper"
 

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppSimpleStatusBannerComponent, type: :component do

--- a/spec/components/app_tab_component_spec.rb
+++ b/spec/components/app_tab_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "govuk_helper"
 # Dir[File.join('./spec', 'components', 'shared', '*.rb')].sort.each { |file| require file }

--- a/spec/components/app_timestamped_entry_component_spec.rb
+++ b/spec/components/app_timestamped_entry_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppTimestampedEntryComponent, type: :component do

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppTriageFormComponent, type: :component do

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppTriageNotesComponent, type: :component do

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AppVaccinateFormComponent, type: :component do

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppActivityLogComponentPreview < ViewComponent::Preview
   def default
     setup

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppConsentComponentPreview < ViewComponent::Preview
   def consent_refused_without_notes
     setup

--- a/spec/components/previews/app_consent_summary_component_preview.rb
+++ b/spec/components/previews/app_consent_summary_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppConsentSummaryComponentPreview < ViewComponent::Preview
   def self_consent
     render AppConsentSummaryComponent.new(

--- a/spec/components/previews/app_flash_message_component_preview.rb
+++ b/spec/components/previews/app_flash_message_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppFlashMessageComponentPreview < ViewComponent::Preview
   def success
     render AppFlashMessageComponent.new(

--- a/spec/components/previews/app_health_questions_component_preview.rb
+++ b/spec/components/previews/app_health_questions_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppHealthQuestionsComponentPreview < ViewComponent::Preview
   def single_consent_triage_not_needed
     setup

--- a/spec/components/previews/app_outcome_banner_component_preview.rb
+++ b/spec/components/previews/app_outcome_banner_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppOutcomeBannerComponentPreview < ViewComponent::Preview
   def triaged_do_not_vaccinate
     patient_session =

--- a/spec/components/previews/app_patient_table_component_preview.rb
+++ b/spec/components/previews/app_patient_table_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppPatientTableComponentPreview < ViewComponent::Preview
   def check_consent
     patient_sessions =

--- a/spec/components/previews/app_simple_status_banner_component_preview.rb
+++ b/spec/components/previews/app_simple_status_banner_component_preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppSimpleStatusBannerComponentPreview < ViewComponent::Preview
   def waiting_for_consent
     patient_session = FactoryBot.create(:patient_session, :added_to_session)

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentFormMailerConcern do

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe PatientSortingConcern do

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe PatientTabsConcern do

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe TriageMailerConcern do

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe VaccinationMailerConcern do

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: batches

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: campaigns

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: consent_forms

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: consents

--- a/spec/factories/example_campaigns.rb
+++ b/spec/factories/example_campaigns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :example_campaign, parent: :campaign do
     transient do

--- a/spec/factories/gillick_assessments.rb
+++ b/spec/factories/gillick_assessments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: gillick_assessments

--- a/spec/factories/health_questions.rb
+++ b/spec/factories/health_questions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: health_questions

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: locations

--- a/spec/factories/offline_passwords.rb
+++ b/spec/factories/offline_passwords.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: offline_passwords

--- a/spec/factories/parents.rb
+++ b/spec/factories/parents.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: parents

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: patient_sessions

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: patients

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: sessions

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: teams

--- a/spec/factories/triage.rb
+++ b/spec/factories/triage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: triage

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: users

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: vaccination_records

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: vaccines

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "HPV Vaccination" do

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "HPV Vaccination" do

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "HPV Vaccination" do

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "HPV Vaccination" do

--- a/spec/features/manage_vaccines_batches_spec.rb
+++ b/spec/features/manage_vaccines_batches_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Batches" do

--- a/spec/features/manage_vaccines_spec.rb
+++ b/spec/features/manage_vaccines_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Manage vaccines" do

--- a/spec/features/nivs_hpv_report_spec.rb
+++ b/spec/features/nivs_hpv_report_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "NIVS HPV report" do

--- a/spec/features/parental_consent_authentication_spec.rb
+++ b/spec/features/parental_consent_authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Parental consent" do

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.feature "Parental consent change answers" do

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Parental consent" do

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Parental consent" do

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Parental consent" do

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Patient sorting and filtering" do

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "csv"
 

--- a/spec/features/pilot_upload_cohort_spec.rb
+++ b/spec/features/pilot_upload_cohort_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Pilot - upload cohort" do

--- a/spec/features/response_matching_spec.rb
+++ b/spec/features/response_matching_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Response matching" do

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Self-consent" do

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Not Gillick competent" do

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Session management" do

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Triage" do

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Triage" do

--- a/spec/features/user_account_spec.rb
+++ b/spec/features/user_account_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "User account" do

--- a/spec/features/user_authentication_spec.rb
+++ b/spec/features/user_authentication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "User authentication" do

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "User authorisation" do

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Verbal consent" do

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Verbal consent" do

--- a/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Verbal consent" do

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Verbal consent" do

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 feature "Verbal consent" do

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe "Verbal consent" do

--- a/spec/govuk_helper.rb
+++ b/spec/govuk_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "view_component/test_helpers"
 
 # require File.expand_path("dummy/config/environment", __dir__)

--- a/spec/govuk_shared/a_component_that_accepts_custom_classes.rb
+++ b/spec/govuk_shared/a_component_that_accepts_custom_classes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples "a component that accepts custom classes" do
   context "when classes are supplied" do
     before do

--- a/spec/govuk_shared/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/govuk_shared/a_component_that_accepts_custom_html_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples "a component that accepts custom HTML attributes" do
   let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue" } }
   let(:updated_kwargs) do

--- a/spec/govuk_shared/a_component_that_supports_custom_branding.rb
+++ b/spec/govuk_shared/a_component_that_supports_custom_branding.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples "a component that supports custom branding" do
   let(:default_brand) { "govuk" }
   let(:custom_brand) { "globex-corp" }

--- a/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_classes.rb
+++ b/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_classes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples "a component with a slot that accepts custom classes" do
   let(:custom_class) { "purple-stripes" }
 

--- a/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
+++ b/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_examples "a component with a slot that accepts custom html attributes" do
   let(:custom_attributes) do
     { lang: "en-GB", style: "background-color: blue;" }

--- a/spec/govuk_shared/setup.rb
+++ b/spec/govuk_shared/setup.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 shared_context "setup" do
   let(:component_css_class_matcher) do
     component_css_class.blank? ? nil : ".#{component_css_class}"

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ApplicationHelper do

--- a/spec/helpers/consent_forms_helper_spec.rb
+++ b/spec/helpers/consent_forms_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentFormsHelper, type: :helper do

--- a/spec/jobs/consent_reminders_job_spec.rb
+++ b/spec/jobs/consent_reminders_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentRemindersJob, type: :job do

--- a/spec/jobs/consent_reminders_session_batch_job_spec.rb
+++ b/spec/jobs/consent_reminders_session_batch_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentRemindersSessionBatchJob, type: :job do

--- a/spec/jobs/consent_requests_job_spec.rb
+++ b/spec/jobs/consent_requests_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentRequestsJob, type: :job do

--- a/spec/jobs/consent_requests_session_batch_job_spec.rb
+++ b/spec/jobs/consent_requests_session_batch_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentRequestsSessionBatchJob, type: :job do

--- a/spec/jobs/session_reminders_batch_job_spec.rb
+++ b/spec/jobs/session_reminders_batch_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe SessionRemindersBatchJob, type: :job do

--- a/spec/jobs/session_reminders_job_spec.rb
+++ b/spec/jobs/session_reminders_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe SessionRemindersJob do

--- a/spec/lib/date_params_validator_spec.rb
+++ b/spec/lib/date_params_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 require "date"
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ApplicationMailer, type: :mailer do

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentFormMailer, type: :mailer do

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsentRequestMailer, type: :mailer do

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe SessionMailer, type: :mailer do

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe TriageMailer, type: :mailer do

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe VaccinationMailer do

--- a/spec/models/cohort_list_row_spec.rb
+++ b/spec/models/cohort_list_row_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe CohortListRow, type: :model do

--- a/spec/models/cohort_list_spec.rb
+++ b/spec/models/cohort_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe CohortList, type: :model do

--- a/spec/models/concerns/age_concern_spec.rb
+++ b/spec/models/concerns/age_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe AgeConcern do

--- a/spec/models/concerns/human_enum_name_concern_spec.rb
+++ b/spec/models/concerns/human_enum_name_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe HumanEnumNameConcern do

--- a/spec/models/concerns/patient_session_state_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe PatientSessionStateConcern do

--- a/spec/models/concerns/wizard_form_concern_spec.rb
+++ b/spec/models/concerns/wizard_form_concern_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 class Dummy

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: consent_forms

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: consents

--- a/spec/models/consolidated_health_answers_spec.rb
+++ b/spec/models/consolidated_health_answers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe ConsolidatedHealthAnswers do

--- a/spec/models/health_question_spec.rb
+++ b/spec/models/health_question_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: health_questions

--- a/spec/models/nivs_report_row_spec.rb
+++ b/spec/models/nivs_report_row_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe NivsReportRow do

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: parents

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: patient_sessions

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: patients

--- a/spec/models/pds/patient_spec.rb
+++ b/spec/models/pds/patient_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe PDS::Patient do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: sessions

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe SessionStats do

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: vaccines

--- a/spec/policies/patient_session_policy_spec.rb
+++ b/spec/policies/patient_session_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe PatientSessionPolicy do

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe SessionPolicy do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"

--- a/spec/routing/vaccinations_routing_spec.rb
+++ b/spec/routing/vaccinations_routing_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe VaccinationsController, type: :routing do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "simplecov"
 SimpleCov.start
 

--- a/spec/support/be_sent_with_govuk_notify_matcher.rb
+++ b/spec/support/be_sent_with_govuk_notify_matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec::Matchers.matcher :be_sent_with_govuk_notify do
   match do |actual|
     unless actual.is_a?(Mail::Notify::Message) ||

--- a/spec/support/email_expectations.rb
+++ b/spec/support/email_expectations.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EmailExpectations
   def expect_email_to(to, template, nth = :first)
     email = sent_emails.send(nth)

--- a/spec/support/faker/national_health_service.rb
+++ b/spec/support/faker/national_health_service.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "faker"
 
 module Faker

--- a/spec/validators/notify_safe_email_validator_spec.rb
+++ b/spec/validators/notify_safe_email_validator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 describe NotifySafeEmailValidator do


### PR DESCRIPTION
This modifies the Rubocop rules to enforce a frozen string literal comment at the top of every Ruby file, and then runs Rubocop with autocorrect to add one to each file.

Frozen string literals was going to be default in Ruby 3.0, but this didn't happen in the end due to concerns about incompatibility, however I think this is good practice for new projects. An alternative to the comment is using the `--enable=frozen-string-literal` flag, however this applies to third party Gems and the standard library, which may then introduce the compatibility issues.

Aside from not needing to manually call `.freeze` on string literals, this approach introduces a small performance increase (although unlikely to be particularly noticable). However, it does reduce the chance of bugs happening related to mutable string literals.