### PR TITLE
Add location code to DPS export

### DIFF
--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -38,10 +38,8 @@ class DPSExportRow
     "location_code_type_uri" #            33
   ].freeze
 
-  attr_reader :vaccination
-
-  def initialize(vaccination)
-    @vaccination = vaccination
+  def initialize(vaccination_record)
+    @vaccination_record = vaccination_record
   end
 
   def to_a
@@ -50,36 +48,46 @@ class DPSExportRow
 
   private
 
+  attr_reader :vaccination_record
+
+  delegate :batch,
+           :campaign,
+           :delivery_site,
+           :patient,
+           :user,
+           :vaccine,
+           to: :vaccination_record
+
   def nhs_number
-    vaccination.patient.nhs_number
+    patient.nhs_number
   end
 
   def person_forename
-    vaccination.patient.first_name
+    patient.first_name
   end
 
   def person_surname
-    vaccination.patient.last_name
+    patient.last_name
   end
 
   def person_dob
-    vaccination.patient.date_of_birth.to_fs(:dps)
+    patient.date_of_birth.to_fs(:dps)
   end
 
   def person_gender_code
-    vaccination.patient.gender_code_before_type_cast
+    patient.gender_code_before_type_cast
   end
 
   def person_postcode
-    vaccination.patient.address_postcode
+    patient.address_postcode
   end
 
   def date_and_time
-    vaccination.recorded_at.strftime("%Y%m%dT%H%M%S00")
+    vaccination_record.recorded_at.strftime("%Y%m%dT%H%M%S00")
   end
 
   def site_code
-    vaccination.campaign.team.ods_code
+    campaign.team.ods_code
   end
 
   def site_code_type_uri
@@ -97,15 +105,15 @@ class DPSExportRow
   end
 
   def performing_professional_forename
-    vaccination&.user&.full_name&.split(" ", 2)&.first
+    user&.full_name&.split(" ", 2)&.first
   end
 
   def performing_professional_surname
-    vaccination&.user&.full_name&.split(" ", 2)&.last
+    user&.full_name&.split(" ", 2)&.last
   end
 
   def recorded_date
-    vaccination.created_at.to_date.to_fs(:dps)
+    vaccination_record.created_at.to_date.to_fs(:dps)
   end
 
   def primary_source
@@ -113,50 +121,50 @@ class DPSExportRow
   end
 
   def vaccination_procedure_code
-    vaccination.vaccine.snomed_procedure_code_and_term.first
+    vaccine.snomed_procedure_code_and_term.first
   end
 
   def vaccination_procedure_term
-    vaccination.vaccine.snomed_procedure_code_and_term.last
+    vaccine.snomed_procedure_code_and_term.last
   end
 
   def dose_sequence
   end
 
   def vaccine_product_code
-    vaccination.vaccine.snomed_product_code
+    vaccine.snomed_product_code
   end
 
   def vaccine_product_term
-    vaccination.vaccine.snomed_product_term
+    vaccine.snomed_product_term
   end
 
   def vaccine_manufacturer
-    vaccination.vaccine.supplier
+    vaccine.supplier
   end
 
   def batch_number
-    vaccination.batch.name
+    batch.name
   end
 
   def expiry_date
-    vaccination.batch.expiry.to_fs(:dps)
+    vaccination_record.batch.expiry.to_fs(:dps)
   end
 
   def route_of_vaccination_code
     VaccinationRecord::DELIVERY_METHOD_SNOMED_CODES_AND_TERMS[
-      vaccination.delivery_method
+      vaccination_record.delivery_method
     ].first
   end
 
   def route_of_vaccination_term
     VaccinationRecord::DELIVERY_METHOD_SNOMED_CODES_AND_TERMS[
-      vaccination.delivery_method
+      vaccination_record.delivery_method
     ].last
   end
 
   def dose_amount
-    vaccination.dose
+    vaccination_record.dose
   end
 
   def dose_unit_code
@@ -179,13 +187,13 @@ class DPSExportRow
 
   def site_of_vaccination_code
     VaccinationRecord::DELIVERY_SITE_SNOMED_CODES_AND_TERMS[
-      vaccination.delivery_site
+      vaccination_record.delivery_site
     ].first
   end
 
   def site_of_vaccination_term
     VaccinationRecord::DELIVERY_SITE_SNOMED_CODES_AND_TERMS[
-      vaccination.delivery_site
+      vaccination_record.delivery_site
     ].last
   end
 end

--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -53,6 +53,7 @@ class DPSExportRow
   delegate :batch,
            :campaign,
            :delivery_site,
+           :location,
            :patient,
            :user,
            :vaccine,
@@ -180,6 +181,7 @@ class DPSExportRow
   end
 
   def location_code
