### PR TITLE
Update immunisation import designs to match prototype

### DIFF
--- a/app/components/app_patient_details_component.rb
+++ b/app/components/app_patient_details_component.rb
@@ -111,6 +111,6 @@ class AppPatientDetailsComponent < ViewComponent::Base
   end
 
   def nhs_number_formatted
-    nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
+    helpers.format_nhs_number(nhs_number)
   end
 end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 
 class CampaignsController < ApplicationController
+  before_action :set_campaign, except: :index
+
   def index
     @campaigns = policy_scope(Campaign)
   end
 
   def show
-    @campaign = policy_scope(Campaign).find(params[:id])
+  end
+
+  def sessions
     @in_progress_sessions = @campaign.sessions.in_progress
     @future_sessions = @campaign.sessions.future
     @past_sessions = @campaign.sessions.past
+  end
+
+  private
+
+  def set_campaign
+    @campaign = policy_scope(Campaign).find(params[:id])
   end
 end

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -6,6 +6,7 @@ class ImmunisationImportsController < ApplicationController
   layout "two_thirds", only: :new
 
   def index
+    @immunisation_imports = @campaign.immunisation_imports.order(:created_at)
   end
 
   def new
@@ -43,7 +44,10 @@ class ImmunisationImportsController < ApplicationController
   private
 
   def set_campaign
-    @campaign = policy_scope(Campaign).find(params[:campaign_id])
+    @campaign =
+      policy_scope(Campaign).includes(:immunisation_imports).find(
+        params[:campaign_id]
+      )
   end
 
   def immunisation_import_params

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -32,7 +32,11 @@ class ImmunisationImportsController < ApplicationController
 
     @immunisation_import.save!
 
-    redirect_to success_campaign_immunisation_import_path(
+    flash[
+      :success
+    ] = "#{@immunisation_import.vaccination_records.count} vaccinations uploaded"
+
+    redirect_to campaign_immunisation_import_path(
                   @campaign,
                   @immunisation_import
                 )

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -3,6 +3,9 @@
 class ImmunisationImportsController < ApplicationController
   before_action :set_campaign
 
+  def index
+  end
+
   def new
     @immunisation_import = ImmunisationImport.new
   end

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -38,6 +38,13 @@ class ImmunisationImportsController < ApplicationController
                 )
   end
 
+  def show
+    @immunisation_import = @campaign.immunisation_imports.find(params[:id])
+
+    @vaccination_records =
+      @immunisation_import.vaccination_records.includes(:location, :patient)
+  end
+
   def success
   end
 

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -3,6 +3,8 @@
 class ImmunisationImportsController < ApplicationController
   before_action :set_campaign
 
+  layout "two_thirds", only: :new
+
   def index
   end
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -3,9 +3,6 @@
 class ReportsController < ApplicationController
   before_action :set_campaign
 
-  def index
-  end
-
   def download
     vaccinations =
       policy_scope(VaccinationRecord)

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PatientHelper
+  def format_nhs_number(nhs_number)
+    nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
+  end
+end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -48,6 +48,7 @@ class VaccinationRecord < ApplicationRecord
   has_one :session, through: :patient_session
   has_one :patient, through: :patient_session
   has_one :campaign, through: :session
+  has_one :location, through: :session
   has_one :team, through: :campaign
 
   scope :administered, -> { where(administered: true) }

