### PR TITLE
Check user's role on cis2 login

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -13,8 +13,12 @@ module AuthenticationConcern
         end
         flash[:info] = "You must be logged in to access this page."
         redirect_to start_path
-      elsif cis2_session? && !selected_cis2_org_is_registered?
-        redirect_to users_team_not_found_path
+      elsif cis2_session?
+        if !selected_cis2_org_is_registered?
+          redirect_to users_team_not_found_path
+        elsif !selected_cis2_role_is_valid?
+          redirect_to users_role_not_found_path
+        end
       end
     end
 
@@ -24,6 +28,16 @@ module AuthenticationConcern
 
     def selected_cis2_org_is_registered?
       Team.exists?(ods_code: session["cis2_info"]["selected_org"]["code"])
+    end
+
+    def valid_cis2_roles
+      ["R8001"]
+    end
+
+    def selected_cis2_role_is_valid?
+      session["cis2_info"]["selected_roles"].keys.any? do
+        valid_cis2_roles.include? _1
+      end
     end
 
     def storable_location?

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -31,7 +31,7 @@ module AuthenticationConcern
     end
 
     def valid_cis2_roles
-      ["R8001"]
+      ["S8000:G8000:R8001"]
     end
 
     def selected_cis2_role_is_valid?

--- a/app/controllers/users/accounts_controller.rb
+++ b/app/controllers/users/accounts_controller.rb
@@ -4,9 +4,12 @@ module Users
   class AccountsController < ApplicationController
     before_action :set_user, only: %i[show update]
 
-    skip_before_action :store_user_location!, only: :team_not_found
-    skip_before_action :authenticate_user!, only: :team_not_found
-    skip_after_action :verify_policy_scoped, only: :team_not_found
+    skip_before_action :store_user_location!,
+                       only: %i[team_not_found role_not_found]
+    skip_before_action :authenticate_user!,
+                       only: %i[team_not_found role_not_found]
+    skip_after_action :verify_policy_scoped,
+                      only: %i[team_not_found role_not_found]
 
     layout "two_thirds"
 
@@ -25,6 +28,15 @@ module Users
     end
 
     def team_not_found
+      if session.key? :cis2_info
+        @cis2_info = session[:cis2_info].with_indifferent_access
+        render status: :not_found
+      else
+        redirect_to root_path
+      end
+    end
+
+    def role_not_found
       if session.key? :cis2_info
         @cis2_info = session[:cis2_info].with_indifferent_access
         render status: :not_found

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -49,16 +49,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
   end
 
-  def selected_cis2_role_codes
-    selected_cis2_nrbac_role["role_code"].split(":")
-  end
-
-  def selected_cis2_role_names
-    selected_cis2_nrbac_role["role_name"].split(":")
-  end
-
   def selected_cis2_roles
-    @selected_cis2_roles ||=
-      Hash[selected_cis2_role_codes.zip(selected_cis2_role_names)]
+    @selected_cis2_roles ||= {
+      selected_cis2_nrbac_role["role_code"] =>
+        selected_cis2_nrbac_role["role_name"]
+    }
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,10 +12,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         "name" => selected_cis2_org["org_name"],
         "code" => selected_cis2_org["org_code"]
       },
+      "selected_roles" => selected_cis2_roles,
       "has_other_roles" => raw_cis2_info["nhsid_nrbac_roles"].length > 1
     }
     if !selected_cis2_org_is_registered?
       redirect_to users_team_not_found_path
+    elsif !selected_cis2_role_is_valid?
+      redirect_to users_role_not_found_path
     else
       @user = User.find_or_create_user_from_cis2_oidc(user_cis2_info)
       sign_in_and_redirect @user, event: :authentication
@@ -44,5 +47,18 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       raw_cis2_info["nhsid_user_orgs"].find do
         _1["org_code"] == selected_cis2_nrbac_role["org_code"]
       end
+  end
+
+  def selected_cis2_role_codes
+    selected_cis2_nrbac_role["role_code"].split(":")
+  end
+
+  def selected_cis2_role_names
+    selected_cis2_nrbac_role["role_name"].split(":")
+  end
+
+  def selected_cis2_roles
+    @selected_cis2_roles ||=
+      Hash[selected_cis2_role_codes.zip(selected_cis2_role_names)]
   end
 end

--- a/app/views/users/accounts/role_not_found.html.erb
+++ b/app/views/users/accounts/role_not_found.html.erb
@@ -1,0 +1,20 @@
+<%= h1 "You do not have permission to use this service" %>
+
+<% if @cis2_info[:has_other_roles] %>
+  <%= govuk_button_to "Change role", user_cis2_omniauth_authorize_path, params: { change_role: true } %>
+<% end %>
+
+<h2 class="nhsuk-heading-m">Contact your registration authority</h2>
+
+<p>
+  If you think you should have permission to use this service, contact your
+  registration authority, Acme Community Hospital NHS Foundation Trust (ACM).
+  Ask for one of the following roles to be added to your Care Identity:
+</p>
+
+<%= govuk_list([
+      "Nurse Access Role (R8001)",
+      "Medical Secretary Access Role (R8006)",
+      "Admin/Clinical Support Access Role (R8008)",
+      "Receptionist Access Role (R8009)",
+    ], type: "bullet") %>

--- a/app/views/users/accounts/role_not_found.html.erb
+++ b/app/views/users/accounts/role_not_found.html.erb
@@ -8,7 +8,15 @@
 
 <p>
   If you think you should have permission to use this service, contact your
