### PR TITLE
Ignore order of emails in triage specs

### DIFF
--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -100,28 +100,31 @@ describe "Triage" do
 
   def and_needs_triage_emails_are_sent_to_both_parents
     expect_email_to @patient.consents.first.parent.email,
-                    EMAILS[:parental_consent_confirmation_needs_triage]
+                    EMAILS[:parental_consent_confirmation_needs_triage],
+                    :any
     expect_email_to @patient.consents.second.parent.email,
                     EMAILS[:parental_consent_confirmation_needs_triage],
-                    :second
+                    :any
     ActionMailer::Base.deliveries.clear
   end
 
   def and_vaccination_wont_happen_emails_are_sent_to_both_parents
     expect_email_to @patient.consents.first.parent.email,
-                    EMAILS[:triage_vaccination_wont_happen]
+                    EMAILS[:triage_vaccination_wont_happen],
+                    :any
     expect_email_to @patient.consents.second.parent.email,
                     EMAILS[:triage_vaccination_wont_happen],
-                    :second
+                    :any
     ActionMailer::Base.deliveries.clear
   end
 
   def and_vaccination_will_happen_emails_are_sent_to_both_parents
     expect_email_to @patient.consents.first.parent.email,
-                    EMAILS[:triage_vaccination_will_happen]
+                    EMAILS[:triage_vaccination_will_happen],
+                    :any
     expect_email_to @patient.consents.second.parent.email,
                     EMAILS[:triage_vaccination_will_happen],
-                    :second
+                    :any
     ActionMailer::Base.deliveries.clear
   end
 end

--- a/spec/support/email_expectations.rb
+++ b/spec/support/email_expectations.rb
@@ -2,7 +2,12 @@
 
 module EmailExpectations
   def expect_email_to(to, template, nth = :first)
-    email = sent_emails.send(nth)
+    email =
+      if nth == :any
+        sent_emails.find { |e| e.to.include?(to) }
+      else
+        sent_emails.send(nth)
+      end
     expect(email).not_to be_nil
     expect(email).to be_sent_with_govuk_notify.using_template(template).to(to)
   end


### PR DESCRIPTION
The triage feature specs were failing intermittently when the order that the emails were sent didn't match the order they were being tested. This change adds a way to ignore the ordering to the support helper used.

Just for the record, the seed `7582` seemed to be able to trigger this error more often than not.