### PR TITLE
Use session date in immunsation import show view

### DIFF
--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -45,7 +45,11 @@ class ImmunisationImportsController < ApplicationController
     @immunisation_import = @campaign.immunisation_imports.find(params[:id])
 
     @vaccination_records =
-      @immunisation_import.vaccination_records.includes(:location, :patient)
+      @immunisation_import.vaccination_records.includes(
+        :location,
+        :patient,
+        :session
+      )
   end
 
   def success

--- a/app/views/immunisation_imports/show.html.erb
+++ b/app/views/immunisation_imports/show.html.erb
@@ -60,7 +60,7 @@
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccinated date</span>
-            <%= vaccination_record.recorded_at.to_fs(:long) %>
+            <%= vaccination_record.session.date.to_fs(:long) %>
           <% end %>
         <% end %>
       <% end %>

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -105,7 +105,8 @@ describe "Immunisation imports" do
       "Full nameNHS numberDate of birthPostcodeVaccinated date"
     )
     expect(page).to have_content(
-      "Full name Chyna Pickle NHS number 742 018 0008 Date of birth 12 September 2012 Postcode LE3 2DA"
+      "Full name Chyna Pickle NHS number 742 018 0008 Date of birth 12 September 2012 " \
+        "Postcode LE3 2DA Vaccinated date 14 May 2024"
     )
   end
 end


### PR DESCRIPTION
Currently we're using the recorded at date, but this will always be when the immunisation import was imported, whereas instead we want to show when the vaccination session happened.