### PR TITLE
Simplify bin/heroku-release

### DIFF
--- a/bin/heroku-release
+++ b/bin/heroku-release
@@ -1,13 +1,3 @@
 #!/bin/bash
 
-set -e
-
-# This file is only used by Heroku.
-
-# If the database is empty, we're on a fresh review app, so init the db.
-if [[ `bin/rails db:version | grep version` == "Current version: 0" ]]; then
-  bin/rails db:schema:load
-  bin/rails db:seed
-else
-  bin/rails db:prepare:ignore_concurrent_migration_exceptions
-fi
+bin/rails db:prepare:ignore_concurrent_migration_exceptions


### PR DESCRIPTION
It appears that `db:prepare` already takes into account whether the database has been setup. It runs `db:schema:load` and `db:seed` the first time, and `db:migrate` on subsequent attempts.