### PR TITLE
Verbal consent spec improvements

### DIFF
--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -8,7 +8,6 @@ describe "Verbal consent" do
   scenario "Given, do not vaccinate" do
     given_i_am_signed_in
     when_i_get_verbal_consent_for_a_patient
-    then_the_consent_form_is_prefilled
 
     when_i_record_that_consent_was_given
     then_i_see_the_consent_responses_page
@@ -31,10 +30,6 @@ describe "Verbal consent" do
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
-
-  def then_the_consent_form_is_prefilled
-    expect(page).to have_field("Full name", with: @patient.parent.name)
   end
 
   def when_i_record_that_consent_was_given

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -7,14 +7,11 @@ describe "Verbal consent" do
 
   scenario "Given, do not vaccinate" do
     given_i_am_signed_in
-    when_i_get_verbal_consent_for_a_patient
 
-    when_i_record_that_consent_was_given
-    then_i_see_the_consent_responses_page
+    when_i_record_that_verbal_consent_was_given_but_that_its_not_safe_to_vaccinate
 
-    when_i_go_to_the_patient
-    then_i_see_that_the_status_is_do_not_vaccinate
-    and_the_will_not_vaccinate_email_is_sent_to_the_parent
+    then_an_email_is_sent_to_the_parent_that_the_vaccination_wont_happen
+    and_the_patients_status_is_do_not_vaccinate
   end
 
   def given_i_am_signed_in
@@ -26,13 +23,11 @@ describe "Verbal consent" do
     sign_in team.users.first
   end
 
-  def when_i_get_verbal_consent_for_a_patient
+  def when_i_record_that_verbal_consent_was_given_but_that_its_not_safe_to_vaccinate
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
 
-  def when_i_record_that_consent_was_given
     # Who are you trying to get consent from?
     click_button "Continue"
 
@@ -57,22 +52,17 @@ describe "Verbal consent" do
 
     # Confirm
     click_button "Confirm"
-  end
 
-  def then_i_see_the_consent_responses_page
     expect(page).to have_content("Check consent responses")
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def when_i_go_to_the_patient
+  def and_the_patients_status_is_do_not_vaccinate
     click_link @patient.full_name
-  end
-
-  def then_i_see_that_the_status_is_do_not_vaccinate
     expect(page).to have_content("Could not vaccinate")
   end
 
-  def and_the_will_not_vaccinate_email_is_sent_to_the_parent
+  def then_an_email_is_sent_to_the_parent_that_the_vaccination_wont_happen
     expect(sent_emails.count).to eq 1
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -7,14 +7,11 @@ describe "Verbal consent" do
 
   scenario "Given, keep in triage" do
     given_i_am_signed_in
-    when_i_get_verbal_consent_for_a_patient
 
-    when_i_record_that_consent_was_given
-    then_i_see_the_consent_responses_page
-    and_the_kept_in_triage_email_is_sent_to_the_parent
+    when_i_record_that_consent_was_given_but_keep_in_triage
 
-    when_i_go_to_the_patient
-    then_i_see_that_the_status_is_needs_triage
+    then_an_email_is_sent_to_the_parent_about_triage
+    and_the_patient_status_is_needing_triage
   end
 
   def given_i_am_signed_in
@@ -26,13 +23,11 @@ describe "Verbal consent" do
     sign_in team.users.first
   end
 
-  def when_i_get_verbal_consent_for_a_patient
+  def when_i_record_that_consent_was_given_but_keep_in_triage
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
 
-  def when_i_record_that_consent_was_given
     # Who are you trying to get consent from?
     click_button "Continue"
 
@@ -57,22 +52,17 @@ describe "Verbal consent" do
 
     # Confirm
     click_button "Confirm"
-  end
 
-  def then_i_see_the_consent_responses_page
     expect(page).to have_content("Check consent responses")
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def when_i_go_to_the_patient
+  def and_the_patient_status_is_needing_triage
     click_link @patient.full_name
-  end
-
-  def then_i_see_that_the_status_is_needs_triage
     expect(page).to have_content("Needs triage")
   end
 
-  def and_the_kept_in_triage_email_is_sent_to_the_parent
+  def then_an_email_is_sent_to_the_parent_about_triage
     expect(sent_emails.count).to eq 1
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -8,7 +8,6 @@ describe "Verbal consent" do
   scenario "Given, keep in triage" do
     given_i_am_signed_in
     when_i_get_verbal_consent_for_a_patient
-    then_the_consent_form_is_prefilled
 
     when_i_record_that_consent_was_given
     then_i_see_the_consent_responses_page
@@ -31,10 +30,6 @@ describe "Verbal consent" do
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
-
-  def then_the_consent_form_is_prefilled
-    expect(page).to have_field("Full name", with: @patient.parent.name)
   end
 
   def when_i_record_that_consent_was_given

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -12,10 +12,10 @@ describe "Verbal consent" do
 
     when_i_record_that_consent_was_given
     then_i_see_the_consent_responses_page
