### PR TITLE
Add vaccine available_delivery_sites/_methods

### DIFF
--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -20,7 +20,7 @@ module VaccinationsHelper
   end
 
   def vaccination_delivery_methods
-    methods = VaccinationRecord.delivery_methods.keys
+    methods = VaccinationRecord.available_delivery_methods
     methods.map do |m|
       [m, VaccinationRecord.human_enum_name("delivery_methods", m)]
     end
@@ -28,7 +28,8 @@ module VaccinationsHelper
 
   def vaccination_delivery_sites
     sites =
-      VaccinationRecord.delivery_sites.keys - vaccination_initial_delivery_sites
+      VaccinationRecord.available_delivery_sites -
+        vaccination_initial_delivery_sites
     sites.map do |s|
       [s, VaccinationRecord.human_enum_name("delivery_sites", s)]
     end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -48,7 +48,9 @@ class VaccinationRecord < ApplicationRecord
 
   default_scope { recorded }
 
-  enum :delivery_method, %w[intramuscular subcutaneous], prefix: true
+  enum :delivery_method,
+       %w[intramuscular subcutaneous nasal_spray],
+       prefix: true
   enum :delivery_site,
        %w[
          left_arm
@@ -59,6 +61,9 @@ class VaccinationRecord < ApplicationRecord
          right_arm_lower_position
          left_thigh
          right_thigh
+         left_buttock
+         right_buttock
+         nose
        ],
        prefix: true
   enum :reason,
@@ -109,6 +114,14 @@ class VaccinationRecord < ApplicationRecord
             },
             on: :edit_reason,
             if: -> { !administered }
+
+  def self.available_delivery_sites
+    delivery_sites.keys - %w[left_buttock right_buttock nose]
+  end
+
+  def self.available_delivery_methods
+    delivery_methods.keys - %w[nasal_spray]
+  end
 
   def vaccine_name
     patient_session.session.campaign.vaccines.first.type


### PR DESCRIPTION
To accomodate NIVS upload, we need to relax the enums by allowing left/right buttocks for delivery sites, as well as a nasal spray method.

These are not currently in use by any of our vaccines. The simplest solution is to create a couple of new methods that remove the unused options and can be used when recording a vaccination to present the available sites and methods.

The logic in these methods will need to become more complex at some point to accommodate different types of vaccines.