### PR TITLE
Standardise date and time formats

### DIFF
--- a/app/components/app_activity_log_component.html.erb
+++ b/app/components/app_activity_log_component.html.erb
@@ -1,7 +1,7 @@
 <% events_by_day.each do |day, events| %>
   <h2 class="nhsuk-heading-xs nhsuk-u-secondary-text-color
              nhsuk-u-font-weight-normal">
-    <%= day %>
+    <%= day.to_fs(:long) %>
   </h2>
 
   <% events.each do |event| %>
@@ -16,7 +16,7 @@
           </blockquote>
         <% end %>
         <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
-          <%= event[:time].to_fs(:nhsuk_date_time) %>
+          <%= event[:time].to_fs(:long) %>
           <% if event[:by] %> · <%= event[:by] %><% end %>
         </p>
       </div>

--- a/app/components/app_activity_log_component.html.erb
+++ b/app/components/app_activity_log_component.html.erb
@@ -16,7 +16,7 @@
           </blockquote>
         <% end %>
         <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
-          <%= event[:time].to_fs(:app_date_time) %>
+          <%= event[:time].to_fs(:nhsuk_date_time) %>
           <% if event[:by] %> · <%= event[:by] %><% end %>
         </p>
       </div>

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -8,9 +8,7 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def events_by_day
-    all_events
-      .sort_by { -_1[:time].to_i }
-      .group_by { _1[:time].to_fs(:nhsuk_date) }
+    all_events.sort_by { -_1[:time].to_i }.group_by { _1[:time].to_date }
   end
 
   def all_events

--- a/app/components/app_compare_consent_form_and_patient_component.html.erb
+++ b/app/components/app_compare_consent_form_and_patient_component.html.erb
@@ -20,8 +20,8 @@
     <%= table.with_body do |body| %>
       <%= body.with_row do |row| %>
         <%= row.with_cell(text: "Date of birth", header: true) %>
-        <%= row.with_cell(text: mark(consent_form.date_of_birth.to_fs(:nhsuk_date), unless: date_of_birth_match?)) %>
-        <%= row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date)) %>
+        <%= row.with_cell(text: mark(consent_form.date_of_birth.to_fs(:long), unless: date_of_birth_match?)) %>
+        <%= row.with_cell(text: patient.date_of_birth.to_fs(:long)) %>
       <% end %>
     <% end %>
 

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -24,7 +24,7 @@
             <br>
             <span class="nhsuk-u-font-size-16"><%= consent.who_responded %></span>
           <% end %>
-          <%= row.with_cell(text: consent.recorded_at.to_fs(:app_date_time)) %>
+          <%= row.with_cell(text: consent.recorded_at.to_fs(:nhsuk_date_time)) %>
           <%= row.with_cell(text: consent.human_enum_name(:response).humanize) %>
         <% end %>
       <% end %>

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -24,7 +24,7 @@
             <br>
             <span class="nhsuk-u-font-size-16"><%= consent.who_responded %></span>
           <% end %>
-          <%= row.with_cell(text: consent.recorded_at.to_fs(:nhsuk_date_time)) %>
+          <%= row.with_cell(text: consent.recorded_at.to_fs(:long)) %>
           <%= row.with_cell(text: consent.human_enum_name(:response).humanize) %>
         <% end %>
       <% end %>

--- a/app/components/app_matching_criteria_component.html.erb
+++ b/app/components/app_matching_criteria_component.html.erb
@@ -19,7 +19,7 @@
      if date_of_birth.present?
        summary_list.with_row do |row|
          row.with_key { "Date of birth" }
-         row.with_value { "#{date_of_birth.to_fs(:nhsuk_date)} (aged #{age})" }
+         row.with_value { "#{date_of_birth.to_fs(:long)} (aged #{age})" }
        end
      end
    

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -89,10 +89,12 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def date_summary
-    if last_action_time.to_date == Time.zone.today
-      "Today (#{last_action_time.to_fs(:nhsuk_date)})"
+    date = last_action_time.to_date
+
+    if date == Time.zone.today
+      "Today (#{date.to_fs(:long)})"
     else
-      last_action_time.to_fs(:nhsuk_date)
+      date.to_fs(:long)
     end
   end
 

--- a/app/components/app_patient_details_component.rb
+++ b/app/components/app_patient_details_component.rb
@@ -32,9 +32,7 @@ class AppPatientDetailsComponent < ViewComponent::Base
       if @object.date_of_birth.present?
         summary_list.with_row do |row|
           row.with_key { "Date of birth" }
