### PR TITLE
Mavis consents: record consent from existing cohort parent, instead of creating new parent contact every time

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -210,7 +210,8 @@ class ManageConsentsController < ApplicationController
       agree: %i[response],
       reason: %i[reason_for_refusal],
       reason_notes: %i[reason_for_refusal_notes],
-      questions: questions_params
+      questions: questions_params,
+      who: %i[new_or_existing_parent]
     }.fetch(current_step)
 
     params

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -175,9 +175,9 @@ class ManageConsentsController < ApplicationController
   def set_parent
     new_or_existing_parent = session[:manage_consents_new_or_existing_parent_id]
     @parent =
-      if new_or_existing_parent == "new" || new_or_existing_parent.nil?
+      if new_or_existing_parent == "new"
         @consent.draft_parent || Parent.new
-      else
+      elsif new_or_existing_parent.present?
         @consent.parent
       end
   end

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -187,6 +187,8 @@ class ManageConsentsController < ApplicationController
       policy_scope(Consent).unscope(where: :recorded_at).find(
         params[:consent_id]
       )
+    @consent.new_or_existing_parent =
+      session[:manage_consents_new_or_existing_parent_id]
   end
 
   def set_patient_session

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -92,6 +92,10 @@ class Consent < ApplicationRecord
     validates :route, inclusion: { in: Consent.routes.keys }, presence: true
   end
 
+  on_wizard_step :who, exact: true do
+    validates :new_or_existing_parent, presence: true
+  end
+
   on_wizard_step :parent_details do
     validate :parent_present_unless_self_consent
   end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -125,6 +125,7 @@ class Consent < ApplicationRecord
 
   def form_steps
     [
+      (:who unless via_self_consent?),
       (:parent_details unless via_self_consent?),
       (:route unless via_self_consent?),
       :agree,

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -91,6 +91,10 @@ class Parent < ApplicationRecord
     end
   end
 
+  def recorded?
+    recorded_at.present?
+  end
+
   private
 
   def reset_unused_fields

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -95,23 +95,31 @@
           summary_list.with_row do |row|
             row.with_key { "Name" }
             row.with_value { @parent.name }
+            row.with_action(text: "Change", href: wizard_path(:who), visually_hidden_text: "parent name")
           end
         
           summary_list.with_row do |row|
             row.with_key { "Relationship" }
             row.with_value { @parent.relationship_label.humanize }
+            row.with_action(text: "Change", href: wizard_path(:who), visually_hidden_text: "parent relationship")
           end
         
           if @parent.email.present?
             summary_list.with_row do |row|
               row.with_key { "Email address" }
               row.with_value { @parent.email }
+              row.with_action(text: "Change", href: wizard_path(:"parent-details"), visually_hidden_text: "parent email")
             end
           end
         
           summary_list.with_row do |row|
             row.with_key { "Phone number" }
-            row.with_value { @parent.phone.presence || "Not provided" }
+            if @parent.phone.present?
+              row.with_value { @parent.phone }
+              row.with_action(text: "Change", href: wizard_path(:"parent-details"), visually_hidden_text: "parent phone number")
+            else
+              row.with_value { govuk_link_to("Add phone number", wizard_path(:"parent-details")) }
+            end
           end
         
           if @parent.contact_method.present?

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -86,7 +86,7 @@
       end %>
 <% end %>
 
-<% if @consent.draft_parent.present? %>
+<% if @parent.present? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Parent or guardian" } %>
     <%= govuk_summary_list(
@@ -94,30 +94,30 @@
         ) do |summary_list|
           summary_list.with_row do |row|
             row.with_key { "Name" }
-            row.with_value { @consent.draft_parent.name }
+            row.with_value { @parent.name }
           end
         
           summary_list.with_row do |row|
             row.with_key { "Relationship" }
-            row.with_value { @consent.draft_parent.relationship_label.humanize }
+            row.with_value { @parent.relationship_label.humanize }
           end
         
-          if @consent.draft_parent.email.present?
+          if @parent.email.present?
             summary_list.with_row do |row|
               row.with_key { "Email address" }
-              row.with_value { @consent.draft_parent.email }
+              row.with_value { @parent.email }
             end
           end
         
           summary_list.with_row do |row|
             row.with_key { "Phone number" }
-            row.with_value { @consent.draft_parent.phone.presence || "Not provided" }
+            row.with_value { @parent.phone.presence || "Not provided" }
           end
         
-          if @consent.draft_parent.contact_method.present?
+          if @parent.contact_method.present?
             summary_list.with_row do |row|
               row.with_key { "Phone contact method" }
-              row.with_value { @consent.draft_parent.phone_contact_method_description }
+              row.with_value { @parent.phone_contact_method_description }
             end
           end
         end %>

--- a/app/views/manage_consents/parent_details.html.erb
+++ b/app/views/manage_consents/parent_details.html.erb
@@ -5,7 +5,7 @@
       ) %>
 <% end %>
 
