### PR TITLE
Show "triaged decision" on the patient triage notes

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -28,16 +28,8 @@ class AppActivityLogComponent < ViewComponent::Base
 
   def triage_events
     @patient_session.triage.map do
-      status_messages = {
-        ready_to_vaccinate: "Safe to vaccinate",
-        do_not_vaccinate: "Do not vaccinate in campaign",
-        delay_vaccination: "Delay vaccination to a later date",
-        needs_follow_up: "Keep in triage"
-      }.with_indifferent_access
-      decision = status_messages[_1.status]
-
       {
-        title: "Triaged decision: #{decision}",
+        title: "Triaged decision: #{_1.human_enum_name(:status)}",
         time: _1.created_at,
         notes: _1.notes,
         by: _1.user.full_name

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -9,21 +9,21 @@
   <%= f.govuk_radio_buttons_fieldset(:status, **fieldset_options) do %>
     <%= f.govuk_radio_button(
           :status, :ready_to_vaccinate,
-          label: { text: Triage.human_enum_name(:status, :ready_to_vaccinate) },
+          label: { text: "Yes, it’s safe to vaccinate" },
           link_errors: true,
         ) %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button(
           :status, :do_not_vaccinate,
-          label: { text: Triage.human_enum_name(:status, :do_not_vaccinate) },
+          label: { text: "No, do not vaccinate" },
         ) %>
     <%= f.govuk_radio_button(
           :status, :delay_vaccination,
-          label: { text: Triage.human_enum_name(:status, :delay_vaccination) },
+          label: { text: "No, delay vaccination to a later date" },
         ) %>
     <%= f.govuk_radio_button(
           :status, :needs_follow_up,
-          label: { text: Triage.human_enum_name(:status, :needs_follow_up) },
+          label: { text: "No, keep in triage" },
         ) %>
   <% end %>
 

--- a/app/components/app_triage_notes_component.html.erb
+++ b/app/components/app_triage_notes_component.html.erb
@@ -8,6 +8,8 @@
   <% end %>
 
   <p class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">
-    <%= triage.user.full_name %>, <%= triage.created_at.to_fs(:long) %>
+    <%= triage.created_at.to_fs(:long) %>
+    &middot;
+    <%= triage.user.full_name %>
   </p>
 <% end %>

--- a/app/components/app_triage_notes_component.html.erb
+++ b/app/components/app_triage_notes_component.html.erb
@@ -1,0 +1,6 @@
+<% entries.map do |triage| %>
+  <p class="nhsuk-u-margin-bottom-1"><%= triage.notes %></p>
+  <p class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">
+    <%= triage.user.full_name %>, <%= triage.created_at.to_fs(:long) %>
+  </p>
+<% end %>

--- a/app/components/app_triage_notes_component.html.erb
+++ b/app/components/app_triage_notes_component.html.erb
@@ -4,7 +4,7 @@
   </h3>
 
   <% if (notes = triage.notes).present? %>
-    <p class="nhsuk-u-margin-bottom-1"><%= notes %></p>
+    <blockquote><p><%= notes %></p></blockquote>
   <% end %>
 
   <p class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">

--- a/app/components/app_triage_notes_component.html.erb
+++ b/app/components/app_triage_notes_component.html.erb
@@ -1,4 +1,4 @@
-<% entries.map do |triage| %>
+<% entries.each_with_index do |triage, index| %>
   <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
     Triaged decision: <%= triage.human_enum_name(:status) %>
   </h3>
@@ -12,4 +12,8 @@
     &middot;
     <%= triage.user.full_name %>
   </p>
+
+  <% if index < entries.size - 1 %>
+    <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--m">
+  <% end %>
 <% end %>

--- a/app/components/app_triage_notes_component.html.erb
+++ b/app/components/app_triage_notes_component.html.erb
@@ -1,5 +1,12 @@
 <% entries.map do |triage| %>
-  <p class="nhsuk-u-margin-bottom-1"><%= triage.notes %></p>
+  <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
+    Triaged decision: <%= triage.human_enum_name(:status) %>
+  </h3>
+
+  <% if (notes = triage.notes).present? %>
+    <p class="nhsuk-u-margin-bottom-1"><%= notes %></p>
+  <% end %>
+
   <p class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">
     <%= triage.user.full_name %>, <%= triage.created_at.to_fs(:long) %>
   </p>

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -14,36 +14,6 @@ class AppTriageNotesComponent < ViewComponent::Base
   private
 
   def entries
-    @entries ||=
-      @patient_session.triage.where.not(notes: nil).order(created_at: :desc)
+    @entries ||= @patient_session.triage.order(created_at: :desc)
   end
-<<<<<<< HEAD
-||||||| parent of 41a4b57a (Show decision on triage notes)
-
-  def triage_notes(triage)
-    [
-      tag.p(class: "nhsuk-u-margin-bottom-1") { triage.notes },
-      tag.p(class: "nhsuk-u-secondary-text-color nhsuk-u-font-size-16") do
-        "#{triage.user.full_name}, #{triage.created_at.to_fs(:app_date_time)}"
-      end
-    ].join("\n").html_safe
-  end
-=======
-
-  def triage_notes(triage)
-    [
-      tag.h3(
-        "Triaged decision: #{triage.human_enum_name(:status)}",
-        class: "nhsuk-heading-s nhsuk-u-margin-bottom-2"
-      ),
-      if (notes = triage.notes).present?
-        tag.p(notes, class: "nhsuk-u-margin-bottom-1")
-      end,
-      tag.p(
-        "#{triage.user.full_name}, #{triage.created_at.to_fs(:app_date_time)}",
-        class: "nhsuk-u-secondary-text-color nhsuk-u-font-size-16"
-      )
-    ].compact.join("\n").html_safe
-  end
->>>>>>> 41a4b57a (Show decision on triage notes)
 end

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -17,4 +17,33 @@ class AppTriageNotesComponent < ViewComponent::Base
     @entries ||=
       @patient_session.triage.where.not(notes: nil).order(created_at: :desc)
   end
+<<<<<<< HEAD
+||||||| parent of 41a4b57a (Show decision on triage notes)
+
+  def triage_notes(triage)
+    [
+      tag.p(class: "nhsuk-u-margin-bottom-1") { triage.notes },
+      tag.p(class: "nhsuk-u-secondary-text-color nhsuk-u-font-size-16") do
+        "#{triage.user.full_name}, #{triage.created_at.to_fs(:app_date_time)}"
+      end
+    ].join("\n").html_safe
+  end
+=======
+
+  def triage_notes(triage)
+    [
+      tag.h3(
+        "Triaged decision: #{triage.human_enum_name(:status)}",
+        class: "nhsuk-heading-s nhsuk-u-margin-bottom-2"
+      ),
+      if (notes = triage.notes).present?
+        tag.p(notes, class: "nhsuk-u-margin-bottom-1")
+      end,
+      tag.p(
+        "#{triage.user.full_name}, #{triage.created_at.to_fs(:app_date_time)}",
+        class: "nhsuk-u-secondary-text-color nhsuk-u-font-size-16"
+      )
+    ].compact.join("\n").html_safe
+  end
+>>>>>>> 41a4b57a (Show decision on triage notes)
 end

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -1,19 +1,6 @@
 # frozen_string_literal: true
 
 class AppTriageNotesComponent < ViewComponent::Base
-  def call
-    if triage_entries.size == 1
-      triage_notes(triage_entries.first)
-    else
-      tag.ul(class: "nhsuk-list") do
-        triage_entries
-          .map { |t| tag.li(t.notes) { triage_notes(t) } }
-          .join("\n")
-          .html_safe
-      end
-    end
-  end
-
   def initialize(patient_session:)
     super
 
@@ -21,27 +8,13 @@ class AppTriageNotesComponent < ViewComponent::Base
   end
 
   def render?
-    triage_entries.present?
+    entries.present?
   end
 
   private
 
-  def triage_entries
-    @triage_entries ||=
+  def entries
+    @entries ||=
       @patient_session.triage.where.not(notes: nil).order(created_at: :desc)
-  end
-
-  def triage_notes(triage)
-    [
-      tag.p(class: "nhsuk-u-margin-bottom-1") { triage.notes },
-      tag.p(class: "nhsuk-u-secondary-text-color nhsuk-u-font-size-16") do
-        author_info(triage:)
-      end
-    ].join("\n").html_safe
-  end
-
-  def author_info(triage:)
-    date_text = triage.created_at.to_fs(:long)
-    "#{triage.user.full_name}, #{date_text}"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,10 +145,10 @@ en:
           vaccinated: Vaccinated
       triage:
         statuses:
-          delay_vaccination: No, delay vaccination to a later date
-          do_not_vaccinate: No, do not vaccinate
-          needs_follow_up: No, keep in triage
-          ready_to_vaccinate: Yes, it’s safe to vaccinate
+          delay_vaccination: Delay vaccination to a later date
+          do_not_vaccinate: Do not vaccinate in campaign
+          needs_follow_up: Keep in triage
+          ready_to_vaccinate: Safe to vaccinate
       vaccination_record:
         delivery_methods:
           intranasal: Intramuscular (IM)

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -49,7 +49,7 @@ describe AppActivityLogComponent, type: :component do
     [
       create(
         :triage,
-        :kept_in_triage,
+        :needs_follow_up,
         patient_session:,
         created_at: Time.zone.parse("2024-05-30 14:00"),
         notes: "Some notes",
@@ -57,7 +57,7 @@ describe AppActivityLogComponent, type: :component do
       ),
       create(
         :triage,
-        :vaccinate,
+        :ready_to_vaccinate,
         patient_session:,
         created_at: Time.zone.parse("2024-05-30 14:30"),
         user:

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -24,11 +24,11 @@ describe AppTriageFormComponent, type: :component do
       end
 
       context "patient_session has existing triage" do
-        let(:old_triage) { create :triage, :kept_in_triage }
+        let(:old_triage) { create :triage, :needs_follow_up }
         let(:patient_session) { create :patient_session, triage: [old_triage] }
 
         it { should_not eq nil }
-        it { should be_needs_follow_up } # AKA kept_in_triage
+        it { should be_needs_follow_up }
       end
     end
 

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -34,7 +34,8 @@ describe AppTriageNotesComponent, type: :component do
 
     it { should have_css("h3", text: "Triaged decision: Safe to vaccinate") }
     it { should have_css("p", text: patient_session.triage.first.notes) }
-    it { should have_css("p", text: "Joe Gear, 4 December 2023 at 10:04am") }
+    it { should have_css("p", text: "4 December 2023 at 10:04am") }
+    it { should have_css("p", text: "Joe Gear") }
   end
 
   context "multiple triage notes are present" do

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -19,22 +19,19 @@ describe AppTriageNotesComponent, type: :component do
   end
 
   context "a single triage note is present" do
-    prepend_before(:context) do
-      Timecop.freeze(Time.zone.local(2023, 12, 4, 10, 4))
+    around(:all) do |example|
+      Timecop.freeze(Time.zone.local(2023, 12, 4, 10, 4)) { example.run }
     end
-
-    after(:context) { Timecop.return }
 
     let(:user) { create(:user, full_name: "Joe Gear") }
     let(:triage) { [create(:triage, notes: "Some notes", user:)] }
 
     it "renders" do
-      expect(component.render?).to be_truthy
+      expect(component.render?).to be true
     end
 
     it { should have_css("p", text: patient_session.triage.first.notes) }
-    it { should have_css("p", text: "Joe Gear, 4 December 2023 at 10:04") }
-    it { should_not have_css("ul") }
+    it { should have_css("p", text: "Joe Gear, 4 December 2023 at 10:04am") }
   end
 
   context "multiple triage notes are present" do
@@ -49,7 +46,7 @@ describe AppTriageNotesComponent, type: :component do
       expect(component.render?).to be_truthy
     end
 
-    it { should have_css("ul p", text: "Some notes") }
-    it { should have_css("ul p", text: "More notes") }
+    it { should have_css("p", text: "Some notes") }
+    it { should have_css("p", text: "More notes") }
   end
 end

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -24,12 +24,15 @@ describe AppTriageNotesComponent, type: :component do
     end
 
     let(:user) { create(:user, full_name: "Joe Gear") }
-    let(:triage) { [create(:triage, notes: "Some notes", user:)] }
+    let(:triage) do
+      [create(:triage, :ready_to_vaccinate, notes: "Some notes", user:)]
+    end
 
     it "renders" do
       expect(component.render?).to be true
     end
 
+    it { should have_css("h3", text: "Triaged decision: Safe to vaccinate") }
     it { should have_css("p", text: patient_session.triage.first.notes) }
     it { should have_css("p", text: "Joe Gear, 4 December 2023 at 10:04am") }
   end

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -36,21 +36,16 @@ describe AppTriageNotesComponent, type: :component do
     it { should have_css("p", text: patient_session.triage.first.notes) }
     it { should have_css("p", text: "4 December 2023 at 10:04am") }
     it { should have_css("p", text: "Joe Gear") }
+    it { should_not have_css("hr") }
   end
 
   context "multiple triage notes are present" do
-    let(:triage) do
-      [
-        create(:triage, notes: "Some notes"),
-        create(:triage, notes: "More notes")
-      ]
-    end
+    let(:triage) { create_list(:triage, 2) }
 
     it "renders" do
       expect(component.render?).to be_truthy
     end
 
-    it { should have_css("p", text: "Some notes") }
-    it { should have_css("p", text: "More notes") }
+    it { should have_css("hr") }
   end
 end

--- a/spec/factories/triage.rb
+++ b/spec/factories/triage.rb
@@ -29,20 +29,6 @@ FactoryBot.define do
     patient_session { create :patient_session }
     user { create :user }
 
-    trait :vaccinate do
-      status { :ready_to_vaccinate }
-    end
-
-    trait :kept_in_triage do
-      status { :needs_follow_up }
-    end
-
-    trait :delay_vaccination do
-      status { :delay_vaccination }
-    end
-
-    trait :do_not_vaccinate do
-      status { :do_not_vaccinate }
-    end
+    traits_for_enum :status
   end
 end


### PR DESCRIPTION
This updates the patient triage notes component to include the triage decision heading that we show in the activity log, and ensures that the service matches the designs in the prototype.

## Screenshots

### Old

<img width="861" alt="Screenshot 2024-06-27 at 14 49 23" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/510498/c88ec8c3-1453-4ec2-87f6-bda1a92be678">

### New

<img width="847" alt="Screenshot 2024-06-28 at 12 02 22" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/510498/efa61723-648d-444b-b835-19cec51dbdd6">

