### PR TITLE
Remove explicit reference to FactoryBot

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -21,7 +21,7 @@ class DevController < ApplicationController
     @session = Session.find(params.fetch(:session_id))
     @vaccine = @session.campaign.vaccines.first
     @consent_form =
-      FactoryBot.build :consent_form, :draft, session_id: @session.id
+      FactoryBot.build(:consent_form, :draft, session_id: @session.id)
     @consent_form.health_answers = @vaccine.health_questions.to_health_answers
     @consent_form.save!
     @consent_form.each_health_answer do |health_answer|

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -7,17 +7,13 @@ describe AppPatientDetailsComponent, type: :component do
 
   before { render_inline(component) }
 
-  let(:session) { FactoryBot.create(:session) }
+  let(:session) { create(:session) }
 
   context "with a patient object" do
     let(:patient) do
-      FactoryBot.create(
-        :patient,
-        nhs_number: 1_234_567_890,
-        common_name: "Homer"
-      )
+      create(:patient, nhs_number: 1_234_567_890, common_name: "Homer")
     end
-    let(:school) { FactoryBot.create(:location) }
+    let(:school) { create(:location) }
     let(:component) { described_class.new(patient:, session:, school:) }
 
     it "renders the patient's full name" do
@@ -70,7 +66,7 @@ describe AppPatientDetailsComponent, type: :component do
     end
 
     context "without a preferred name" do