-<% page_title = "Who are you trying to get consent from?" %>
+<% page_title = "Details for parent or guardian" %>
 
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">

--- a/app/views/manage_consents/parent_details.html.erb
+++ b/app/views/manage_consents/parent_details.html.erb
@@ -5,7 +5,11 @@
       ) %>
 <% end %>
 
-<% page_title = "Details for parent or guardian" %>
+<% page_title = if @parent.recorded?
+       "Details for #{@parent.name} (#{@parent.relationship_label})"
+     else
+       page_title = "Details for parent or guardian"
+     end %>
 
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
@@ -17,33 +21,35 @@
 <%= form_for @parent, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_text_field :name, label: { text: "Full name" } %>
+  <% unless @parent.recorded? %>
+    <%= f.govuk_text_field :name, label: { text: "Full name" } %>
 
-  <%= f.govuk_radio_buttons_fieldset(:relationship,
-                                     legend: { size: "s",
-                                               text: "Relationship to the child" }) do %>
-    <%= f.govuk_radio_button :relationship, "mother",
-                             label: { text: "Mum" }, link_errors: true %>
-    <%= f.govuk_radio_button :relationship, "father",
-                             label: { text: "Dad" } %>
-    <%= f.govuk_radio_button :relationship, "guardian",
-                             label: { text: "Guardian" } %>
-    <%= f.govuk_radio_button :relationship, "other",
-                             label: { text: "Other" } do %>
-      <p>They need parental responsibility to give consent.</p>
-      <%= f.govuk_text_field :relationship_other,
-                             label: { text: "Relationship to the child" },
-                             hint: { text: "For example, carer" } %>
-      <%= f.govuk_radio_buttons_fieldset(:parental_responsibility,
-                                         legend: { size: "s",
-                                                   text: "Do they have parental responsibility?" },
-                                         hint: { text: "This means they have legal rights and duties relating to the child" }) do %>
-        <%= f.govuk_radio_button :parental_responsibility, "yes",
-                                 label: { text: "Yes" }, link_errors: true %>
-        <%= f.govuk_radio_button :parental_responsibility, "no",
-                                 label: { text: "No" } %>
+    <%= f.govuk_radio_buttons_fieldset(:relationship,
+                                       legend: { size: "s",
+                                                 text: "Relationship to the child" }) do %>
+      <%= f.govuk_radio_button :relationship, "mother",
+                               label: { text: "Mum" }, link_errors: true %>
+      <%= f.govuk_radio_button :relationship, "father",
+                               label: { text: "Dad" } %>
+      <%= f.govuk_radio_button :relationship, "guardian",
+                               label: { text: "Guardian" } %>
+      <%= f.govuk_radio_button :relationship, "other",
+                               label: { text: "Other" } do %>
+        <p>They need parental responsibility to give consent.</p>
+        <%= f.govuk_text_field :relationship_other,
+                               label: { text: "Relationship to the child" },
+                               hint: { text: "For example, carer" } %>
+        <%= f.govuk_radio_buttons_fieldset(:parental_responsibility,
+                                           legend: { size: "s",
+                                                     text: "Do they have parental responsibility?" },
+                                           hint: { text: "This means they have legal rights and duties relating to the child" }) do %>
+          <%= f.govuk_radio_button :parental_responsibility, "yes",
+                                   label: { text: "Yes" }, link_errors: true %>
+          <%= f.govuk_radio_button :parental_responsibility, "no",
+                                   label: { text: "No" } %>
+        <% end %>
+
       <% end %>
-
     <% end %>
   <% end %>
 

--- a/app/views/manage_consents/parent_details.html.erb
+++ b/app/views/manage_consents/parent_details.html.erb
@@ -14,7 +14,7 @@
   <%= page_title %>
 <% end %>
 
-<%= form_for @consent.draft_parent, url: wizard_path, method: :put do |f| %>
+<%= form_for @parent, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_text_field :name, label: { text: "Full name" } %>

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -16,6 +16,9 @@
 
 <%= form_for @consent, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:new_or_existing_parent, legend: nil) do %>
