### PR TITLE
Add bin/test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ $ bin/dev
 
 ### Testing
 
+To run all the test:
+
+```bash
+bin/test
+```
+
 To run the Rails tests:
 
 ```bash

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eu
+
+bin/bundle exec rspec
+yarn test
+yarn test:e2e


### PR DESCRIPTION
This adds a script, similar to bin/lint, which automatically runs all the tests in one go. It's meant to be used for convenience when needing to run all the test, but won't replace CI or the running RSpec directly.