+    and_the_kept_in_triage_email_is_sent_to_the_parent
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_needs_triage
-    and_the_kept_in_triage_email_is_sent_to_the_parent
   end
 
   def given_i_am_signed_in

--- a/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
@@ -12,10 +12,10 @@ describe "Verbal consent" do
 
     when_i_record_that_consent_was_given
     then_i_see_the_consent_responses_page
+    and_the_kept_in_triage_email_is_sent_to_the_parent
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_safe_to_vaccinate
-    and_the_kept_in_triage_email_is_sent_to_the_parent
   end
 
   def given_i_am_signed_in

--- a/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
@@ -8,7 +8,6 @@ describe "Verbal consent" do
   scenario "Given, ready to vaccinate" do
     given_i_am_signed_in
     when_i_get_verbal_consent_for_a_patient
-    then_the_consent_form_is_prefilled
 
     when_i_record_that_consent_was_given
     then_i_see_the_consent_responses_page
@@ -31,10 +30,6 @@ describe "Verbal consent" do
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
-
-  def then_the_consent_form_is_prefilled
-    expect(page).to have_field("Full name", with: @patient.parent.name)
   end
 
   def when_i_record_that_consent_was_given

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -5,16 +5,13 @@ require "rails_helper"
 describe "Verbal consent" do
   include EmailExpectations
 
-  scenario "Given, ready to vaccinate" do
+  scenario "Given, with health notes but safe to vaccinate" do
     given_i_am_signed_in
-    when_i_get_verbal_consent_for_a_patient
 
-    when_i_record_that_consent_was_given
-    then_i_see_the_consent_responses_page
-    and_the_kept_in_triage_email_is_sent_to_the_parent
+    when_i_record_that_consent_was_given_with_some_health_notes_that_dont_contraindicate
 
-    when_i_go_to_the_patient
-    then_i_see_that_the_status_is_safe_to_vaccinate
+    then_an_email_is_sent_to_the_parent_that_vaccination_will_happen
+    and_the_patients_status_is_safe_to_vaccinate
   end
 
   def given_i_am_signed_in
@@ -26,13 +23,11 @@ describe "Verbal consent" do
     sign_in team.users.first
   end
 
-  def when_i_get_verbal_consent_for_a_patient
+  def when_i_record_that_consent_was_given_with_some_health_notes_that_dont_contraindicate
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
 
-  def when_i_record_that_consent_was_given
     # Who are you trying to get consent from?
     click_button "Continue"
 
@@ -57,22 +52,17 @@ describe "Verbal consent" do
 
     # Confirm
     click_button "Confirm"
-  end
 
-  def then_i_see_the_consent_responses_page
     expect(page).to have_content("Check consent responses")
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def when_i_go_to_the_patient
+  def and_the_patients_status_is_safe_to_vaccinate
     click_link @patient.full_name
-  end
-
-  def then_i_see_that_the_status_is_safe_to_vaccinate
     expect(page).to have_content("Safe to vaccinate")
   end
 
-  def and_the_kept_in_triage_email_is_sent_to_the_parent
+  def then_an_email_is_sent_to_the_parent_that_vaccination_will_happen
     expect(sent_emails).not_to be_empty
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -7,16 +7,14 @@ describe "Verbal consent" do
 
   scenario "Given" do
     given_i_am_signed_in
-    when_i_get_consent_for_a_patient
-    then_the_consent_form_is_prefilled
+    when_i_start_recording_consent_for_a_patient
+    then_the_parent_details_are_prefilled
 
     when_i_record_that_verbal_consent_was_given
-    then_i_see_the_consent_responses_page
-    and_an_email_is_sent_to_the_parent_confirming_their_consent
 
-    when_i_go_to_the_patient
-    then_i_see_that_the_status_is_safe_to_vaccinate
-    and_i_can_see_the_consent_response
+    then_an_email_is_sent_to_the_parent_confirming_their_consent
+    and_the_patients_status_is_safe_to_vaccinate
+    and_i_can_see_the_consent_response_details
   end
 
   def given_i_am_signed_in
@@ -28,13 +26,13 @@ describe "Verbal consent" do
     sign_in team.users.first
   end
 
-  def when_i_get_consent_for_a_patient
+  def when_i_start_recording_consent_for_a_patient
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
   end
 
-  def then_the_consent_form_is_prefilled
+  def then_the_parent_details_are_prefilled
     expect(page).to have_field("Full name", with: @patient.parent.name)
   end
 
@@ -63,22 +61,18 @@ describe "Verbal consent" do
     expect(page).to have_content("Check and confirm answers")
     expect(page).to have_content(["Response method", "By phone"].join)
     click_button "Confirm"
-  end
 
-  def then_i_see_the_consent_responses_page
+    # Back on the consent responses page
     expect(page).to have_content("Check consent responses")
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def when_i_go_to_the_patient
+  def and_the_patients_status_is_safe_to_vaccinate
     click_link @patient.full_name
