### PR TITLE
Fix Sass deprecation for nested rules

### DIFF
--- a/app/assets/stylesheets/_button-group.scss
+++ b/app/assets/stylesheets/_button-group.scss
@@ -7,32 +7,10 @@
   flex-wrap: wrap;
   gap: nhsuk-spacing(3) nhsuk-spacing(4);
 
-  .nhsuk-link {
-    @include nhsuk-font($size: 19, $line-height: 19px);
-    display: inline-block;
-    margin-bottom: nhsuk-spacing(2);
-    margin-top: nhsuk-spacing(2);
-    max-width: 100%;
-    text-align: center;
-  }
-
-  .nhsuk-button {
-    margin-bottom: 0;
-    width: 100%;
-  }
-
   @include mq($from: tablet) {
     align-items: baseline;
     flex-direction: row;
     flex-wrap: wrap;
-
-    .nhsuk-button {
-      width: auto;
-    }
-
-    .nhsuk-link {
-      text-align: left;
-    }
   }
 
   &--table {
@@ -53,5 +31,27 @@
     @include mq($from: desktop) {
       flex-wrap: nowrap;
     }
+  }
+}
+
+.app-button-group .nhsuk-link {
+  @include nhsuk-font($size: 19, $line-height: 19px);
+  display: inline-block;
+  margin-bottom: nhsuk-spacing(2);
+  margin-top: nhsuk-spacing(2);
+  max-width: 100%;
+  text-align: center;
+
+  @include mq($from: tablet) {
+    text-align: left;
+  }
+}
+
+.app-button-group .nhsuk-button {
+  margin-bottom: 0;
+  width: 100%;
+
+  @include mq($from: tablet) {
+    width: auto;
   }
 }


### PR DESCRIPTION
Fix nested rules for button group styles to address the following Sass deprecation notice:

> DEPRECATION WARNING: Sass's behavior for declarations that appear after nested
> rules will be changing to match the behavior specified by CSS in an upcoming
> version. To keep the existing behavior, move the declaration above the nested
> rule. To opt into the new behavior, wrap the declaration in `& {}`.
>
> More info: https://sass-lang.com/d/mixed-decls