--- a/app/views/campaigns/sessions.html.erb
+++ b/app/views/campaigns/sessions.html.erb
@@ -19,7 +19,7 @@
         selected: true,
       )
       nav.with_item(
-        text: "Reports",
+        text: "Uploaded reports",
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>

--- a/app/views/campaigns/sessions.html.erb
+++ b/app/views/campaigns/sessions.html.erb
@@ -1,0 +1,80 @@
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – School sessions",
+                      size: "l" %>
+
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: dashboard_path },
+                                          { text: t("campaigns.index.title"), href: campaigns_path },
+                                        ]) %>
+<% end %>
+
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(
+        text: "Overview",
+        href: campaign_path(@campaign),
+      )
+      nav.with_item(
+        text: "School sessions",
+        href: sessions_campaign_path(@campaign),
+        selected: true,
+      )
+      nav.with_item(
+        text: "Reports",
+        href: campaign_immunisation_imports_path(@campaign),
+      )
+    end %>
+
+<% [[@in_progress_sessions, "In progress sessions"],
+    [@future_sessions, "Planned sessions"],
+    [@past_sessions, "Past sessions"]]
+     .select { |sessions, _| sessions.any? }.each do |sessions, title| %>
+  <div class="nhsuk-table__panel-with-heading-tab">
+    <h3 class="nhsuk-table__heading-tab"><%= title %></h3>
+    <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Date") %>
+          <% row.with_cell(text: "Time") %>
+          <% row.with_cell(text: "Location") %>
+          <% row.with_cell(text: "Consent period") %>
+          <% row.with_cell(text: "Cohort") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% sessions.each do |session| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Date</span>
+              <%= session.date.to_fs(:long) %>
+            <% end %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Time</span>
+              <%= session.time_of_day.humanize %>
+            <% end %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Location</span>
+              <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
+                <%= link_to session.location.name, session_path(session) %>
+                <br>
+                <%= session.location.address %>
+              </p>
+            <% end %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Consent period</span>
+              <% if session.close_consent_at.past? %>
+                <%= "Closed #{session.close_consent_at.to_fs(:short)}" %>
+              <% else %>
+                <%= "Open until #{session.close_consent_at.to_fs(:short)}" %>
+              <% end %>
+            <% end %>
+            <% row.with_cell(numeric: true) do %>
+              <span class="nhsuk-table-responsive__heading">Cohort</span>
+              <%= session.patients.count %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -23,3 +23,5 @@
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>
+
+<%= govuk_link_to "Download immunisation report (CSV)", download_campaign_reports_path(@campaign), class: "nhsuk-button" %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -19,7 +19,7 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Reports",
+        text: "Uploaded reports",
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -16,7 +16,7 @@
       )
       nav.with_item(
         text: "Reports",
-        href: campaign_reports_path(@campaign),
+        href: campaign_immunisation_imports_path(@campaign),
       )
     end %>
 

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -1,4 +1,4 @@
-<%= h1 @campaign.name, page_title: "#{@campaign.name} – School sessions",
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – Overview",
                       size: "l" %>
 
 <% content_for :before_main do %>
@@ -10,67 +10,16 @@
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
-        text: "School sessions",
+        text: "Overview",
         href: campaign_path(@campaign),
         selected: true,
+      )
+      nav.with_item(
+        text: "School sessions",
+        href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
         text: "Reports",
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>
-
-<% [[@in_progress_sessions, "In progress sessions"],
-    [@future_sessions, "Planned sessions"],
-    [@past_sessions, "Past sessions"]]
-     .select { |sessions, _| sessions.any? }.each do |sessions, title| %>
-  <div class="nhsuk-table__panel-with-heading-tab">
-    <h3 class="nhsuk-table__heading-tab"><%= title %></h3>
-    <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: "Date") %>
-          <% row.with_cell(text: "Time") %>
-          <% row.with_cell(text: "Location") %>
-          <% row.with_cell(text: "Consent period") %>
-          <% row.with_cell(text: "Cohort") %>
-        <% end %>
-      <% end %>
-
-      <% table.with_body do |body| %>
-        <% sessions.each do |session| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Date</span>
-              <%= session.date.to_fs(:long) %>
-            <% end %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Time</span>
-              <%= session.time_of_day.humanize %>
-            <% end %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Location</span>
-              <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
-                <%= link_to session.location.name, session_path(session) %>
-                <br>
-                <%= session.location.address %>
-              </p>
-            <% end %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Consent period</span>
-              <% if session.close_consent_at.past? %>
-                <%= "Closed #{session.close_consent_at.to_fs(:short)}" %>
-              <% else %>
-                <%= "Open until #{session.close_consent_at.to_fs(:short)}" %>
-              <% end %>
-            <% end %>
-            <% row.with_cell(numeric: true) do %>
-              <span class="nhsuk-table-responsive__heading">Cohort</span>
-              <%= session.patients.count %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-<% end %>

--- a/app/views/immunisation_imports/_breadcrumbs.html.erb
+++ b/app/views/immunisation_imports/_breadcrumbs.html.erb
@@ -2,6 +2,6 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
-                                          { text: @campaign.name, href: campaign_reports_path(@campaign) },
+                                          { text: @campaign.name, href: campaign_immunisation_imports_path(@campaign) },
                                         ]) %>
 <% end %>

--- a/app/views/immunisation_imports/errors.html.erb
+++ b/app/views/immunisation_imports/errors.html.erb
@@ -31,5 +31,5 @@
 <% end %>
 
 <p>
