### PR TITLE
Configure RSpec linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Rails/UnknownEnv:
     - staging
     - test
 
+RSpec/ContextWording:
+  Enabled: false
+
 RSpec/ImplicitExpect:
   EnforcedStyle: should
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Rails/UnknownEnv:
     - staging
     - test
 
+RSpec/ImplicitExpect:
+  EnforcedStyle: should
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_gem:
   rubocop-govuk:
     - config/default.yml
     - config/rails.yml
+    - config/rspec.yml
 
 inherit_from:
   - node_modules/@prettier/plugin-ruby/rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,12 @@ Rails/UnknownEnv:
 RSpec/ImplicitExpect:
   EnforcedStyle: should
 
+RSpec/VerifiedDoubles:
+  Exclude:
+    - spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+    - spec/controllers/concerns/triage_mailer_concern_spec.rb
+    - spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,9 @@ Rails/UnknownEnv:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/NamedSubject:
+  Enabled: false
+
 RSpec/ImplicitExpect:
   EnforcedStyle: should
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,21 +17,13 @@ AllCops:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
-Lint/UnreachableLoop:
-  Exclude:
-    - spec/lib/health_answers_list_spec.rb
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - production
+    - staging
+    - test
 
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true
-
-Style/NumericLiterals:
-  Exclude:
-    - db/schema.rb
-
-Rails/UnknownEnv:
-  Environments:
-    - development
-    - test
-    - staging
-    - production

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 shared_examples "card" do |params|
   title, date, notes, by = params.values_at(:title, :date, :notes, :by)
   it "renders card '#{title}'" do
-    expect(page).to have_css(".nhsuk-card h3", text: title)
+    expect(subject).to have_css(".nhsuk-card h3", text: title)
 
-    card = page.find(".nhsuk-card h3", text: title).ancestor(".nhsuk-card")
+    card = subject.find(".nhsuk-card h3", text: title).ancestor(".nhsuk-card")
     expect(card).to have_css("p", text: date)
     expect(card).to have_css("blockquote", text: notes) if notes
     expect(card).to have_css("p", text: by) if by
@@ -18,67 +18,6 @@ describe AppActivityLogComponent, type: :component do
   subject { page }
 
   let(:team) { create(:team) }
-  let(:user) { create(:user, teams: [team], full_name: "Nurse Joy") }
-  let(:campaign) { create(:campaign, team:) }
-  let(:location) { create(:location, team:, name: "Hogwarts") }
-  let(:session) { create(:session, campaign:, location:) }
-  let(:patient) { create(:patient, location:) }
-
-  let!(:consents) do
-    [
-      create(
-        :consent,
-        :given,
-        :from_mum,
-        campaign:,
-        patient:,
-        parent: create(:parent, :mum, name: "Jane Doe"),
-        recorded_at: Time.zone.parse("2024-05-30 12:00")
-      ),
-      create(
-        :consent,
-        :refused,
-        :from_dad,
-        campaign:,
-        patient:,
-        parent: create(:parent, :dad, name: "John Doe"),
-        recorded_at: Time.zone.parse("2024-05-30 13:00")
-      )
-    ]
-  end
-
-  let!(:triages) do
-    [
-      create(
-        :triage,
-        :needs_follow_up,
-        patient_session:,
-        created_at: Time.zone.parse("2024-05-30 14:00"),
-        notes: "Some notes",
-        user:
-      ),
-      create(
-        :triage,
-        :ready_to_vaccinate,
-        patient_session:,
-        created_at: Time.zone.parse("2024-05-30 14:30"),
-        user:
-      )
-    ]
-  end
-
-  let!(:vaccination_records) do
-    [
-      create(
-        :vaccination_record,
-        patient_session:,
-        created_at: Time.zone.parse("2024-05-31 12:00"),
-        user:,
-        notes: "Some notes"
-      )
-    ]
-  end
-
   let(:patient_session) do
     create(
       :patient_session,
@@ -89,8 +28,57 @@ describe AppActivityLogComponent, type: :component do
     )
   end
   let(:component) { described_class.new(patient_session) }
+  let(:user) { create(:user, teams: [team], full_name: "Nurse Joy") }
+  let(:campaign) { create(:campaign, team:) }
+  let(:location) { create(:location, team:, name: "Hogwarts") }
+  let(:session) { create(:session, campaign:, location:) }
+  let(:patient) { create(:patient, location:) }
 
-  before { render_inline(component) }
+  before do
+    create(
+      :consent,
+      :given,
+      :from_mum,
+      campaign:,
+      patient:,
+      parent: create(:parent, :mum, name: "Jane Doe"),
+      recorded_at: Time.zone.parse("2024-05-30 12:00")
+    )
+    create(
+      :consent,
+      :refused,
+      :from_dad,
+      campaign:,
+      patient:,
+      parent: create(:parent, :dad, name: "John Doe"),
+      recorded_at: Time.zone.parse("2024-05-30 13:00")
+    )
+
+    create(
+      :triage,
+      :needs_follow_up,
+      patient_session:,
+      created_at: Time.zone.parse("2024-05-30 14:00"),
+      notes: "Some notes",
+      user:
+    )
+    create(
+      :triage,
+      :ready_to_vaccinate,
+      patient_session:,
+      created_at: Time.zone.parse("2024-05-30 14:30"),
+      user:
+    )
+
+    create(
+      :vaccination_record,
+      patient_session:,
+      created_at: Time.zone.parse("2024-05-31 12:00"),
+      user:,
+      notes: "Some notes"
+    )
+    render_inline(component)
+  end
 
   it "renders headings in correct order" do
     expect(subject).to have_css("h2:nth-of-type(1)", text: "31 May 2024")

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -15,6 +15,7 @@ shared_examples "card" do |params|
 end
 
 describe AppActivityLogComponent, type: :component do
+  subject { page }
   let(:team) { create(:team) }
   let(:user) { create(:user, teams: [team], full_name: "Nurse Joy") }
   let(:campaign) { create(:campaign, team:) }
@@ -89,8 +90,6 @@ describe AppActivityLogComponent, type: :component do
   let(:component) { described_class.new(patient_session) }
 
   before { render_inline(component) }
-
-  subject { page }
 
   it "renders headings in correct order" do
     should have_css("h2:nth-of-type(1)", text: "31 May 2024")

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -16,6 +16,7 @@ end
 
 describe AppActivityLogComponent, type: :component do
   subject { page }
+
   let(:team) { create(:team) }
   let(:user) { create(:user, teams: [team], full_name: "Nurse Joy") }
   let(:campaign) { create(:campaign, team:) }

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -93,9 +93,9 @@ describe AppActivityLogComponent, type: :component do
   before { render_inline(component) }
 
   it "renders headings in correct order" do
-    should have_css("h2:nth-of-type(1)", text: "31 May 2024")
-    should have_css("h2:nth-of-type(2)", text: "30 May 2024")
-    should have_css("h2:nth-of-type(3)", text: "29 May 2024")
+    expect(subject).to have_css("h2:nth-of-type(1)", text: "31 May 2024")
+    expect(subject).to have_css("h2:nth-of-type(2)", text: "30 May 2024")
+    expect(subject).to have_css("h2:nth-of-type(3)", text: "29 May 2024")
   end
 
   include_examples "card",

--- a/spec/components/app_backlink_component_spec.rb
+++ b/spec/components/app_backlink_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppBacklinkComponent, type: :component do
   subject { page }
+
   before { render_inline(component) }
 
   let(:component) { described_class.new(href:, name:, classes:, attributes:) }

--- a/spec/components/app_backlink_component_spec.rb
+++ b/spec/components/app_backlink_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppBacklinkComponent, type: :component do
-  before { render_inline(component) }
-
   subject { page }
+  before { render_inline(component) }
 
   let(:component) { described_class.new(href:, name:, classes:, attributes:) }
   let(:href) { "/previous_page" }

--- a/spec/components/app_breadcrumb_component_spec.rb
+++ b/spec/components/app_breadcrumb_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppBreadcrumbComponent, type: :component do
   subject { page }
+
   before { render_inline(component) }
 
   let(:component) { described_class.new(items:, classes:, attributes:) }

--- a/spec/components/app_breadcrumb_component_spec.rb
+++ b/spec/components/app_breadcrumb_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppBreadcrumbComponent, type: :component do
-  before { render_inline(component) }
-
   subject { page }
+  before { render_inline(component) }
 
   let(:component) { described_class.new(items:, classes:, attributes:) }
 

--- a/spec/components/app_compare_consent_form_and_patient_component_spec.rb
+++ b/spec/components/app_compare_consent_form_and_patient_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppCompareConsentFormAndPatientComponent, type: :component do
   subject { page }
