### PR TITLE
Don't specify form builder in views

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -35,8 +35,7 @@
 <p>
   <%= form_for :consent,
                url: session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
-               method: :post,
-               builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+               method: :post do |f| %>
     <%= f.govuk_submit "Get consent" %>
   <% end %>
 </p>

--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -5,8 +5,7 @@
                   class: "app-patients__filters",
                   data: { module: "autosubmit",
                           turbo: "true",
-                          turbo_action: "replace" },
-                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+                          turbo_action: "replace" } do |f| %>
       <%= f.govuk_fieldset legend: { text: "Filter results", size: "s" } do %>
         <%= f.govuk_text_field :name, label: { text: "By name" },
                                       value: params[:name],

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -1,9 +1,4 @@
-<%= form_with(
-     model: @triage,
-     url: @url,
-     method: @method,
-     builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-   ) do |f| %>
+<%= form_with(model: @triage, url: @url, method: @method) do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:status, **fieldset_options) do %>

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -3,7 +3,6 @@
      url:,
      method: :post,
      class: "nhsuk-card",
-     builder: GOVUKDesignSystemFormBuilder::FormBuilder,
    ) do |f| %>
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">


### PR DESCRIPTION
We've set `GOVUKDesignSystemFormBuilder::FormBuilder` as the default form builder for forms so we don't need to specify this elsewhere.