### PR TITLE
Update vaccination record and immunsation import designs

### DIFF
--- a/app/components/app_patient_details_component.rb
+++ b/app/components/app_patient_details_component.rb
@@ -67,7 +67,7 @@ class AppPatientDetailsComponent < ViewComponent::Base
       if nhs_number.present?
         summary_list.with_row do |row|
           row.with_key { "NHS number" }
-          row.with_value(classes: ["app-u-monospace"]) { nhs_number_formatted }
+          row.with_value { helpers.format_nhs_number(nhs_number) }
         end
       end
     end
@@ -107,10 +107,6 @@ class AppPatientDetailsComponent < ViewComponent::Base
   end
 
   def nhs_number
-    @object.nhs_number if @object.respond_to? :nhs_number
-  end
-
-  def nhs_number_formatted
-    helpers.format_nhs_number(nhs_number)
+    @object.try(:nhs_number)
   end
 end

--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -46,7 +46,7 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
       if @vaccine.present?
         summary_list.with_row do |row|
           row.with_key { "Dose" }
-          row.with_value { helpers.vaccine_dose(@vaccine) }
+          row.with_value { "#{@vaccination_record.dose} ml" }
         end
       end
 

--- a/app/components/app_vaccination_record_table_component.html.erb
+++ b/app/components/app_vaccination_record_table_component.html.erb
@@ -1,0 +1,43 @@
+<div class="nhsuk-table__panel-with-heading-tab">
+  <h3 class="nhsuk-table__heading-tab">Vaccination records</h3>
+  <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
+    <% table.with_caption(text: "#{vaccination_records.count} vaccination records") %>
+
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Full name") %>
+        <% row.with_cell(text: "NHS number") %>
+        <% row.with_cell(text: "Date of birth") %>
+        <% row.with_cell(text: "Postcode") %>
+        <% row.with_cell(text: "Vaccinated date") %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% vaccination_records.each do |vaccination_record| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Full name</span>
+            <%= govuk_link_to vaccination_record.patient.full_name, campaign_vaccination_record_path(vaccination_record.campaign, vaccination_record) %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">NHS number</span>
+            <span class="app-u-monospace"><%= helpers.format_nhs_number(vaccination_record.patient.nhs_number) %></span>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Date of birth</span>
+            <%= vaccination_record.patient.date_of_birth.to_fs(:long) %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Postcode</span>
+            <%= vaccination_record.patient.address_postcode %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Vaccinated date</span>
+            <%= vaccination_record.session.date.to_fs(:long) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/app_vaccination_record_table_component.html.erb
+++ b/app/components/app_vaccination_record_table_component.html.erb
@@ -22,7 +22,7 @@
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">NHS number</span>
-            <span class="app-u-monospace"><%= helpers.format_nhs_number(vaccination_record.patient.nhs_number) %></span>
+            <%= helpers.format_nhs_number(vaccination_record.patient.nhs_number) %>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Date of birth</span>

--- a/app/components/app_vaccination_record_table_component.rb
+++ b/app/components/app_vaccination_record_table_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AppVaccinationRecordTableComponent < ViewComponent::Base
+  def initialize(vaccination_records)
+    super
+
+    @vaccination_records = vaccination_records
+  end
+
+  private
+
+  attr_reader :vaccination_records
+end

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -3,15 +3,19 @@
 class VaccinationRecordsController < ApplicationController
   def show
     @vaccination_record =
-      policy_scope(VaccinationRecord).includes(
-        :vaccine,
-        :batch,
-        patient: :location,
-        session: :location
-      ).find(params[:id])
+      policy_scope(VaccinationRecord)
+        .includes(:vaccine, :batch, patient: :location, session: :location)
+        .where(campaign:)
+        .find(params[:id])
 
     @patient = @vaccination_record.patient
     @session = @vaccination_record.session
     @school = @patient.location
+  end
+
+  private
+
+  def campaign
+    @campaign ||= policy_scope(Campaign).find(params[:campaign_id])
   end
 end

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
 class VaccinationRecordsController < ApplicationController
-  def show
-    @vaccination_record =
-      policy_scope(VaccinationRecord)
-        .includes(:vaccine, :batch, patient: :location, session: :location)
-        .where(campaign:)
-        .find(params[:id])
+  def index
+    @vaccination_records = vaccination_records
+  end
 
+  def show
+    @vaccination_record = vaccination_records.find(params[:id])
     @patient = @vaccination_record.patient
     @session = @vaccination_record.session
     @school = @patient.location