-  <%= govuk_link_to "Upload new vaccination events (CSV)", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
+  <%= govuk_link_to "Upload a new vaccination report", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
 </p>

--- a/app/views/immunisation_imports/errors.html.erb
+++ b/app/views/immunisation_imports/errors.html.erb
@@ -1,13 +1,16 @@
-<% title = "The vaccination events could not be added" %>
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: new_campaign_immunisation_import_path(@campaign),
+        name: @campaign.name,
+      ) %>
+<% end %>
 
-<% content_for :page_title, "#{@campaign.name} – #{title}" %>
+<% title = "The vaccinations could not be added" %>
 
-<%= render "breadcrumbs" %>
-
-<%= h1 title %>
+<%= h1 title, page_title: "#{@campaign.name} – #{title}" %>
 
 <p>
-  It wasn’t possible to add the vaccination events due to the following errors in the uploaded CSV file:
+  It wasn’t possible to add the vaccinations due to the following errors in the uploaded CSV file:
 </p>
 
 <% @immunisation_import.errors.each do |error| %>
@@ -29,7 +32,3 @@
     <% end %>
   </ul>
 <% end %>
-
-<p>
-  <%= govuk_link_to "Upload a new vaccination report", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
-</p>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -24,5 +24,3 @@
     end %>
 
 <%= govuk_link_to "Upload vaccination events (CSV)", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
-
-<%= govuk_link_to "Download NIVS data (CSV)", download_campaign_reports_path(@campaign), class: "nhsuk-button" %>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -40,7 +40,7 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Upload date</span>
-            <%= immunisation_import.created_at.to_fs(:long) %>
+            <%= govuk_link_to immunisation_import.created_at.to_fs(:long), campaign_immunisation_import_path(@campaign, immunisation_import) %>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Uploaded by</span>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -9,8 +9,12 @@
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
-        text: "School sessions",
+        text: "Overview",
         href: campaign_path(@campaign),
+      )
+      nav.with_item(
+        text: "School sessions",
+        href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
         text: "Reports",

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -23,4 +23,4 @@
       )
     end %>
 
-<%= govuk_link_to "Upload vaccination events (CSV)", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
+<%= govuk_link_to "Upload a new vaccination report", new_campaign_immunisation_import_path, class: "nhsuk-button" %>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -23,4 +23,35 @@
       )
     end %>
 
-<%= govuk_link_to "Upload a new vaccination report", new_campaign_immunisation_import_path, class: "nhsuk-button" %>
+<%= govuk_link_to "Upload a new vaccination report", new_campaign_immunisation_import_path, class: "nhsuk-button nhsuk-u-margin-0" %>
+
+<div class="nhsuk-table__panel-with-heading-tab">
+  <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Upload date") %>
+        <% row.with_cell(text: "Uploaded by") %>
+        <% row.with_cell(text: "Records", numeric: true) %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% @immunisation_imports.each do |immunisation_import| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Upload date</span>
+            <%= immunisation_import.created_at.to_fs(:long) %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Uploaded by</span>
+            <%= immunisation_import.user.full_name %>
+          <% end %>
+          <% row.with_cell(numeric: true) do %>
+            <span class="nhsuk-table-responsive__heading">Records</span>
+            <%= immunisation_import.vaccination_records.count %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -1,4 +1,4 @@
-<%= h1 @campaign.name, page_title: "#{@campaign.name} – Reports" %>
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – Uploaded reports" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
@@ -14,7 +14,7 @@
       )
       nav.with_item(
         text: "Reports",
-        href: campaign_reports_path(@campaign),
+        href: campaign_immunisation_imports_path(@campaign),
         selected: true,
       )
     end %>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -17,7 +17,7 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Reports",
+        text: "Uploaded reports",
         href: campaign_immunisation_imports_path(@campaign),
         selected: true,
       )

--- a/app/views/immunisation_imports/new.html.erb
+++ b/app/views/immunisation_imports/new.html.erb
@@ -1,13 +1,19 @@
-<% title = "Upload vaccination events" %>
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: campaign_immunisation_imports_path(@campaign),
+        name: @campaign.name,
+      ) %>
+<% end %>
 
-<% content_for :page_title, "#{@campaign.name} – #{title}" %>
+<% title = "Upload a report on #{@campaign.name} vaccinations" %>
+<% hint = "This will go to NHS England. Make sure the CSV you upload has the same format as your usual reporting template." %>
 