+    location&.urn.presence || campaign.team.ods_code
   end
 
   def location_code_type_uri

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -28,7 +28,7 @@ describe TriageMailerConcern do
 
     context "when the parents agree, triage is required and it is safe to vaccinate" do
       let(:patient_session) do
-        build(:patient_session, :triaged_ready_to_vaccinate)
+        create(:patient_session, :triaged_ready_to_vaccinate)
       end
 
       it "sends an email saying triage was needed and vaccination will happen" do
@@ -41,7 +41,7 @@ describe TriageMailerConcern do
 
     context "when the parents agree, triage is required but it isn't safe to vaccinate" do
       let(:patient_session) do
-        build(:patient_session, :triaged_do_not_vaccinate)
+        create(:patient_session, :triaged_do_not_vaccinate)
       end
 
       it "sends an email saying triage was needed but vaccination won't happen" do
@@ -54,7 +54,7 @@ describe TriageMailerConcern do
 
     context "when the parents agree and triage is not required" do
       let(:patient_session) do
-        build(:patient_session, :consent_given_triage_not_needed)
+        create(:patient_session, :consent_given_triage_not_needed)
       end
 
       it "sends an email saying vaccination will happen" do
@@ -67,7 +67,7 @@ describe TriageMailerConcern do
 
     context "when the parents agree, triage is required and a decision hasn't been made" do
       let(:patient_session) do
-        build(:patient_session, :consent_given_triage_needed)
+        create(:patient_session, :consent_given_triage_needed)
       end
 
       it "sends an email saying triage is required" do
@@ -78,7 +78,7 @@ describe TriageMailerConcern do
     end
 
     context "when the parents have verbally refused consent" do
-      let(:patient_session) { build(:patient_session, :consent_refused) }
+      let(:patient_session) { create(:patient_session, :consent_refused) }
 
       it "sends an email confirming they've refused consent" do
         expect(ConsentFormMailer).to have_received(:confirmation_refused).with(

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -28,10 +28,11 @@ FactoryBot.define do
       campaign { create :campaign }
       user { create :user }
       patient_attributes { {} }
+      session_attributes { {} }
     end
 
-    patient { create :patient, session:, **patient_attributes }
-    session { create(:session, campaign:) }
+    session { association :session, campaign:, **session_attributes }
+    patient { association :patient, session:, **patient_attributes }
     created_by { user }
 
     trait :added_to_session do

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -41,10 +41,14 @@ FactoryBot.define do
     transient do
       campaign { create :campaign }
       patient_attributes { {} }
+      session_attributes { {} }
     end
 
     patient_session do
-      association :patient_session, campaign:, patient_attributes:
+      association :patient_session,
+                  campaign:,
+                  patient_attributes:,
+                  session_attributes:
     end
     recorded_at { "2023-06-09" }
     delivery_site { "left_arm_upper_position" }

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -6,13 +6,16 @@ require "csv"
 describe DPSExportRow do
   subject(:row) { described_class.new(vaccination_record) }
 
-  let(:vaccine) { create :vaccine, :gardasil_9, dose: 0.5 }
-  let(:patient) { create :patient, date_of_birth: "2012-12-29" }
+  let(:team) { create(:team) }
+  let(:campaign) { create(:campaign, team:) }
+  let(:vaccine) { create(:vaccine, :gardasil_9, dose: 0.5) }
+  let(:location) { create(:location) }
   let(:vaccination_record) do
     create(
       :vaccination_record,
       vaccine:,
       batch: create(:batch, vaccine:, name: "AB1234", expiry: "2025-07-01"),
+      campaign:,
       delivery_site: :left_arm_upper_position,
       delivery_method: :intramuscular,
       recorded_at: Time.zone.local(2024, 7, 23, 19, 31, 47),
@@ -20,6 +23,9 @@ describe DPSExportRow do
       user: create(:user, full_name: "Jane Doe"),
       patient_attributes: {
         date_of_birth: "2012-12-29"
+      },
+      session_attributes: {
+        location:
       }
     )
   end
@@ -174,6 +180,25 @@ describe DPSExportRow do
 
     it "has indication_code" do
       expect(array[31]).to be_nil
+    end
+
+    describe "location_code" do
+      subject(:location_code) { array[32] }
+
+      it { should_not be_nil }
+
+      context "when the session has a location" do
+        let(:location) { create(:location, urn: "12345") }
+
+        it { should eq("12345") }
+      end
+
+      context "when the session doesn't have a location" do
+        let(:location) { nil }
+        let(:team) { create(:team, ods_code: "ABC") }
+
+        it { should eq("ABC") }
+      end
     end
   end
 end


### PR DESCRIPTION
This ensures that the location code is included as part of the DPS export, either coming from the URN of the location itself or if that's not available, the ODS code of the team running the campaign.

I've also done a small refactor in the first commit that can be reviewed separately.