-      let(:patient) { FactoryBot.create(:patient, common_name: nil) }
+      let(:patient) { create(:patient, common_name: nil) }
 
       it "does not render known as" do
         expect(page).not_to(
@@ -82,13 +78,9 @@ describe AppPatientDetailsComponent, type: :component do
 
   context "with a consent_form object" do
     let(:consent_form) do
-      FactoryBot.create(
-        :consent_form,
-        common_name: "Homer",
-        use_common_name: true
-      )
+      create(:consent_form, common_name: "Homer", use_common_name: true)
     end
-    let(:school) { FactoryBot.create(:location) }
+    let(:school) { create(:location) }
     let(:component) { described_class.new(consent_form:, session:, school:) }
 
     it "renders the child's full name" do
@@ -151,7 +143,7 @@ describe AppPatientDetailsComponent, type: :component do
     end
 
     context "without a common name" do
-      let(:consent_form) { FactoryBot.create(:consent_form, common_name: nil) }
+      let(:consent_form) { create(:consent_form, common_name: nil) }
 
       it "does not render known as" do
         expect(page).not_to(
@@ -161,9 +153,7 @@ describe AppPatientDetailsComponent, type: :component do
     end
 
     context "when child does not have a date of birth on record" do
-      let(:consent_form) do
-        FactoryBot.create(:consent_form, date_of_birth: nil)
-      end
+      let(:consent_form) { create(:consent_form, date_of_birth: nil) }
 
       it "does not render the child's date of birth" do
         expect(page).not_to(
@@ -174,7 +164,7 @@ describe AppPatientDetailsComponent, type: :component do
 
     context "when child does not have a GP" do
       let(:consent_form) do
-        FactoryBot.create(
+        create(
           :consent_form,
           common_name: "Homer",
           gp_name: nil,
@@ -195,7 +185,7 @@ describe AppPatientDetailsComponent, type: :component do
 
     context "when it's unknown whether the child has a GP" do
       let(:consent_form) do
-        FactoryBot.create(
+        create(
           :consent_form,
           common_name: "Homer",
           gp_name: nil,

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -27,7 +27,7 @@ describe AppPatientPageComponent, type: :component do
 
   context "session in progress, patient in triage" do
     let(:patient_session) do
-      FactoryBot.create(
+      create(
         :patient_session,
         :consent_given_triage_needed,
         :session_in_progress
@@ -57,7 +57,7 @@ describe AppPatientPageComponent, type: :component do
 
   context "session in progress, patient ready to vaccinate" do
     let(:patient_session) do
-      FactoryBot.create(
+      create(
         :patient_session,
         :triaged_ready_to_vaccinate,
         :session_in_progress

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -17,10 +17,10 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
     @user = @team.users.first
     @session = @campaign.sessions.first
     @location = @session.location
-    @patient = FactoryBot.create(:patient, location: @location)
+    @patient = create(:patient, location: @location)
 
     @consents = [
-      FactoryBot.create(
+      create(
         :consent,
         :given,
         :from_mum,
@@ -29,7 +29,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
         parent: create(:parent, :mum, name: "Jane Doe"),
         recorded_at: Time.zone.parse("2024-05-30 12:00")
       ),
-      FactoryBot.create(
+      create(
         :consent,
         :refused,
         :from_dad,
@@ -41,7 +41,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
     ]
 
     @patient_session =
-      FactoryBot.create(
+      create(
         :patient_session,
         patient: @patient,
         session: @session,
@@ -49,7 +49,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
       )
 
     @triage = [
-      FactoryBot.create(
+      create(
         :triage,
         :kept_in_triage,
         patient_session: @patient_session,
@@ -57,21 +57,21 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
         notes: "Some notes",
         user: @user
       ),
-      FactoryBot.create(
+      create(
         :triage,
         :do_not_vaccinate,
         patient_session: @patient_session,
         created_at: Time.zone.parse("2024-05-30 14:10"),
         user: @user
       ),
-      FactoryBot.create(
+      create(
         :triage,
         :delay_vaccination,
         patient_session: @patient_session,
         created_at: Time.zone.parse("2024-05-30 14:20"),
         user: @user
       ),
-      FactoryBot.create(
+      create(
         :triage,
         :vaccinate,
         patient_session: @patient_session,
@@ -81,7 +81,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
     ]
 
     @vaccination_records = [
-      FactoryBot.create(
+      create(
         :vaccination_record,
         patient_session: @patient_session,
         created_at: Time.zone.parse("2024-05-31 12:00"),

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -4,8 +4,7 @@ class AppConsentComponentPreview < ViewComponent::Preview
   def consent_refused_without_notes
     setup
 
-    patient_session =
-      FactoryBot.create(:patient_session, :consent_refused, session:)
+    patient_session = create(:patient_session, :consent_refused, session:)
 
     render AppConsentComponent.new(patient_session:, route: "triage")
   end
@@ -14,7 +13,7 @@ class AppConsentComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(:patient_session, :consent_refused_with_notes, session:)
+      create(:patient_session, :consent_refused_with_notes, session:)
 
     render AppConsentComponent.new(patient_session:, route: "triage")
   end
@@ -23,20 +22,15 @@ class AppConsentComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session:
-      )
+      create(:patient_session, :consent_given_triage_not_needed, session:)
     render AppConsentComponent.new(patient_session:, route: "triage")
   end
 
   def two_refusals_from_the_same_parent
     setup
 
-    patient_session =
-      FactoryBot.create(:patient_session, :consent_refused, session:)
-    FactoryBot.create(
+    patient_session = create(:patient_session, :consent_refused, session:)
+    create(
       :consent,
       :refused,
       patient_session:,
@@ -51,12 +45,8 @@ class AppConsentComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session:
-      )
-    FactoryBot.create(:consent, :refused, :from_mum, patient_session:)
+      create(:patient_session, :consent_given_triage_not_needed, session:)
+    create(:consent, :refused, :from_mum, patient_session:)
 
     render AppConsentComponent.new(patient_session:, route: "triage")
   end
@@ -66,12 +56,7 @@ class AppConsentComponentPreview < ViewComponent::Preview
   attr_reader :campaign, :session
 
   def setup
-    @campaign =
-      FactoryBot.create(
-        :campaign,
-        :hpv,
-        team: Team.first || FactoryBot.create(:team)
-      )
-    @session = FactoryBot.create(:session, patients_in_session: 0, campaign:)
+    @campaign = create(:campaign, :hpv, team: Team.first || create(:team))
+    @session = create(:session, patients_in_session: 0, campaign:)
   end
 end

--- a/spec/components/previews/app_consent_summary_component_preview.rb
+++ b/spec/components/previews/app_consent_summary_component_preview.rb
@@ -59,7 +59,7 @@ class AppConsentSummaryComponentPreview < ViewComponent::Preview
                  text: "Consent given (phone)",
                  timestamp: Time.zone.local(2024, 3, 5, 12, 48, 0),
                  recorded_by:
-                   FactoryBot.build(
+                   build(
                      :user,
                      full_name: "Nurse Joy",
                      email: "nurse.joy@example.com"

--- a/spec/components/previews/app_health_questions_component_preview.rb
+++ b/spec/components/previews/app_health_questions_component_preview.rb
@@ -5,11 +5,7 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session:
-      )
+      create(:patient_session, :consent_given_triage_not_needed, session:)
 
     render AppHealthQuestionsComponent.new(consents: patient_session.consents)
   end
@@ -18,11 +14,7 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(
-        :patient_session,
-        :consent_given_triage_needed,
-        session:
-      )
+      create(:patient_session, :consent_given_triage_needed, session:)
 
     render AppHealthQuestionsComponent.new(consents: patient_session.consents)
   end
@@ -31,12 +23,8 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session:
-      )
-    FactoryBot.create(
+      create(:patient_session, :consent_given_triage_not_needed, session:)
+    create(
       :consent,
       :given,
       :no_contraindications,
@@ -51,15 +39,11 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
     setup
 
     patient_session =
-      FactoryBot.create(
-        :patient_session,
-        :consent_given_triage_needed,
-        session:
-      )
+      create(:patient_session, :consent_given_triage_needed, session:)
     patient_session.consents.first.update!(parent_relationship: :mother)
 
     dad_consent =
-      FactoryBot.create(
+      create(
         :consent,
         :given,
         :health_question_notes,
@@ -81,12 +65,7 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
   attr_reader :campaign, :session
 
   def setup
-    @campaign =
-      FactoryBot.create(
-        :campaign,
-        :hpv,
-        team: Team.first || FactoryBot.create(:team)
-      )
-    @session = FactoryBot.create(:session, patients_in_session: 0, campaign:)
+    @campaign = create(:campaign, :hpv, team: Team.first || create(:team))
+    @session = create(:session, patients_in_session: 0, campaign:)
   end
 end

--- a/spec/components/previews/app_outcome_banner_component_preview.rb
+++ b/spec/components/previews/app_outcome_banner_component_preview.rb
@@ -2,20 +2,19 @@
 
 class AppOutcomeBannerComponentPreview < ViewComponent::Preview
   def triaged_do_not_vaccinate
-    patient_session =
-      FactoryBot.create(:patient_session, :triaged_do_not_vaccinate)
+    patient_session = create(:patient_session, :triaged_do_not_vaccinate)
 
     render AppOutcomeBannerComponent.new(patient_session:)
   end
 
   def unable_to_vaccinate_with_contradications
-    patient_session = FactoryBot.create(:patient_session, :unable_to_vaccinate)
+    patient_session = create(:patient_session, :unable_to_vaccinate)
 
     render AppOutcomeBannerComponent.new(patient_session:)
   end
 
   def vaccinated
-    patient_session = FactoryBot.create(:patient_session, :vaccinated)
+    patient_session = create(:patient_session, :vaccinated)
     patient_session.vaccination_records.first.update!(
       notes: "Patient felt dizzy"
     )

--- a/spec/components/previews/app_patient_table_component_preview.rb
+++ b/spec/components/previews/app_patient_table_component_preview.rb
@@ -3,7 +3,7 @@
 class AppPatientTableComponentPreview < ViewComponent::Preview
   def check_consent
     patient_sessions =
-      FactoryBot.create_list(:patient_session, 2, :triaged_ready_to_vaccinate)
+      create_list(:patient_session, 2, :triaged_ready_to_vaccinate)
 
     # add a common name to one of the patients
     patient_sessions.first.patient.update!(common_name: "Bobby")
@@ -17,8 +17,7 @@ class AppPatientTableComponentPreview < ViewComponent::Preview
   end
 
   def matching_consent_form_to_a_patient
-    patient_sessions =
-      FactoryBot.create_list(:patient_session, 2, :added_to_session)
+    patient_sessions = create_list(:patient_session, 2, :added_to_session)
 
     # add a common name to one of the patients above
     patient_sessions.first.patient.update!(common_name: "Bobby")
@@ -29,7 +28,7 @@ class AppPatientTableComponentPreview < ViewComponent::Preview
     end
 
     consent_form =
-      FactoryBot.create(:consent_form, session: patient_sessions.first.session)
+      create(:consent_form, session: patient_sessions.first.session)
 
     render AppPatientTableComponent.new(
              patient_sessions:,

--- a/spec/components/previews/app_simple_status_banner_component_preview.rb
+++ b/spec/components/previews/app_simple_status_banner_component_preview.rb
@@ -2,60 +2,55 @@
 
 class AppSimpleStatusBannerComponentPreview < ViewComponent::Preview
   def waiting_for_consent
-    patient_session = FactoryBot.create(:patient_session, :added_to_session)
+    patient_session = create(:patient_session, :added_to_session)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def no_consent_and_not_gillick_competent
-    patient_session =
-      FactoryBot.create(:patient_session, :not_gillick_competent)
+    patient_session = create(:patient_session, :not_gillick_competent)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def consent_refused
-    patient_session = FactoryBot.create(:patient_session, :consent_refused)
+    patient_session = create(:patient_session, :consent_refused)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def consent_conflicts
-    patient_session = FactoryBot.create(:patient_session, :consent_conflicting)
+    patient_session = create(:patient_session, :consent_conflicting)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def needs_triage
-    patient_session =
-      FactoryBot.create(:patient_session, :consent_given_triage_needed)
+    patient_session = create(:patient_session, :consent_given_triage_needed)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def triaged_keep_in_triage
-    patient_session =
-      FactoryBot.create(:patient_session, :triaged_kept_in_triage)
+    patient_session = create(:patient_session, :triaged_kept_in_triage)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def triaged_do_not_vaccinate
-    patient_session =
-      FactoryBot.create(:patient_session, :triaged_do_not_vaccinate)
+    patient_session = create(:patient_session, :triaged_do_not_vaccinate)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def triaged_ready_to_vaccinate
-    patient_session =
-      FactoryBot.create(:patient_session, :triaged_ready_to_vaccinate)
+    patient_session = create(:patient_session, :triaged_ready_to_vaccinate)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end
 
   def triaged_out_delay_vaccination
-    patient_session = FactoryBot.create(:patient_session, :delay_vaccination)
+    patient_session = create(:patient_session, :delay_vaccination)
 
     render AppSimpleStatusBannerComponent.new(patient_session:)
   end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -31,11 +31,11 @@ require "rails_helper"
 describe Session do
   describe "validations" do
     context "when form_step is location" do
-      subject { FactoryBot.build :session, form_step:, campaign: }
+      subject { build(:session, form_step:, campaign:) }
 
       let(:form_step) { :location }
-      let(:team) { create :team }
-      let(:campaign) { create :campaign, team: }
+      let(:team) { create(:team) }
+      let(:campaign) { create(:campaign, team:) }
 
       it { should validate_presence_of(:location_id).on(:update) }
     end
@@ -45,19 +45,19 @@ describe Session do
     subject { session.in_progress? }
 
     context "when the session is scheduled for today" do
-      let(:session) { FactoryBot.create :session, :in_progress }
+      let(:session) { create(:session, :in_progress) }
 
       it { should be_truthy }
     end
 
     context "when the session is scheduled in the past" do
-      let(:session) { FactoryBot.create :session, :in_past }
+      let(:session) { create(:session, :in_past) }
 
       it { should be_falsey }
     end
 
     context "when the session is scheduled in the future" do
-      let(:session) { FactoryBot.create :session, :in_future }
+      let(:session) { create(:session, :in_future) }
 
       it { should be_falsey }
     end
@@ -66,8 +66,8 @@ describe Session do
   describe ".active scope" do
     subject { described_class.active }
 
-    let!(:active_session) { FactoryBot.create :session }
-    let!(:draft_session) { FactoryBot.create :session, draft: true }
+    let!(:active_session) { create(:session) }
+    let!(:draft_session) { create(:session, draft: true) }
 
     it { should include active_session }
     it { should_not include draft_session }

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -20,17 +20,17 @@ require "rails_helper"
 describe Vaccine do
   describe "#contains_gelatine?" do
     it "returns true if the vaccine is a nasal flu vaccine" do
-      vaccine = FactoryBot.build(:vaccine, :fluenz_tetra)
+      vaccine = build(:vaccine, :fluenz_tetra)
       expect(vaccine.contains_gelatine?).to be true
     end
 
     it "returns false if the vaccine is an injected flu vaccine" do
-      vaccine = FactoryBot.build(:vaccine, :fluarix_tetra)
+      vaccine = build(:vaccine, :fluarix_tetra)
       expect(vaccine.contains_gelatine?).to be false
     end
 
     it "returns false if the vaccine is not a flu vaccine" do
-      vaccine = FactoryBot.build(:vaccine, :gardasil_9)
+      vaccine = build(:vaccine, :gardasil_9)
       expect(vaccine.contains_gelatine?).to be false
     end
   end


### PR DESCRIPTION
FactoryBot is already in the global scope in the context of RSpec tests so we don't need to call it with the FactoryBot prefix.

This change is purely stylistic and should have no changes to the tests themselves.