-<%= render "breadcrumbs" %>
+<% content_for :page_title, title %>
 
 <%= form_with model: @immunisation_import, url: campaign_immunisation_imports_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_file_field :csv, label: { text: title, tag: "h1", size: "l" } %>
+  <%= f.govuk_file_field :csv, label: { text: title, tag: "h1", size: "l" }, hint: { text: hint } %>
 
-  <%= f.govuk_submit "Upload vaccination events" %>
+  <%= f.govuk_submit %>
 <% end %>

--- a/app/views/immunisation_imports/show.html.erb
+++ b/app/views/immunisation_imports/show.html.erb
@@ -1,0 +1,69 @@
+<%= render "breadcrumbs" %>
+
+<%= h1 "Vaccination report (uploaded #{@immunisation_import.created_at.to_fs(:long)})" %>
+
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading { "Vaccination report" } %>
+
+  <%= govuk_summary_list(
+        classes: %w[app-summary-list--no-bottom-border
+                    nhsuk-u-margin-bottom-0],
+      ) do |summary_list| %>
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { "Uploaded on" } %>
+      <%= row.with_value { @immunisation_import.created_at.to_fs(:long) } %>
+    <% end %>
+
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { "Uploaded by" } %>
+      <%= row.with_value { @immunisation_import.user.full_name } %>
+    <% end %>
+
+    <%= summary_list.with_row do |row| %>
+      <%= row.with_key { "Campaign" } %>
+      <%= row.with_value { @campaign.name } %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<div class="nhsuk-table__panel-with-heading-tab">
+  <h3 class="nhsuk-table__heading-tab">Records</h3>
+  <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Full name") %>
+        <% row.with_cell(text: "NHS number") %>
+        <% row.with_cell(text: "Date of birth") %>
+        <% row.with_cell(text: "Postcode") %>
+        <% row.with_cell(text: "Vaccinated date") %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% @vaccination_records.each do |vaccination_record| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Full name</span>
+            <%= vaccination_record.patient.full_name %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">NHS number</span>
+            <%= format_nhs_number(vaccination_record.patient.nhs_number) %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Date of birth</span>
+            <%= vaccination_record.patient.date_of_birth.to_fs(:long) %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Postcode</span>
+            <%= vaccination_record.location.postcode %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Vaccinated date</span>
+            <%= vaccination_record.recorded_at.to_fs(:long) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/immunisation_imports/success.html.erb
+++ b/app/views/immunisation_imports/success.html.erb
@@ -1,9 +1,0 @@
-<% title = "Vaccination events uploaded" %>
-
-<% content_for :page_title, "#{@campaign.name} – #{title}" %>
-
-<%= render "breadcrumbs" %>
-
-<%= govuk_panel(title_text: title, classes: "nhsuk-u-margin-bottom-6") do %>
-  The vaccination events have been uploaded.
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,9 +68,7 @@ Rails.application.routes.draw do
 
     resources :immunisation_imports,
               path: "/immunisation-imports",
-              only: %i[index new create show] do
-      get "success", on: :member
-    end
+              only: %i[index new create show]
 
     resources :reports, only: [] do
       get "download", on: :collection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,11 +66,11 @@ Rails.application.routes.draw do
   resources :campaigns, only: %i[index show] do
     resources :immunisation_imports,
               path: "/immunisation-imports",
-              only: %i[new create] do
+              only: %i[index new create] do
       get "success", on: :member
     end
 
-    resources :reports, only: %i[index] do
+    resources :reports, only: [] do
       get "download", on: :collection
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,7 +68,7 @@ Rails.application.routes.draw do
 
     resources :immunisation_imports,
               path: "/immunisation-imports",
-              only: %i[index new create] do
+              only: %i[index new create show] do
       get "success", on: :member
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,8 @@ Rails.application.routes.draw do
   end
 
   resources :campaigns, only: %i[index show] do
+    get "sessions", on: :member
+
     resources :immunisation_imports,
               path: "/immunisation-imports",
               only: %i[index new create] do

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -52,11 +52,11 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_upload_page
-    expect(page).to have_content("Upload vaccination events")
+    expect(page).to have_content("Upload a report on HPV vaccinations")
   end
 
   def when_i_continue_without_uploading_a_file