-          row.with_value do
-            "#{@object.date_of_birth.to_fs(:nhsuk_date)} (#{aged})"
-          end
+          row.with_value { "#{@object.date_of_birth.to_fs(:long)} (#{aged})" }
         end
       end
 

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -47,8 +47,7 @@ class AppPatientTableComponent < ViewComponent::Base
       {
         text: patient_session.patient.date_of_birth.to_fs(:nhsuk_date),
         html_attributes: {
-          "data-filter":
-            patient_session.patient.date_of_birth.strftime("%d/%m/%Y"),
+          "data-filter": patient_session.patient.date_of_birth.to_fs(:uk_short),
           "data-sort": patient_session.patient.date_of_birth
         }
       }

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -45,7 +45,7 @@ class AppPatientTableComponent < ViewComponent::Base
       { text: name_cell(patient_session) }
     when :dob
       {
-        text: patient_session.patient.date_of_birth.to_fs(:nhsuk_date),
+        text: patient_session.patient.date_of_birth.to_fs(:long),
         html_attributes: {
           "data-filter": patient_session.patient.date_of_birth.to_fs(:uk_short),
           "data-sort": patient_session.patient.date_of_birth

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -45,8 +45,7 @@ class AppPatientTableComponent < ViewComponent::Base
       { text: name_cell(patient_session) }
     when :dob
       {
-        text:
-          patient_session.patient.date_of_birth.to_fs(:nhsuk_date_short_month),
+        text: patient_session.patient.date_of_birth.to_fs(:nhsuk_date),
         html_attributes: {
           "data-filter":
             patient_session.patient.date_of_birth.strftime("%d/%m/%Y"),

--- a/app/components/app_session_details_component.rb
+++ b/app/components/app_session_details_component.rb
@@ -16,7 +16,7 @@ class AppSessionDetailsComponent < ViewComponent::Base
   end
 
   def date
-    @session.date.to_fs(:nhsuk_date_day_of_week)
+    @session.date.to_fs(:long_day_of_week)
   end
 
   def time
@@ -29,19 +29,18 @@ class AppSessionDetailsComponent < ViewComponent::Base
   end
 
   def consent_requests
-    "Send on #{@session.send_consent_at.to_fs(:nhsuk_date_day_of_week)}"
+    "Send on #{@session.send_consent_at.to_fs(:long_day_of_week)}"
   end
 
   def reminders
-    "Send on #{@session.send_reminders_at.to_fs(:nhsuk_date_day_of_week)}"
+    "Send on #{@session.send_reminders_at.to_fs(:long_day_of_week)}"
   end
 
   def deadline_for_responses
     if @session.date == @session.close_consent_at
       "Allow responses until the day of the session"
     else
-      close_consent_at =
-        @session.close_consent_at.to_fs(:nhsuk_date_day_of_week)
+      close_consent_at = @session.close_consent_at.to_fs(:long_day_of_week)
       "Allow responses until #{close_consent_at}"
     end
   end

--- a/app/components/app_timestamped_entry_component.rb
+++ b/app/components/app_timestamped_entry_component.rb
@@ -9,7 +9,7 @@ class AppTimestampedEntryComponent < ViewComponent::Base
       <% if @recorded_by.present? %>
         <%= mail_to(@recorded_by.email, @recorded_by.full_name) %>,
       <% end %>
-      <%= @timestamp.to_fs(:app_date_time) %>
+      <%= @timestamp.to_fs(:nhsuk_date_time) %>
     </p>
   ERB
 

--- a/app/components/app_timestamped_entry_component.rb
+++ b/app/components/app_timestamped_entry_component.rb
@@ -9,7 +9,7 @@ class AppTimestampedEntryComponent < ViewComponent::Base
       <% if @recorded_by.present? %>
         <%= mail_to(@recorded_by.email, @recorded_by.full_name) %>,
       <% end %>
-      <%= @timestamp.to_fs(:nhsuk_date_time) %>
+      <%= @timestamp.to_fs(:long) %>
     </p>
   ERB
 

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -41,7 +41,7 @@ class AppTriageNotesComponent < ViewComponent::Base
   end
 
   def author_info(triage:)
-    date_text = triage.created_at.strftime("%-d %B %Y at %-l:%M%P")
+    date_text = triage.created_at.to_fs(:nhsuk_date_time)
     "#{triage.user.full_name}, #{date_text}"
   end
 end

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -41,7 +41,7 @@ class AppTriageNotesComponent < ViewComponent::Base
   end
 
   def author_info(triage:)
-    date_text = triage.created_at.to_fs(:nhsuk_date_time)
+    date_text = triage.created_at.to_fs(:long)
     "#{triage.user.full_name}, #{date_text}"
   end
 end

--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -31,7 +31,7 @@ module PatientSortingConcern
 
     if params[:dob].present?
       patient_sessions.select! do
-        _1.patient.date_of_birth.strftime("%d/%m/%Y").include?(params[:dob])
+        _1.patient.date_of_birth.to_fs(:uk_short).include?(params[:dob])
       end
     end
   end

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -7,11 +7,11 @@ module VaccinationsHelper
     current_date = Time.zone.today
 
     if date == current_date
-      "Today (#{date.to_fs(:nhsuk_date)})"
+      "Today (#{date.to_fs(:long)})"
     elsif date == current_date - 1
-      "Yesterday (#{date.to_fs(:nhsuk_date)})"
+      "Yesterday (#{date.to_fs(:long)})"
     else
-      date.to_fs(:nhsuk_date)
+      date.to_fs(:long)
     end
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -61,11 +61,11 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def short_date
-    @session.date.strftime("%-d %B")
+    @session.date.to_fs(:short)
   end
 
   def long_date
-    @session.date.strftime("%A %-d %B")
+    @session.date.to_fs(:short_day_of_week)
   end
 
   def team_email

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -63,6 +63,6 @@ class ConsentFormMailer < ApplicationMailer
   def survey_deadline_date
     recorded_at = @consent_form&.recorded_at || @consent.recorded_at
 
-    (recorded_at + 7.days).to_fs(:nhsuk_date)
+    (recorded_at + 7.days).to_date.to_fs(:long)
   end
 end

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -37,10 +37,10 @@ class ConsentRequestMailer < ApplicationMailer
   def consent_request_personalisation
     personalisation.merge(
       consent_link:,
-      session_date: @session.date.to_fs(:sunday_1_may),
-      session_short_date: @session.date.to_fs(:"1_may"),
-      close_consent_date: @session.close_consent_at.to_fs(:sunday_1_may),
-      close_consent_short_date: @session.close_consent_at.to_fs(:"1_may")
+      session_date: @session.date.to_fs(:short_day_of_week),
+      session_short_date: @session.date.to_fs(:short),
+      close_consent_date: @session.close_consent_at.to_fs(:short_day_of_week),
+      close_consent_short_date: @session.close_consent_at.to_fs(:short)
     )
   end
 

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -52,7 +52,7 @@ class VaccinationMailer < ApplicationMailer
     if @vaccination_record.recorded_at.today?
       "today"
     else
-      @vaccination_record.recorded_at.to_fs(:nhsuk_date_short_month)
+      @vaccination_record.recorded_at.to_fs(:nhsuk_date)
     end
   end
 

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -52,7 +52,7 @@ class VaccinationMailer < ApplicationMailer
     if @vaccination_record.recorded_at.today?
       "today"
     else
-      @vaccination_record.recorded_at.to_fs(:nhsuk_date)
+      @vaccination_record.recorded_at.to_date.to_fs(:long)
     end
   end
 

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -61,7 +61,7 @@ class VaccinationMailer < ApplicationMailer
   end
 
   def day_month_year_of_vaccination
-    @vaccination_record.recorded_at.strftime("%d/%m/%Y")
+    @vaccination_record.recorded_at.to_date.to_fs(:uk_short)
   end
 
   def reason_did_not_vaccinate

--- a/app/models/nivs_report_row.rb
+++ b/app/models/nivs_report_row.rb
@@ -26,13 +26,13 @@ class NivsReportRow
       patient.nhs_number,
       patient.first_name,
       patient.last_name,
-      patient.date_of_birth.to_fs(:YYYYMMDD),
+      patient.date_of_birth.to_fs(:number),
       "Not Known", # gender code not available
       patient.address_postcode,
-      vaccination.recorded_at.to_date.to_fs(:YYYYMMDD),
+      vaccination.recorded_at.to_date.to_fs(:number),
       batch.vaccine.brand,
       batch.name,
-      batch.expiry.to_fs(:YYYYMMDD),
+      batch.expiry.to_fs(:number),
       delivery_site,
       "1", # dose sequence hard-coded to 1 for HPV
       "MAVIS-#{patient.id}",

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -30,7 +30,7 @@
           <% body.with_row do |row| %>
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Date</span>
-              <%= session.date.to_fs(:nhsuk_date) %>
+              <%= session.date.to_fs(:long) %>
             <% end %>
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Time</span>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -47,9 +47,9 @@
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Consent period</span>
               <% if session.close_consent_at.past? %>
-                <%= "Closed #{session.close_consent_at.strftime("%-d %b")}" %>
+                <%= "Closed #{session.close_consent_at.to_fs(:short)}" %>
               <% else %>
-                <%= "Open until #{session.close_consent_at.strftime("%-d %b")}" %>
+                <%= "Open until #{session.close_consent_at.to_fs(:short)}" %>
               <% end %>
             <% end %>
             <% row.with_cell(numeric: true) do %>

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -26,7 +26,7 @@
         table.with_body do |body|
           @unmatched_consent_responses.each do |consent_form|
             body.with_row do |row|
-              row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date))
+              row.with_cell(text: consent_form.recorded_at&.to_date&.to_fs(:long))
               row.with_cell(text: consent_form.full_name)
               row.with_cell(text: consent_form.parent.name)
               row.with_cell(text: govuk_link_to("Find match", consent_form))

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -26,7 +26,7 @@
         table.with_body do |body|
           @unmatched_consent_responses.each do |consent_form|
             body.with_row do |row|
-              row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
+              row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date))
               row.with_cell(text: consent_form.full_name)
               row.with_cell(text: consent_form.parent.name)
               row.with_cell(text: govuk_link_to("Find match", consent_form))

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -14,7 +14,7 @@
       ) do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Response date" }
