### PR TITLE
Replace mark CSS with app-highlight

### DIFF
--- a/app/assets/stylesheets/_highlight.scss
+++ b/app/assets/stylesheets/_highlight.scss
@@ -1,0 +1,25 @@
+.app-highlight {
+  background-color: mix(white, $color_nhsuk-warm-yellow, 80%);
+  border-bottom: 3px solid $color_nhsuk-warm-yellow;
+
+  // Ensure highlight is announced by screen readers
+  // @link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark#accessibility
+  &::before,
+  &::after {
+    clip-path: inset(100%);
+    clip: rect(1px, 1px, 1px, 1px);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  &::before {
+    content: " [highlight start] ";
+  }
+
+  &::after {
+    content: " [highlight end] ";
+  }
+}

--- a/app/assets/stylesheets/_overrides.scss
+++ b/app/assets/stylesheets/_overrides.scss
@@ -1,8 +1,3 @@
-// Use NHSUK colour for <mark>
-mark {
-  background-color: $color_nhsuk-pale-yellow;
-}
-
 // `$nhsuk-page-width` isn’t globally editable, so need to apply manually
 .app-signed-in {
   .nhsuk-width-container,

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,6 +41,7 @@ $color_app-dark-orange: darken(
 @import "globals";
 @import "header";
 @import "heading-group";
+@import "highlight";
 @import "list";
 @import "notification-banner";
 // @import "offline";

--- a/app/components/app_compare_consent_form_and_patient_component.rb
+++ b/app/components/app_compare_consent_form_and_patient_component.rb
@@ -25,8 +25,7 @@ class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
 
   def mark(text, opts)
     if !opts[:unless] && !opts[:if]
-      tag.span(class: "nhsuk-u-visually-hidden") { "Inconsistent: " } +
-        tag.mark(text)
+      tag.mark(text, class: "app-highlight")
     else
       text
     end

--- a/spec/components/app_compare_consent_form_and_patient_component_spec.rb
+++ b/spec/components/app_compare_consent_form_and_patient_component_spec.rb
@@ -72,21 +72,13 @@ describe AppCompareConsentFormAndPatientComponent, type: :component do
     end
 
     it "displays the key consent form details with the unmatched details highlighted" do
+      expect(page).to have_text(["Child’s name", "John Doe", "Jane Doe"].join)
       expect(page).to have_text(
-        ["Child’s name", "Inconsistent: ", "John Doe", "Jane Doe"].join
-      )
-      expect(page).to have_text(
-        [
-          "Date of birth",
-          "Inconsistent: ",
-          "1 January 2000",
-          "2 January 2000"
-        ].join
+        ["Date of birth", "1 January 2000", "2 January 2000"].join
       )
       expect(page).to have_text(
         [
           "Address",
-          "Inconsistent: ",
           "1 Main Street",
           "Area",
           "Some Town",


### PR DESCRIPTION
Copied from prototype: https://github.com/nhsuk/manage-vaccinations-in-schools-prototype/commit/8b1f6ff15f5e3700dcbd1b69e7fa6b78a48b1b9e

### After

<img width="784" alt="Screenshot 2024-07-09 at 16 48 35" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/1650875/a34ad35b-a699-4b4c-9120-f7ec0968d963">
