### PR TITLE
Add reports page to campaigns

### DIFF
--- a/app/components/app_secondary_navigation_component.rb
+++ b/app/components/app_secondary_navigation_component.rb
@@ -7,13 +7,14 @@ class AppSecondaryNavigationComponent < ViewComponent::Base
     attr_reader :href, :selected
 
     def call
-      content
+      content || @text || raise(ArgumentError, "no text or content")
     end
 
-    def initialize(href:, selected: false)
+    def initialize(href:, text: nil, selected: false)
       super
 
       @href = href
+      @text = html_escape(text)
       @selected = selected
     end
   end

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -8,6 +8,18 @@
                                         ]) %>
 <% end %>
 
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(
+        text: "School sessions",
+        href: campaign_path(@campaign),
+        selected: true,
+      )
+      nav.with_item(
+        text: "Reports",
+        href: campaign_reports_path(@campaign),
+      )
+    end %>
+
 <% [[@in_progress_sessions, "In progress sessions"],
     [@future_sessions, "Planned sessions"],
     [@past_sessions, "Past sessions"]]

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,16 +1,22 @@
-<% page_title = "Reports" %>
-
-<%= h1 page_title, size: "xl" %>
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – Reports" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
-                                          { text: page_title },
+                                          { text: t("campaigns.index.title"), href: campaigns_path },
                                         ]) %>
 <% end %>
 
-<h2 class="nhsuk-heading-l nhsuk-u-margin-bottom-4">
-  NIVS download
-</h2>
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(
+        text: "School sessions",
+        href: campaign_path(@campaign),
+      )
+      nav.with_item(
+        text: "Reports",
+        href: campaign_reports_path(@campaign),
+        selected: true,
+      )
+    end %>
 
-<%= govuk_link_to "Download data (CSV)", report_path(id: "hpv"), class: "nhsuk-u-margin-bottom-2 nhsuk-button" %>
+<%= govuk_link_to "Download NIVS data (CSV)", download_campaign_reports_path(@campaign), class: "nhsuk-button" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :campaigns, only: %i[index show]
+  resources :campaigns, only: %i[index show] do
+    resources :reports, only: %i[index] do
+      get "download", on: :collection
+    end
+  end
 
   resources :sessions, only: %i[create edit index show] do
     namespace :parent_interface, path: "/" do
@@ -196,8 +200,6 @@ Rails.application.routes.draw do
       post "make-default", on: :member, as: :make_default
     end
   end
-
-  resources :reports, only: %i[index show]
 
   resources :consent_forms, path: "consent-forms", only: [:show] do
     get "match/:patient_session_id",

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -11,9 +11,11 @@ describe AppSecondaryNavigationComponent, type: :component do
   let(:component) do
     described_class.new.tap do |nav|
       nav.with_item(selected: true, href: "https://example.com") { "Example 1" }
-      nav.with_item(selected: false, href: "https://example.com") do
-        "Example 2"
-      end
+      nav.with_item(
+        selected: false,
+        text: "Example 2",
+        href: "https://example.com"
+      )
     end
   end
 
@@ -47,4 +49,6 @@ describe AppSecondaryNavigationComponent, type: :component do
   end
 
   it { should have_link("Example 1", href: "https://example.com") }
+
+  it { should have_link("Example 2", href: "https://example.com") }
 end

--- a/spec/features/nivs_hpv_report_spec.rb
+++ b/spec/features/nivs_hpv_report_spec.rb
@@ -39,13 +39,15 @@ describe "NIVS HPV report" do
   end
 
   def when_i_go_to_the_reports_page
-    visit "/reports"
+    visit "/dashboard"
 
-    expect(page).to have_css("h1", text: "Reports")
+    click_on "Vaccination programmes", match: :first
+    click_on "HPV"
+    click_on "Reports"
   end
 
   def and_i_download_the_nivs_hpv_report
-    click_on "Download data (CSV)"
+    click_on "Download NIVS data (CSV)"
   end
 
   def then_i_should_see_all_the_administered_vaccinations_from_my_teams_hpv_campaign


### PR DESCRIPTION
This adds a new tab shown on the campaign page which allows the user to download the NIVS data report, currently only available by going directly to the `/reports` URL. This moves us closer to the designs in the prototype, and it's where we will start to add the journey related to uploading data from NIVS.

## Screenshot

![Screenshot 2024-07-09 at 11 14 13](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/510498/846ceb9b-703a-454a-b788-5b9d2746e69b)
