### PR TITLE
Import dose sequence from HPV files

### DIFF
--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -91,13 +91,13 @@ describe "Immunisation imports" do
   def when_i_upload_a_valid_file
     attach_file(
       "immunisation_import[csv]",
-      "spec/fixtures/immunisation_import/valid_flu.csv"
+      "spec/fixtures/immunisation_import/valid_hpv.csv"
     )
     click_on "Continue"
   end
 
   def then_i_should_see_the_success_banner
-    expect(page).to have_content("11 vaccinations uploaded")
+    expect(page).to have_content("7 vaccinations uploaded")
   end
 
   def and_i_should_see_the_upload

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -134,7 +134,20 @@ describe ImmunisationImportRow, type: :model do
       end
     end
 
-    context "with valid fields" do
+    context "with an invalid dose sequence" do
+      let(:data) { { "DOSE_SEQUENCE" => "4" } }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:dose_sequence]).to include(
+          /must be less than/
+        )
+      end
+    end
+
+    context "with valid fields for Flu" do
+      let(:campaign) { create(:campaign, :flu) }
+
       let(:data) do
         {
           "ORGANISATION_CODE" => "abc",
@@ -177,7 +190,8 @@ describe ImmunisationImportRow, type: :model do
         "PERSON_POSTCODE" => address_postcode,
         "PERSON_GENDER_CODE" => "Male",
         "NHS_NUMBER" => nhs_number,
-        "DATE_OF_VACCINATION" => "20240101"
+        "DATE_OF_VACCINATION" => "20240101",
+        "DOSE_SEQUENCE" => "1"
       }
     end
 
@@ -385,6 +399,28 @@ describe ImmunisationImportRow, type: :model do
       let(:data) { { "ANATOMICAL_SITE" => "other" } }
 
       it { should be_nil }
+    end
+  end
+
+  describe "#dose_sequence" do
+    subject(:dose_sequence) { immunisation_import_row.dose_sequence }
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with an invalid value" do
+      let(:data) { { "DOSE_SEQUENCE" => "abc" } }
+
+      it { should be_nil }
+    end
+
+    context "with a valid value" do
+      let(:data) { { "DOSE_SEQUENCE" => "1" } }
+
+      it { should eq(1) }
     end
   end
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -24,8 +24,11 @@
 require "rails_helper"
 
 describe ImmunisationImport, type: :model do
-  subject(:immunisation_import) { create(:immunisation_import, csv:, user:) }
+  subject(:immunisation_import) do
+    create(:immunisation_import, campaign:, csv:, user:)
+  end
 
+  let(:campaign) { create(:campaign) }
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
   let(:team) { create(:team, ods_code: "R1L") }
@@ -68,6 +71,7 @@ describe ImmunisationImport, type: :model do
     before { immunisation_import.parse_rows! }
 
     context "with valid Flu rows" do
+      let(:campaign) { create(:campaign, :flu) }
       let(:file) { "valid_flu.csv" }
 
       it "populates the rows" do
@@ -77,6 +81,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with valid HPV rows" do
+      let(:campaign) { create(:campaign, :hpv) }
       let(:file) { "valid_hpv.csv" }
 
       it "populates the rows" do
@@ -99,6 +104,7 @@ describe ImmunisationImport, type: :model do
     subject(:process!) { immunisation_import.process! }
 
     context "with valid Flu rows" do
+      let(:campaign) { create(:campaign, :flu) }
       let(:file) { "valid_flu.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -124,6 +130,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with valid HPV rows" do
+      let(:campaign) { create(:campaign, :hpv) }
       let(:file) { "valid_hpv.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -149,6 +156,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with an existing patient matching the name" do
+      let(:campaign) { create(:campaign, :flu) }
       let(:file) { "valid_flu.csv" }
 
       let!(:patient) do


### PR DESCRIPTION
For HPV, it's valid to have a dose sequence and therefore we need to ensure that it's imported correctly. This is an optional field, as Flu files won't contain a dose sequence.

To determine whether we need to import the dose sequence or not we use the maximum dose sequence on the vaccine.

This depends on the vaccine being imported, which hasn't yet been implemented.