-    click_on "Upload vaccination events"
+    click_on "Continue"
   end
 
   def then_i_should_see_an_error
@@ -68,7 +68,7 @@ describe "Immunisation imports" do
       "immunisation_import[csv]",
       "spec/fixtures/immunisation_import/invalid_rows.csv"
     )
-    click_on "Upload vaccination events"
+    click_on "Continue"
   end
 
   def then_i_should_see_the_errors_page
@@ -85,7 +85,7 @@ describe "Immunisation imports" do
       "immunisation_import[csv]",
       "spec/fixtures/immunisation_import/nivs.csv"
     )
-    click_on "Upload vaccination events"
+    click_on "Continue"
   end
 
   def then_i_should_see_the_success_page

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -93,6 +93,8 @@ describe "Immunisation imports" do
 
   def then_i_should_see_the_success_page
     expect(page).to have_content("Vaccination events uploaded")
+
+    # TODO: Check the vaccination reports are shown once we process the CSV files.
   end
 
   def when_i_click_on_the_back_link

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -22,6 +22,9 @@ describe "Immunisation imports" do
 
     when_i_upload_a_valid_file
     then_i_should_see_the_success_page
+
+    when_i_click_on_the_back_link
+    then_i_should_see_the_upload
   end
 
   def given_i_am_signed_in
@@ -90,5 +93,14 @@ describe "Immunisation imports" do
 
   def then_i_should_see_the_success_page
     expect(page).to have_content("Vaccination events uploaded")
+  end
+
+  def when_i_click_on_the_back_link
+    click_on "HPV"
+  end
+
+  def then_i_should_see_the_upload
+    expect(page).to have_content("Uploaded by Test User")
+    expect(page).to have_content("Records 0")
   end
 end

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -74,12 +74,12 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_errors_page
-    expect(page).to have_content("The vaccination events could not be added")
+    expect(page).to have_content("The vaccinations could not be added")
     expect(page).to have_content("Row 2")
   end
 
   def and_i_go_back_to_the_upload_page
-    click_on "Upload a new vaccination report"
+    click_on "Back"
   end
 
   def when_i_upload_a_valid_file

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -21,10 +21,9 @@ describe "Immunisation imports" do
     and_i_go_back_to_the_upload_page
 
     when_i_upload_a_valid_file
-    then_i_should_see_the_success_page
-
-    when_i_click_on_the_back_link
-    then_i_should_see_the_upload
+    then_i_should_see_the_success_banner
+    and_i_should_see_the_upload
+    and_i_should_see_the_vaccination_records
   end
 
   def given_i_am_signed_in
@@ -91,18 +90,17 @@ describe "Immunisation imports" do
     click_on "Continue"
   end
 
-  def then_i_should_see_the_success_page
-    expect(page).to have_content("Vaccination events uploaded")
-
-    # TODO: Check the vaccination reports are shown once we process the CSV files.
+  def then_i_should_see_the_success_banner
+    expect(page).to have_content("0 vaccinations uploaded")
   end
 
-  def when_i_click_on_the_back_link
-    click_on "HPV"
+  def and_i_should_see_the_upload
+    expect(page).to have_content("Uploaded on")
+    expect(page).to have_content("Uploaded byTest User")
+    expect(page).to have_content("CampaignHPV")
   end
 
-  def then_i_should_see_the_upload
-    expect(page).to have_content("Uploaded by Test User")
-    expect(page).to have_content("Records 0")
+  def and_i_should_see_the_vaccination_records
+    # TODO: Check the vaccination reports are shown once we process the CSV files
   end
 end

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -40,7 +40,7 @@ describe "Immunisation imports" do
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
-    click_on "Reports"
+    click_on "Uploaded reports"
   end
 
   def then_i_should_see_the_upload_link

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -44,11 +44,11 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_upload_link
-    expect(page).to have_link("Upload vaccination events (CSV)")
+    expect(page).to have_link("Upload a new vaccination report")
   end
 
   def when_i_click_on_the_upload_link
-    click_on "Upload vaccination events (CSV)"
+    click_on "Upload a new vaccination report"
   end
 
   def then_i_should_see_the_upload_page
@@ -77,7 +77,7 @@ describe "Immunisation imports" do
   end
 
   def and_i_go_back_to_the_upload_page
-    click_on "Upload new vaccination events (CSV)"
+    click_on "Upload a new vaccination report"
   end
 
   def when_i_upload_a_valid_file

