### PR TITLE
Mavis consents: Make it easy to pick parents from previous consents

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -13,6 +13,9 @@ class ManageConsentsController < ApplicationController
   before_action :set_consent, except: %i[create]
   before_action :set_steps, except: %i[create]
   before_action :setup_wizard_translated, except: %i[create]
+  before_action :set_parent_options,
+                only: %i[show update],
+                if: -> { step == "who" }
   before_action :set_parent,
                 except: %i[create],
                 if: -> { step.in?(%w[parent-details confirm]) }
@@ -170,6 +173,10 @@ class ManageConsentsController < ApplicationController
 
   def set_patient
     @patient = @session.patients.find(params.fetch(:patient_id))
+  end
+
+  def set_parent_options
+    @parent_options = [@patient.parent]
   end
 
   def set_parent

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -13,13 +13,13 @@ class ManageConsentsController < ApplicationController
   before_action :set_consent, except: %i[create]
   before_action :set_steps, except: %i[create]
   before_action :setup_wizard_translated, except: %i[create]
-  before_action :set_parent_options,
-                only: %i[show update],
-                if: -> { step == "who" }
   before_action :set_parent,
                 except: %i[create],
                 if: -> { step.in?(%w[parent-details confirm]) }
   before_action :set_patient_session
+  before_action :set_parent_options,
+                only: %i[show update],
+                if: -> { step == "who" }
   before_action :set_triage,
                 except: %i[create],
                 if: -> { step.in?(%w[triage confirm]) }
@@ -176,7 +176,11 @@ class ManageConsentsController < ApplicationController
   end
 
   def set_parent_options
-    @parent_options = [@patient.parent]
+    @parent_options =
+      (
+        [@patient.parent] +
+          @patient_session.consents.includes(:parent).map(&:parent)
+      ).compact.uniq.sort_by(&:name)
   end
 
   def set_parent

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -205,10 +205,9 @@ class Consent < ApplicationRecord
 
   def new_or_existing_parent=(value)
     @new_or_existing_parent = value
-
-    if value != "new" && (patient.parent.id.to_s == value)
-      self.parent = patient.parent
-    end
+    self.parent_id = value if value.to_i.in?(
+      patient.consents.pluck(:parent_id) + [patient.parent.id]
+    )
   end
 
   private

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -18,10 +18,12 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset(:new_or_existing_parent, legend: nil) do %>
-    <%= f.govuk_radio_button :new_or_existing_parent, @patient.parent.id,
-                             label: { text: "#{@patient.parent.name} (#{@patient.parent.relationship_label})" },
-                             hint: { text: @patient.parent.phone },
-                             link_errors: true %>
+    <% @parent_options.each.with_index do |parent, i| %>
+      <%= f.govuk_radio_button :new_or_existing_parent, parent.id,
+                               label: { text: "#{parent.name} (#{parent.relationship_label})" },
+                               hint: { text: parent.phone },
+                               link_errors: i == 0 %>
+    <% end %>
     <%= f.govuk_radio_divider %>
     <%= f.govuk_radio_button :new_or_existing_parent, "new",
                              label: { text: "Add a new parental contact" } %>

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -75,13 +75,7 @@ FactoryBot.define do
     trait :from_mum do
       parent do
         if patient.parent.relationship_mother?
-          create(
-            :parent,
-            :mum,
-            last_name: patient.last_name,
-            phone: patient.parent.phone,
-            email: patient.parent.email
-          )
+          patient.parent
         else
           create(:parent, :mum, last_name: patient.last_name)
         end
@@ -91,13 +85,7 @@ FactoryBot.define do
     trait :from_dad do
       parent do
         if patient.parent.relationship_father?
-          create(
-            :parent,
-            :dad,
-            last_name: patient.last_name,
-            phone: patient.parent.phone,
-            email: patient.parent.email
-          )
+          patient.parent
         else
           create(:parent, :dad, last_name: patient.last_name)
         end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -47,17 +47,12 @@ feature "Verbal consent" do
     click_on "Get consent"
 
     # contacting the same parent who refused
-    # TODO: update this when it's possible to pick an existing parental contact from a consent form
-    choose "Add a new parental contact"
+    choose @refusing_parent.name
     click_button "Continue"
 
     # Details for parent or guardian
     fill_in "Phone number", with: @refusing_parent.phone
     fill_in "Email address", with: @refusing_parent.email
-    fill_in "Full name", with: @refusing_parent.name
-    # relationship to the child
-    choose @refusing_parent.relationship_label
-
     click_button "Continue"
 
     choose "By phone"


### PR DESCRIPTION
Make it easier to contact parents from previous consents, not just the cohort parent.

## Before

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/35283111-3e11-4e01-bd2a-5d11ccdaf3fb">

## After

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/c472b46d-220b-453c-b7b3-db2e8185c6c8">
