### PR TITLE
Fix spec warning

### DIFF
--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -19,7 +19,7 @@ describe AppTriageNotesComponent, type: :component do
   end
 
   context "a single triage note is present" do
-    around(:all) do |example|
+    around(:each) do |example|
       Timecop.freeze(Time.zone.local(2023, 12, 4, 10, 4)) { example.run }
     end
 


### PR DESCRIPTION
Fixes the following:

> WARNING: `around(:context)` hooks are not supported and behave like `around(:example). Called from spec/components/app_triage_notes_component_spec.rb:22:in `block (2 levels) in <top (required)>'.
