### PR TITLE
Include FactoryBot methods in previews

### DIFF
--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -2,6 +2,7 @@
 
 class ComponentPreviewsController < ApplicationController
   include ViewComponent::PreviewActions
+
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped
 

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AppActivityLogComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def default
     setup
 

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -53,7 +53,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
     @triage = [
       create(
         :triage,
-        :kept_in_triage,
+        :needs_follow_up,
         patient_session: @patient_session,
         created_at: Time.zone.parse("2024-05-30 14:00"),
         notes: "Some notes",
@@ -75,7 +75,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
       ),
       create(
         :triage,
-        :vaccinate,
+        :ready_to_vaccinate,
         patient_session: @patient_session,
         created_at: Time.zone.parse("2024-05-30 14:30"),
         user: @user

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AppConsentComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def consent_refused_without_notes
     setup
 

--- a/spec/components/previews/app_health_questions_component_preview.rb
+++ b/spec/components/previews/app_health_questions_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AppHealthQuestionsComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def single_consent_triage_not_needed
     setup
 

--- a/spec/components/previews/app_outcome_banner_component_preview.rb
+++ b/spec/components/previews/app_outcome_banner_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AppOutcomeBannerComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def triaged_do_not_vaccinate
     patient_session = create(:patient_session, :triaged_do_not_vaccinate)
 

--- a/spec/components/previews/app_patient_table_component_preview.rb
+++ b/spec/components/previews/app_patient_table_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AppPatientTableComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def check_consent
     patient_sessions =
       create_list(:patient_session, 2, :triaged_ready_to_vaccinate)

--- a/spec/components/previews/app_simple_status_banner_component_preview.rb
+++ b/spec/components/previews/app_simple_status_banner_component_preview.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AppSimpleStatusBannerComponentPreview < ViewComponent::Preview
+  include FactoryBot::Syntax::Methods
+
   def waiting_for_consent
     patient_session = create(:patient_session, :added_to_session)
 


### PR DESCRIPTION
This fixes an issue that was introduced in https://github.com/nhsuk/manage-vaccinations-in-schools/commit/3869396d1d696cea865e2be15e7da5a3bfe9e6a6 where the components could no longer be rendered as they were referring to `FactoryBot` methods implicitly which are not automatically included in previews.

I was hoping there was a way of including this automatically in all previews, but aside from creating our own `ViewComponent::Preview` base class there doesn't seem to be a nice way of doing it.