-          row.with_value { @consent.recorded_at.to_fs(:nhsuk_date_time) }
+          row.with_value { @consent.recorded_at.to_fs(:long) }
         end
       
         summary_list.with_row do |row|
@@ -55,7 +55,7 @@
       
         summary_list.with_row do |row|
           row.with_key { "Date of birth" }
-          row.with_value { @consent.patient.date_of_birth.to_fs(:nhsuk_date) }
+          row.with_value { @consent.patient.date_of_birth.to_fs(:long) }
         end
       
         if @consent.consent_form.present?

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -14,7 +14,7 @@
       ) do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Response date" }
-          row.with_value { @consent.recorded_at.to_fs(:app_date_time) }
+          row.with_value { @consent.recorded_at.to_fs(:nhsuk_date_time) }
         end
       
         summary_list.with_row do |row|

--- a/app/views/edit_sessions/cohort.html.erb
+++ b/app/views/edit_sessions/cohort.html.erb
@@ -46,7 +46,7 @@
                 end
               end
               row.with_cell(text: patient.full_name)
-              row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date))
+              row.with_cell(text: patient.date_of_birth.to_fs(:long))
               row.with_cell(
                 text: t("activerecord.attributes.patient.year_group.#{patient.year_group}"),
               )

--- a/app/views/edit_sessions/cohort.html.erb
+++ b/app/views/edit_sessions/cohort.html.erb
@@ -46,7 +46,7 @@
                 end
               end
               row.with_cell(text: patient.full_name)