-  registration authority, Acme Community Hospital NHS Foundation Trust (ACM).
+  registration authority:
+</p>
+
+<%= govuk_inset_text do %>
+  <%= @cis2_info[:selected_org][:name] %><br />
+  (<%= @cis2_info[:selected_org][:code] %>)
+<% end %>
+
+<p>
   Ask for one of the following roles to be added to your Care Identity:
 </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,6 +222,7 @@ Rails.application.routes.draw do
     resources :accounts, only: %i[show update]
 
     get "team-not-found", controller: :accounts
+    get "role-not-found", controller: :accounts
   end
 
   scope via: :all do

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -6,7 +6,7 @@ require "fixtures/cis2_auth_info"
 describe "User CIS2 authentication" do
   let(:test_team_ods_code) { "AB12" }
 
-  let(:cis2_auth_info) { CIS2_AUTH_INFO }
+  let(:cis2_auth_info) { CIS2_AUTH_INFO.deep_dup }
 
   scenario "user has wrong role selected" do
     given_the_cis2_feature_flag_is_enabled

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "fixtures/cis2_auth_info"
+
+describe "User CIS2 authentication" do
+  let(:test_team_ods_code) { "AB12" }
+
+  let(:cis2_auth_info) { CIS2_AUTH_INFO }
+
+  scenario "user has wrong role selected" do
+    given_the_cis2_feature_flag_is_enabled
+    and_my_team_is_setup_in_mavis
+    and_i_do_not_have_a_valid_role_for_mavis
+    when_i_go_to_the_sessions_page
+    then_i_am_on_the_start_page
+    when_i_click_the_cis2_login_button
+    then_i_see_the_team_not_found_error
+
+    when_i_click_the_change_role_button_and_select_the_right_role
+    then_i_see_the_sessions_page
+  end
+
+  def setup_cis2_auth_mock
+    OmniAuth.config.add_mock(:cis2, cis2_auth_info)
+  end
+
+  def setup_role_in_cis2_response(code, name)
+    cis2_auth_info.tap do |info|
+      info["extra"]["raw_info"]["nhsid_nrbac_roles"][0]["role_code"] = code
+      info["extra"]["raw_info"]["nhsid_nrbac_roles"][0]["role_name"] = name
+    end
+
+    setup_cis2_auth_mock
+  end
+
+  def given_the_cis2_feature_flag_is_enabled
+    Flipper.enable(:cis2)
+  end
+
+  def and_my_team_is_setup_in_mavis
+    @team = create :team, ods_code: test_team_ods_code
+  end
+
+  def and_i_do_not_have_a_valid_role_for_mavis
+    setup_role_in_cis2_response(
+      "S8002:G8003:R0001",
+      '"Admin and Clerical":"Admin and Clerical":"Privacy Officer"'
+    )
+  end
+
+  def when_i_click_the_cis2_login_button
+    click_button "Care Identity"
+  end
+
+  def then_i_am_on_the_start_page
+    expect(page).to have_current_path start_path
+  end
+
+  def when_i_go_to_the_sessions_page
+    visit sessions_path
+  end
+
+  def then_i_see_the_sessions_page
+    expect(page).to have_current_path sessions_path
+  end
+
+  def then_i_see_the_team_not_found_error
+    expect(
+      page
+    ).to have_heading "You do not have permission to use this service"
+  end
+
+  def when_i_click_the_change_role_button_and_select_the_right_role
+    # With don't actually get to select the right role directly in our test
+    # setup so we change the cis2 response to simulate it.
+    setup_role_in_cis2_response(
+      "S8000:G8000:R8001",
+      '"Clinical":"Clinical Provision":"Nurse Access Role"'
+    )
+    click_button "Change role"
+  end
+end

--- a/spec/features/user_cis2_authentication_with_wrong_team_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_team_spec.rb
@@ -7,7 +7,7 @@ describe "User CIS2 authentication" do
   let(:test_team_ods_code) { "AB12" }
 
   let(:cis2_auth_mock) do
-    CIS2_AUTH_INFO.tap do |info|
+    CIS2_AUTH_INFO.deep_dup.tap do |info|
       info["extra"]["raw_info"]["nhsid_nrbac_roles"][0][
         "org_code"
       ] = test_team_ods_code

--- a/spec/fixtures/cis2_auth_info.rb
+++ b/spec/fixtures/cis2_auth_info.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 CIS2_AUTH_INFO = {
@@ -27,9 +26,8 @@ CIS2_AUTH_INFO = {
           "person_orgid" => "1111222233334444",
           "person_roleid" => "5555666677778888",
           "org_code" => "AB12",
-          "role_name" =>
-            "\"Admin and Clerical\":\"Admin and Clerical\":\"Privacy Officer\"",
-          "role_code" => "S8002:G8003:R0001",
+          "role_name" => '"Clinical":"Clinical Provision":"Nurse Access Role"',
+          "role_code" => "S8000:G8000:R8001",
           "activities" => [
             "Receive Self Claimed LR Alerts",
             "Receive Legal Override and Emergency View Alerts",
@@ -41,8 +39,7 @@ CIS2_AUTH_INFO = {
           "person_orgid" => "1234123412341234",
           "person_roleid" => "5678567856785678",
           "org_code" => "CD34",
-          "role_name" =>
-            "\"Clinical\":\"Clinical Provision\":\"Nurse Access Role\"",
+          "role_name" => '"Clinical":"Clinical Provision":"Nurse Access Role"',
           "role_code" => "S8000:G8000:R8001",
           "activities" => [
             "Personal Medication Administration",


### PR DESCRIPTION
Users must have certain roles to be able to access the system. If they do not have an appropriate role they will get the page below. The list of valid roles is still naively implemented, we will refine that as we develop authorisation flows to match the designs.

<img width="1130" alt="image" src="https://github.com/nhsuk/manage-vaccinations-in-schools/assets/15608/b1fc368e-797a-4bd1-a0c5-88686aa3826c">

