### PR TITLE
Update primary_source value to 'TRUE' in DPS Export

### DIFF
--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -117,8 +117,9 @@ class DPSExportRow
     vaccination_record.created_at.to_date.to_fs(:dps)
   end
 
+  # needs to equal 'true' as the record is coming from the organisation that is administering the vaccine
   def primary_source
-    "FALSE"
+    "TRUE"
   end
 
   def vaccination_procedure_code
@@ -177,7 +178,7 @@ class DPSExportRow
   end
 
   def indication_code
-    # is not required if PRIMARY_SOURCE is FALSE
+    # is not required
   end
 
   def location_code

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -88,7 +88,7 @@ describe DPSExportRow do
     end
 
     it "has primary_source" do
-      expect(array[15]).to eq "FALSE"
+      expect(array[15]).to eq "TRUE"
     end
 
     it "has vaccination_procedure_code" do


### PR DESCRIPTION
The primary_source value in DPSExportRow is updated to 'TRUE' to reflect that the record is coming from the organisation administering the vaccine.