### PR TITLE
Tidy up cis 2 role info in session

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -35,9 +35,7 @@ module AuthenticationConcern
     end
 
     def selected_cis2_role_is_valid?
-      session["cis2_info"]["selected_roles"].keys.any? do
-        valid_cis2_roles.include? _1
-      end
+      session["cis2_info"]["selected_role"]["code"].in? valid_cis2_roles
     end
 
     def storable_location?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,14 +7,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_after_action :verify_policy_scoped
 
   def cis2
-    session["cis2_info"] = {
-      "selected_org" => {
-        "name" => selected_cis2_org["org_name"],
-        "code" => selected_cis2_org["org_code"]
-      },
-      "selected_roles" => selected_cis2_roles,
-      "has_other_roles" => raw_cis2_info["nhsid_nrbac_roles"].length > 1
-    }
+    set_cis2_session_info
+
     if !selected_cis2_org_is_registered?
       redirect_to users_team_not_found_path
     elsif !selected_cis2_role_is_valid?
@@ -49,10 +43,17 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
   end
 
-  def selected_cis2_roles
-    @selected_cis2_roles ||= {
-      selected_cis2_nrbac_role["role_code"] =>
-        selected_cis2_nrbac_role["role_name"]
+  def set_cis2_session_info
+    session["cis2_info"] = {
+      "selected_org" => {
+        "name" => selected_cis2_org["org_name"],
+        "code" => selected_cis2_org["org_code"]
+      },
+      "selected_role" => {
+        "name" => selected_cis2_nrbac_role["role_name"],
+        "code" => selected_cis2_nrbac_role["role_code"]
+      },
+      "has_other_roles" => raw_cis2_info["nhsid_nrbac_roles"].length > 1
     }
   end
 end


### PR DESCRIPTION
No functional change. This changes it so we only accommodate a single role to be selected in CIS2, which tracks our understanding of how CIS2 works: you can only select one org / role combo at a time.

This was originally going to be part of a bigger bit of work, but that is now waiting for more design input so I thought I'd 🚢 this.