+
   let(:consent_form) do
     create(
       :consent_form,

--- a/spec/components/app_compare_consent_form_and_patient_component_spec.rb
+++ b/spec/components/app_compare_consent_form_and_patient_component_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe AppCompareConsentFormAndPatientComponent, type: :component do
+  subject { page }
   let(:consent_form) do
     create(
       :consent_form,
@@ -17,7 +18,6 @@ describe AppCompareConsentFormAndPatientComponent, type: :component do
   end
   let(:patient) { create(:patient) }
   let(:component) { described_class.new(heading: "", consent_form:, patient:) }
-  subject { page }
 
   before { render_inline(component) }
 

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -61,10 +61,4 @@ describe AppConsentComponent, type: :component do
 
     it { should_not have_css("a", text: "Contact #{consent.parent.name}") }
   end
-
-  context "consent given needing triage and patient has been vaccinated" do
-    let(:patient_session) { create(:patient_session, :vaccinated) }
-
-    let(:summary) { "Consent given by #{consent.parent.name} (#{relation})" }
-  end
 end

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -3,14 +3,11 @@
 require "rails_helper"
 
 describe AppConsentComponent, type: :component do
-  subject { page }
-
-  before { rendered_component }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) do
     described_class.new(patient_session:, section: "triage", tab: "needed")
   end
-  let(:rendered_component) { render_inline(component) }
 
   let(:consent) { patient_session.consents.first }
   let(:relation) { consent.parent.relationship_label.capitalize }

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppConsentComponent, type: :component do
-  before { rendered_component }
-
   subject { page }
+  before { rendered_component }
 
   let(:component) do
     described_class.new(patient_session:, section: "triage", tab: "needed")

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -39,6 +39,7 @@ describe AppConsentComponent, type: :component do
     it { should have_css("p.app-status", text: "Refused") }
 
     let(:summary) { "Consent refused by #{consent.parent.name} (#{relation})" }
+
     it { should have_css("table tr", text: /#{consent.parent.name}/) }
     it { should have_css("table tr", text: /#{relation}/) }
 
@@ -57,6 +58,7 @@ describe AppConsentComponent, type: :component do
     it { should have_css("p.app-status", text: "Given") }
 
     let(:summary) { "Consent given by #{consent.parent.name} (#{relation})" }
+
     it { should_not have_css("a", text: "Contact #{consent.parent.name}") }
   end
 

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -43,7 +43,7 @@ describe AppConsentComponent, type: :component do
     it { should have_css("table tr", text: /#{relation}/) }
 
     it "displays the response" do
-      should have_css("table tr", text: /Consent refused/)
+      expect(subject).to have_css("table tr", text: /Consent refused/)
     end
 
     it { should_not have_css("details", text: "Responses to health questions") }

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -37,6 +37,7 @@ describe AppConsentComponent, type: :component do
     let(:patient_session) { create(:patient_session, :consent_refused) }
 
     let(:summary) { "Consent refused by #{consent.parent.name} (#{relation})" }
+
     it { should have_css("p.app-status", text: "Refused") }
 
     it { should have_css("table tr", text: /#{consent.parent.name}/) }
@@ -55,6 +56,7 @@ describe AppConsentComponent, type: :component do
     end
 
     let(:summary) { "Consent given by #{consent.parent.name} (#{relation})" }
+
     it { should have_css("p.app-status", text: "Given") }
 
     it { should_not have_css("a", text: "Contact #{consent.parent.name}") }

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppConsentComponent, type: :component do
   subject { page }
+
   before { rendered_component }
 
   let(:component) do

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -36,9 +36,8 @@ describe AppConsentComponent, type: :component do
   context "consent is refused" do
     let(:patient_session) { create(:patient_session, :consent_refused) }
 
-    it { should have_css("p.app-status", text: "Refused") }
-
     let(:summary) { "Consent refused by #{consent.parent.name} (#{relation})" }
+    it { should have_css("p.app-status", text: "Refused") }
 
     it { should have_css("table tr", text: /#{consent.parent.name}/) }
     it { should have_css("table tr", text: /#{relation}/) }
@@ -55,9 +54,8 @@ describe AppConsentComponent, type: :component do
       create(:patient_session, :consent_given_triage_needed)
     end
 
-    it { should have_css("p.app-status", text: "Given") }
-
     let(:summary) { "Consent given by #{consent.parent.name} (#{relation})" }
+    it { should have_css("p.app-status", text: "Given") }
 
     it { should_not have_css("a", text: "Contact #{consent.parent.name}") }
   end

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppConsentStatusComponent, type: :component do
-  before { render_inline(component) }
-
   subject { page }
+  before { render_inline(component) }
 
   let(:component) { described_class.new(patient_session:) }
   let(:patient_session) { create(:patient_session) }

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppConsentStatusComponent, type: :component do
   subject { page }
+
   before { render_inline(component) }
 
   let(:component) { described_class.new(patient_session:) }

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe AppConsentSummaryComponent, type: :component do
+  subject { page }
   let(:component) do
     described_class.new(
       name: "Jane Smith",
@@ -21,8 +22,6 @@ describe AppConsentSummaryComponent, type: :component do
       }
     )
   end
-
-  subject { page }
 
   before { render_inline(component) }
 

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -33,7 +33,9 @@ describe AppConsentSummaryComponent, type: :component do
   it { should have_text("Consent refused (online)") }
   it { should have_text("1 March 2024 at 2:23pm") }
   it do
-    should have_text("Refusal reasonAlready vaccinated\nVaccinated at the GP")
+    expect(subject).to have_text(
+      "Refusal reasonAlready vaccinated\nVaccinated at the GP"
+    )
   end
 
   context "with only mandatory fields" do

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppConsentSummaryComponent, type: :component do
   subject { page }
+
   let(:component) do
     described_class.new(
       name: "Jane Smith",

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -32,6 +32,7 @@ describe AppConsentSummaryComponent, type: :component do
   it { should have_text("jane@example.com") }
   it { should have_text("Consent refused (online)") }
   it { should have_text("1 March 2024 at 2:23pm") }
+
   it do
     expect(subject).to have_text(
       "Refusal reasonAlready vaccinated\nVaccinated at the GP"

--- a/spec/components/app_details_component_spec.rb
+++ b/spec/components/app_details_component_spec.rb
@@ -18,7 +18,7 @@ describe AppDetailsComponent, type: :component do
     expect(subject).to have_css(
       ".nhsuk-details__text",
       text: content,
-      visible: false
+      visible: :hidden
     )
   end
 
@@ -29,7 +29,7 @@ describe AppDetailsComponent, type: :component do
       expect(subject).to have_css(
         ".nhsuk-details__text",
         text: content,
-        visible: true
+        visible: :visible
       )
     end
   end

--- a/spec/components/app_details_component_spec.rb
+++ b/spec/components/app_details_component_spec.rb
@@ -15,14 +15,22 @@ describe AppDetailsComponent, type: :component do
   it { should have_css(".nhsuk-details__summary", text: summary) }
 
   it "defaults to being closed" do
-    should have_css(".nhsuk-details__text", text: content, visible: false)
+    expect(subject).to have_css(
+      ".nhsuk-details__text",
+      text: content,
+      visible: false
+    )
   end
 
   context "open flag is true" do
     let(:component) { described_class.new(summary:, open: true) }
 
     it "displays the content section" do
-      should have_css(".nhsuk-details__text", text: content, visible: true)
+      expect(subject).to have_css(
+        ".nhsuk-details__text",
+        text: content,
+        visible: true
+      )
     end
   end
 end

--- a/spec/components/app_details_component_spec.rb
+++ b/spec/components/app_details_component_spec.rb
@@ -3,11 +3,10 @@
 require "rails_helper"
 
 describe AppDetailsComponent, type: :component do
+  subject { page }
   let(:summary) { "A summary" }
   let(:content) { "A content" }
   let(:component) { described_class.new(summary:) }
-
-  subject { page }
 
   before { render_inline(component) { content } }
 

--- a/spec/components/app_details_component_spec.rb
+++ b/spec/components/app_details_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppDetailsComponent, type: :component do
   subject { page }
+
   let(:summary) { "A summary" }
   let(:content) { "A content" }
   let(:component) { described_class.new(summary:) }

--- a/spec/components/app_dev_tools_component_spec.rb
+++ b/spec/components/app_dev_tools_component_spec.rb
@@ -3,13 +3,12 @@
 require "rails_helper"
 
 describe AppDevToolsComponent, type: :component do
+  subject { page }
   let(:consent) { create(:consent, :refused, :from_dad, parent_name: "Harry") }
   let(:consents) { [consent] }
   let(:component) { described_class.new }
   let!(:rendered) { render_inline(component) { body } }
   let(:body) { "Hello dev tools!" }
-
-  subject { page }
 
   it "renders in development" do
     allow(Rails).to receive(:env).and_return("development".inquiry)

--- a/spec/components/app_dev_tools_component_spec.rb
+++ b/spec/components/app_dev_tools_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppDevToolsComponent, type: :component do
   subject { page }
+
   let(:consent) { create(:consent, :refused, :from_dad, parent_name: "Harry") }
   let(:consents) { [consent] }
   let(:component) { described_class.new }

--- a/spec/components/app_dev_tools_component_spec.rb
+++ b/spec/components/app_dev_tools_component_spec.rb
@@ -3,21 +3,20 @@
 require "rails_helper"
 
 describe AppDevToolsComponent, type: :component do
-  subject { page }
+  subject(:rendered) { render_inline(component) { body } }
 
   let(:consent) { create(:consent, :refused, :from_dad, parent_name: "Harry") }
   let(:consents) { [consent] }
   let(:component) { described_class.new }
-  let!(:rendered) { render_inline(component) { body } }
   let(:body) { "Hello dev tools!" }
 
   it "renders in development" do
     allow(Rails).to receive(:env).and_return("development".inquiry)
-    expect(render_inline(component).to_html).to include("Hello dev tools!")
+    expect(rendered.to_html).to include("Hello dev tools!")
   end
 
   it "does not render in production" do
     allow(Rails).to receive(:env).and_return("production".inquiry)
-    expect(render_inline(component).to_html).to be_blank
+    expect(rendered.to_html).to be_blank
   end
 end

--- a/spec/components/app_empty_list_component_spec.rb
+++ b/spec/components/app_empty_list_component_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 describe AppEmptyListComponent, type: :component do
+  subject { page }
   let(:component) { described_class.new(title:) }
   before { render_inline(component) }
-
-  subject { page }
 
   context "when no title is provided" do
     let(:component) { described_class.new }

--- a/spec/components/app_empty_list_component_spec.rb
+++ b/spec/components/app_empty_list_component_spec.rb
@@ -6,6 +6,7 @@ describe AppEmptyListComponent, type: :component do
   subject { page }
 
   let(:component) { described_class.new(title:) }
+
   before { render_inline(component) }
 
   context "when no title is provided" do

--- a/spec/components/app_empty_list_component_spec.rb
+++ b/spec/components/app_empty_list_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppEmptyListComponent, type: :component do
   subject { page }
+
   let(:component) { described_class.new(title:) }
   before { render_inline(component) }
 

--- a/spec/components/app_flash_message_component_spec.rb
+++ b/spec/components/app_flash_message_component_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 describe AppFlashMessageComponent, type: :component do
-  subject { page }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) { described_class.new(flash:) }
-  let!(:rendered) { render_inline(component) }
 
   context "when no flash message is provided" do
     let(:flash) { {} }

--- a/spec/components/app_flash_message_component_spec.rb
+++ b/spec/components/app_flash_message_component_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 describe AppFlashMessageComponent, type: :component do
+  subject { page }
   let(:component) { described_class.new(flash:) }
   let!(:rendered) { render_inline(component) }
-  subject { page }
 
   context "when no flash message is provided" do
     let(:flash) { {} }

--- a/spec/components/app_flash_message_component_spec.rb
+++ b/spec/components/app_flash_message_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppFlashMessageComponent, type: :component do
   subject { page }
+
   let(:component) { described_class.new(flash:) }
   let!(:rendered) { render_inline(component) }
 

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppHealthQuestionsComponent, type: :component do
-  before { render_inline(component) }
-
   subject { page }
+  before { render_inline(component) }
 
   let(:component) { described_class.new(consents:) }
 

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppHealthQuestionsComponent, type: :component do
   subject { page }
+
   before { render_inline(component) }
 
   let(:component) { described_class.new(consents:) }

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -30,7 +30,9 @@ describe AppHealthQuestionsComponent, type: :component do
 
     it { should have_content(/First question\?\s*Mum responded: No/) }
     it do
-      should have_content(/Second question\?\s*Mum responded: Yes:\s*Notes/)
+      expect(subject).to have_content(
+        /Second question\?\s*Mum responded: Yes:\s*Notes/
+      )
     end
   end
 
@@ -64,9 +66,9 @@ describe AppHealthQuestionsComponent, type: :component do
 
     it { should have_content(/First question\?\s*All responded: No/) }
     it do
-      should have_content(
-               /Second question\?\s*Mum responded: No\s*Dad responded: Yes:\s*Notes/
-             )
+      expect(subject).to have_content(
+        /Second question\?\s*Mum responded: No\s*Dad responded: Yes:\s*Notes/
+      )
     end
   end
 

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -29,6 +29,7 @@ describe AppHealthQuestionsComponent, type: :component do
     end
 
     it { should have_content(/First question\?\s*Mum responded: No/) }
+
     it do
       expect(subject).to have_content(
         /Second question\?\s*Mum responded: Yes:\s*Notes/
@@ -65,6 +66,7 @@ describe AppHealthQuestionsComponent, type: :component do
     end
 
     it { should have_content(/First question\?\s*All responded: No/) }
+
     it do
       expect(subject).to have_content(
         /Second question\?\s*Mum responded: No\s*Dad responded: Yes:\s*Notes/

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppOutcomeBannerComponent, type: :component do
   subject { page }
+
   let(:user) { create :user }
   let(:patient_session) { create :patient_session, user: }
   let(:component) { described_class.new(patient_session:, current_user: user) }

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -3,12 +3,11 @@
 require "rails_helper"
 
 describe AppOutcomeBannerComponent, type: :component do
-  subject { page }
+  subject(:rendered) { render_inline(component) }
 
   let(:user) { create :user }
   let(:patient_session) { create :patient_session, user: }
   let(:component) { described_class.new(patient_session:, current_user: user) }
-  let!(:rendered) { render_inline(component) }
   let(:triage_nurse_name) { patient_session.triage.last.user.full_name }
   let(:patient_name) { patient_session.patient.full_name }
 
@@ -22,7 +21,12 @@ describe AppOutcomeBannerComponent, type: :component do
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("Alya Merton has already had the vaccine") }
-    it { should have_text("Location#{patient_session.session.location.name}") }
+
+    it do
+      expect(subject).to have_text(
+        "Location\n#{patient_session.session.location.name}"
+      )
+    end
   end
 
   context "state is vaccinated" do
@@ -36,11 +40,11 @@ describe AppOutcomeBannerComponent, type: :component do
 
     it { should have_css(".app-card--green") }
     it { should have_css(".nhsuk-card__heading", text: "Vaccinated") }
-    it { should have_text("VaccineHPV (#{vaccine.brand}, #{batch.name})") }
-    it { should have_text("SiteLeft arm") }
-    it { should have_text("Date#{date}") }
-    it { should have_text("Time#{time}") }
-    it { should have_text("Location#{location.name}") }
+    it { should have_text("Vaccine\nHPV (#{vaccine.brand}, #{batch.name})") }
+    it { should have_text("Site\nLeft arm") }
+    it { should have_text("Date\n#{date}") }
+    it { should have_text("Time\n#{time}") }
+    it { should have_text("Location\n#{location.name}") }
 
     context "recorded_at is today" do
       let(:patient_session) do
@@ -50,7 +54,7 @@ describe AppOutcomeBannerComponent, type: :component do
       end
       let(:date) { Time.zone.today.to_fs(:long) }
 
-      it { should have_text("DateToday (#{date})") }
+      it { should have_text("Date\nToday (#{date})") }
     end
   end
 
@@ -65,10 +69,10 @@ describe AppOutcomeBannerComponent, type: :component do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
-    it { should have_text("ReasonDo not vaccinate in campaign") }
-    it { should have_text("DateToday (#{date})") }
+    it { should have_text("Reason\nDo not vaccinate in campaign") }
+    it { should have_text("Date\nToday (#{date})") }
     it { should_not have_text("Location") }
-    it { should have_text("Decided byYou (#{triage.user.full_name})") }
+    it { should have_text("Decided by\nYou (#{triage.user.full_name})") }
 
     context "recorded_at is not today" do
       let(:date) { Time.zone.now - 2.days }
@@ -78,7 +82,7 @@ describe AppOutcomeBannerComponent, type: :component do
         end
       end
 
-      it { should have_text("Date#{date.to_date.to_fs(:long)}") }
+      it { should have_text("Date\n#{date.to_date.to_fs(:long)}") }
     end
   end
 end

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -3,14 +3,13 @@
 require "rails_helper"
 
 describe AppOutcomeBannerComponent, type: :component do
+  subject { page }
   let(:user) { create :user }
   let(:patient_session) { create :patient_session, user: }
   let(:component) { described_class.new(patient_session:, current_user: user) }
   let!(:rendered) { render_inline(component) }
   let(:triage_nurse_name) { patient_session.triage.last.user.full_name }
   let(:patient_name) { patient_session.patient.full_name }
-
-  subject { page }
 
   prepend_before do
     patient_session.patient.update!(first_name: "Alya", last_name: "Merton")

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppPatientDetailsComponent, type: :component do
   subject { page }
+
   before { render_inline(component) }
 
   let(:session) { FactoryBot.create(:session) }

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -20,19 +20,19 @@ describe AppPatientDetailsComponent, type: :component do
     let(:school) { FactoryBot.create(:location) }
     let(:component) { described_class.new(patient:, session:, school:) }
 
-    it "should render the patient's full name" do
+    it "renders the patient's full name" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "Name#{patient.full_name}")
       )
     end
 
-    it "should render the patient's preferred name" do
+    it "renders the patient's preferred name" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "Known asHomer")
       )
     end
 
-    it "should render the patient's date of birth" do
+    it "renders the patient's date of birth" do
       expected_dob =
         "#{patient.date_of_birth.to_fs(:long)} (aged #{patient.age})"
       expect(page).to(
@@ -43,23 +43,23 @@ describe AppPatientDetailsComponent, type: :component do
       )
     end
 
-    it "should render the school name" do
+    it "renders the school name" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "School#{school.name}")
       )
     end
 
-    it "should not render a GP name" do
+    it "does not render a GP name" do
       expect(page).not_to have_css(".nhsuk-summary-list__row", text: /^GP/)
     end
 
-    it "should not render a GP response" do
+    it "does not render a GP response" do
       expect(page).not_to(
         have_css(".nhsuk-summary-list__row", text: "Registered with a GP")
       )
     end
 
-    it "should render the patient's NHS number" do
+    it "renders the patient's NHS number" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "NHS Number123 456 7890")
       )
@@ -68,7 +68,7 @@ describe AppPatientDetailsComponent, type: :component do
     context "without a preferred name" do
       let(:patient) { FactoryBot.create(:patient, common_name: nil) }
 
-      it "should not render known as" do
+      it "does not render known as" do
         expect(page).not_to(
           have_css(".nhsuk-summary-list__row", text: "Known as")
         )
@@ -87,7 +87,7 @@ describe AppPatientDetailsComponent, type: :component do
     let(:school) { FactoryBot.create(:location) }
     let(:component) { described_class.new(consent_form:, session:, school:) }
 
-    it "should render the child's full name" do
+    it "renders the child's full name" do
       expect(page).to(
         have_css(
           ".nhsuk-summary-list__row",
@@ -96,14 +96,14 @@ describe AppPatientDetailsComponent, type: :component do
       )
     end
 
-    it "should render the child's common name" do
+    it "renders the child's common name" do
       expect(page).to have_css(
         ".nhsuk-summary-list__row",
         text: "Known asHomer"
       )
     end
 
-    it "should render the child's date of birth" do
+    it "renders the child's date of birth" do
       formatted_date = consent_form.date_of_birth.to_fs(:long)
       expected_dob = "#{formatted_date} (aged #{consent_form.age})"
       expect(page).to(
@@ -114,7 +114,7 @@ describe AppPatientDetailsComponent, type: :component do
       )
     end
 
-    it "should render the child's address" do
+    it "renders the child's address" do
       expect(page).to(
         have_css(
           ".nhsuk-summary-list__row",
@@ -128,19 +128,19 @@ describe AppPatientDetailsComponent, type: :component do
       )
     end
 
-    it "should render the school name" do
+    it "renders the school name" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "School#{school.name}")
       )
     end
 
-    it "should render the GP name" do
+    it "renders the GP name" do
       expect(page).to(
         have_css(".nhsuk-summary-list__row", text: "GP#{consent_form.gp_name}")
       )
     end
 
-    it "should not render an NHS number" do
+    it "does not render an NHS number" do
       expect(page).not_to(
         have_css(".nhsuk-summary-list__row", text: "NHS Number")
       )
@@ -149,7 +149,7 @@ describe AppPatientDetailsComponent, type: :component do
     context "without a common name" do
       let(:consent_form) { FactoryBot.create(:consent_form, common_name: nil) }
 
-      it "should not render known as" do
+      it "does not render known as" do
         expect(page).not_to(
           have_css(".nhsuk-summary-list__row", text: "Known as")
         )
@@ -161,7 +161,7 @@ describe AppPatientDetailsComponent, type: :component do
         FactoryBot.create(:consent_form, date_of_birth: nil)
       end
 
-      it "should not render the child's date of birth" do
+      it "does not render the child's date of birth" do
         expect(page).not_to(
           have_css(".nhsuk-summary-list__row", text: "Date of birth")
         )
@@ -178,11 +178,11 @@ describe AppPatientDetailsComponent, type: :component do
         )
       end
 
-      it "should not render a GP name" do
+      it "does not render a GP name" do
         expect(page).not_to(have_css(".nhsuk-summary-list__row", text: /^GP/))
       end
 
-      it "should render GP response" do
+      it "renders GP response" do
         expect(page).to(
           have_css(".nhsuk-summary-list__row", text: "Registered with a GPNo")
         )
@@ -199,11 +199,11 @@ describe AppPatientDetailsComponent, type: :component do
         )
       end
 
-      it "should not render a GP name" do
+      it "does not render a GP name" do
         expect(page).not_to(have_css(".nhsuk-summary-list__row", text: /^GP/))
       end
 
-      it "should render GP response" do
+      it "renders GP response" do
         expect(page).to(
           have_css(
             ".nhsuk-summary-list__row",

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppPatientDetailsComponent, type: :component do
-  before { render_inline(component) }
-
   subject { page }
+  before { render_inline(component) }
 
   let(:session) { FactoryBot.create(:session) }
 

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -34,10 +34,16 @@ describe AppPatientPageComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should_not have_css(".nhsuk-card__heading", text: "Triage notes") }
     it "shows the triage form" do
-      should have_selector(:heading, text: "Is it safe to vaccinate")
+      expect(subject).to have_selector(
+        :heading,
+        text: "Is it safe to vaccinate"
+      )
     end
     it "does not show the vaccination form" do
-      should_not have_css(".nhsuk-card", text: "Did they get the HPV vaccine?")
+      expect(subject).not_to have_css(
+        ".nhsuk-card",
+        text: "Did they get the HPV vaccine?"
+      )
     end
     it { should have_css("a", text: "Give your assessment") }
   end
@@ -55,16 +61,16 @@ describe AppPatientPageComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should have_css(".nhsuk-card__heading", text: "Triage notes") }
     it "does not show the triage form" do
-      should_not have_css(
-                   ".nhsuk-card__heading",
-                   text: "Is it safe to vaccinate"
-                 )
+      expect(subject).not_to have_css(
+        ".nhsuk-card__heading",
+        text: "Is it safe to vaccinate"
+      )
     end
     it "shows the vaccination form" do
-      should have_css(
-               ".nhsuk-card__heading",
-               text: "Did they get the HPV vaccine?"
-             )
+      expect(subject).to have_css(
+        ".nhsuk-card__heading",
+        text: "Did they get the HPV vaccine?"
+      )
     end
   end
 end

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe AppPatientPageComponent, type: :component do
-  subject { page }
+  subject(:rendered) { render_inline(component) }
 
   before do
     allow_any_instance_of(AppSimpleStatusBannerComponent).to receive(
@@ -19,7 +19,6 @@ describe AppPatientPageComponent, type: :component do
       triage: nil
     )
   end
-  let!(:rendered) { render_inline(component) }
 
   context "session in progress, patient in triage" do
     let(:patient_session) do

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -6,9 +6,11 @@ describe AppPatientPageComponent, type: :component do
   subject(:rendered) { render_inline(component) }
 
   before do
+    # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(AppSimpleStatusBannerComponent).to receive(
       :new_session_patient_triage_path
     ).and_return("/session/patient/triage/new")
+    # rubocop:enable RSpec/AnyInstance
   end
 
   let(:component) do

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -33,18 +33,21 @@ describe AppPatientPageComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Child details") }
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should_not have_css(".nhsuk-card__heading", text: "Triage notes") }
+
     it "shows the triage form" do
       expect(subject).to have_selector(
         :heading,
         text: "Is it safe to vaccinate"
       )
     end
+
     it "does not show the vaccination form" do
       expect(subject).not_to have_css(
         ".nhsuk-card",
         text: "Did they get the HPV vaccine?"
       )
     end
+
     it { should have_css("a", text: "Give your assessment") }
   end
 
@@ -60,12 +63,14 @@ describe AppPatientPageComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Child details") }
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should have_css(".nhsuk-card__heading", text: "Triage notes") }
+
     it "does not show the triage form" do
       expect(subject).not_to have_css(
         ".nhsuk-card__heading",
         text: "Is it safe to vaccinate"
       )
     end
+
     it "shows the vaccination form" do
       expect(subject).to have_css(
         ".nhsuk-card__heading",

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppPatientPageComponent, type: :component do
   subject { page }
+
   before do
     allow_any_instance_of(AppSimpleStatusBannerComponent).to receive(
       :new_session_patient_triage_path

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe AppPatientPageComponent, type: :component do
+  subject { page }
   before do
     allow_any_instance_of(AppSimpleStatusBannerComponent).to receive(
       :new_session_patient_triage_path
@@ -18,8 +19,6 @@ describe AppPatientPageComponent, type: :component do
     )
   end
   let!(:rendered) { render_inline(component) }
-
-  subject { page }
 
   context "session in progress, patient in triage" do
     let(:patient_session) do

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe AppPatientTableComponent, type: :component do
+  subject { page }
   before do
     allow(component).to receive(:session_patient_path).and_return(
       "/session/patient/"
@@ -10,8 +11,6 @@ describe AppPatientTableComponent, type: :component do
 
     render_inline(component)
   end
-
-  subject { page }
 
   let(:section) { :consent }
   let(:patient_sessions) { create_list(:patient_session, 2) }

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -73,10 +73,10 @@ describe AppPatientTableComponent, type: :component do
     let(:tab) { :actions }
 
     it do
-      should have_link(
-               patient_sessions.first.patient.full_name,
-               href: "/session/patient/"
-             )
+      expect(subject).to have_link(
+        patient_sessions.first.patient.full_name,
+        href: "/session/patient/"
+      )
     end
   end
 

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppPatientTableComponent, type: :component do
   subject { page }
+
   before do
     allow(component).to receive(:session_patient_path).and_return(
       "/session/patient/"

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -5,6 +5,7 @@ require "govuk_helper"
 
 describe AppSecondaryNavigationComponent, type: :component do
   subject { rendered_content }
+
   before { render_inline(component) }
 
   let(:component) do

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -4,9 +4,8 @@ require "rails_helper"
 require "govuk_helper"
 
 describe AppSecondaryNavigationComponent, type: :component do
-  before { render_inline(component) }
-
   subject { rendered_content }
+  before { render_inline(component) }
 
   let(:component) do
     described_class.new.tap do |nav|

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -19,27 +19,28 @@ describe AppSecondaryNavigationComponent, type: :component do
 
   it { should have_tag("nav", with: { class: "app-secondary-navigation" }) }
   it do
-    should have_tag("ul", with: { class: "app-secondary-navigation__list" })
+    expect(subject).to have_tag(
+      "ul",
+      with: {
+        class: "app-secondary-navigation__list"
+      }
+    )
   end
   it do
-    should have_tag(
-             "li",
-             with: {
-               class: "app-secondary-navigation__list-item"
-             }
-           )
+    expect(subject).to have_tag(
+      "li",
+      with: {
+        class: "app-secondary-navigation__list-item"
+      }
+    )
   end
   it do
-    should have_tag(
-             "li",
-             with: {
-               class: "app-secondary-navigation__list-item--current"
-             }
-           )
+    expect(subject).to have_tag(
+      "li",
+      with: {
+        class: "app-secondary-navigation__list-item--current"
+      }
+    )
   end
-  it do
-    should have_tag("a", with: { href: "https://example.com" }) do
-      with_text("Example 1")
-    end
-  end
+  it { should have_link("Example 1", href: "https://example.com") }
 end

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -18,6 +18,7 @@ describe AppSecondaryNavigationComponent, type: :component do
   end
 
   it { should have_tag("nav", with: { class: "app-secondary-navigation" }) }
+
   it do
     expect(subject).to have_tag(
       "ul",
@@ -26,6 +27,7 @@ describe AppSecondaryNavigationComponent, type: :component do
       }
     )
   end
+
   it do
     expect(subject).to have_tag(
       "li",
@@ -34,6 +36,7 @@ describe AppSecondaryNavigationComponent, type: :component do
       }
     )
   end
+
   it do
     expect(subject).to have_tag(
       "li",
@@ -42,5 +45,6 @@ describe AppSecondaryNavigationComponent, type: :component do
       }
     )
   end
+
   it { should have_link("Example 1", href: "https://example.com") }
 end

--- a/spec/components/app_session_details_component_spec.rb
+++ b/spec/components/app_session_details_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppSessionDetailsComponent, type: :component do
   subject { page }
+
   before { render_inline(component) }
 
   let(:component) { described_class.new(session:) }

--- a/spec/components/app_session_details_component_spec.rb
+++ b/spec/components/app_session_details_component_spec.rb
@@ -35,7 +35,7 @@ describe AppSessionDetailsComponent, type: :component do
       create(:session, date:, close_consent_at:, patients_in_session: 1)
     end
 
-    it "should pluralize 'child' correctly" do
+    it "pluralizes 'child' correctly" do
       expect(component.cohort).to eq "1 child"
     end
   end
@@ -45,7 +45,7 @@ describe AppSessionDetailsComponent, type: :component do
       create(:session, date:, close_consent_at:, patients_in_session: 2)
     end
 
-    it "should pluralize 'child' correctly" do
+    it "pluralizes 'child' correctly" do
       expect(component.cohort).to eq "2 children"
     end
   end

--- a/spec/components/app_session_details_component_spec.rb
+++ b/spec/components/app_session_details_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppSessionDetailsComponent, type: :component do
-  before { render_inline(component) }
-
   subject { page }
+  before { render_inline(component) }
 
   let(:component) { described_class.new(session:) }
   let(:date) { Time.zone.today }

--- a/spec/components/app_session_details_component_spec.rb
+++ b/spec/components/app_session_details_component_spec.rb
@@ -24,7 +24,9 @@ describe AppSessionDetailsComponent, type: :component do
     let(:close_consent_at) { date - 1.day }
 
     it do
-      should have_content "Allow responses until #{close_consent_at.to_fs(:long_day_of_week)}"
+      expect(
+        subject
+      ).to have_content "Allow responses until #{close_consent_at.to_fs(:long_day_of_week)}"
     end
   end
 

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppSimpleStatusBannerComponent, type: :component do
   subject { page }
+
   before do
     allow(component).to receive(:new_session_patient_triage_path).and_return(
       "/session/patient/triage/new"

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -74,9 +74,9 @@ describe AppSimpleStatusBannerComponent, type: :component do
     it { should have_css(".app-card--purple") }
     it { should have_css(".nhsuk-card__heading", text: "Safe to vaccinate") }
     it do
-      should have_text(
-               "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
-             )
+      expect(subject).to have_text(
+        "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
+      )
     end
     it { should have_link("Update triage") }
   end
@@ -87,9 +87,9 @@ describe AppSimpleStatusBannerComponent, type: :component do
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it do
-      should have_text(
-               "#{triage_nurse_name} decided that #{patient_name} should not be vaccinated"
-             )
+      expect(subject).to have_text(
+        "#{triage_nurse_name} decided that #{patient_name} should not be vaccinated"
+      )
     end
     it { should have_link("Update triage") }
   end
@@ -100,9 +100,9 @@ describe AppSimpleStatusBannerComponent, type: :component do
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it do
-      should have_text(
-               "#{vaccination_nurse_name} decided that #{patient_name}’s vaccination should be delayed"
-             )
+      expect(subject).to have_text(
+        "#{vaccination_nurse_name} decided that #{patient_name}’s vaccination should be delayed"
+      )
     end
     it { should have_link("Update triage") }
   end

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -10,6 +10,7 @@ describe AppSimpleStatusBannerComponent, type: :component do
       "/session/patient/triage/new"
     )
   end
+
   let(:user) { create :user }
   let(:patient_session) { create :patient_session, user: }
   let(:component) { described_class.new(patient_session:) }

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -73,11 +73,13 @@ describe AppSimpleStatusBannerComponent, type: :component do
 
     it { should have_css(".app-card--purple") }
     it { should have_css(".nhsuk-card__heading", text: "Safe to vaccinate") }
+
     it do
       expect(subject).to have_text(
         "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
       )
     end
+
     it { should have_link("Update triage") }
   end
 
@@ -86,11 +88,13 @@ describe AppSimpleStatusBannerComponent, type: :component do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
+
     it do
       expect(subject).to have_text(
         "#{triage_nurse_name} decided that #{patient_name} should not be vaccinated"
       )
     end
+
     it { should have_link("Update triage") }
   end
 
@@ -99,11 +103,13 @@ describe AppSimpleStatusBannerComponent, type: :component do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
+
     it do
       expect(subject).to have_text(
         "#{vaccination_nurse_name} decided that #{patient_name}’s vaccination should be delayed"
       )
     end
+
     it { should have_link("Update triage") }
   end
 end

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe AppSimpleStatusBannerComponent, type: :component do
+  subject { page }
   before do
     allow(component).to receive(:new_session_patient_triage_path).and_return(
       "/session/patient/triage/new"
@@ -17,8 +18,6 @@ describe AppSimpleStatusBannerComponent, type: :component do
     patient_session.vaccination_records.last.user.full_name
   end
   let(:patient_name) { patient_session.patient.full_name }
-
-  subject { page }
 
   prepend_before do
     patient_session.patient.update!(first_name: "Alya", last_name: "Merton")

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe AppSimpleStatusBannerComponent, type: :component do
-  subject { page }
+  subject(:rendered) { render_inline(component) }
 
   before do
     allow(component).to receive(:new_session_patient_triage_path).and_return(
@@ -14,7 +14,6 @@ describe AppSimpleStatusBannerComponent, type: :component do
   let(:user) { create :user }
   let(:patient_session) { create :patient_session, user: }
   let(:component) { described_class.new(patient_session:) }
-  let!(:rendered) { render_inline(component) }
   let(:triage_nurse_name) { patient_session.triage.last.user.full_name }
   let(:vaccination_nurse_name) do
     patient_session.vaccination_records.last.user.full_name

--- a/spec/components/app_tab_component_spec.rb
+++ b/spec/components/app_tab_component_spec.rb
@@ -6,7 +6,7 @@ require "govuk_helper"
 
 describe(AppTabComponent, type: :component) do
   subject! do
-    render_inline(AppTabComponent.new(**kwargs)) do |component|
+    render_inline(described_class.new(**kwargs)) do |component|
       tabs.each { |label, content| component.with_tab(label:) { content } }
     end
   end
@@ -144,7 +144,7 @@ describe(AppTabComponent, type: :component) do
 
   context "when text is passed to a tab instead of a block" do
     subject! do
-      render_inline(AppTabComponent.new(**kwargs)) do |component|
+      render_inline(described_class.new(**kwargs)) do |component|
         tabs.each { |label, content| component.with_tab(label:, text: content) }
       end
     end

--- a/spec/components/app_tab_component_spec.rb
+++ b/spec/components/app_tab_component_spec.rb
@@ -5,6 +5,11 @@ require "govuk_helper"
 # Dir[File.join('./spec', 'components', 'shared', '*.rb')].sort.each { |file| require file }
 
 describe(AppTabComponent, type: :component) do
+  subject! do
+    render_inline(AppTabComponent.new(**kwargs)) do |component|
+      tabs.each { |label, content| component.with_tab(label:) { content } }
+    end
+  end
   let(:title) { "My favourite tabs" }
   let(:label) { "A tab" }
   let(:component_css_class) { "nhsuk-tabs" }
@@ -18,12 +23,6 @@ describe(AppTabComponent, type: :component) do
   end
 
   let(:kwargs) { { title: } }
-
-  subject! do
-    render_inline(AppTabComponent.new(**kwargs)) do |component|
-      tabs.each { |label, content| component.with_tab(label:) { content } }
-    end
-  end
 
   let(:html) { Nokogiri.parse(rendered_content) }
 
@@ -177,8 +176,6 @@ describe(AppTabComponent, type: :component) do
     it_behaves_like "a component with a slot that accepts custom html attributes"
 
     context "when id is supplied" do
-      let(:id) { "some-id" }
-
       subject! do
         render_inline(described_class.send(:new, **kwargs)) do |component|
           component.send("with_#{slot}", label: "id testination", id:) do
@@ -186,6 +183,7 @@ describe(AppTabComponent, type: :component) do
           end
         end
       end
+      let(:id) { "some-id" }
 
       specify "the id is present in the rendered output" do
         expect(rendered_content).to have_tag("div", with: { id: "some-id" })

--- a/spec/components/app_tab_component_spec.rb
+++ b/spec/components/app_tab_component_spec.rb
@@ -10,6 +10,7 @@ describe(AppTabComponent, type: :component) do
       tabs.each { |label, content| component.with_tab(label:) { content } }
     end
   end
+
   let(:title) { "My favourite tabs" }
   let(:label) { "A tab" }
   let(:component_css_class) { "nhsuk-tabs" }
@@ -183,6 +184,7 @@ describe(AppTabComponent, type: :component) do
           end
         end
       end
+
       let(:id) { "some-id" }
 
       specify "the id is present in the rendered output" do

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -4,12 +4,11 @@ require "rails_helper"
 
 describe AppTriageFormComponent, type: :component do
   describe "#initialize" do
+    subject { page }
     let(:patient_session) { create :patient_session }
     let(:component) { described_class.new(patient_session:, url: "#") }
 
     before { render_inline(component) }
-
-    subject { page }
 
     it { should have_text("Is it safe to vaccinate") }
     it { should have_css(".app-fieldset__legend--reset") }

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -19,7 +19,7 @@ describe AppTriageFormComponent, type: :component do
 
       context "patient_session has no existing triage" do
         it "creates a new Triage object" do
-          should be_a Triage
+          expect(subject).to be_a Triage
         end
       end
 

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe AppTriageFormComponent, type: :component do
   describe "#initialize" do
     subject { page }
+
     let(:patient_session) { create :patient_session }
     let(:component) { described_class.new(patient_session:, url: "#") }
 

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppTriageNotesComponent, type: :component do
   subject { page }
+
   before { render_component }
 
   let(:component) { described_class.new(patient_session:) }

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -14,7 +14,7 @@ describe AppTriageNotesComponent, type: :component do
 
   context "triage notes are not present" do
     it "does not render" do
-      expect(component.render?).to be_falsey
+      expect(component).not_to be_render
     end
   end
 
@@ -43,7 +43,7 @@ describe AppTriageNotesComponent, type: :component do
     let(:triage) { create_list(:triage, 2) }
 
     it "renders" do
-      expect(component.render?).to be_truthy
+      expect(component).to be_render
     end
 
     it { should have_css("hr") }

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -19,7 +19,7 @@ describe AppTriageNotesComponent, type: :component do
   end
 
   context "a single triage note is present" do
-    around(:all) do |example|
+    around do |example|
       Timecop.freeze(Time.zone.local(2023, 12, 4, 10, 4)) { example.run }
     end
 

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -3,9 +3,8 @@
 require "rails_helper"
 
 describe AppTriageNotesComponent, type: :component do
-  before { render_component }
-
   subject { page }
+  before { render_component }
 
   let(:component) { described_class.new(patient_session:) }
   let(:render_component) { render_inline(component) }

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe AppVaccinateFormComponent, type: :component do
-  subject { page }
+  subject(:rendered) { render_inline(component) }
 
   let(:heading) { "A Heading" }
   let(:body) { "A Body" }
@@ -20,7 +20,6 @@ describe AppVaccinateFormComponent, type: :component do
       tab: "needed"
     )
   end
-  let!(:rendered) { render_inline(component) }
 
   it { should have_css(".nhsuk-card") }
 

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe AppVaccinateFormComponent, type: :component do
   subject { page }
+
   let(:heading) { "A Heading" }
   let(:body) { "A Body" }
   let(:session) { create :session, :in_progress }

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe AppVaccinateFormComponent, type: :component do
+  subject { page }
   let(:heading) { "A Heading" }
   let(:body) { "A Body" }
   let(:session) { create :session, :in_progress }
@@ -19,8 +20,6 @@ describe AppVaccinateFormComponent, type: :component do
     )
   end
   let!(:rendered) { render_inline(component) }
-
-  subject { page }
 
   it { should have_css(".nhsuk-card") }
 

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -25,10 +25,10 @@ describe AppVaccinateFormComponent, type: :component do
   it { should have_css(".nhsuk-card") }
 
   it "has the correct heading" do
-    should have_css(
-             "h2.nhsuk-card__heading",
-             text: "Did they get the HPV vaccine?"
-           )
+    expect(subject).to have_css(
+      "h2.nhsuk-card__heading",
+      text: "Did they get the HPV vaccine?"
+    )
   end
 
   it { should have_field("Yes, they got the HPV vaccine") }

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe PatientSortingConcern do
+  subject { klass.new(params) }
   let(:klass) do
     Class.new do
       include PatientSortingConcern
@@ -13,8 +14,6 @@ describe PatientSortingConcern do
       end
     end
   end
-
-  subject { klass.new(params) }
 
   let(:alex) do
     create(:patient, first_name: "Alex", date_of_birth: "2010-01-01")

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe PatientSortingConcern do
   subject { klass.new(params) }
+
   let(:klass) do
     Class.new do
       include PatientSortingConcern

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -64,32 +64,6 @@ describe TriageMailerConcern do
       end
     end
 
-    context "when the parents agree, triage is required and it is safe to vaccinate" do
-      let(:patient_session) do
-        build(:patient_session, :triaged_ready_to_vaccinate)
-      end
-
-      it "sends an email saying triage was needed and vaccination will happen" do
-        expect(TriageMailer).to have_received(:vaccination_will_happen).with(
-          patient_session,
-          consent
-        )
-      end
-    end
-
-    context "when the parents agree, triage is required but it isn't safe to vaccinate" do
-      let(:patient_session) do
-        build(:patient_session, :triaged_do_not_vaccinate)
-      end
-
-      it "sends an email saying triage was needed but vaccination won't happen" do
-        expect(TriageMailer).to have_received(:vaccination_wont_happen).with(
-          patient_session,
-          consent
-        )
-      end
-    end
-
     context "when the parents agree and triage is not required" do
       let(:patient_session) do
         build(:patient_session, :consent_given_triage_not_needed)

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -57,18 +57,6 @@ describe TriageMailerConcern do
         build(:patient_session, :consent_given_triage_not_needed)
       end
 
-      it "doesn't send an email" do
-        expect(ConsentFormMailer).not_to have_received(:confirmation).with(
-          consent
-        )
-      end
-    end
-
-    context "when the parents agree and triage is not required" do
-      let(:patient_session) do
-        build(:patient_session, :consent_given_triage_not_needed)
-      end
-
       it "sends an email saying vaccination will happen" do
         expect(ConsentFormMailer).to have_received(:confirmation).with(
           consent:,

--- a/spec/features/user_authentication_spec.rb
+++ b/spec/features/user_authentication_spec.rb
@@ -54,7 +54,7 @@ describe "User authentication" do
   end
 
   def then_i_see_the_dashboard
-    expect(current_path).to eq dashboard_path
+    expect(page).to have_current_path dashboard_path, ignore_query: true
   end
 
   def when_i_sign_out
@@ -80,7 +80,7 @@ describe "User authentication" do
   end
 
   def then_i_see_the_sessions_page
-    expect(current_path).to eq sessions_path
+    expect(page).to have_current_path sessions_path, ignore_query: true
     expect(page).to have_content "Today’s sessions"
   end
 end

--- a/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
@@ -78,7 +78,7 @@ describe "Verbal consent" do
   end
 
   def and_the_kept_in_triage_email_is_sent_to_the_parent
-    expect(sent_emails)
+    expect(sent_emails).not_to be_empty
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(
       EMAILS[:triage_vaccination_will_happen]

--- a/spec/govuk_shared/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/govuk_shared/a_component_that_accepts_custom_html_attributes.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 shared_examples "a component that accepts custom HTML attributes" do
+  subject! { render_inline(described_class.send(:new, **updated_kwargs)) }
   let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue" } }
   let(:updated_kwargs) do
     kwargs.deep_merge(
       { html_attributes: { lang: "en-GB", style: "background-color: blue" } }
     )
   end
-
-  subject! { render_inline(described_class.send(:new, **updated_kwargs)) }
 
   specify "the custom HTML attributes should be set correctly" do
     expect(rendered_content).to have_tag("*", with: custom_attributes)

--- a/spec/govuk_shared/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/govuk_shared/a_component_that_accepts_custom_html_attributes.rb
@@ -2,6 +2,7 @@
 
 shared_examples "a component that accepts custom HTML attributes" do
   subject! { render_inline(described_class.send(:new, **updated_kwargs)) }
+
   let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue" } }
   let(:updated_kwargs) do
     kwargs.deep_merge(

--- a/spec/govuk_shared/a_component_that_supports_custom_branding.rb
+++ b/spec/govuk_shared/a_component_that_supports_custom_branding.rb
@@ -4,12 +4,10 @@ shared_examples "a component that supports custom branding" do
   let(:default_brand) { "govuk" }
   let(:custom_brand) { "globex-corp" }
 
-  before do
-    @original_brand = Govuk::Components.config.brand
-    Govuk::Components.configure { |conf| conf.brand = custom_brand }
-  end
+  let!(:original_brand) { Govuk::Components.config.brand }
 
-  after { Govuk::Components.configure { |conf| conf.brand = @original_brand } }
+  before { Govuk::Components.configure { |conf| conf.brand = custom_brand } }
+  after { Govuk::Components.configure { |conf| conf.brand = original_brand } }
 
   specify "should contain the custom branding" do
     render_inline(described_class.new(**kwargs))

--- a/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_classes.rb
+++ b/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_classes.rb
@@ -8,6 +8,7 @@ shared_examples "a component with a slot that accepts custom classes" do
       end
     end
   end
+
   let(:custom_class) { "purple-stripes" }
 
   specify "the rendered slot should have the custom class" do

--- a/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_classes.rb
+++ b/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_classes.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples "a component with a slot that accepts custom classes" do
-  let(:custom_class) { "purple-stripes" }
-
   subject! do
     render_inline(described_class.send(:new, **kwargs)) do |component|
       component.send("with_#{slot}", classes: custom_class, **slot_kwargs) do
@@ -10,6 +8,7 @@ shared_examples "a component with a slot that accepts custom classes" do
       end
     end
   end
+  let(:custom_class) { "purple-stripes" }
 
   specify "the rendered slot should have the custom class" do
     expect(rendered_content).to have_tag("*", with: { class: custom_class })

--- a/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
+++ b/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 shared_examples "a component with a slot that accepts custom html attributes" do
-  let(:custom_attributes) do
-    { lang: "en-GB", style: "background-color: blue;" }
-  end
-
   subject! do
     render_inline(described_class.send(:new, **kwargs)) do |component|
       component.send(
@@ -13,6 +9,9 @@ shared_examples "a component with a slot that accepts custom html attributes" do
         **slot_kwargs
       ) { content.call }
     end
+  end
+  let(:custom_attributes) do
+    { lang: "en-GB", style: "background-color: blue;" }
   end
 
   specify "the rendered slot should have the HTML attributes" do

--- a/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
+++ b/spec/govuk_shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
@@ -10,6 +10,7 @@ shared_examples "a component with a slot that accepts custom html attributes" do
       ) { content.call }
     end
   end
+
   let(:custom_attributes) do
     { lang: "en-GB", style: "background-color: blue;" }
   end

--- a/spec/helpers/consent_forms_helper_spec.rb
+++ b/spec/helpers/consent_forms_helper_spec.rb
@@ -16,10 +16,10 @@ describe ConsentFormsHelper, type: :helper do
       create(:consent_form, :with_health_answers_asthma_branching)
     end
     let(:health_answer) { consent_form.health_answers.first }
-    let(:final_wizard_path) { double("final_wizard_path") }
-    let(:previous_wizard_path) { double("previous_wizard_path") }
+    let(:final_wizard_path) { "final_wizard_path" }
+    let(:previous_wizard_path) { "previous_wizard_path" }
     let(:previous_health_question_wizard_path) do
-      double("previous_health_question_wizard_path")
+      "previous_health_question_wizard_path"
     end
 
     before do
@@ -86,8 +86,8 @@ describe ConsentFormsHelper, type: :helper do
       create(:consent_form, :with_health_answers_asthma_branching)
     end
     let(:health_answer) { consent_form.health_answers.first }
-    let(:final_wizard_path) { double("final_wizard_path") }
-    let(:previous_wizard_path) { double("previous_wizard_path") }
+    let(:final_wizard_path) { "final_wizard_path" }
+    let(:previous_wizard_path) { "previous_wizard_path" }
 
     before do
       allow(helper).to receive(:wizard_path).with(

--- a/spec/helpers/consent_forms_helper_spec.rb
+++ b/spec/helpers/consent_forms_helper_spec.rb
@@ -8,7 +8,7 @@ describe ConsentFormsHelper, type: :helper do
   before do
     # For some reason the helper doesn't include this in the test environment.
     # There may be some other way to achieve this, but this works for now.
-    ConsentFormsHelper.include Wicked::Controller::Concerns::Path
+    described_class.include Wicked::Controller::Concerns::Path
   end
 
   describe "#health_question_backlink_path" do

--- a/spec/lib/date_params_validator_spec.rb
+++ b/spec/lib/date_params_validator_spec.rb
@@ -20,7 +20,6 @@ describe DateParamsValidator do
     dummy_class.new.tap { |obj| obj.errors = ActiveModel::Errors.new(obj) }
   end
   let(:field_name) { "date_of_birth" }
-  let(:params) { {} }
   let(:validator) do
     described_class.new(field_name:, object: dummy_object, params:)
   end

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -17,20 +17,19 @@ describe ConsentRequestMailer, type: :mailer do
       it { should include(session_date: session.date.strftime("%A %-d %B")) }
       it { should include(session_short_date: session.date.strftime("%-d %B")) }
       it do
-        should include(
-                 close_consent_date:
-                   session.close_consent_at.strftime("%A %-d %B")
-               )
+        expect(subject).to include(
+          close_consent_date: session.close_consent_at.strftime("%A %-d %B")
+        )
       end
       it { should include(location_name: session.location.name) }
       it { should include(team_email: session.team.email) }
       it { should include(team_phone: session.team.phone) }
 
       it "uses the consent url for the session" do
-        should include(
-                 consent_link:
-                   start_session_parent_interface_consent_forms_url(session)
-               )
+        expect(subject).to include(
+          consent_link:
+            start_session_parent_interface_consent_forms_url(session)
+        )
       end
     end
   end
@@ -48,26 +47,24 @@ describe ConsentRequestMailer, type: :mailer do
 
       it { should include(session_date: session.date.strftime("%A %-d %B")) }
       it do
-        should include(
-                 close_consent_date:
-                   session.close_consent_at.strftime("%A %-d %B")
-               )
+        expect(subject).to include(
+          close_consent_date: session.close_consent_at.strftime("%A %-d %B")
+        )
       end
       it do
-        should include(
-                 close_consent_short_date:
-                   session.close_consent_at.strftime("%-d %B")
-               )
+        expect(subject).to include(
+          close_consent_short_date: session.close_consent_at.strftime("%-d %B")
+        )
       end
       it { should include(location_name: session.location.name) }
       it { should include(team_email: session.team.email) }
       it { should include(team_phone: session.team.phone) }
 
       it "uses the consent url for the session" do
-        should include(
-                 consent_link:
-                   start_session_parent_interface_consent_forms_url(session)
-               )
+        expect(subject).to include(
+          consent_link:
+            start_session_parent_interface_consent_forms_url(session)
+        )
       end
     end
   end

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe ConsentRequestMailer, type: :mailer do
   describe "#consent_request" do
     subject(:mail) { ConsentRequestMailer.consent_request(session, patient) }
+
     let(:patient) { create(:patient) }
     let(:session) { create(:session, patients: [patient]) }
 
@@ -36,6 +37,7 @@ describe ConsentRequestMailer, type: :mailer do
 
   describe "#consent_reminder" do
     subject(:mail) { ConsentRequestMailer.consent_reminder(session, patient) }
+
     let(:patient) { create(:patient) }
     let(:session) { create(:session, patients: [patient]) }
 

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe ConsentRequestMailer, type: :mailer do
   describe "#consent_request" do
-    subject(:mail) { ConsentRequestMailer.consent_request(session, patient) }
+    subject(:mail) { described_class.consent_request(session, patient) }
 
     let(:patient) { create(:patient) }
     let(:session) { create(:session, patients: [patient]) }
@@ -36,7 +36,7 @@ describe ConsentRequestMailer, type: :mailer do
   end
 
   describe "#consent_reminder" do
-    subject(:mail) { ConsentRequestMailer.consent_reminder(session, patient) }
+    subject(:mail) { described_class.consent_reminder(session, patient) }
 
     let(:patient) { create(:patient) }
     let(:session) { create(:session, patients: [patient]) }

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -16,11 +16,13 @@ describe ConsentRequestMailer, type: :mailer do
 
       it { should include(session_date: session.date.strftime("%A %-d %B")) }
       it { should include(session_short_date: session.date.strftime("%-d %B")) }
+
       it do
         expect(subject).to include(
           close_consent_date: session.close_consent_at.strftime("%A %-d %B")
         )
       end
+
       it { should include(location_name: session.location.name) }
       it { should include(team_email: session.team.email) }
       it { should include(team_phone: session.team.phone) }
@@ -46,16 +48,19 @@ describe ConsentRequestMailer, type: :mailer do
       subject { mail.message.header["personalisation"].unparsed_value }
 
       it { should include(session_date: session.date.strftime("%A %-d %B")) }
+
       it do
         expect(subject).to include(
           close_consent_date: session.close_consent_at.strftime("%A %-d %B")
         )
       end
+
       it do
         expect(subject).to include(
           close_consent_short_date: session.close_consent_at.strftime("%-d %B")
         )
       end
+
       it { should include(location_name: session.location.name) }
       it { should include(team_email: session.team.email) }
       it { should include(team_phone: session.team.phone) }

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 describe ConsentRequestMailer, type: :mailer do
   describe "#consent_request" do
+    subject(:mail) { ConsentRequestMailer.consent_request(session, patient) }
     let(:patient) { create(:patient) }
     let(:session) { create(:session, patients: [patient]) }
-    subject(:mail) { ConsentRequestMailer.consent_request(session, patient) }
 
     it { should have_attributes(to: [patient.parent.email]) }
 
@@ -35,9 +35,9 @@ describe ConsentRequestMailer, type: :mailer do
   end
 
   describe "#consent_reminder" do
+    subject(:mail) { ConsentRequestMailer.consent_reminder(session, patient) }
     let(:patient) { create(:patient) }
     let(:session) { create(:session, patients: [patient]) }
-    subject(:mail) { ConsentRequestMailer.consent_reminder(session, patient) }
 
     it { should have_attributes(to: [patient.parent.email]) }
 

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 describe SessionMailer, type: :mailer do
   describe "#session_reminder" do
+    subject(:mail) { SessionMailer.session_reminder(session:, patient:) }
     let(:patient) { create(:patient, common_name: "Joey") }
     let(:session) { create(:session, patients: [patient]) }
-    subject(:mail) { SessionMailer.session_reminder(session:, patient:) }
 
     it { should have_attributes(to: [patient.parent.email]) }
 

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe SessionMailer, type: :mailer do
   describe "#session_reminder" do
     subject(:mail) { SessionMailer.session_reminder(session:, patient:) }
+
     let(:patient) { create(:patient, common_name: "Joey") }
     let(:session) { create(:session, patients: [patient]) }
 

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe SessionMailer, type: :mailer do
   describe "#session_reminder" do
-    subject(:mail) { SessionMailer.session_reminder(session:, patient:) }
+    subject(:mail) { described_class.session_reminder(session:, patient:) }
 
     let(:patient) { create(:patient, common_name: "Joey") }
     let(:session) { create(:session, patients: [patient]) }

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -7,6 +7,7 @@ describe TriageMailer, type: :mailer do
     subject(:mail) do
       TriageMailer.vaccination_will_happen(patient_session, consent)
     end
+
     let(:patient_session) do
       create(:patient_session, :consent_given_triage_not_needed)
     end
@@ -25,6 +26,7 @@ describe TriageMailer, type: :mailer do
     subject(:mail) do
       TriageMailer.vaccination_wont_happen(patient_session, consent)
     end
+
     let(:patient_session) { create(:patient_session, :consent_refused) }
     let(:consent) { patient_session.patient.consents.first }
 

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe TriageMailer, type: :mailer do
   describe "#vaccination_will_happen" do
     subject(:mail) do
-      TriageMailer.vaccination_will_happen(patient_session, consent)
+      described_class.vaccination_will_happen(patient_session, consent)
     end
 
     let(:patient_session) do
@@ -24,7 +24,7 @@ describe TriageMailer, type: :mailer do
 
   describe "#vaccination_wont_happen" do
     subject(:mail) do
-      TriageMailer.vaccination_wont_happen(patient_session, consent)
+      described_class.vaccination_wont_happen(patient_session, consent)
     end
 
     let(:patient_session) { create(:patient_session, :consent_refused) }

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -4,14 +4,13 @@ require "rails_helper"
 
 describe TriageMailer, type: :mailer do
   describe "#vaccination_will_happen" do
+    subject(:mail) do
+      TriageMailer.vaccination_will_happen(patient_session, consent)
+    end
     let(:patient_session) do
       create(:patient_session, :consent_given_triage_not_needed)
     end
     let(:consent) { patient_session.patient.consents.first }
-
-    subject(:mail) do
-      TriageMailer.vaccination_will_happen(patient_session, consent)
-    end
 
     it { should have_attributes(to: [consent.parent.email]) }
 
@@ -23,12 +22,11 @@ describe TriageMailer, type: :mailer do
   end
 
   describe "#vaccination_wont_happen" do
-    let(:patient_session) { create(:patient_session, :consent_refused) }
-    let(:consent) { patient_session.patient.consents.first }
-
     subject(:mail) do
       TriageMailer.vaccination_wont_happen(patient_session, consent)
     end
+    let(:patient_session) { create(:patient_session, :consent_refused) }
+    let(:consent) { patient_session.patient.consents.first }
 
     it { should have_attributes(to: [consent.parent.email]) }
 

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -4,13 +4,12 @@ require "rails_helper"
 
 describe VaccinationMailer do
   describe "hpv_vaccination_has_taken_place" do
-    let(:patient) { create(:patient, consents: [create(:consent_given)]) }
-    let(:patient_session) { create(:patient_session, patient:) }
-    let(:vaccination_record) { create(:vaccination_record, patient_session:) }
-
     subject(:mail) do
       VaccinationMailer.hpv_vaccination_has_taken_place(vaccination_record:)
     end
+    let(:patient) { create(:patient, consents: [create(:consent_given)]) }
+    let(:patient_session) { create(:patient_session, patient:) }
+    let(:vaccination_record) { create(:vaccination_record, patient_session:) }
 
     it { should have_attributes(to: [patient.consents.last.parent.email]) }
 
@@ -59,11 +58,10 @@ describe VaccinationMailer do
       end
 
       describe "today_or_date_of_vaccination field" do
+        subject { personalisation[:today_or_date_of_vaccination] }
         let(:vaccination_record) do
           create(:vaccination_record, patient_session:, recorded_at:)
         end
-
-        subject { personalisation[:today_or_date_of_vaccination] }
 
         context "when the vaccination was recorded today" do
           let(:recorded_at) { Time.zone.today }
@@ -79,6 +77,9 @@ describe VaccinationMailer do
   end
 
   describe "hpv_vaccination_has_not_place" do
+    subject(:mail) do
+      VaccinationMailer.hpv_vaccination_has_not_taken_place(vaccination_record:)
+    end
     let(:patient) { create(:patient, consents: [create(:consent_given)]) }
     let(:patient_session) { create(:patient_session, patient:) }
     let(:vaccination_record) do
@@ -86,10 +87,6 @@ describe VaccinationMailer do
              patient_session:,
              administered: false,
              reason: :not_well
-    end
-
-    subject(:mail) do
-      VaccinationMailer.hpv_vaccination_has_not_taken_place(vaccination_record:)
     end
 
     it { should have_attributes(to: [patient.consents.last.parent.email]) }

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -67,11 +67,13 @@ describe VaccinationMailer do
 
         context "when the vaccination was recorded today" do
           let(:recorded_at) { Time.zone.today }
+
           it { should eq("today") }
         end
 
         context "when the vaccination was recorded 2 days ago" do
           let(:recorded_at) { Date.new(2023, 3, 1) }
+
           it { should eq("1 March 2023") }
         end
       end

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -7,6 +7,7 @@ describe VaccinationMailer do
     subject(:mail) do
       VaccinationMailer.hpv_vaccination_has_taken_place(vaccination_record:)
     end
+
     let(:patient) { create(:patient, consents: [create(:consent_given)]) }
     let(:patient_session) { create(:patient_session, patient:) }
     let(:vaccination_record) { create(:vaccination_record, patient_session:) }
@@ -59,6 +60,7 @@ describe VaccinationMailer do
 
       describe "today_or_date_of_vaccination field" do
         subject { personalisation[:today_or_date_of_vaccination] }
+
         let(:vaccination_record) do
           create(:vaccination_record, patient_session:, recorded_at:)
         end
@@ -80,6 +82,7 @@ describe VaccinationMailer do
     subject(:mail) do
       VaccinationMailer.hpv_vaccination_has_not_taken_place(vaccination_record:)
     end
+
     let(:patient) { create(:patient, consents: [create(:consent_given)]) }
     let(:patient_session) { create(:patient_session, patient:) }
     let(:vaccination_record) do

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 describe VaccinationMailer do
   describe "hpv_vaccination_has_taken_place" do
     subject(:mail) do
-      VaccinationMailer.hpv_vaccination_has_taken_place(vaccination_record:)
+      described_class.hpv_vaccination_has_taken_place(vaccination_record:)
     end
 
     let(:patient) { create(:patient, consents: [create(:consent_given)]) }
@@ -80,7 +80,7 @@ describe VaccinationMailer do
 
   describe "hpv_vaccination_has_not_place" do
     subject(:mail) do
-      VaccinationMailer.hpv_vaccination_has_not_taken_place(vaccination_record:)
+      described_class.hpv_vaccination_has_not_taken_place(vaccination_record:)
     end
 
     let(:patient) { create(:patient, consents: [create(:consent_given)]) }

--- a/spec/models/cohort_list_row_spec.rb
+++ b/spec/models/cohort_list_row_spec.rb
@@ -4,12 +4,11 @@ require "rails_helper"
 
 describe CohortListRow, type: :model do
   describe "school_urn validations" do
+    subject(:cohort_list_row) { described_class.new(team:) }
     let(:user) { create(:user, team:) }
     let(:location) { create(:location) }
     let(:location2) { create(:location) }
     let(:team) { create(:team, locations: [location]) }
-
-    subject(:cohort_list_row) { described_class.new(team:) }
 
     it { should_not allow_value(location2.id).for(:school_urn) }
   end

--- a/spec/models/cohort_list_row_spec.rb
+++ b/spec/models/cohort_list_row_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe CohortListRow, type: :model do
   describe "school_urn validations" do
     subject(:cohort_list_row) { described_class.new(team:) }
+
     let(:user) { create(:user, team:) }
     let(:location) { create(:location) }
     let(:location2) { create(:location) }

--- a/spec/models/cohort_list_spec.rb
+++ b/spec/models/cohort_list_spec.rb
@@ -121,9 +121,7 @@ describe CohortList, type: :model do
       cohort_list.load_data!
       cohort_list.parse_rows!
 
-      expect { cohort_list.generate_patients! }.to change { Patient.count }.by(
-        2
-      )
+      expect { cohort_list.generate_patients! }.to change(Patient, :count).by(2)
 
       expect(Patient.first).to have_attributes(
         nhs_number: "1234567890",

--- a/spec/models/concerns/patient_session_state_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_concern_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe PatientSessionStateConcern do
   subject(:fsm) { fake_state_machine_class.new }
+
   let(:fake_state_machine_class) do
     Class.new do
       attr_accessor :state

--- a/spec/models/concerns/patient_session_state_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_concern_spec.rb
@@ -16,7 +16,7 @@ describe PatientSessionStateConcern do
   describe "#state" do
     subject { fsm.state }
 
-    RSpec.shared_examples "it supports the state" do |state:, conditions:|
+    shared_examples "it supports the state" do |state:, conditions:|
       conditions_list = conditions.to_sentence
 
       conditions_hash =
@@ -40,7 +40,9 @@ describe PatientSessionStateConcern do
       }.merge(conditions_hash)
 
       context "with conditions #{conditions_list}" do
+        # rubocop:disable RSpec/SubjectStub
         before { allow(fsm).to receive_messages(**messages) }
+        # rubocop:enable RSpec/SubjectStub
 
         it { should eq state.to_s }
       end

--- a/spec/models/concerns/patient_session_state_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_concern_spec.rb
@@ -3,6 +3,7 @@
 require "rails_helper"
 
 describe PatientSessionStateConcern do
+  subject(:fsm) { fake_state_machine_class.new }
   let(:fake_state_machine_class) do
     Class.new do
       attr_accessor :state
@@ -10,8 +11,6 @@ describe PatientSessionStateConcern do
       include PatientSessionStateConcern
     end
   end
-
-  subject(:fsm) { fake_state_machine_class.new }
 
   describe "#state" do
     subject { fsm.state }

--- a/spec/models/concerns/wizard_form_concern_spec.rb
+++ b/spec/models/concerns/wizard_form_concern_spec.rb
@@ -16,6 +16,7 @@ describe WizardFormConcern do
 
   describe "on_wizard_step" do
     subject { Dummy.new }
+
     before do
       Dummy.class_eval do
         attr_accessor :foo, :bar, :qux

--- a/spec/models/concerns/wizard_form_concern_spec.rb
+++ b/spec/models/concerns/wizard_form_concern_spec.rb
@@ -11,7 +11,7 @@ describe WizardFormConcern do
   describe ".form_step" do
     subject { Dummy.new.form_step }
 
-    it { is_expected.to be_nil }
+    it { should be_nil }
   end
 
   describe "on_wizard_step" do
@@ -39,7 +39,7 @@ describe WizardFormConcern do
 
     subject { Dummy.new }
 
-    it { is_expected.to be_valid }
+    it { should be_valid }
 
     context "when no step is set" do
       before { subject.valid?(:update) }

--- a/spec/models/concerns/wizard_form_concern_spec.rb
+++ b/spec/models/concerns/wizard_form_concern_spec.rb
@@ -15,6 +15,7 @@ describe WizardFormConcern do
   end
 
   describe "on_wizard_step" do
+    subject { Dummy.new }
     before do
       Dummy.class_eval do
         attr_accessor :foo, :bar, :qux
@@ -36,8 +37,6 @@ describe WizardFormConcern do
         end
       end
     end
-
-    subject { Dummy.new }
 
     it { should be_valid }
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -582,11 +582,11 @@ describe ConsentForm, type: :model do
     context "when there are no patients in the session" do
       let(:patients_in_session) { 0 }
 
-      it { is_expected.to be_nil }
+      it { should be_nil }
     end
 
     context "when there are unmatched patients in the session" do
-      it { is_expected.to be_nil }
+      it { should be_nil }
     end
 
     context "when there is one patient with matching first name and dob" do
@@ -599,7 +599,7 @@ describe ConsentForm, type: :model do
         )
       end
 
-      it { is_expected.to be_nil }
+      it { should be_nil }
     end
 
     context "when there are multiple patients with matching full_name and dob" do
@@ -623,7 +623,7 @@ describe ConsentForm, type: :model do
         )
       end
 
-      it { is_expected.to be_nil }
+      it { should be_nil }
     end
 
     context "when there is one patient with matching full_name and dob" do
@@ -637,7 +637,7 @@ describe ConsentForm, type: :model do
         )
       end
 
-      it { is_expected.to eq patients.first }
+      it { should eq patients.first }
     end
 
     context "when there is one patient with matching full_name and postcode" do
@@ -651,7 +651,7 @@ describe ConsentForm, type: :model do
         )
       end
 
-      it { is_expected.to eq patients.first }
+      it { should eq patients.first }
     end
 
     context "when there is one patient with matching f_name, dob, postcode" do
@@ -665,7 +665,7 @@ describe ConsentForm, type: :model do
         )
       end
 
