### PR TITLE
Use db:seed:replant in reset script

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
-
 FEATURE_FLAGS = %i[make_session_in_progress_button].freeze
 
 FEATURE_FLAGS.each { |flag| Flipper.add(flag) unless Flipper.exist?(flag) }
@@ -39,3 +31,6 @@ Audited
       user:
     )
   end
+
+Team.find_by(ods_code: "Y51") ||
+  FactoryBot.create(:team, name: "NMEPFIT SAIS Team", ods_code: "Y51")


### PR DESCRIPTION
`replant` was added in Rails 6 and seems like it does what we want in this case:

```sh
bin/rails db:seed:replant
    Truncate tables of each database for current environment and load the seeds
```

This also aligns the seeds to populate the `Y51` team.

Notable differences:

- We don't reset the identity counter anymore, so IDs will continue incrementing after resets from where they left off. This is fine; we used to rely on predictable IDs for the Playwright tests, but it isn't necessary anymore.
- We opted out of resetting feature flags before, which made local development easier on new features that relied on us keeping a feature flag around. In that situation, I think we could include the feature flags into `seeds` as well. `seeds` are already configured not to run in prod-like environments, so this should be safe.