### PR TITLE
Add location code type URI to DPS export

### DIFF
--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -185,6 +185,11 @@ class DPSExportRow
   end
 
   def location_code_type_uri
+    if location&.urn.present?
+      "https://fhir.hl7.org.uk/Id/urn-school-number"
+    else
+      "https://fhir.nhs.uk/Id/ods-organization-code"
+    end
   end
 
   def site_of_vaccination_code

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -200,5 +200,23 @@ describe DPSExportRow do
         it { should eq("ABC") }
       end
     end
+
+    describe "location_code_type_uri" do
+      subject(:location_code_type_uri) { array[33] }
+
+      it { should_not be_nil }
+
+      context "when the session has a location" do
+        let(:location) { create(:location) }
+
+        it { should eq("https://fhir.hl7.org.uk/Id/urn-school-number") }
+      end
+
+      context "when the session doesn't have a location" do
+        let(:location) { nil }
+
+        it { should eq("https://fhir.nhs.uk/Id/ods-organization-code") }
+      end
+    end
   end
 end


### PR DESCRIPTION
This ensures that the location code type URI is included as part of the DPS export, either created from the URN of the location itself or if that's not available, the ODS code of the team running the campaign.

I've also done a small refactor in the first commit that can be reviewed separately.