+    <%= f.govuk_radio_button :new_or_existing_parent, @patient.parent.id,
+                             label: { text: "#{@patient.parent.name} (#{@patient.parent.relationship_label})" }, link_errors: true %>
+    <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :new_or_existing_parent, "new",
                              label: { text: "Add a new parental contact" }, link_errors: true %>
   <% end %>

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -17,10 +17,12 @@
 <%= form_for @consent, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:new_or_existing_parent, legend: nil) do %>
     <%= f.govuk_radio_button :new_or_existing_parent, @patient.parent.id,
-                             label: { text: "#{@patient.parent.name} (#{@patient.parent.relationship_label})" }, link_errors: true %>
+                             label: { text: "#{@patient.parent.name} (#{@patient.parent.relationship_label})" },
+                             hint: { text: @patient.parent.phone },
+                             link_errors: true %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :new_or_existing_parent, "new",
-                             label: { text: "Add a new parental contact" }, link_errors: true %>
+                             label: { text: "Add a new parental contact" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: back_link_path,
+        name: "patient page",
+      ) %>
+<% end %>
+
+<% page_title = "Who are you trying to get consent from?" %>
+
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<%= form_for @consent, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_radio_buttons_fieldset(:new_or_existing_parent, legend: nil) do %>
+    <%= f.govuk_radio_button :new_or_existing_parent, "new",
+                             label: { text: "Add a new parental contact" }, link_errors: true %>
+  <% end %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
+<% end %>

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -15,6 +15,8 @@
 <% end %>
 
 <%= form_for @consent, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_radio_buttons_fieldset(:new_or_existing_parent, legend: nil) do %>
     <%= f.govuk_radio_button :new_or_existing_parent, @patient.parent.id,
                              label: { text: "#{@patient.parent.name} (#{@patient.parent.relationship_label})" },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,8 @@ en:
               blank: Enter a batch
         consent:
           attributes:
+            new_or_existing_parent:
+              blank: Choose who you are trying to get consent from
             reason_for_refusal:
               inclusion: Choose a reason
             reason_for_refusal_notes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,3 +586,4 @@ en:
     timeline: timeline
     triage: triage
     when: when
+    who: who

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -176,6 +176,12 @@ describe "Pilot journey" do
 
   def when_i_register_verbal_consent_and_triage
     click_button "Get consent"
+
+    # TODO: update this when it's possible to pick an existing parental contact
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian: leave prepopulated details
     click_button "Continue"
 
     choose "By phone"

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -177,8 +177,7 @@ describe "Pilot journey" do
   def when_i_register_verbal_consent_and_triage
     click_button "Get consent"
 
-    # TODO: update this when it's possible to pick an existing parental contact
-    choose "Add a new parental contact"
+    choose "Big Daddy Tests"
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -30,6 +30,10 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian
     fill_in "Full name", with: "Jane Smith"
     choose "Mum"
     fill_in "Email address", with: "jsmith@example.com"

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -29,6 +29,11 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
+    # TODO: update this when it's possible to pick an existing parental contact
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian: leave prepopulated details
     click_button "Continue"
 
     # How was the response given?

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -29,8 +29,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    # TODO: update this when it's possible to pick an existing parental contact
-    choose "Add a new parental contact"
+    choose @patient.parent.name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -29,6 +29,11 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
+    # TODO: update this when it's possible to pick an existing parental contact
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian: leave prepopulated details
     click_button "Continue"
 
     # How was the response given?

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -29,8 +29,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    # TODO: update this when it's possible to pick an existing parental contact
-    choose "Add a new parental contact"
+    choose @patient.parent.name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -29,6 +29,11 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
+    # TODO: update this when it's possible to pick an existing parental contact
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian: leave prepopulated details
     click_button "Continue"
 
     # How was the response given?

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -29,11 +29,10 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    # TODO: update this when it's possible to pick an existing parental contact
-    choose "Add a new parental contact"
+    choose @patient.parent.name
     click_button "Continue"
 
-    # Details for parent or guardian: leave prepopulated details
+    # Details for parent or guardian: leave existing contact details
     click_button "Continue"
 
     # How was the response given?

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -7,8 +7,6 @@ describe "Verbal consent" do
 
   scenario "Given" do
     given_i_am_signed_in
-    when_i_start_recording_consent_for_a_patient
-    then_the_parent_details_are_prefilled
 
     when_i_record_that_verbal_consent_was_given
 
@@ -26,22 +24,20 @@ describe "Verbal consent" do
     sign_in team.users.first
   end
 
-  def when_i_start_recording_consent_for_a_patient
+  def when_i_record_that_verbal_consent_was_given
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
 
-    choose "Add a new parental contact"
-    click_button "Continue"
-  end
-
-  def then_the_parent_details_are_prefilled
-    expect(page).to have_field("Full name", with: @patient.parent.name)
-  end
-
-  def when_i_record_that_verbal_consent_was_given
     # Who are you trying to get consent from?