-  end
-
-  def then_i_see_that_the_status_is_safe_to_vaccinate
     expect(page).to have_content("Safe to vaccinate")
   end
 
-  def and_i_can_see_the_consent_response
+  def and_i_can_see_the_consent_response_details
     click_link @patient.parent.name
 
     expect(page).to have_content(
@@ -110,7 +104,7 @@ describe "Verbal consent" do
     )
   end
 
-  def and_an_email_is_sent_to_the_parent_confirming_their_consent
+  def then_an_email_is_sent_to_the_parent_confirming_their_consent
     expect(sent_emails.count).to eq 1
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -12,11 +12,11 @@ describe "Verbal consent" do
 
     when_i_record_that_verbal_consent_was_given
     then_i_see_the_consent_responses_page
+    and_an_email_is_sent_to_the_parent_confirming_their_consent
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_safe_to_vaccinate
     and_i_can_see_the_consent_response
-    and_an_email_is_sent_to_the_parent_confirming_their_consent
   end
 
   def given_i_am_signed_in

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -8,7 +8,6 @@ describe "Verbal consent" do
   scenario "Refused" do
     given_i_am_signed_in
     when_i_get_verbal_consent_for_a_patient
-    then_the_consent_form_is_prefilled
 
     when_i_record_the_consent_refusal_and_reason
     then_i_see_the_consent_responses_page
@@ -32,13 +31,6 @@ describe "Verbal consent" do
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
-
-  def then_the_consent_form_is_prefilled
-    expect(page).to have_field("Full name", with: @patient.parent.name)
-  end
-
-  def given_i_call_the_parent_and_they_refuse_consent
   end
 
   def when_i_record_the_consent_refusal_and_reason

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -7,15 +7,12 @@ describe "Verbal consent" do
 
   scenario "Refused" do
     given_i_am_signed_in
-    when_i_get_verbal_consent_for_a_patient
 
     when_i_record_the_consent_refusal_and_reason
-    then_i_see_the_consent_responses_page
-    and_an_email_is_sent_to_the_parent_confirming_the_refusal
 
-    when_i_go_to_the_patient
-    then_i_see_that_the_status_is_do_not_vaccinate
-    and_i_can_see_the_consent_response
+    then_an_email_is_sent_to_the_parent_confirming_the_refusal
+    and_the_patients_status_is_do_not_vaccinate
+    and_i_can_see_the_consent_response_details
   end
 
   def given_i_am_signed_in
@@ -27,13 +24,11 @@ describe "Verbal consent" do
     sign_in team.users.first
   end
 
-  def when_i_get_verbal_consent_for_a_patient
+  def when_i_record_the_consent_refusal_and_reason
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
-  end
 
-  def when_i_record_the_consent_refusal_and_reason
     # Who are you trying to get consent from?
     click_button "Continue"
 
@@ -57,22 +52,17 @@ describe "Verbal consent" do
     expect(page).to have_content(["Decision", "Consent refused"].join)
     expect(page).to have_content(["Name", @patient.parent.name].join)
     click_button "Confirm"
-  end
 
-  def then_i_see_the_consent_responses_page
     expect(page).to have_content("Check consent responses")
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def when_i_go_to_the_patient
+  def and_the_patients_status_is_do_not_vaccinate
     click_link @patient.full_name
-  end
-
-  def then_i_see_that_the_status_is_do_not_vaccinate
     expect(page).to have_content("Could not vaccinate")
   end
 
-  def and_i_can_see_the_consent_response
+  def and_i_can_see_the_consent_response_details
     click_link @patient.parent.name
 
     expect(page).to have_content(
@@ -101,7 +91,7 @@ describe "Verbal consent" do
     expect(page).not_to have_content("Answers to health questions")
   end
 
-  def and_an_email_is_sent_to_the_parent_confirming_the_refusal
+  def then_an_email_is_sent_to_the_parent_confirming_the_refusal
     expect_email_to @patient.parent.email,
                     EMAILS[:parental_consent_confirmation_refused]
   end

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -12,11 +12,11 @@ describe "Verbal consent" do
 
     when_i_record_the_consent_refusal_and_reason
     then_i_see_the_consent_responses_page
+    and_an_email_is_sent_to_the_parent_confirming_the_refusal
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_do_not_vaccinate
     and_i_can_see_the_consent_response
-    and_an_email_is_sent_to_the_parent_confirming_the_refusal
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
I was doing more design alignment work around the consents recorded by staff. The current verbal consent specs feel more awkward to work with than they could be, due in part to:

* the top-level specs including lots of granular 'how' steps (e.g. talking about page navigation), instead of focusing on the 'what' (i.e. what the user is trying to achieve)
* some extra bits that can be checked once and don't need to be repeated across multiple specs

I've revised each of the specs, so hopefully they are easier to read, and it's more obvious how they differ from one other.
