### PR TITLE
Redirect www subdomain to root

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # Redirect www subdomain to root in production envs
+  unless Rails.env.development? || Rails.env.test?
+    match "(*any)",
+          to: redirect(subdomain: ""),
+          via: :all,
+          constraints: {
+            subdomain: "www"
+          }
+  end
+
   devise_for :users,
              module: :users,
              path_names: {


### PR DESCRIPTION
This ensures that our production deployment steers users to the naked/root domain, so that users don't end up with cookies on both domains and a potentially confusing user experience.

Based on https://masilotti.com/rails-redirect-www/

Tested locally by temporarily whitelisting two domains in `config/application.rb`:

```ruby
config.hosts << "app.local:4000"
config.hosts << "www.app.local:4000"
```

I added those to my hosts file:

```bash
127.0.0.1  app.local
127.0.0.1  www.app.local
```

The result is that the www subdomain redirects to the root:

```bash
$ curl -I http://www.app.local:4000
HTTP/1.1 301 Moved Permanently
location: http://app.local:4000/
content-type: text/html; charset=UTF-8
cache-control: no-cache
x-request-id: 7b54f3fa-0fc6-4109-96b3-d97bf7615ece
x-runtime: 0.013215
server-timing: sql.active_record;dur=0.63, redirect.action_dispatch;dur=0.12
Content-Length: 0
```