### PR TITLE
Make parents optional on patients

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -39,7 +39,7 @@ class Patient < ApplicationRecord
   audited
 
   belongs_to :location, optional: true
-  belongs_to :parent
+  belongs_to :parent, optional: true
   has_many :patient_sessions
   has_many :sessions, through: :patient_sessions
   has_many :triage, through: :patient_sessions


### PR DESCRIPTION
When importing NIVS immunisation data, we don't get the parent information. Rather than making up a parent record, we should allow patient records without parent records.