### PR TITLE
Create Session and PatientSession records during import

### DIFF
--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -28,15 +28,13 @@ class ImmunisationImport < ApplicationRecord
 
   belongs_to :user
   belongs_to :campaign
-  has_many :vaccination_records,
-           dependent: :restrict_with_exception,
-           foreign_key: :imported_from_id
-  has_many :locations,
-           dependent: :restrict_with_exception,
-           foreign_key: :imported_from_id
-  has_many :patients,
-           dependent: :restrict_with_exception,
-           foreign_key: :imported_from_id
+  with_options dependent: :restrict_with_exception,
+               foreign_key: :imported_from_id do
+    has_many :vaccination_records
+    has_many :locations
+    has_many :sessions
+    has_many :patients
+  end
 
   EXPECTED_HEADERS = %w[
     ANATOMICAL_SITE

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -14,11 +14,17 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  campaign_id       :bigint
+#  imported_from_id  :bigint
 #  location_id       :bigint
 #
 # Indexes
 #
-#  index_sessions_on_campaign_id  (campaign_id)
+#  index_sessions_on_campaign_id       (campaign_id)
+#  index_sessions_on_imported_from_id  (imported_from_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (imported_from_id => immunisation_imports.id)
 #
 class Session < ApplicationRecord
   include WizardFormConcern
@@ -33,6 +39,7 @@ class Session < ApplicationRecord
   delegate :team, to: :campaign
   belongs_to :campaign, optional: true
   belongs_to :location, optional: true
+  belongs_to :imported_from, class_name: "ImmunisationImport", optional: true
   has_many :consent_forms
   has_many :patient_sessions
   has_many :patients, through: :patient_sessions

--- a/db/migrate/20240717155646_add_imported_from_to_sessions.rb
+++ b/db/migrate/20240717155646_add_imported_from_to_sessions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddImportedFromToSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :sessions,
+                  :imported_from,
+                  foreign_key: {
+                    to_table: :immunisation_imports
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -328,7 +328,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_102202) do
     t.date "send_reminders_at"
     t.date "close_consent_at"
     t.integer "time_of_day"
+    t.bigint "imported_from_id"
     t.index ["campaign_id"], name: "index_sessions_on_campaign_id"
+    t.index ["imported_from_id"], name: "index_sessions_on_imported_from_id"
   end
 
   create_table "teams", force: :cascade do |t|
@@ -441,6 +443,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_102202) do
   add_foreign_key "patients", "immunisation_imports", column: "imported_from_id"
   add_foreign_key "patients", "locations"
   add_foreign_key "patients", "parents"
+  add_foreign_key "sessions", "immunisation_imports", column: "imported_from_id"
   add_foreign_key "triage", "patient_sessions"
   add_foreign_key "triage", "users"
   add_foreign_key "vaccination_records", "batches"

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -14,11 +14,17 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  campaign_id       :bigint
+#  imported_from_id  :bigint
 #  location_id       :bigint
 #
 # Indexes
 #
-#  index_sessions_on_campaign_id  (campaign_id)
+#  index_sessions_on_campaign_id       (campaign_id)
+#  index_sessions_on_imported_from_id  (imported_from_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (imported_from_id => immunisation_imports.id)
 #
 FactoryBot.define do
   factory :session do

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -3,8 +3,11 @@
 require "rails_helper"
 
 describe ImmunisationImport::Row, type: :model do
-  subject(:immunisation_import_row) { described_class.new(data:, team:) }
+  subject(:immunisation_import_row) do
+    described_class.new(data:, campaign:, team:)
+  end
 
+  let(:campaign) { create(:campaign) }
   let(:team) { create(:team, ods_code: "abc") }
 
   describe "validations" do
@@ -64,7 +67,8 @@ describe ImmunisationImport::Row, type: :model do
           "PERSON_FORENAME" => "Harry",
           "PERSON_SURNAME" => "Potter",
           "PERSON_DOB" => "20120101",
-          "NHS_NUMBER" => "1234567890"
+          "NHS_NUMBER" => "1234567890",
+          "DATE_OF_VACCINATION" => "20240101"
         }
       end
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -92,6 +92,7 @@ describe ImmunisationImport, type: :model do
         .to change(immunisation_import.vaccination_records, :count).by(11)
         .and change(immunisation_import.locations, :count).by(4)
         .and change(immunisation_import.patients, :count).by(11)
+        .and change(immunisation_import.sessions, :count).by(4)
 
       # Second import should duplicate the vaccination records but nothing else.
 
@@ -100,6 +101,7 @@ describe ImmunisationImport, type: :model do
         .to change(immunisation_import.vaccination_records, :count).by(11)
         .and not_change(immunisation_import.locations, :count)
         .and not_change(immunisation_import.patients, :count)
+        .and not_change(immunisation_import.sessions, :count)
     end
   end
 end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -84,24 +84,23 @@ describe ImmunisationImport, type: :model do
 
   describe "#process!" do
     it "creates locations, patients, and vaccination records" do
-      # TEMPORARY: Pass in a dummy patient session. We will iterate this out.
-      patient_session = create(:patient_session, user:)
-
       # stree-ignore
-      expect { immunisation_import.process!(patient_session:) }
+      expect { immunisation_import.process! }
         .to change(immunisation_import.vaccination_records, :count).by(11)
         .and change(immunisation_import.locations, :count).by(4)
         .and change(immunisation_import.patients, :count).by(11)
         .and change(immunisation_import.sessions, :count).by(4)
+        .and change(PatientSession, :count).by(11)
 
       # Second import should duplicate the vaccination records but nothing else.
 
       # stree-ignore
-      expect { immunisation_import.process!(patient_session:) }
+      expect { immunisation_import.process! }
         .to change(immunisation_import.vaccination_records, :count).by(11)
         .and not_change(immunisation_import.locations, :count)
         .and not_change(immunisation_import.patients, :count)
         .and not_change(immunisation_import.sessions, :count)
+        .and not_change(PatientSession, :count)
     end
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -14,11 +14,17 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  campaign_id       :bigint
+#  imported_from_id  :bigint
 #  location_id       :bigint
 #
 # Indexes
 #
-#  index_sessions_on_campaign_id  (campaign_id)
+#  index_sessions_on_campaign_id       (campaign_id)
+#  index_sessions_on_imported_from_id  (imported_from_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (imported_from_id => immunisation_imports.id)
 #
 require "rails_helper"
 


### PR DESCRIPTION
This allows us to finally replace the stubbed patient_session.

Reviewing the individual commits might be easier.