-    # Here we are effectively picking the parent that is already on the system, in the cohort
+    choose "#{@patient.parent.name} (#{@patient.parent.relationship_label})"
+    click_button "Continue"
+
+    # Details for parent or guardian
+    expect(page).to have_content(
+      "Details for #{@patient.parent.name} (#{@patient.parent.relationship_label})"
+    )
+    # don't change any details
     click_button "Continue"
 
     # How was the response given?

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -30,6 +30,11 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
+    click_button "Continue"
+    expect(page).to have_content(
+      "Choose who you are trying to get consent from"
+    )
+
     choose "#{@patient.parent.name} (#{@patient.parent.relationship_label})"
     click_button "Continue"
 

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -30,6 +30,9 @@ describe "Verbal consent" do
     visit session_consents_path(@session)
     click_link @patient.full_name
     click_button "Get consent"
+
+    choose "Add a new parental contact"
+    click_button "Continue"
   end
 
   def then_the_parent_details_are_prefilled

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -34,7 +34,7 @@ feature "Verbal consent" do
   end
 
   def when_i_record_the_consent_given_for_that_child_from_the_same_parent
-    refusing_parent = @session.patient_sessions.first.consents.first.parent
+    @refusing_parent = @session.patient_sessions.first.consents.first.parent
 
     visit "/dashboard"
     click_on "Vaccination programmes", match: :first
@@ -46,16 +46,16 @@ feature "Verbal consent" do
     click_on "Get consent"
 
     # contacting the same parent who refused
-    # TODO: update this when it's possible to pick an existing parental contact
+    # TODO: update this when it's possible to pick an existing parental contact from a consent form
     choose "Add a new parental contact"
     click_button "Continue"
 
     # Details for parent or guardian
-    expect(page).to have_field("Full name", with: @child.parent.name)
-    fill_in "Phone number", with: refusing_parent.phone
-    fill_in "Full name", with: refusing_parent.name
+    fill_in "Phone number", with: @refusing_parent.phone
+    fill_in "Email address", with: @refusing_parent.email
+    fill_in "Full name", with: @refusing_parent.name
     # relationship to the child
-    choose refusing_parent.relationship_label
+    choose @refusing_parent.relationship_label
 
     click_button "Continue"
 
@@ -88,7 +88,7 @@ feature "Verbal consent" do
 
     expect(sent_emails.last).to be_sent_with_govuk_notify.using_template(
       EMAILS[:parental_consent_confirmation]
-    ).to(@child.parent.email)
+    ).to(@refusing_parent.email)
   end
 
   def and_the_child_is_shown_as_having_consent_given

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -44,9 +44,14 @@ feature "Verbal consent" do
     click_on "Refused"
     click_on @child.full_name
     click_on "Get consent"
-    expect(page).to have_field("Full name", with: @child.parent.name)
 
     # contacting the same parent who refused
+    # TODO: update this when it's possible to pick an existing parental contact
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian
+    expect(page).to have_field("Full name", with: @child.parent.name)
     fill_in "Phone number", with: refusing_parent.phone
     fill_in "Full name", with: refusing_parent.name
     # relationship to the child

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -30,6 +30,11 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
+    # TODO: update this when it's possible to pick an existing parental contact
+    choose "Add a new parental contact"
+    click_button "Continue"
+
+    # Details for parent or guardian: leave prepopulated details
     click_button "Continue"
 
     # How was the response given?

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -30,8 +30,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    # TODO: update this when it's possible to pick an existing parental contact
-    choose "Add a new parental contact"
+    choose @patient.parent.name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details


### PR DESCRIPTION
## Pick between cohort parent or new parent

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/e2c08a40-fcee-44dd-988b-ca91ec6ff7fb">

## Error: user hits continue without choosing anything

<img width="1138" alt="image" src="https://github.com/user-attachments/assets/66b84b74-9d9f-4d72-bf22-4bd383ec3965">

## New parent details

<img width="898" alt="image" src="https://github.com/user-attachments/assets/0b907f08-4744-423e-9f35-40af458bc730">

## Existing parent details

<img width="895" alt="image" src="https://github.com/user-attachments/assets/360b256c-707c-45d4-8137-71ac8e360420">

## Change links on the confirmation page

<img width="614" alt="image" src="https://github.com/user-attachments/assets/bfbe78f4-6b08-4a4e-9985-99514745af49">

## Out of scope work

* allow the "who" to be a parent from a previous consent form or consent
* allow the "who" to be the child after they've been assessed as Gillick competent