### PR TITLE
Show immunisation import errors

### DIFF
--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -10,14 +10,26 @@ class ImmunisationImportsController < ApplicationController
   def create
     @immunisation_import = ImmunisationImport.new(immunisation_import_params)
 
-    if @immunisation_import.save
-      redirect_to success_campaign_immunisation_import_path(
-                    @campaign,
-                    @immunisation_import
-                  )
-    else
+    @immunisation_import.load_data!
+    if @immunisation_import.invalid?
       render :new, status: :unprocessable_entity
+      return
     end
+
+    @immunisation_import.parse_rows!
+    if @immunisation_import.invalid?
+      render :errors, status: :unprocessable_entity
+      return
+    end
+
+    # TODO: @immunisation_import.process!
+
+    @immunisation_import.save!
+
+    redirect_to success_campaign_immunisation_import_path(
+                  @campaign,
+                  @immunisation_import
+                )
   end
 
   def success

--- a/app/views/immunisation_imports/_breadcrumbs.html.erb
+++ b/app/views/immunisation_imports/_breadcrumbs.html.erb
@@ -1,0 +1,7 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: dashboard_path },
+                                          { text: t("campaigns.index.title"), href: campaigns_path },
+                                          { text: @campaign.name, href: campaign_reports_path(@campaign) },
+                                        ]) %>
+<% end %>

--- a/app/views/immunisation_imports/errors.html.erb
+++ b/app/views/immunisation_imports/errors.html.erb
@@ -1,0 +1,41 @@
+<% title = "The vaccination events could not be added" %>
+
+<% content_for :page_title, "#{@campaign.name} – #{title}" %>
+
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: dashboard_path },
+                                          { text: t("campaigns.index.title"), href: campaigns_path },
+                                          { text: @campaign.name, href: campaign_reports_path(@campaign) },
+                                        ]) %>
+<% end %>
+
+<%= h1 title %>
+
+<p>
+  It wasn’t possible to add the vaccination events due to the following errors in the uploaded CSV file:
+</p>
+
+<% @immunisation_import.errors.each do |error| %>
+  <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
+    <% if error.attribute == :csv %>
+      CSV
+    <% else %>
+      <%= error.attribute.to_s.humanize %>
+    <% end %>
+  </h2>
+
+  <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-font-size-16">
+    <% if error.type.is_a?(Array) %>
+      <% error.type.each do |type| %>
+        <li><%= sanitize type %></li>
+      <% end %>
+    <% else %>
+      <li><%= sanitize error.type %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+<p>
+  <%= govuk_link_to "Upload new vaccination events (CSV)", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
+</p>

--- a/app/views/immunisation_imports/errors.html.erb
+++ b/app/views/immunisation_imports/errors.html.erb
@@ -2,13 +2,7 @@
 
 <% content_for :page_title, "#{@campaign.name} – #{title}" %>
 
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
-                                          { text: t("campaigns.index.title"), href: campaigns_path },
-                                          { text: @campaign.name, href: campaign_reports_path(@campaign) },
-                                        ]) %>
-<% end %>
+<%= render "breadcrumbs" %>
 
 <%= h1 title %>
 

--- a/app/views/immunisation_imports/new.html.erb
+++ b/app/views/immunisation_imports/new.html.erb
@@ -1,6 +1,6 @@
-<% page_title = "Upload vaccination events" %>
+<% title = "Upload vaccination events" %>
 
-<%= content_for :page_title, "#{@campaign.name} – Upload vaccination events" %>
+<% content_for :page_title, "#{@campaign.name} – #{title}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
@@ -13,7 +13,7 @@
 <%= form_with model: @immunisation_import, url: campaign_immunisation_imports_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_file_field :csv, label: { text: page_title, tag: "h1", size: "l" } %>
+  <%= f.govuk_file_field :csv, label: { text: title, tag: "h1", size: "l" } %>
 
   <%= f.govuk_submit "Upload vaccination events" %>
 <% end %>

--- a/app/views/immunisation_imports/new.html.erb
+++ b/app/views/immunisation_imports/new.html.erb
@@ -2,13 +2,7 @@
 
 <% content_for :page_title, "#{@campaign.name} – #{title}" %>
 
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
-                                          { text: t("campaigns.index.title"), href: campaigns_path },
-                                          { text: @campaign.name, href: campaign_reports_path(@campaign) },
-                                        ]) %>
-<% end %>
+<%= render "breadcrumbs" %>
 
 <%= form_with model: @immunisation_import, url: campaign_immunisation_imports_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/immunisation_imports/success.html.erb
+++ b/app/views/immunisation_imports/success.html.erb
@@ -2,6 +2,8 @@
 
 <% content_for :page_title, "#{@campaign.name} – #{title}" %>
 
+<%= render "breadcrumbs" %>
+
 <%= govuk_panel(title_text: title, classes: "nhsuk-u-margin-bottom-6") do %>
   The vaccination events have been uploaded.
 <% end %>

--- a/app/views/immunisation_imports/success.html.erb
+++ b/app/views/immunisation_imports/success.html.erb
@@ -1,7 +1,7 @@
-<% page_title = "Vaccination events uploaded" %>
+<% title = "Vaccination events uploaded" %>
 
-<% content_for :page_title, page_title %>
+<% content_for :page_title, "#{@campaign.name} – #{title}" %>
 
-<%= govuk_panel(title_text: page_title, classes: "nhsuk-u-margin-bottom-6") do %>
+<%= govuk_panel(title_text: title, classes: "nhsuk-u-margin-bottom-6") do %>
   The vaccination events have been uploaded.
 <% end %>

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -16,7 +16,11 @@ describe "Immunisation imports" do
     when_i_continue_without_uploading_a_file
     then_i_should_see_an_error
 
-    when_i_upload_a_nivs_file
+    when_i_upload_an_invalid_file
+    then_i_should_see_the_errors_page
+    and_i_go_back_to_the_upload_page
+
+    when_i_upload_a_valid_file
     then_i_should_see_the_success_page
   end
 
@@ -58,7 +62,24 @@ describe "Immunisation imports" do
     expect(page).to have_content("There is a problem")
   end
 
-  def when_i_upload_a_nivs_file
+  def when_i_upload_an_invalid_file
+    attach_file(
+      "immunisation_import[csv]",
+      "spec/fixtures/immunisation_import/invalid_rows.csv"
+    )
+    click_on "Upload vaccination events"
+  end
+
+  def then_i_should_see_the_errors_page
+    expect(page).to have_content("The vaccination events could not be added")
+    expect(page).to have_content("Row 2")
+  end
+
+  def and_i_go_back_to_the_upload_page
+    click_on "Upload new vaccination events (CSV)"
+  end
+
+  def when_i_upload_a_valid_file
     attach_file(
       "immunisation_import[csv]",
       "spec/fixtures/immunisation_import/nivs.csv"


### PR DESCRIPTION
This ensures that if any validation errors occur as part of importing vaccination events, they are shown to the user who originally uploaded the file.

This is based on a similar journey in the pilot cohort list, and will be further improved with designs later.

## Screenshot

![Screenshot 2024-07-11 at 14 07 15](https://github.com/nhsuk/manage-vaccinations-in-schools/assets/510498/7568336c-bd59-44f2-b3e5-168759e932c4)