@@ -17,5 +16,15 @@ class VaccinationRecordsController < ApplicationController
 
   def campaign
     @campaign ||= policy_scope(Campaign).find(params[:campaign_id])
+  end
+
+  def vaccination_records
+    @vaccination_records ||=
+      policy_scope(VaccinationRecord).includes(
+        :vaccine,
+        :batch,
+        patient: :location,
+        session: :location
+      ).where(campaign:)
   end
 end

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module PatientHelper
-  def format_nhs_number(nhs_number)
-    nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
-  end
-end

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PatientsHelper
+  def format_nhs_number(nhs_number)
+    tag.span(class: "app-u-monospace") do
+      nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
+    end
+  end
+end

--- a/app/helpers/vaccines_helper.rb
+++ b/app/helpers/vaccines_helper.rb
@@ -4,8 +4,4 @@ module VaccinesHelper
   def vaccine_heading(vaccine)
     sprintf("%s (%s)", vaccine.brand, t(vaccine.type, scope: "vaccines"))
   end
-
-  def vaccine_dose(vaccine)
-    "#{vaccine.human_enum_name(:dose)} ml"
-  end
 end

--- a/app/views/campaigns/sessions.html.erb
+++ b/app/views/campaigns/sessions.html.erb
@@ -3,8 +3,8 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
+                                          { text: @campaign.name, href: campaign_path(@campaign) },
                                         ]) %>
 <% end %>
 
@@ -19,11 +19,11 @@
         selected: true,
       )
       nav.with_item(
-        text: "Vaccination records",
+        text: t("vaccination_records.index.title"),
         href: campaign_vaccination_records_path(@campaign),
       )
       nav.with_item(
-        text: "Uploads",
+        text: t("immunisation_imports.index.title"),
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>

--- a/app/views/campaigns/sessions.html.erb
+++ b/app/views/campaigns/sessions.html.erb
@@ -19,7 +19,7 @@
         selected: true,
       )
       nav.with_item(
-        text: "Uploaded reports",
+        text: "Uploads",
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>

--- a/app/views/campaigns/sessions.html.erb
+++ b/app/views/campaigns/sessions.html.erb
@@ -19,6 +19,10 @@
         selected: true,
       )
       nav.with_item(
+        text: "Vaccination records",
+        href: campaign_vaccination_records_path(@campaign),
+      )
+      nav.with_item(
         text: "Uploads",
         href: campaign_immunisation_imports_path(@campaign),
       )

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -19,9 +19,9 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Uploaded reports",
+        text: "Uploads",
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>
 
-<%= govuk_link_to "Download immunisation report (CSV)", download_campaign_reports_path(@campaign), class: "nhsuk-button" %>
+<%= govuk_link_to "Download vaccination report (CSV)", download_campaign_reports_path(@campaign), class: "nhsuk-button" %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -3,7 +3,6 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
                                         ]) %>
 <% end %>
@@ -19,11 +18,11 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Vaccination records",
+        text: t("vaccination_records.index.title"),
         href: campaign_vaccination_records_path(@campaign),
       )
       nav.with_item(
-        text: "Uploads",
+        text: t("immunisation_imports.index.title"),
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>

--- a/app/views/immunisation_imports/_breadcrumbs.html.erb
+++ b/app/views/immunisation_imports/_breadcrumbs.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
-                                          { text: @campaign.name, href: campaign_immunisation_imports_path(@campaign) },
+                                          { text: @campaign.name, href: campaign_path(@campaign) },
+                                          { text: t("immunisation_imports.index.title"), href: campaign_immunisation_imports_path(@campaign) },
                                         ]) %>
 <% end %>

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -1,9 +1,9 @@
-<%= h1 @campaign.name, page_title: "#{@campaign.name} – Uploads" %>
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – #{t("immunisation_imports.index.title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
+                                          { text: @campaign.name, href: campaign_path(@campaign) },
                                         ]) %>
 <% end %>
 
@@ -17,11 +17,11 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Vaccination records",
+        text: t("vaccination_records.index.title"),
         href: campaign_vaccination_records_path(@campaign),
       )
       nav.with_item(
-        text: "Uploads",
+        text: t("immunisation_imports.index.title"),
         href: campaign_immunisation_imports_path(@campaign),
         selected: true,
       )

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -17,6 +17,10 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
+        text: "Vaccination records",
+        href: campaign_vaccination_records_path(@campaign),
+      )
+      nav.with_item(
         text: "Uploads",
         href: campaign_immunisation_imports_path(@campaign),
         selected: true,

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -1,4 +1,4 @@
-<%= h1 @campaign.name, page_title: "#{@campaign.name} – Uploaded reports" %>
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – Uploads" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
@@ -17,15 +17,17 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Uploaded reports",
+        text: "Uploads",
         href: campaign_immunisation_imports_path(@campaign),
         selected: true,
       )
     end %>
 