-      it { is_expected.to eq patients.first }
+      it { should eq patients.first }
     end
 
     context "when there is one patient with matching l_name, dob, postcode" do
@@ -679,7 +679,7 @@ describe ConsentForm, type: :model do
         )
       end
 
-      it { is_expected.to eq patients.first }
+      it { should eq patients.first }
     end
   end
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -44,12 +44,6 @@ require "rails_helper"
 
 describe ConsentForm, type: :model do
   describe "Validations" do
-    let(:use_common_name) { false }
-    let(:response) { nil }
-    let(:reason) { nil }
-    let(:gp_response) { nil }
-    let(:health_answers) { [] }
-    let(:session) { build(:session) }
     subject(:consent_form) do
       build(
         :consent_form,
@@ -62,6 +56,12 @@ describe ConsentForm, type: :model do
         session:
       )
     end
+    let(:use_common_name) { false }
+    let(:response) { nil }
+    let(:reason) { nil }
+    let(:gp_response) { nil }
+    let(:health_answers) { [] }
+    let(:session) { build(:session) }
 
     context "when form_step is nil" do
       let(:form_step) { nil }

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -56,6 +56,7 @@ describe ConsentForm, type: :model do
         session:
       )
     end
+
     let(:use_common_name) { false }
     let(:response) { nil }
     let(:reason) { nil }

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -111,6 +111,7 @@ describe ConsentForm, type: :model do
       end
 
       it { should validate_presence_of(:is_this_their_school).on(:update) }