-              row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date_short_month))
+              row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date))
               row.with_cell(
                 text: t("activerecord.attributes.patient.year_group.#{patient.year_group}"),
               )

--- a/app/views/edit_sessions/timeline.html.erb
+++ b/app/views/edit_sessions/timeline.html.erb
@@ -13,7 +13,7 @@
     <span class="nhsuk-visually-hidden">Information: </span>
 
     <p>
-      Session scheduled for <%= @session.date.to_fs(:nhsuk_date_day_of_week) %> (<%= @session.human_enum_name(:time_of_day) %>)
+      Session scheduled for <%= @session.date.to_fs(:long_day_of_week) %> (<%= @session.human_enum_name(:time_of_day) %>)
     </p>
   <% end %>
 

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -61,7 +61,7 @@
       
         summary_list.with_row do |row|
           row.with_key { "Date of birth" }
-          row.with_value { @consent.patient.date_of_birth.to_fs(:nhsuk_date) }
+          row.with_value { @consent.patient.date_of_birth.to_fs(:long) }
         end
       
         if @consent.consent_form.present?

--- a/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
@@ -1,6 +1,6 @@
 <% title = t("consent_forms.confirmation_agreed.title.#{@session.type.downcase}",
             full_name: @consent_form.full_name,
-            date: @session.date.to_fs(:nhsuk_date)) %>
+            date: @session.date.to_fs(:long)) %>
 <% content_for :page_title, title %>
 
 <%= govuk_panel(title_text: title, classes: "app-panel nhsuk-u-margin-bottom-6") %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -84,7 +84,7 @@
       
         summary_list.with_row do |row|
           row.with_key { "Date of birth" }
