### PR TITLE
Add vaccination record page

### DIFF
--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class AppVaccinationRecordDetailsComponent < ViewComponent::Base
+  def initialize(vaccination_record)
+    super
+
+    @vaccination_record = vaccination_record
+    @vaccine = vaccination_record.vaccine
+    @batch = vaccination_record.batch
+  end
+
+  def call
+    govuk_summary_list(
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
+    ) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Outcome" }
+        row.with_value do
+          @vaccination_record.administered ? "Vaccinated" : "Not vaccinated"
+        end
+      end
+
+      if @vaccine.present?
+        summary_list.with_row do |row|
+          row.with_key { "Vaccine" }
+          row.with_value { helpers.vaccine_heading(@vaccine) }
+        end
+      end
+
+      if @vaccination_record.delivery_method.present?
+        summary_list.with_row do |row|
+          row.with_key { "Method" }
+          row.with_value do
+            @vaccination_record.human_enum_name(:delivery_method)
+          end
+        end
+      end
+
+      if @vaccination_record.delivery_site.present?
+        summary_list.with_row do |row|
+          row.with_key { "Site" }
+          row.with_value { @vaccination_record.human_enum_name(:delivery_site) }
+        end
+      end
+
+      if @vaccine.present?
+        summary_list.with_row do |row|
+          row.with_key { "Dose" }
+          row.with_value { helpers.vaccine_dose(@vaccine) }
+        end
+      end
+
+      if @batch.present?
+        summary_list.with_row do |row|
+          row.with_key { "Batch ID" }
+          row.with_value(classes: ["app-u-monospace"]) { @batch.name }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Batch expiry date" }
+          row.with_value { @batch.expiry.to_fs(:long) }
+        end
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Date and time" }
+        row.with_value { @vaccination_record.recorded_at.to_fs(:long) }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Nurse" }
+        row.with_value { @vaccination_record.user.full_name }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Location" }
+        row.with_value { @vaccination_record.session.location.name }
+      end
+    end
+  end
+end

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class VaccinationRecordsController < ApplicationController
+  def show
+    @vaccination_record =
+      policy_scope(VaccinationRecord).includes(
+        :vaccine,
+        :batch,
+        patient: :location,
+        session: :location
+      ).find(params[:id])
+
+    @patient = @vaccination_record.patient
+    @session = @vaccination_record.session
+    @school = @patient.location
+  end
+end

--- a/app/helpers/vaccines_helper.rb
+++ b/app/helpers/vaccines_helper.rb
@@ -4,4 +4,8 @@ module VaccinesHelper
   def vaccine_heading(vaccine)
     sprintf("%s (%s)", vaccine.brand, t(vaccine.type, scope: "vaccines"))
   end
+
+  def vaccine_dose(vaccine)
+    "#{vaccine.human_enum_name(:dose)} ml"
+  end
 end

--- a/app/views/immunisation_imports/show.html.erb
+++ b/app/views/immunisation_imports/show.html.erb
@@ -44,7 +44,7 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Full name</span>
-            <%= vaccination_record.patient.full_name %>
+            <%= govuk_link_to vaccination_record.patient.full_name, vaccination_record_path(vaccination_record) %>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">NHS number</span>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -1,0 +1,11 @@
+<%= h1 @patient.full_name %>
+
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Child record" } %>
+  <%= render AppPatientDetailsComponent.new(patient: @patient, session: @session, school: @school) %>
+<% end %>
+
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Vaccination record" } %>
+  <%= render AppVaccinationRecordDetailsComponent.new(@vaccination_record) %>
+<% end %>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -55,7 +55,7 @@
         Dose
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <%= @vaccine.human_enum_name(:dose) %> ml
+        <%= vaccine_dose(@vaccine) %>
       </dd>
     </div>
     <div class="nhsuk-summary-list__row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,8 @@ Rails.application.routes.draw do
     get "/:tab", to: "errors#not_found", as: "section_tab"
   end
 
