### PR TITLE
Cancel in progress deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,10 @@ jobs:
       id-token: write
       contents: read
 
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
This block accomplishes two things:

- The `concurrency.group` setting ensures that only 1 deploy can be attempted at any time
- The `concurrency.cancel-in-progress` setting ensures that the last scheduled deploy cancels any in-progress earlier deploys

This should lead to less failed deploys on Tuesday when we usually merge a few Dependabot PRs back to back and cause a deploy queue to occur.

Using `github.workflow` and `github-ref` to identify the concurrency group ensures that deploys from different branches or to different environments should not clash.