### PR TITLE
Import postcodes

### DIFF
--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -151,6 +151,7 @@ class ImmunisationImport < ApplicationRecord
               format: {
                 with: /\A\d{8}\z/
               }
+    validates :patient_postcode, presence: true, postcode: true
 
     validates :session_date, presence: true, format: { with: /\A\d{8}\z/ }
 
@@ -184,6 +185,7 @@ class ImmunisationImport < ApplicationRecord
       patient.first_name ||= patient_first_name
       patient.last_name ||= patient_last_name
       patient.date_of_birth ||= patient_date_of_birth
+      patient.address_postcode ||= patient_postcode
       patient.location ||= to_location
       patient
     end
@@ -260,6 +262,12 @@ class ImmunisationImport < ApplicationRecord
 
     def patient_date_of_birth
       @data["PERSON_DOB"]&.strip
+    end
+
+    def patient_postcode
+      if (postcode = @data["PERSON_POSTCODE"]).present?
+        UKPostcode.parse(postcode).to_s
+      end
     end
 
     def patient_nhs_number

--- a/app/views/immunisation_imports/show.html.erb
+++ b/app/views/immunisation_imports/show.html.erb
@@ -56,7 +56,7 @@
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Postcode</span>
-            <%= vaccination_record.location.postcode %>
+            <%= vaccination_record.patient.address_postcode %>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccinated date</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
               blank: is required but missing
             organisation_code:
               blank: is required but missing
+            patient_postcode:
+              blank: is required but missing
   activerecord:
     attributes:
       consent:

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -105,7 +105,7 @@ describe "Immunisation imports" do
       "Full nameNHS numberDate of birthPostcodeVaccinated date"
     )
     expect(page).to have_content(
-      "Full name Chyna Pickle NHS number 742 018 0008 Date of birth 12 September 2012"
+      "Full name Chyna Pickle NHS number 742 018 0008 Date of birth 12 September 2012 Postcode LE3 2DA"
     )
   end
 end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -39,6 +39,9 @@ describe ImmunisationImport::Row, type: :model do
         expect(immunisation_import_row.errors[:organisation_code]).to include(
           "is required but missing"
         )
+        expect(immunisation_import_row.errors[:patient_postcode]).to include(
+          "is required but missing"
+        )
       end
     end
 
@@ -56,6 +59,17 @@ describe ImmunisationImport::Row, type: :model do
       end
     end
 
+    context "with an invalid postcode" do
+      let(:data) { { "PERSON_POSTCODE" => "ABC DEF" } }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:patient_postcode]).to include(
+          /Enter a valid postcode/
+        )
+      end
+    end
+
     context "with valid fields" do
       let(:data) do
         {
@@ -67,6 +81,7 @@ describe ImmunisationImport::Row, type: :model do
           "PERSON_FORENAME" => "Harry",
           "PERSON_SURNAME" => "Potter",
           "PERSON_DOB" => "20120101",
+          "PERSON_POSTCODE" => "SW1A 1AA",
           "NHS_NUMBER" => "1234567890",
           "DATE_OF_VACCINATION" => "20240101"
         }
@@ -203,6 +218,34 @@ describe ImmunisationImport::Row, type: :model do
       let(:data) { { "ORGANISATION_CODE" => "abc" } }
 
       it { should eq("abc") }
+    end
+  end
+
+  describe "#patient_postcode" do
+    subject(:patient_postcode) { immunisation_import_row.patient_postcode }
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with an invalid postcode" do
+      let(:data) { { "PERSON_POSTCODE" => "abc" } }
+
+      it { should eq("abc") }
+    end
+
+    context "with a valid postcode" do
+      let(:data) { { "PERSON_POSTCODE" => "SW1 1AA" } }
+
+      it { should eq("SW1 1AA") }
+    end
+
+    context "with a valid unformatted postcode" do
+      let(:data) { { "PERSON_POSTCODE" => "sw11aa" } }
+
+      it { should eq("SW1 1AA") }
     end
   end
 


### PR DESCRIPTION
This ensures that postcodes are imported from the CSV immunisation import and then displayed as part of the patient records.