### PR TITLE
Fix deploy concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: ${{ github.ref }}-${{ github.event.inputs.environment }}
       cancel-in-progress: true
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, deploys to training are being cancelled by deploys to `test` because the deploy environment isn't part of the concurrency group.