-          row.with_value { @consent_form.date_of_birth.to_fs(:nhsuk_date) }
+          row.with_value { @consent_form.date_of_birth.to_fs(:long) }
           row.with_action(
             text: "Change",
             href: change_link[:date_of_birth],

--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -1,7 +1,7 @@
 <tr class="nhsuk-table__row">
   <td class="nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Date</span>
-    <%= session.date.to_fs(:nhsuk_date) %>
+    <%= session.date.to_fs(:long) %>
   </td>
   <td class="nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Time</span>

--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -1,7 +1,7 @@
 <tr class="nhsuk-table__row">
   <td class="nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Date</span>
-    <%= session.date.to_fs(:nhsuk_date_short_month) %>
+    <%= session.date.to_fs(:nhsuk_date) %>
   </td>
   <td class="nhsuk-table__cell">
     <span class="nhsuk-table-responsive__heading">Time</span>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -11,7 +11,7 @@
 <%= h1 page_title: do %>
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    <%= @session.date.to_fs(:nhsuk_date) %> (<%= @session.human_enum_name(:time_of_day) %>) ·
+    <%= @session.date.to_fs(:long) %> (<%= @session.human_enum_name(:time_of_day) %>) ·
     <%= pluralize(@patient_sessions.size, "child") %> in cohort
   </span>
 <% end %>

--- a/app/views/vaccinations/batch.html.erb
+++ b/app/views/vaccinations/batch.html.erb
@@ -19,7 +19,7 @@
     <% @batches.each_with_index do |batch, idx| %>
       <% label = proc do %>
         <span class="app-u-monospace"><%= batch.name %></span>
-        (expires <%= batch.expiry.to_fs(:nhsuk_date) %>)
+        (expires <%= batch.expiry.to_fs(:long) %>)
       <% end %>
       <%= f.govuk_radio_button(:id, batch.id, label:, link_errors: idx.zero?) %>
     <% end %>

--- a/app/views/vaccinations/batches/edit.html.erb
+++ b/app/views/vaccinations/batches/edit.html.erb
@@ -19,7 +19,7 @@
     <% @batches.each do |batch| %>
       <% label = proc do %>
         <span class="app-u-monospace"><%= batch.name %></span>
-        (expires <%= batch.expiry.to_fs(:nhsuk_date) %>)
+        (expires <%= batch.expiry.to_fs(:long) %>)
       <% end %>
       <%= f.govuk_radio_button(:batch_id, batch.id, label:) do %>
         <%= f.govuk_check_box(

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -45,7 +45,7 @@
               row.with_key { "Batch" }
               row.with_value do
                 batch = @draft_vaccination_record.batch
-                "#{batch.name} (expires #{batch.expiry.to_fs(:nhsuk_date)})"
+                "#{batch.name} (expires #{batch.expiry.to_fs(:long)})"
               end
             end
         
@@ -67,7 +67,7 @@
         
           summary_list.with_row do |row|
             row.with_key { "Date" }
-            row.with_value { "Today (#{Time.zone.now.to_fs(:nhsuk_date)})" }
+            row.with_value { "Today (#{Time.zone.today.to_fs(:long)})" }
           end
         
           summary_list.with_row do |row|

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -35,8 +35,8 @@
                   </span>
                 <% end %>
               <% end %>
-              <% row.with_cell(text: batch.created_at.to_fs(:nhsuk_date)) %>
-              <% row.with_cell(text: batch.expiry.to_fs(:nhsuk_date)) %>
+              <% row.with_cell(text: batch.created_at.to_date.to_fs(:long)) %>
+              <% row.with_cell(text: batch.expiry.to_fs(:long)) %>
               <% row.with_cell do %>
                 <%= link_to "Change", edit_vaccine_batch_path(vaccine, batch) %>
               <% end %>

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -9,4 +9,6 @@ Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
 
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
-Time::DATE_FORMATS[:app_date_time] = "%-d %B %Y at %-l:%M%P" # 5 January 2023 at 3:45pm
+Time::DATE_FORMATS[
+  :nhsuk_date_time
+] = "#{Time::DATE_FORMATS[:nhsuk_date]} at #{Time::DATE_FORMATS[:time]}"

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -2,13 +2,11 @@
 
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
-Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y" # 5 Jan 2023
 Date::DATE_FORMATS[:sunday_1_may] = "%A %-d %B" # Sunday 1 May
 Date::DATE_FORMATS[:"1_may"] = "%-d %B" # 1 May
 
 Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
-Time::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y" # 5 Jan 2023
 
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
 Time::DATE_FORMATS[:app_date_time] = "%-d %b %Y at %-l:%M%P" # 5 Jan 2023 at 3:45pm

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -12,4 +12,3 @@ Time::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y" # 5 Jan 2023
 
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
 Time::DATE_FORMATS[:app_date_time] = "%-d %b %Y at %-l:%M%P" # 5 Jan 2023 at 3:45pm
-Time::DATE_FORMATS[:app_date_time_long] = "%A %-d %B %Y at %-l:%M%P" # Wednesday 5 January 2023 at 3:45pm

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
+Date::DATE_FORMATS[:short] = "%-d %B" # 1 January
+Date::DATE_FORMATS[:short_day_of_week] = "%A %-d %B" # Monday 1 January
+
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
-Date::DATE_FORMATS[:sunday_1_may] = "%A %-d %B" # Sunday 1 May
-Date::DATE_FORMATS[:"1_may"] = "%-d %B" # 1 May
 
 Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -3,6 +3,8 @@
 Date::DATE_FORMATS[:short] = "%-d %B" # 1 January
 Date::DATE_FORMATS[:short_day_of_week] = "%A %-d %B" # Monday 1 January
 
+Date::DATE_FORMATS[:uk_short] = "%d/%m/%Y" # 01/01/2020
+
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
 

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -5,7 +5,6 @@ Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 Jan
 Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y" # 5 Jan 2023
 Date::DATE_FORMATS[:sunday_1_may] = "%A %-d %B" # Sunday 1 May
 Date::DATE_FORMATS[:"1_may"] = "%-d %B" # 1 May
-Date::DATE_FORMATS[:YYYYMMDD] = "%Y%m%d" # 20230105
 
 Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -9,4 +9,4 @@ Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
 Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
 
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
-Time::DATE_FORMATS[:app_date_time] = "%-d %b %Y at %-l:%M%P" # 5 Jan 2023 at 3:45pm
+Time::DATE_FORMATS[:app_date_time] = "%-d %B %Y at %-l:%M%P" # 5 January 2023 at 3:45pm

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Here we replace the standard Rails date and time formats with slightly
+# different versions based on the guidance in the NHS service manual.
+# See https://railsdatetimeformats.com/ for the default values.
+
+# Dates - https://service-manual.nhs.uk/content/numbers-measurements-dates-time#dates
+
 Date::DATE_FORMATS[:short] = "%-d %B" # 1 January
 Date::DATE_FORMATS[:short_day_of_week] = "%A %-d %B" # Monday 1 January
 
@@ -7,6 +13,8 @@ Date::DATE_FORMATS[:long] = "%-d %B %Y" # 5 January 2023
 Date::DATE_FORMATS[:long_day_of_week] = "%A %-d %B %Y" # Wednesday 5 January 2023
 
 Date::DATE_FORMATS[:uk_short] = "%d/%m/%Y" # 01/01/2020
+
+# Time - https://service-manual.nhs.uk/content/numbers-measurements-dates-time#time
 
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
 

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -3,15 +3,11 @@
 Date::DATE_FORMATS[:short] = "%-d %B" # 1 January
 Date::DATE_FORMATS[:short_day_of_week] = "%A %-d %B" # Monday 1 January
 
+Date::DATE_FORMATS[:long] = "%-d %B %Y" # 5 January 2023
 Date::DATE_FORMATS[:long_day_of_week] = "%A %-d %B %Y" # Wednesday 5 January 2023
 
 Date::DATE_FORMATS[:uk_short] = "%d/%m/%Y" # 01/01/2020
 
-Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
-
-Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
-
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
-Time::DATE_FORMATS[
-  :nhsuk_date_time
-] = "#{Time::DATE_FORMATS[:nhsuk_date]} at #{Time::DATE_FORMATS[:time]}"
+
+Time::DATE_FORMATS[:long] = "%-d %B %Y at %-l:%M%P" # 5 January 2023 at 3:45pm

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -3,13 +3,13 @@
 Date::DATE_FORMATS[:short] = "%-d %B" # 1 January
 Date::DATE_FORMATS[:short_day_of_week] = "%A %-d %B" # Monday 1 January
 
+Date::DATE_FORMATS[:long_day_of_week] = "%A %-d %B %Y" # Wednesday 5 January 2023
+
 Date::DATE_FORMATS[:uk_short] = "%d/%m/%Y" # 01/01/2020
 
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
-Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
 
 Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y" # 5 January 2023
-Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y" # Wednesday, 5 January 2023
 
 Time::DATE_FORMATS[:time] = "%-l:%M%P" # 3:45pm
 Time::DATE_FORMATS[

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -6,7 +6,7 @@ task :performance, [] => :environment do |_task, _args|
 
   puts "Copy and paste the following into Slack:"
   puts ""
-  puts ":chart_with_upwards_trend: *PILOT PERFORMANCE* _#{Time.zone.now.to_fs(:nhsuk_date_day_of_week)}_"
+  puts ":chart_with_upwards_trend: *PILOT PERFORMANCE* _#{Time.zone.today.to_fs(:long_day_of_week)}_"
   puts ""
 
   teams = Team.all - Team.where(name: "Team MAVIS")

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -31,7 +31,7 @@ describe AppConsentSummaryComponent, type: :component do
   it { should have_text("07987654321") }
   it { should have_text("jane@example.com") }
   it { should have_text("Consent refused (online)") }
-  it { should have_text("1 Mar 2024 at 2:23pm") }
+  it { should have_text("1 March 2024 at 2:23pm") }
   it do
     should have_text("Refusal reasonAlready vaccinated\nVaccinated at the GP")
   end
@@ -49,7 +49,7 @@ describe AppConsentSummaryComponent, type: :component do
 
     it { should have_text("Jane Smith") }
     it { should have_text("Consent given (online)") }
-    it { should have_text("1 Mar 2024 at 2:23pm") }
+    it { should have_text("1 March 2024 at 2:23pm") }
     it { should_not have_text("Relationship") }
     it { should_not have_text("Contact") }
     it { should_not have_text("Refusal reason") }
@@ -92,9 +92,9 @@ describe AppConsentSummaryComponent, type: :component do
 
     it { should have_text("Jane Smith") }
     it { should have_text("Consent given (online)") }
-    it { should have_text("1 Mar 2024 at 2:23pm") }
+    it { should have_text("1 March 2024 at 2:23pm") }
     it { should have_text("Consent refused (online)") }
-    it { should have_text("2 Mar 2024 at 2:24pm") }
+    it { should have_text("2 March 2024 at 2:24pm") }
   end
 
   context "with response being an array with one element" do
@@ -110,7 +110,7 @@ describe AppConsentSummaryComponent, type: :component do
       )
     end
 
-    it { should have_text("1 Mar 2024 at 2:23pm") }
+    it { should have_text("1 March 2024 at 2:23pm") }
     it { should_not have_css("li") }
   end
 end

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -31,7 +31,7 @@ describe AppOutcomeBannerComponent, type: :component do
     let(:vaccine) { patient_session.session.campaign.vaccines.first }
     let(:location) { patient_session.session.location }
     let(:batch) { vaccine.batches.first }
-    let(:date) { vaccination_record.recorded_at.to_fs(:nhsuk_date) }
+    let(:date) { vaccination_record.recorded_at.to_date.to_fs(:long) }
     let(:time) { vaccination_record.recorded_at.to_fs(:time) }
 
     it { should have_css(".app-card--green") }
@@ -48,7 +48,7 @@ describe AppOutcomeBannerComponent, type: :component do
           ps.vaccination_records.first.update(recorded_at: Time.zone.now)
         end
       end
-      let(:date) { Time.zone.now.to_fs(:nhsuk_date) }
+      let(:date) { Time.zone.today.to_fs(:long) }
 
       it { should have_text("DateToday (#{date})") }
     end
@@ -61,7 +61,7 @@ describe AppOutcomeBannerComponent, type: :component do
     let(:vaccination_record) { patient_session.vaccination_records.first }
     let(:location) { patient_session.session.location }
     let(:triage) { patient_session.triage.first }
-    let(:date) { triage.created_at.to_fs(:nhsuk_date) }
+    let(:date) { triage.created_at.to_date.to_fs(:long) }
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
@@ -78,7 +78,7 @@ describe AppOutcomeBannerComponent, type: :component do
         end
       end
 
-      it { should have_text("Date#{date.to_fs(:nhsuk_date)}") }
+      it { should have_text("Date#{date.to_date.to_fs(:long)}") }
     end
   end
 end

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -34,7 +34,7 @@ describe AppPatientDetailsComponent, type: :component do
 
     it "should render the patient's date of birth" do
       expected_dob =
-        "#{patient.date_of_birth.to_fs(:nhsuk_date)} (aged #{patient.age})"
+        "#{patient.date_of_birth.to_fs(:long)} (aged #{patient.age})"
       expect(page).to(
         have_css(
           ".nhsuk-summary-list__row",
@@ -104,7 +104,7 @@ describe AppPatientDetailsComponent, type: :component do
     end
 
     it "should render the child's date of birth" do
-      formatted_date = consent_form.date_of_birth.to_fs(:nhsuk_date)
+      formatted_date = consent_form.date_of_birth.to_fs(:long)
       expected_dob = "#{formatted_date} (aged #{consent_form.age})"
       expect(page).to(
         have_css(

--- a/spec/components/app_session_details_component_spec.rb
+++ b/spec/components/app_session_details_component_spec.rb
@@ -24,7 +24,7 @@ describe AppSessionDetailsComponent, type: :component do
     let(:close_consent_at) { date - 1.day }
 
     it do
-      should have_content "Allow responses until #{close_consent_at.to_fs(:nhsuk_date_day_of_week)}"
+      should have_content "Allow responses until #{close_consent_at.to_fs(:long_day_of_week)}"
     end
   end
 

--- a/spec/components/app_timestamped_entry_component_spec.rb
+++ b/spec/components/app_timestamped_entry_component_spec.rb
@@ -19,7 +19,7 @@ describe AppTimestampedEntryComponent, type: :component do
     let(:consents) { [consent] }
 
     it { should have_text("Summary of a thing") }
-    it { should have_text("17 Feb 2024 at 12:23pm") }
+    it { should have_text("17 February 2024 at 12:23pm") }
   end
 
   context "with a user who recorded the entry" do

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -137,13 +137,13 @@ describe "Pilot journey" do
     expect(page).to have_content("1 child")
 
     expect(page).to have_content(
-      "Consent requestsSend on Tuesday, 27 February 2024"
+      "Consent requestsSend on Tuesday 27 February 2024"
     )
-    expect(page).to have_content("RemindersSend on Thursday, 29 February 2024")
+    expect(page).to have_content("RemindersSend on Thursday 29 February 2024")
     expect(page).to have_content(
       "Deadline for responsesAllow responses until the day of the session"
     )
-    expect(page).to have_content("DateFriday, 1 March 2024")
+    expect(page).to have_content("DateFriday 1 March 2024")
 
     click_on "Confirm"
   end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -85,7 +85,7 @@ describe "Verbal consent" do
       "Consent response from #{@patient.parent.name}"
     )
     expect(page).to have_content(
-      ["Response date", Time.zone.today.to_fs(:nhsuk_date_short_month)].join
+      ["Response date", Time.zone.now.to_fs(:app_date_time)].join
     )
     expect(page).to have_content(["Decision", "Consent given"].join)
     expect(page).to have_content(["Response method", "By phone"].join)

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -85,7 +85,7 @@ describe "Verbal consent" do
       "Consent response from #{@patient.parent.name}"
     )
     expect(page).to have_content(
-      ["Response date", Time.zone.now.to_fs(:app_date_time)].join
+      ["Response date", Time.zone.now.to_fs(:nhsuk_date_time)].join
     )
     expect(page).to have_content(["Decision", "Consent given"].join)
     expect(page).to have_content(["Response method", "By phone"].join)

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -85,14 +85,14 @@ describe "Verbal consent" do
       "Consent response from #{@patient.parent.name}"
     )
     expect(page).to have_content(
-      ["Response date", Time.zone.now.to_fs(:nhsuk_date_time)].join
+      ["Response date", Time.zone.today.to_fs(:long)].join
     )
     expect(page).to have_content(["Decision", "Consent given"].join)
     expect(page).to have_content(["Response method", "By phone"].join)
 
     expect(page).to have_content(["Full name", @patient.full_name].join)
     expect(page).to have_content(
-      ["Date of birth", @patient.date_of_birth.to_fs(:nhsuk_date)].join
+      ["Date of birth", @patient.date_of_birth.to_fs(:long)].join
     )
     expect(page).to have_content(["School", @patient.location.name].join)
 

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -84,7 +84,7 @@ describe "Verbal consent" do
     click_link @patient.parent.name
 
     expect(page).to have_content(
-      ["Response date", Time.zone.now.to_fs(:nhsuk_date_time)].join
+      ["Response date", Time.zone.today.to_fs(:long)].join
     )
     expect(page).to have_content(["Decision", "Consent refused"].join)
     expect(page).to have_content(["Response method", "By phone"].join)
@@ -95,7 +95,7 @@ describe "Verbal consent" do
 
     expect(page).to have_content(["Full name", @patient.full_name].join)
     expect(page).to have_content(
-      ["Date of birth", @patient.date_of_birth.to_fs(:nhsuk_date)].join
+      ["Date of birth", @patient.date_of_birth.to_fs(:long)].join
     )
     expect(page).to have_content(["School", @patient.location.name].join)
 

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -84,7 +84,7 @@ describe "Verbal consent" do
     click_link @patient.parent.name
 
     expect(page).to have_content(
-      ["Response date", Time.zone.today.to_fs(:nhsuk_date_short_month)].join
+      ["Response date", Time.zone.now.to_fs(:app_date_time)].join
     )
     expect(page).to have_content(["Decision", "Consent refused"].join)
     expect(page).to have_content(["Response method", "By phone"].join)

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -84,7 +84,7 @@ describe "Verbal consent" do
     click_link @patient.parent.name
 
     expect(page).to have_content(
-      ["Response date", Time.zone.now.to_fs(:app_date_time)].join
+      ["Response date", Time.zone.now.to_fs(:nhsuk_date_time)].join
     )
     expect(page).to have_content(["Decision", "Consent refused"].join)
     expect(page).to have_content(["Response method", "By phone"].join)

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -72,7 +72,7 @@ describe VaccinationMailer do
 
         context "when the vaccination was recorded 2 days ago" do
           let(:recorded_at) { Date.new(2023, 3, 1) }
-          it { should eq("1 Mar 2023") }
+          it { should eq("1 March 2023") }
         end
       end
     end


### PR DESCRIPTION
This standardises the date and time formats across the service to ensure that, where possible, we use a consistent format everywhere. It's based on [the standard date and time formats](https://railsdatetimeformats.com/) that is provided by Rails and then slightly modified to match the NHS service manual (in general, this means months are written in full).

See individual commits for more details on the changes. Overall this change has minimal impact on the frontend, but there are a number of places currently where months are written truncated which this PR has changed to write them out in full.

This was inspired from a conversation in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1439#pullrequestreview-2145769187.