-<%= govuk_link_to "Upload a new vaccination report", new_campaign_immunisation_import_path, class: "nhsuk-button nhsuk-u-margin-0" %>
+<%= govuk_link_to "Upload new vaccination records", new_campaign_immunisation_import_path, class: "nhsuk-button nhsuk-u-margin-0" %>
 
 <div class="nhsuk-table__panel-with-heading-tab">
+  <h3 class="nhsuk-table__heading-tab">Uploads</h3>
+
   <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>

--- a/app/views/immunisation_imports/new.html.erb
+++ b/app/views/immunisation_imports/new.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <% title = "Upload a report on #{@campaign.name} vaccinations" %>
-<% hint = "This will go to NHS England. Make sure the CSV you upload has the same format as your usual reporting template." %>
+<% hint = "This will go to NHS England and GPs. Make sure the CSV you upload has the same format as your usual reporting template." %>
 
 <% content_for :page_title, title %>
 

--- a/app/views/immunisation_imports/show.html.erb
+++ b/app/views/immunisation_imports/show.html.erb
@@ -44,7 +44,7 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Full name</span>
-            <%= govuk_link_to vaccination_record.patient.full_name, vaccination_record_path(vaccination_record) %>
+            <%= govuk_link_to vaccination_record.patient.full_name, campaign_vaccination_record_path(@campaign, vaccination_record) %>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">NHS number</span>

--- a/app/views/immunisation_imports/show.html.erb
+++ b/app/views/immunisation_imports/show.html.erb
@@ -26,44 +26,4 @@
   <% end %>
 <% end %>
 
-<div class="nhsuk-table__panel-with-heading-tab">
-  <h3 class="nhsuk-table__heading-tab">Records</h3>
-  <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
-    <% table.with_head do |head| %>
-      <% head.with_row do |row| %>
-        <% row.with_cell(text: "Full name") %>
-        <% row.with_cell(text: "NHS number") %>
-        <% row.with_cell(text: "Date of birth") %>
-        <% row.with_cell(text: "Postcode") %>
-        <% row.with_cell(text: "Vaccinated date") %>
-      <% end %>
-    <% end %>
-
-    <% table.with_body do |body| %>
-      <% @vaccination_records.each do |vaccination_record| %>
-        <% body.with_row do |row| %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Full name</span>
-            <%= govuk_link_to vaccination_record.patient.full_name, campaign_vaccination_record_path(@campaign, vaccination_record) %>
-          <% end %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">NHS number</span>
-            <span class="app-u-monospace"><%= format_nhs_number(vaccination_record.patient.nhs_number) %></span>
-          <% end %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Date of birth</span>
-            <%= vaccination_record.patient.date_of_birth.to_fs(:long) %>
-          <% end %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Postcode</span>
-            <%= vaccination_record.patient.address_postcode %>
-          <% end %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Vaccinated date</span>
-            <%= vaccination_record.session.date.to_fs(:long) %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
-  <% end %>
-</div>
+<%= render AppVaccinationRecordTableComponent.new(@vaccination_records) %>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -1,11 +1,11 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
+                                          { text: @campaign.name, href: campaign_path(@campaign) },
                                         ]) %>
 <% end %>
 
-<%= h1 @campaign.name, page_title: "#{@campaign.name} – Vaccination records" %>
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – #{t("vaccination_records.index.title")}" %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
@@ -17,12 +17,12 @@
         href: sessions_campaign_path(@campaign),
       )
       nav.with_item(
-        text: "Vaccination records",
+        text: t("vaccination_records.index.title"),
         href: campaign_vaccination_records_path(@campaign),
         selected: true,
       )
       nav.with_item(
-        text: "Uploads",
+        text: t("immunisation_imports.index.title"),
         href: campaign_immunisation_imports_path(@campaign),
       )
     end %>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -1,6 +1,3 @@
-<%= h1 @campaign.name, page_title: "#{@campaign.name} – Overview",
-                      size: "l" %>
-
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
@@ -8,11 +5,12 @@
                                         ]) %>
 <% end %>
 
