### PR TITLE
Handle variations in gender code column name

### DIFF
--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -36,14 +36,13 @@ class ImmunisationImport < ApplicationRecord
     has_many :patients
   end
 
-  EXPECTED_HEADERS = %w[
+  REQUIRED_HEADERS = %w[
     ANATOMICAL_SITE
     DATE_OF_VACCINATION
     NHS_NUMBER
     ORGANISATION_CODE
     PERSON_DOB
     PERSON_FORENAME
-    PERSON_GENDER_CODE
     PERSON_POSTCODE
     PERSON_SURNAME
     REASON_NOT_VACCINATED
@@ -327,7 +326,8 @@ class ImmunisationImport < ApplicationRecord
     }.freeze
 
     def patient_gender_code
-      PATIENT_GENDER_CODES[@data["PERSON_GENDER_CODE"]&.strip&.downcase]
+      gender_code = @data["PERSON_GENDER_CODE"] || @data["PERSON_GENDER"]
+      PATIENT_GENDER_CODES[gender_code&.strip&.downcase]
     end
 
     def patient_postcode
@@ -376,7 +376,7 @@ class ImmunisationImport < ApplicationRecord
   def headers_are_valid
     return unless data
 
-    missing_headers = EXPECTED_HEADERS - data.headers
+    missing_headers = REQUIRED_HEADERS - data.headers
     errors.add(:csv, :missing_headers, missing_headers:) if missing_headers.any?
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -289,35 +289,40 @@ describe ImmunisationImport::Row, type: :model do
       it { should be_nil }
     end
 
-    context "with an unknown value" do
-      let(:data) { { "PERSON_GENDER_CODE" => "unknown" } }
+    shared_examples "with a value" do |key|
+      context "with an unknown value" do
+        let(:data) { { key => "unknown" } }
 
-      it { should be_nil }
+        it { should be_nil }
+      end
+
+      context "with a 'not known' value" do
+        let(:data) { { key => "Not Known" } }
+
+        it { should eq(0) }
+      end
+
+      context "with a 'male' value" do
+        let(:data) { { key => "Male" } }
+
+        it { should eq(1) }
+      end
+
+      context "with a 'female' value" do
+        let(:data) { { key => "Female" } }
+
+        it { should eq(2) }
+      end
+
+      context "with a 'not specified' value" do
+        let(:data) { { key => "Not Specified" } }
+
+        it { should eq(9) }
+      end
     end
 
-    context "with a 'not known' value" do
-      let(:data) { { "PERSON_GENDER_CODE" => "Not Known" } }
-
-      it { should eq(0) }
-    end
-
-    context "with a 'male' value" do
-      let(:data) { { "PERSON_GENDER_CODE" => "Male" } }
-
-      it { should eq(1) }
-    end
-
-    context "with a 'female' value" do
-      let(:data) { { "PERSON_GENDER_CODE" => "Female" } }
-
-      it { should eq(2) }
-    end
-
-    context "with a 'not specified' value" do
-      let(:data) { { "PERSON_GENDER_CODE" => "Not Specified" } }
-
-      it { should eq(9) }
-    end
+    include_examples "with a value", "PERSON_GENDER_CODE"
+    include_examples "with a value", "PERSON_GENDER"
   end
 
   describe "#patient_postcode" do


### PR DESCRIPTION
We expect that some import CSV will use the column `GENDER_CODE` and some will use `GENDER` so we need to update the importer to handle both.

I've also removed this column from the required columns validation as it could be either. This will still raise a row-level validation error on the gender if neither column exists, but we might want to improve the header validation in the future to handle optional values.