### PR TITLE
Deterministically encrypt NHS number

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -67,9 +67,10 @@ class Patient < ApplicationRecord
            :last_name,
            :common_name,
            :address_postcode,
+           :nhs_number,
            deterministic: true
 
-  encrypts :nhs_number, :address_line_1, :address_line_2, :address_town
+  encrypts :address_line_1, :address_line_2, :address_town
 
   before_save :remove_spaces_from_nhs_number
 


### PR DESCRIPTION
The uniqueness validation and database constraint on the `nhs_number` field is currently failing to work because the field is changing each time it's saved.

This also allows us to `find_by(nhs_number:)` which is very likely to be a need at some point.