--- a/spec/features/nivs_hpv_report_spec.rb
+++ b/spec/features/nivs_hpv_report_spec.rb
@@ -44,7 +44,7 @@ describe "NIVS HPV report" do
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
-    click_on "Reports"
+    click_on "Uploaded reports"
   end
 
   def and_i_download_the_nivs_hpv_report

--- a/spec/features/nivs_hpv_report_spec.rb
+++ b/spec/features/nivs_hpv_report_spec.rb
@@ -6,7 +6,7 @@ describe "NIVS HPV report" do
   scenario "User downloads the NIVS HPV report" do
     given_i_am_signed_in
     and_vaccinations_have_happened_in_my_teams_hpv_campaign
-    when_i_go_to_the_reports_page
+    when_i_go_to_the_campaign_overview_page
     and_i_download_the_nivs_hpv_report
     then_i_should_see_all_the_administered_vaccinations_from_my_teams_hpv_campaign
   end
@@ -39,16 +39,15 @@ describe "NIVS HPV report" do
     @patient_sessions = session.patient_sessions
   end
 
-  def when_i_go_to_the_reports_page
+  def when_i_go_to_the_campaign_overview_page
     visit "/dashboard"
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
-    click_on "Uploaded reports"
   end
 
   def and_i_download_the_nivs_hpv_report
-    click_on "Download NIVS data (CSV)"
+    click_on "Download immunisation report (CSV)"
   end
 
   def then_i_should_see_all_the_administered_vaccinations_from_my_teams_hpv_campaign

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -135,6 +135,7 @@ describe "Parental consent" do
     visit "/dashboard"
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
   end
@@ -148,6 +149,7 @@ describe "Parental consent" do
   def and_the_action_in_the_vaccination_session_is_to_check_refusal
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Record vaccinations"
 

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -48,6 +48,7 @@ describe "Parental consent" do
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
   end
@@ -162,6 +163,7 @@ describe "Parental consent" do
     visit "/dashboard"
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
   end

--- a/spec/features/response_matching_spec.rb
+++ b/spec/features/response_matching_spec.rb
@@ -46,6 +46,7 @@ describe "Response matching" do
 
   def and_i_click_on_the_check_consent_responses_link
     click_on @campaign.name
+    click_on "School sessions"
     click_on @school.name
     click_on "Check consent responses"
   end

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -39,6 +39,7 @@ describe "Self-consent" do
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
 

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -34,6 +34,7 @@ describe "Not Gillick competent" do
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
 

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -48,6 +48,7 @@ describe "User authorisation" do
     visit "/dashboard"
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
   end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -39,6 +39,7 @@ feature "Verbal consent" do
     visit "/dashboard"
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
+    click_on "School sessions"
     click_on "Pilot School"
     click_on "Check consent responses"
     click_on "Refused"

--- a/spec/helpers/patient_helper_spec.rb
+++ b/spec/helpers/patient_helper_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PatientHelper do
+  describe "#format_nhs_number" do
+    subject(:formatted_nhs_number) { helper.format_nhs_number(nhs_number) }
+
+    let(:nhs_number) { "0123456789" }
+
+    it "adds spaces in the right place" do
+      expect(formatted_nhs_number).to eq("012 345 6789")
+    end
+  end
+end


### PR DESCRIPTION
This makes a number of changes to the pages related to immunisation imports to match the prototype. See individual commits for more details. It's a relatively large PR, and I could extract some of the changes to separate PRs if that's preferred.

As we don't currently process the import and generate vaccination records, there will always be 0 records shown, but once we process the import we can update the tests to ensure the records come through.

## Screenshots

<img width="756" alt="Screenshot 2024-07-18 at 14 20 44" src="https://github.com/user-attachments/assets/535aea1f-63dd-4278-95c7-3c5da08150fc">
<img width="519" alt="Screenshot 2024-07-18 at 14 20 40" src="https://github.com/user-attachments/assets/22d281f6-be92-40b0-9872-746466aeb51a">
<img width="1134" alt="Screenshot 2024-07-18 at 14 20 36" src="https://github.com/user-attachments/assets/bd6d1e89-7179-429c-8d23-b209177ae118">
<img width="1170" alt="Screenshot 2024-07-18 at 14 20 30" src="https://github.com/user-attachments/assets/aab9c744-0e8d-437c-ab76-7c68e49d4040">