+  resources :vaccination_records, path: "vaccination-records", only: :show
+
   resources :vaccines, only: %i[index show] do
     resources :batches, only: %i[create edit new update] do
       post "make-default", on: :member, as: :make_default

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe AppVaccinationRecordDetailsComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(vaccination_record) }
+
+  let(:administered) { true }
+  let(:location) { create(:location, name: "Hogwarts") }
+  let(:session) { create(:session, location:) }
+  let(:patient_session) { create(:patient_session, session:) }
+  let(:vaccine) { create(:vaccine, :hpv) }
+  let(:batch) do
+    create(:batch, name: "ABC", expiry: Date.new(2020, 1, 1), vaccine:)
+  end
+
+  let(:vaccination_record) do
+    create(
+      :vaccination_record,
+      administered:,
+      batch:,
+      vaccine:,
+      patient_session:
+    )
+  end
+
+  describe "outcome row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Outcome\nVaccinated"
+      )
+    end
+
+    context "when not administered" do
+      let(:administered) { false }
+
+      it do
+        expect(rendered).to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Outcome\nNot vaccinated"
+        )
+      end
+    end
+  end
+
+  describe "vaccine row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Vaccine\nGardasil 9 (HPV)"
+      )
+    end
+
+    context "without a vaccine" do
+      let(:vaccine) { nil }
+      let(:batch) { nil }
+
+      it { should_not have_css(".nhsuk-summary-list__row", text: "Vaccine") }
+    end
+  end
+
+  describe "method row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Method\nIntramuscular"
+      )
+    end
+  end
+
+  describe "site row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Site\nLeft arm (upper position)"
+      )
+    end
+  end
+
+  describe "dose row" do
+    it { should have_css(".nhsuk-summary-list__row", text: "Dose\n0.5 ml") }
+
+    context "without a vaccine" do
+      let(:vaccine) { nil }
+      let(:batch) { nil }
+
+      it { should_not have_css(".nhsuk-summary-list__row", text: "Dose") }
+    end
+  end
+
+  describe "batch ID row" do
+    it { should have_css(".nhsuk-summary-list__row", text: "Batch ID\nABC") }
+
+    context "without a vaccine" do
+      let(:vaccine) { nil }
+      let(:batch) { nil }
+
+      it { should_not have_css(".nhsuk-summary-list__row", text: "Batch ID") }
+    end
+  end
+
+  describe "batch expiry date row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Batch expiry date\n1 January 2020"
+      )
+    end
+
+    context "without a vaccine" do
+      let(:vaccine) { nil }
+      let(:batch) { nil }
+
+      it do
+        expect(rendered).not_to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Batch expiry date"
+        )
+      end
+    end
+  end
+
+  describe "date and time row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Date and time\n9 June 2023 at 12:00am"
+      )
+    end
+  end
+
+  describe "nurse row" do
+    it { should have_css(".nhsuk-summary-list__row", text: "Nurse\nTest User") }
+  end
+
+  describe "location row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Location\nHogwarts"
+      )
+    end
+  end
+end

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -22,15 +22,10 @@
 
 FactoryBot.define do
   factory :batch do
-    transient do
-      random { Random.new }
-      prefix { ("A".."Z").to_a.sample(2, random:).join }
-      days_to_expiry_range { 10..50 }
-      days_to_expiry { random.rand(days_to_expiry_range) }
-    end
+    transient { prefix { Faker::Alphanumeric.alpha(number: 2).upcase } }
 
-    name { "#{prefix}#{sprintf("%04d", random.rand(10_000))}" }
-    expiry { Time.zone.today + days_to_expiry }
-    vaccine { create(:vaccine) }
+    name { "#{prefix}#{Faker::Number.number(digits: 4)}" }
+    expiry { Faker::Time.forward(days: 50) }
+    vaccine
   end
 end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
   factory :vaccination_record do
     transient { campaign { create :campaign } }
 
-    patient_session { create :patient_session, campaign: }
+    patient_session { association :patient_session, campaign: }
     recorded_at { "2023-06-09" }
     delivery_site { "left_arm_upper_position" }
     delivery_method { "intramuscular" }

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -24,6 +24,9 @@ describe "Immunisation imports" do
     then_i_should_see_the_success_banner
     and_i_should_see_the_upload
     and_i_should_see_the_vaccination_records
+
+    when_i_click_on_a_vaccination_record
+    then_i_should_see_the_vaccination_record
   end
 
   def given_i_am_signed_in
@@ -108,5 +111,17 @@ describe "Immunisation imports" do
       "Full name Chyna Pickle NHS number 742 018 0008 Date of birth 12 September 2012 " \
         "Postcode LE3 2DA Vaccinated date 14 May 2024"
     )
+  end
+
+  def when_i_click_on_a_vaccination_record
+    click_on "Chyna Pickle"
+  end
+
+  def then_i_should_see_the_vaccination_record
+    expect(page).to have_content("Chyna Pickle")
+    expect(page).to have_content("Child record")
+    expect(page).to have_content("NameChyna Pickle")
+    expect(page).to have_content("Vaccination record")
+    expect(page).to have_content("OutcomeVaccinated")
   end
 end

--- a/spec/helpers/vaccines_helper_spec.rb
+++ b/spec/helpers/vaccines_helper_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VaccinesHelper, type: :helper do
+  let(:vaccine) { create(:vaccine, :flu) }
+
+  describe "#vaccine_heading" do
+    subject(:vaccine_heading) { helper.vaccine_heading(vaccine) }
+
+    it { should eq("Fluenz Tetra (Flu)") }
+  end
+
+  describe "#vaccine_dose" do
+    subject(:vaccine_dose) { helper.vaccine_dose(vaccine) }
+
+    it { should eq("0.2 ml") }
+  end
+end


### PR DESCRIPTION
This adds a page which users can use to view the details of a particular vaccination record that may have been imported from an immunisation import.

## Screenshot

![Screenshot 2024-07-23 at 14 13 07](https://github.com/user-attachments/assets/b5e7abf0-1920-4a92-b22f-b0003ed10266)