+<%= h1 @campaign.name, page_title: "#{@campaign.name} – Vaccination records" %>
+
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
         text: "Overview",
         href: campaign_path(@campaign),
-        selected: true,
       )
       nav.with_item(
         text: "School sessions",
@@ -21,6 +19,7 @@
       nav.with_item(
         text: "Vaccination records",
         href: campaign_vaccination_records_path(@campaign),
+        selected: true,
       )
       nav.with_item(
         text: "Uploads",
@@ -28,4 +27,4 @@
       )
     end %>
 
-<%= govuk_link_to "Download vaccination report (CSV)", download_campaign_reports_path(@campaign), class: "nhsuk-button" %>
+<%= render AppVaccinationRecordTableComponent.new(@vaccination_records) %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
-                                          { text: @campaign.name, href: campaign_path(@campaign) },
+                                          { text: @campaign.name, href: campaign_vaccination_records_path(@campaign) },
                                         ]) %>
 <% end %>
 

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -1,3 +1,11 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: dashboard_path },
+                                          { text: t("campaigns.index.title"), href: campaigns_path },
+                                          { text: @campaign.name, href: campaign_path(@campaign) },
+                                        ]) %>
+<% end %>
+
 <%= h1 @patient.full_name %>
 
 <%= render AppCardComponent.new do |c| %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
                                           { text: t("campaigns.index.title"), href: campaigns_path },
                                           { text: @campaign.name, href: campaign_vaccination_records_path(@campaign) },
+                                          { text: t("vaccination_records.index.title"), href: campaign_vaccination_records_path(@campaign) },
                                         ]) %>
 <% end %>
 

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -55,7 +55,7 @@
         Dose
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <%= vaccine_dose(@vaccine) %>
+        <%= @vaccine.dose %> ml
       </dd>
     </div>
     <div class="nhsuk-summary-list__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,6 +481,9 @@ en:
         other: Why are they refusing to give consent?
         personal_choice: Why are they refusing to give consent?
         will_be_vaccinated_elsewhere: Where will their child get their vaccination?
+  immunisation_imports:
+    index:
+      title: Uploads
   mailers:
     consent_form_mailer:
       reasons_for_refusal:
@@ -555,6 +558,9 @@ en:
   table:
     no_filtered_results: We couldn’t find any children that matched your filters.
     no_results: No results
+  vaccination_records:
+    index:
+      title: Vaccination records
   vaccinations:
     reason:
       title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
     get "sessions", on: :member
 
     resources :immunisation_imports,
-              path: "/immunisation-imports",
+              path: "immunisation-imports",
               only: %i[index new create show]
 
     resources :reports, only: [] do
@@ -75,6 +75,8 @@ Rails.application.routes.draw do
       post "dps-export", on: :collection
       post "dps-export-reset", on: :collection
     end
+
+    resources :vaccination_records, path: "vaccination-records", only: :show
   end
 
   resources :sessions, only: %i[create edit index show] do
@@ -197,8 +199,6 @@ Rails.application.routes.draw do
     get "/", to: "errors#not_found", as: "section"
     get "/:tab", to: "errors#not_found", as: "section_tab"
   end
-
-  resources :vaccination_records, path: "vaccination-records", only: :show
 
   resources :vaccines, only: %i[index show] do
     resources :batches, only: %i[create edit new update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,9 @@ Rails.application.routes.draw do
       post "dps-export-reset", on: :collection
     end
 
-    resources :vaccination_records, path: "vaccination-records", only: :show
+    resources :vaccination_records,
+              path: "vaccination-records",
+              only: %i[index show]
   end
 
   resources :sessions, only: %i[create edit index show] do

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe AppVaccinationRecordTableComponent, type: :component do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(vaccination_records) }
+
+  let(:vaccination_records) do
+    [
+      create(
+        :vaccination_record,
+        patient_attributes: {
+          first_name: "John",
+          last_name: "Smith",
+          nhs_number: "9999999999",
+          date_of_birth: Date.new(2000, 5, 28),
+          address_postcode: "SW1A 2AA"
+        },
+        session_attributes: {
+          date: Date.new(2020, 1, 1)
+        }
+      )
+    ] + create_list(:vaccination_record, 9)
+  end
+
+  it "renders a heading tab" do
+    expect(rendered).to have_css(
+      ".nhsuk-table__heading-tab",
+      text: "Vaccination records"
+    )
+  end
+
+  it "renders a caption" do
+    expect(rendered).to have_css(
+      ".nhsuk-table__caption",
+      text: "10 vaccination records"
+    )
+  end
+
+  it "renders the headers" do
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Full name")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "NHS number")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Date of birth")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Postcode")
+    expect(rendered).to have_css(
+      ".nhsuk-table__header",
+      text: "Vaccinated date"
+    )
+  end
+
+  it "renders the rows" do
+    expect(rendered).to have_css(
+      ".nhsuk-table__body .nhsuk-table__row",
+      count: 10
+    )
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "John Smith")
+    expect(rendered).to have_link("John Smith")
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "999 999 9999")
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "SW1A 2AA")
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "28 May 2000")
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "1 January 2020")
+  end
+end

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -45,15 +45,15 @@ describe "Immunisation imports" do
 
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
-    click_on "Uploaded reports"
+    click_on "Uploads"
   end
 
   def then_i_should_see_the_upload_link
