### PR TITLE
Do not duplicate vaccination records during import

### DIFF
--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -112,6 +112,7 @@ class ImmunisationImport < ApplicationRecord
 
       rows
         .map { [_1.to_patient_session, _1.to_vaccination_record] }
+        .reject { |_, record| record.persisted? }
         .each do |patient_session, record|
           patient_session.created_by ||= user
           patient_session.save! if patient_session.changed?
@@ -218,12 +219,14 @@ class ImmunisationImport < ApplicationRecord
     def to_vaccination_record
       return unless valid?
 
-      VaccinationRecord.new(
-        administered:,
-        delivery_site:,
-        delivery_method:,
-        recorded_at:
-      )
+      record =
+        VaccinationRecord.find_or_initialize_by(
+          administered:,
+          delivery_site:,
+          delivery_method:
+        )
+      record.recorded_at = recorded_at
+      record
     end
 
     def administered

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -113,8 +113,8 @@ class ImmunisationImport < ApplicationRecord
       rows
         .map { [_1.to_patient_session, _1.to_vaccination_record] }
         .each do |patient_session, record|
-          patient_session.created_by = user
-          patient_session.save!
+          patient_session.created_by ||= user
+          patient_session.save! if patient_session.changed?
 
           record.user = user
           record.patient_session = patient_session

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -92,11 +92,12 @@ describe ImmunisationImport, type: :model do
         .and change(immunisation_import.sessions, :count).by(4)
         .and change(PatientSession, :count).by(11)
 
-      # Second import should duplicate the vaccination records but nothing else.
+      # Second import should not duplicate the vaccination records if they're
+      # identical.
 
       # stree-ignore
       expect { immunisation_import.process! }
-        .to change(immunisation_import.vaccination_records, :count).by(11)
+        .to not_change(immunisation_import.vaccination_records, :count)
         .and not_change(immunisation_import.locations, :count)
         .and not_change(immunisation_import.patients, :count)
         .and not_change(immunisation_import.sessions, :count)


### PR DESCRIPTION
If the vaccine record is at a previously created patient session, it's in the same delivery site and using the same delivery method, it's likely the same vaccination record as before. So we should skip it.