+
       it do
         expect(subject).to validate_inclusion_of(
           :is_this_their_school

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -415,6 +415,9 @@ describe ConsentForm, type: :model do
 
       context "no answers requiring follow-up recorded" do
         it "yields all the health answers in order" do
+          consent_form.health_answers[0].response = "no"
+          consent_form.health_answers[2].response = "no"
+
           expect { |b| consent_form.each_health_answer(&b) }.to(
             yield_successive_args(
               consent_form.health_answers[0],
@@ -427,6 +430,10 @@ describe ConsentForm, type: :model do
 
       context "answers require follow-up recorded" do
         it "yields all the health answers in order" do
+          consent_form.health_answers[0].response = "yes"
+          consent_form.health_answers[1].response = "yes"
+          consent_form.health_answers[2].response = "yes"
+
           expect { |b| consent_form.each_health_answer(&b) }.to(
             yield_successive_args(
               consent_form.health_answers[0],
@@ -471,7 +478,7 @@ describe ConsentForm, type: :model do
 
       context "answers require follow-up " do
         it "yields the normal and follow-up health answer in order" do
-          consent_form.health_answers[0].response = "yse"
+          consent_form.health_answers[0].response = "yes"
           consent_form.health_answers[1].response = "yes"
           consent_form.health_answers[2].response = "yes"
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -112,9 +112,9 @@ describe ConsentForm, type: :model do
 
       it { should validate_presence_of(:is_this_their_school).on(:update) }
       it do
-        should validate_inclusion_of(:is_this_their_school).in_array(
-                 %w[yes no]
-               ).on(:update)
+        expect(subject).to validate_inclusion_of(
+          :is_this_their_school
+        ).in_array(%w[yes no]).on(:update)
       end
     end
 
@@ -221,7 +221,9 @@ describe ConsentForm, type: :model do
       it { should validate_presence_of(:address_postcode).on(:update) }
 
       it do
-        should_not allow_value("invalid").for(:address_postcode).on(:update)
+        expect(subject).not_to allow_value("invalid").for(:address_postcode).on(
+          :update
+        )
       end
     end
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -549,8 +549,8 @@ describe ConsentForm, type: :model do
     let(:matched_consent_form) { create(:consent_form, consent:) }
 
     it "returns unmatched consent forms" do
-      expect(ConsentForm.unmatched).to include unmatched_consent_form
-      expect(ConsentForm.unmatched).not_to include matched_consent_form
+      expect(described_class.unmatched).to include unmatched_consent_form
+      expect(described_class.unmatched).not_to include matched_consent_form
     end
   end
 
@@ -560,8 +560,8 @@ describe ConsentForm, type: :model do
     let(:draft_consent_form) { create(:consent_form, consent:) }
 
     it "returns unmatched consent forms" do
-      expect(ConsentForm.recorded).to include recorded_consent_form
-      expect(ConsentForm.recorded).not_to include draft_consent_form
+      expect(described_class.recorded).to include recorded_consent_form
+      expect(described_class.recorded).not_to include draft_consent_form
     end
   end
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -271,7 +271,7 @@ describe ConsentForm, type: :model do
 
       it "is invalid if health answers do not have responses" do
         consent_form.save # rubocop:disable Rails/SaveBang
-        expect(consent_form).to_not be_valid
+        expect(consent_form).not_to be_valid
       end
 
       it "checks follow-up questions if necessary" do
@@ -280,7 +280,7 @@ describe ConsentForm, type: :model do
         health_answers[2].response = "no"
 
         consent_form.save # rubocop:disable Rails/SaveBang
-        expect(consent_form).to_not be_valid
+        expect(consent_form).not_to be_valid
       end
 
       context "health_question_number is set" do

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -71,6 +71,7 @@ describe Consent do
       subject(:consent) do
         Consent.from_consent_form!(consent_form, patient_session)
       end
+
       let(:session) { create(:session) }
       let(:consent_form) { create(:consent_form, session:) }
       let(:patient_session) { create(:patient_session, session:) }

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -69,7 +69,7 @@ describe Consent do
   describe "#from_consent_form!" do
     describe "the created consent object" do
       subject(:consent) do
-        Consent.from_consent_form!(consent_form, patient_session)
+        described_class.from_consent_form!(consent_form, patient_session)
       end
 
       let(:session) { create(:session) }

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -68,13 +68,12 @@ describe Consent do
 
   describe "#from_consent_form!" do
     describe "the created consent object" do
-      let(:session) { create(:session) }
-      let(:consent_form) { create(:consent_form, session:) }
-      let(:patient_session) { create(:patient_session, session:) }
-
       subject(:consent) do
         Consent.from_consent_form!(consent_form, patient_session)
       end
+      let(:session) { create(:session) }
+      let(:consent_form) { create(:consent_form, session:) }
+      let(:patient_session) { create(:patient_session, session:) }
 
       it "copies over attributes from consent_form" do
         expect(consent.reload).to(

--- a/spec/models/nivs_report_row_spec.rb
+++ b/spec/models/nivs_report_row_spec.rb
@@ -4,11 +4,10 @@ require "rails_helper"
 
 describe NivsReportRow do
   describe "#to_a" do
+    subject { nivs_report_row.to_a }
     let(:patient_session) { create(:patient_session, :vaccinated) }
     let(:vaccination) { patient_session.vaccination_records.first }
     let(:nivs_report_row) { NivsReportRow.new(vaccination) }
-
-    subject { nivs_report_row.to_a }
 
     it "includes information about the team who administered the vaccinatino" do
       vaccination.campaign.team.update!(ods_code: "X26")

--- a/spec/models/nivs_report_row_spec.rb
+++ b/spec/models/nivs_report_row_spec.rb
@@ -8,7 +8,7 @@ describe NivsReportRow do
 
     let(:patient_session) { create(:patient_session, :vaccinated) }
     let(:vaccination) { patient_session.vaccination_records.first }
-    let(:nivs_report_row) { NivsReportRow.new(vaccination) }
+    let(:nivs_report_row) { described_class.new(vaccination) }
 
     it "includes information about the team who administered the vaccinatino" do
       vaccination.campaign.team.update!(ods_code: "X26")

--- a/spec/models/nivs_report_row_spec.rb
+++ b/spec/models/nivs_report_row_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe NivsReportRow do
   describe "#to_a" do
     subject { nivs_report_row.to_a }
+
     let(:patient_session) { create(:patient_session, :vaccinated) }
     let(:vaccination) { patient_session.vaccination_records.first }
     let(:nivs_report_row) { NivsReportRow.new(vaccination) }

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -61,7 +61,7 @@ describe PatientSession do
       let(:patient) { create(:patient, consents: [consent_1, consent_2]) }
 
       it "groups consents by parent name" do
-        should contain_exactly(consent_1, consent_2)
+        expect(subject).to contain_exactly(consent_1, consent_2)
       end
     end
 
@@ -72,7 +72,7 @@ describe PatientSession do
       let(:patient) { create(:patient, consents: [consent_1, consent_2]) }
 
       it "returns the latest consent for each parent" do
-        should eq [consent_2]
+        expect(subject).to eq [consent_2]
       end
     end
 
@@ -91,7 +91,7 @@ describe PatientSession do
       let(:patient) { create(:patient, consents: [consent_1, consent_2]) }
 
       it "does not return a draft consent record" do
-        should eq [consent_1]
+        expect(subject).to eq [consent_1]
       end
     end
   end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -50,10 +50,9 @@ describe PatientSession do
   end
 
   describe "#latest_consents" do
+    subject { patient_session.latest_consents }
     let(:campaign) { create(:campaign) }
     let(:patient_session) { create(:patient_session, patient:, campaign:) }
-
-    subject { patient_session.latest_consents }
 
     context "multiple consent given responses from different parents" do
       let(:consent_1) { build(:consent, campaign:, response: :given) }

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -51,6 +51,7 @@ describe PatientSession do
 
   describe "#latest_consents" do
     subject { patient_session.latest_consents }
+
     let(:campaign) { create(:campaign) }
     let(:patient_session) { create(:patient_session, patient:, campaign:) }
 

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -61,8 +61,7 @@ describe PatientSession do
       let(:patient) { create(:patient, consents: [consent_1, consent_2]) }
 
       it "groups consents by parent name" do
-        is_expected.to include(consent_1, consent_2)
-        expect(subject.size).to eq 2
+        should contain_exactly(consent_1, consent_2)
       end
     end
 
@@ -73,7 +72,7 @@ describe PatientSession do
       let(:patient) { create(:patient, consents: [consent_1, consent_2]) }
 
       it "returns the latest consent for each parent" do
-        is_expected.to eq [consent_2]
+        should eq [consent_2]
       end
     end
 
@@ -92,7 +91,7 @@ describe PatientSession do
       let(:patient) { create(:patient, consents: [consent_1, consent_2]) }
 
       it "does not return a draft consent record" do
-        is_expected.to eq [consent_1]
+        should eq [consent_1]
       end
     end
   end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -37,12 +37,11 @@ require "rails_helper"
 
 describe Patient do
   describe "#year_group" do
+    subject { patient.year_group }
     before { Timecop.freeze(date) }
     after { Timecop.return }
 
     let(:patient) { Patient.new(date_of_birth: dob) }
-
-    subject { patient.year_group }
 
     context "child born BEFORE 1 Sep 2016, date is BEFORE 1 Sep 2024" do
       let(:dob) { Date.new(2016, 8, 31) }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -38,6 +38,7 @@ require "rails_helper"
 describe Patient do
   describe "#year_group" do
     subject { patient.year_group }
+
     before { Timecop.freeze(date) }
     after { Timecop.return }
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -42,7 +42,7 @@ describe Patient do
     before { Timecop.freeze(date) }
     after { Timecop.return }
 
-    let(:patient) { Patient.new(date_of_birth: dob) }
+    let(:patient) { described_class.new(date_of_birth: dob) }
 
     context "child born BEFORE 1 Sep 2016, date is BEFORE 1 Sep 2024" do
       let(:dob) { Date.new(2016, 8, 31) }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -26,6 +26,7 @@ describe Session do
   describe "validations" do
     context "when form_step is location" do
       subject { FactoryBot.build :session, form_step:, campaign: }
+
       let(:form_step) { :location }
       let(:location) { create :location }
       let(:team) { create :team, locations: [location] }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -67,7 +67,7 @@ describe Session do
   end
 
   describe ".active scope" do
-    subject { Session.active }
+    subject { described_class.active }
 
     let!(:active_session) { FactoryBot.create :session }
     let!(:draft_session) { FactoryBot.create :session, draft: true }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -25,12 +25,11 @@ require "rails_helper"
 describe Session do
   describe "validations" do
     context "when form_step is location" do
+      subject { FactoryBot.build :session, form_step:, campaign: }
       let(:form_step) { :location }
       let(:location) { create :location }
       let(:team) { create :team, locations: [location] }
       let(:campaign) { create :campaign, team: }
-
-      subject { FactoryBot.build :session, form_step:, campaign: }
 
       it { should validate_presence_of(:location_id).on(:update) }
 

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -4,11 +4,10 @@ require "rails_helper"
 
 describe SessionStats do
   describe "#call" do
-    let(:session) { create :session }
-
     subject do
       described_class.new(patient_sessions: session.patient_sessions, session:)
     end
+    let(:session) { create :session }
 
     it "returns a hash of session stats" do
       expect(subject.to_h).to eq(

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -7,6 +7,7 @@ describe SessionStats do
     subject do
       described_class.new(patient_sessions: session.patient_sessions, session:)
     end
+
     let(:session) { create :session }
 
     it "returns a hash of session stats" do

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 describe SessionPolicy do
   describe "Scope#resolve" do
     subject { SessionPolicy::Scope.new(user, Session).resolve }
+
     let(:team1) { create :team }
     let(:team2) { create :team }
     let(:user) { create :user, teams: [team1] }
@@ -19,6 +20,7 @@ describe SessionPolicy do
 
   describe "DraftScope#resolve" do
     subject { SessionPolicy::DraftScope.new(user, Session).resolve }
+
     let(:team) { create :team }
     let(:user) { create :user, teams: [team] }
     let(:location) { create :location, team: }

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 describe SessionPolicy do
   describe "Scope#resolve" do
+    subject { SessionPolicy::Scope.new(user, Session).resolve }
     let(:team1) { create :team }
     let(:team2) { create :team }
     let(:user) { create :user, teams: [team1] }
@@ -12,21 +13,18 @@ describe SessionPolicy do
     let(:session1) { create :session, campaign: campaign1 }
     let(:session2) { create :session, campaign: campaign2 }
 
-    subject { SessionPolicy::Scope.new(user, Session).resolve }
-
     it { should include session1 }
     it { should_not include session2 }
   end
 
   describe "DraftScope#resolve" do
+    subject { SessionPolicy::DraftScope.new(user, Session).resolve }
     let(:team) { create :team }
     let(:user) { create :user, teams: [team] }
     let(:location) { create :location, team: }
     let(:campaign) { create :campaign, team: }
     let(:draft_session) { create :session, draft: true, location:, campaign: }
     let(:session) { create :session, location:, campaign: }
-
-    subject { SessionPolicy::DraftScope.new(user, Session).resolve }
 
     it { should include draft_session }
     it { should_not include session }


### PR DESCRIPTION
This configures Rubocop to also lint any RSpec code, according to the rules in [`rubocop-govuk`](https://github.com/alphagov/rubocop-govuk), except for a few areas where we differ or the effort required to fix the issues isn't worth it.