### PR TITLE
Ignore scratchpad dir in Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ inherit_mode:
   merge:
     - Exclude
 
+AllCops:
+  Exclude:
+    - scratchpad/*
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 


### PR DESCRIPTION
This is a convention we've adopted for a local directory to store project-related files that we don't want to add to the repo. It's ignored in the other files, but recently I've added some dirty, smelly Ruby code that even Rubocop couldn't fix for me, and its errors were blocking running bin/lint, so let's just ignore it.