### PR TITLE
Bugfix: reinstate parent email validation messages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,9 +93,6 @@ en:
           other: Other
           text: I can only receive text messages
           voice: I can only receive voice calls
-        parent_relationships:
-          father: dad
-          mother: mum
         reasons:
           already_vaccinated: Vaccine already received
           contains_gelatine: Vaccine contains gelatine from pigs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,6 +286,10 @@ en:
             contact_method_other:
               blank: Enter details about how to contact you
               too_long: Enter details that are less than 300 characters long
+            email:
+              blank: Enter an email address
+              invalid: Enter a valid email address, such as j.doe@gmail.com
+              too_long: Enter a email address that is less than 300 characters long
             name:
               blank: Enter a name
               too_long: Enter a name that is less than 300 characters long


### PR DESCRIPTION
These messages got lost during the refactoring to the `Parent` model.

## Before

![screencapture-localhost-4000-sessions-3-consents-11-edit-parent-2024-07-01-10_06_47](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/88c349f1-c4e2-4f2b-a11c-5612cfbf893a)

![screencapture-localhost-4000-sessions-3-consents-11-edit-parent-2024-07-01-10_07_02](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/60de9f49-3f8f-4003-9039-16a4eb19ffc3)

## After

![screencapture-localhost-4000-sessions-3-consents-11-edit-parent-2024-07-01-11_52_25](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/c1e3689b-1005-405b-860c-0ee1618379cd)

![screencapture-localhost-4000-sessions-3-consents-11-edit-parent-2024-07-01-11_52_37](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/23801/0683ffae-774f-40f1-8a8e-cf585b90ca49)