-    expect(page).to have_link("Upload a new vaccination report")
+    expect(page).to have_link("Upload new vaccination records")
   end
 
   def when_i_click_on_the_upload_link
-    click_on "Upload a new vaccination report"
+    click_on "Upload new vaccination records"
   end
 
   def then_i_should_see_the_upload_page

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -122,6 +122,7 @@ describe "Immunisation imports" do
 
   def when_i_click_on_vaccination_records
     click_on "HPV"
+    click_on "Vaccination records"
   end
 
   def then_i_should_see_the_vaccination_record

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "Immunisation imports" do
-  scenario "User uploads a file" do
+  scenario "User uploads a file and views vaccination records" do
     given_i_am_signed_in
     and_an_hpv_campaign_is_underway
 
@@ -27,6 +27,9 @@ describe "Immunisation imports" do
 
     when_i_click_on_a_vaccination_record
     then_i_should_see_the_vaccination_record
+
+    when_i_click_on_vaccination_records
+    and_i_should_see_the_vaccination_records
   end
 
   def given_i_am_signed_in
@@ -115,6 +118,10 @@ describe "Immunisation imports" do
 
   def when_i_click_on_a_vaccination_record
     click_on "Chyna Pickle"
+  end
+
+  def when_i_click_on_vaccination_records
+    click_on "HPV"
   end
 
   def then_i_should_see_the_vaccination_record

--- a/spec/features/nivs_hpv_report_spec.rb
+++ b/spec/features/nivs_hpv_report_spec.rb
@@ -47,7 +47,7 @@ describe "NIVS HPV report" do
   end
 
   def and_i_download_the_nivs_hpv_report
-    click_on "Download immunisation report (CSV)"
+    click_on "Download vaccination report (CSV)"
   end
 
   def then_i_should_see_all_the_administered_vaccinations_from_my_teams_hpv_campaign

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -2,14 +2,14 @@
 
 require "rails_helper"
 
-RSpec.describe PatientHelper do
+RSpec.describe PatientsHelper, type: :helper do
   describe "#format_nhs_number" do
     subject(:formatted_nhs_number) { helper.format_nhs_number(nhs_number) }
 
     let(:nhs_number) { "0123456789" }
 
-    it "adds spaces in the right place" do
-      expect(formatted_nhs_number).to eq("012 345 6789")
-    end
+    it { should be_html_safe }
+
+    it { should eq("<span class=\"app-u-monospace\">012 345 6789</span>") }
   end
 end

--- a/spec/helpers/vaccines_helper_spec.rb
+++ b/spec/helpers/vaccines_helper_spec.rb
@@ -10,10 +10,4 @@ RSpec.describe VaccinesHelper, type: :helper do
 
     it { should eq("Fluenz Tetra (Flu)") }
   end
-
-  describe "#vaccine_dose" do
-    subject(:vaccine_dose) { helper.vaccine_dose(vaccine) }
-
-    it { should eq("0.2 ml") }
-  end
 end


### PR DESCRIPTION
This improves various pages related to vaccination records, immunisation imports and campaigns to match the latest designs in the prototype. See individual commits for more details.

## Screenshots

<img width="1139" alt="Screenshot 2024-07-25 at 11 37 33" src="https://github.com/user-attachments/assets/0291d33f-fa8f-4a15-9704-648b3a55a939">
<img width="627" alt="Screenshot 2024-07-25 at 11 37 28" src="https://github.com/user-attachments/assets/61d3ab5f-5ca1-4308-b9db-312e99ee9a62">
<img width="643" alt="Screenshot 2024-07-25 at 11 37 24" src="https://github.com/user-attachments/assets/b49cd500-a617-4552-8d36-0a05accb52b4">
