### PR TITLE
Import vaccines from NIVS spreadsheets

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -56,7 +56,14 @@ class PatientSession < ApplicationRecord
   end
 
   def draft_vaccination_record
-    vaccination_records.draft.find_or_initialize_by(recorded_at: nil)
+    # HACK: this code will need to be revisited in future as it only really works for HPV, where we only have one
+    # vaccine. It is likely to fail for the Doubles programme as that has 2 vaccines. It is also likely to fail for
+    # the flu programme for the SAIS teams that offer both nasal and injectable vaccines.
+    vaccine = campaign&.vaccines&.first
+    vaccination_records
+      .draft
+      .create_with(vaccine:)
+      .find_or_initialize_by(recorded_at: nil)
   end
 
   def gillick_competent?

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -84,15 +84,6 @@ class VaccinationRecord < ApplicationRecord
 
   default_scope { recorded }
 
-  # HACK: this code will need to be revisited in future as it only really works for HPV, where we only have one vaccine
-  # It is likely to fail for the Doubles programme as that has 2 vaccines
-  # It is also likely to fail for the flu programme for the SAIS teams that offer both nasal and injectable vaccines
-  after_initialize do
-    if patient_session.present?
-      self.vaccine_id ||= patient_session.session.campaign.vaccines.first&.id
-    end
-  end
-
   enum :delivery_method,
        %w[intramuscular subcutaneous nasal_spray],
        prefix: true

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -87,7 +87,7 @@ describe AppActivityLogComponent, type: :component do
   end
 
   include_examples "card",
-                   title: "Vaccinated with Gardasil 9 (HPV)",
+                   title: "Vaccinated with Cervarix (HPV)",
                    date: "31 May 2024 at 12:00pm",
                    notes: "Some notes",
                    by: "Nurse Joy"

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -9,10 +9,10 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
 
   let(:administered) { true }
   let(:location) { create(:location, name: "Hogwarts") }
-  let(:campaign) { create(:campaign, :hpv) }
+  let(:campaign) { create(:campaign, vaccines: [vaccine].compact) }
   let(:session) { create(:session, campaign:, location:) }
   let(:patient_session) { create(:patient_session, session:) }
-  let(:vaccine) { campaign.vaccines.first }
+  let(:vaccine) { create(:vaccine, :gardasil_9) }
   let(:batch) do
     create(:batch, name: "ABC", expiry: Date.new(2020, 1, 1), vaccine:)
   end

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -23,7 +23,13 @@ FactoryBot.define do
 
     trait :hpv do
       name { "HPV" }
-      vaccines { [create(:vaccine, :hpv, batch_count:)] }
+      vaccines do
+        [
+          create(:vaccine, :cervaris, batch_count:),
+          create(:vaccine, :gardasil, batch_count:),
+          create(:vaccine, :gardasil_9, batch_count:)
+        ]
+      end
     end
 
     trait :hpv_no_batches do
@@ -35,7 +41,8 @@ FactoryBot.define do
       name { "Flu" }
       vaccines do
         [
-          create(:vaccine, :flu, batch_count:),
+          create(:vaccine, :flucelvax_tetra, batch_count:),
+          create(:vaccine, :fluenz_tetra, batch_count:),
           create(:vaccine, :quadrivalent_influenza, batch_count:)
         ]
       end
@@ -43,7 +50,7 @@ FactoryBot.define do
 
     trait :flu_nasal_only do
       name { "Flu" }
-      vaccines { [create(:vaccine, :flu, batch_count:)] }
+      vaccines { [create(:vaccine, :fluenz_tetra, batch_count:)] }
     end
   end
 end

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -29,18 +29,23 @@ FactoryBot.define do
   factory :vaccine do
     transient { batch_count { 1 } }
 
+    type { %w[flu hpv].sample }
+    brand { Faker::Commerce.product_name }
     manufacturer { Faker::Company.name }
-    nivs_name { Faker::Commerce.product_name }
+    nivs_name { brand }
     dose { Faker::Number.decimal(l_digits: 0) }
     snomed_product_code { Faker::Number.decimal_part(digits: 17) }
     snomed_product_term { Faker::Lorem.sentence }
+    add_attribute(:method) { %i[nasal injection].sample }
+
+    traits_for_enum :method
 
     after(:create) do |vaccine, evaluator|
       create_list(:batch, evaluator.batch_count, vaccine:)
     end
 
     trait :flu do
-      fluenz_tetra
+      type { "flu" }
 
       after(:create) do |vaccine|
         asthma = create(:health_question, :asthma, vaccine:)
@@ -69,37 +74,50 @@ FactoryBot.define do
       end
     end
 
+    trait :flucelvax_tetra do
+      flu
+      injection
+      brand { "Flucelvax Tetra - QIVc" }
+      manufacturer { "Seqirus" }
+      nivs_name { "Seqirus Flucelvax Tetra QIVC" }
+      snomed_product_code { "36509011000001106" }
+      snomed_product_term do
+        "Flucelvax Tetra vaccine suspension for injection 0.5ml" \
+          " pre-filled syringes (Seqirus UK Ltd) (product)"
+      end
+      dose { 0.5 }
+    end
+
     trait :fluenz_tetra do
+      flu
+      nasal
       type { "flu" }
-      brand { "Fluenz Tetra" }
-      manufacturer { "AstraZeneca UK Ltd" }
+      brand { "Fluenz Tetra - LAIV" }
+      manufacturer { "AstraZeneca" }
       nivs_name { "AstraZeneca Fluenz Tetra LAIV" }
-      gtin { "05000456078276" }
       snomed_product_code { "27114211000001105" }
       snomed_product_term do
         "Fluenz Tetra vaccine nasal suspension 0.2ml unit dose (AstraZeneca UK Ltd) (product)"
       end
-      add_attribute(:method) { :nasal }
       dose { 0.2 }
     end
 
     trait :quadrivalent_influenza do
-      type { "flu" }
+      flu
+      injection
       brand { "Quadrivalent Influenza vaccine - QIVe" }
       manufacturer { "Sanofi" }
       nivs_name { "Sanofi Pasteur QIVe" }
-      gtin { "3664798046564" }
       snomed_product_code { "34680411000001107" }
       snomed_product_term do
         "Quadrivalent influenza vaccine (split virion, inactivated) suspension" \
           " for injection 0.5ml pre-filled syringes (Sanofi) (product)"
       end
-      add_attribute(:method) { :injection }
       dose { 0.5 }
     end
 
     trait :hpv do
-      gardasil_9
+      type { "hpv" }
 
       after(:create) do |vaccine|
         severe_allergies = create(:health_question, :severe_allergies, vaccine:)
@@ -112,17 +130,42 @@ FactoryBot.define do
       end
     end
 
+    trait :cervaris do
+      hpv
+      injection
+      brand { "Cervarix" }
+      manufacturer { "GlaxoSmithKline" }
+      nivs_name { "Cervarix" }
+      snomed_product_code { "12238911000001100" }
+      snomed_product_term do
+        "Cervarix vaccine suspension for injection 0.5ml pre-filled syringes (GlaxoSmithKline) (product)"
+      end
+      dose { 0.5 }
+    end
+
+    trait :gardasil do
+      hpv
+      injection
+      brand { "Gardasil" }
+      manufacturer { "Merck Sharp & Dohme" }
+      nivs_name { "Gardasil" }
+      snomed_product_code { "10880211000001104" }
+      snomed_product_term do
+        "Gardasil vaccine suspension for injection 0.5ml pre-filled syringes (Merck Sharp & Dohme (UK) Ltd) (product)"
+      end
+      dose { 0.5 }
+    end
+
     trait :gardasil_9 do
-      type { "hpv" }
+      hpv
+      injection
       brand { "Gardasil 9" }
-      manufacturer { "Merck Sharp & Dohme (UK) Ltd" }
+      manufacturer { "Merck Sharp & Dohme" }
       nivs_name { "Gardasil9" }
-      gtin { "00191778001693" }
       snomed_product_code { "33493111000001108" }
       snomed_product_term do
         "Gardasil 9 vaccine suspension for injection 0.5ml pre-filled syringes (Merck Sharp & Dohme (UK) Ltd) (product)"
       end
-      add_attribute(:method) { :injection }
       dose { 0.5 }
     end
   end

--- a/spec/features/manage_vaccines_batches_spec.rb
+++ b/spec/features/manage_vaccines_batches_spec.rb
@@ -47,7 +47,7 @@ describe "Batches" do
   end
 
   def when_i_add_a_new_batch
-    click_on "Add a batch"
+    click_on "Add a batch", match: :first
 
     fill_in "Batch", with: "AB1234"
 

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -1,8 +1,8 @@
 ORGANISATION_CODE,SCHOOL_URN,SCHOOL_NAME,NHS_NUMBER,PERSON_FORENAME,PERSON_SURNAME,PERSON_DOB,PERSON_GENDER_CODE,PERSON_POSTCODE,DATE_OF_VACCINATION,VACCINE_GIVEN,BATCH_NUMBER,BATCH_EXPIRY_DATE,ANATOMICAL_SITE,DOSE_SEQUENCE,LOCAL_PATIENT_ID,LOCAL_PATIENT_ID_URI,CARE_SETTING
-R1L,110158,Eton College,7420180008,Chyna,Pickle,20120912,Not Specified,LE3 2DA,20240514,GlaxoSmithKlein Cervarix,123013325,20220730,Left Buttock,1,LocalPatient1,www.LocalPatient1,1
-R1L,110158,Eton College,,Renie,Parrish,20120913,Not Specified,LE1 2DA,20240514,Merck Sharp & Dome Gardasil,123013325,20220730,Right Buttock,1,LocalPatient2,www.LocalPatient2,1
-R1L,110158,Eton College,4146825652,Caden,Attwater,20120914,Male,LE1 2DA,20240514,Merck Sharp & Dome Gardasil 9,123013325,20220730,Left Thigh,1,LocalPatient3,www.LocalPatient3,1
-R1L,110158,Eton College,2675725722,Berry,Hamilton,20120915,Female,LE8 2DA,20240514,GlaxoSmithKlein Cervarix,123013325,20220730,Nasal,1,LocalPatient4,www.LocalPatient4,1
-R1L,110158,Eton College,1108533868,Jordin,Mould,20120916,Male,LE2 2PX,20240514,Merck Sharp & Dome Gardasil,123013325,20220730,Left Upper Arm,1,LocalPatient5,www.LocalPatient5,1
-R1L,110158,Eton College,8160442742,Oliver,Bowers,20120917,Male,LE5 2RP,20240514,Merck Sharp & Dome Gardasil 9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
-R1L,110158,Eton College,3314278071,Rosalind,Penn,20120918,Female,LE10 2DA,20240514,GlaxoSmithKlein Cervarix,123013326,20220730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1
+R1L,110158,Eton College,7420180008,Chyna,Pickle,20120912,Not Specified,LE3 2DA,20240514,Cervarix,123013325,20220730,Left Buttock,1,LocalPatient1,www.LocalPatient1,1
+R1L,110158,Eton College,,Renie,Parrish,20120913,Not Specified,LE1 2DA,20240514,Gardasil,123013325,20220730,Right Buttock,1,LocalPatient2,www.LocalPatient2,1
+R1L,110158,Eton College,4146825652,Caden,Attwater,20120914,Male,LE1 2DA,20240514,Gardasil9,123013325,20220730,Left Thigh,1,LocalPatient3,www.LocalPatient3,1
+R1L,110158,Eton College,2675725722,Berry,Hamilton,20120915,Female,LE8 2DA,20240514,Cervarix,123013325,20220730,Nasal,1,LocalPatient4,www.LocalPatient4,1
+R1L,110158,Eton College,1108533868,Jordin,Mould,20120916,Male,LE2 2PX,20240514,Gardasil,123013325,20220730,Left Upper Arm,1,LocalPatient5,www.LocalPatient5,1
+R1L,110158,Eton College,8160442742,Oliver,Bowers,20120917,Male,LE5 2RP,20240514,Gardasil9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
+R1L,110158,Eton College,3314278071,Rosalind,Penn,20120918,Female,LE10 2DA,20240514,Cervarix,123013326,20220730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1

--- a/spec/helpers/vaccines_helper_spec.rb
+++ b/spec/helpers/vaccines_helper_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe VaccinesHelper, type: :helper do
-  let(:vaccine) { create(:vaccine, :flu) }
+  let(:vaccine) { create(:vaccine, :fluenz_tetra) }
 
   describe "#vaccine_heading" do
     subject(:vaccine_heading) { helper.vaccine_heading(vaccine) }
 
-    it { should eq("Fluenz Tetra (Flu)") }
+    it { should eq("Fluenz Tetra - LAIV (Flu)") }
   end
 end

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -141,7 +141,7 @@ describe DPSExportRow do
     end
 
     it "has vaccine_manufacturer" do
-      expect(array[21]).to eq "Merck Sharp & Dohme (UK) Ltd"
+      expect(array[21]).to eq "Merck Sharp & Dohme"
     end
 
     it "has batch_number" do

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -12,7 +12,7 @@ describe ImmunisationImportRow, type: :model do
     )
   end
 
-  let(:campaign) { create(:campaign) }
+  let(:campaign) { create(:campaign, :flu) }
   let(:team) { create(:team, ods_code: "abc") }
   let(:user) { create(:user, teams: [team]) }
   let(:immunisation_import) { create(:immunisation_import, campaign:, user:) }
@@ -141,7 +141,9 @@ describe ImmunisationImportRow, type: :model do
     end
 
     context "with an invalid dose sequence" do
-      let(:data) { { "DOSE_SEQUENCE" => "4" } }
+      let(:campaign) { create(:campaign, :hpv) }
+
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil", "DOSE_SEQUENCE" => "4" } }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -168,7 +170,8 @@ describe ImmunisationImportRow, type: :model do
           "PERSON_DOB" => "20120101",
           "PERSON_POSTCODE" => "SW1A 1AA",
           "PERSON_GENDER_CODE" => "Male",
-          "DATE_OF_VACCINATION" => "20240101"
+          "DATE_OF_VACCINATION" => "20240101",
+          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
         }
       end
 
@@ -201,7 +204,7 @@ describe ImmunisationImportRow, type: :model do
         "PERSON_GENDER_CODE" => "Male",
         "NHS_NUMBER" => nhs_number,
         "DATE_OF_VACCINATION" => "20240101",
-        "DOSE_SEQUENCE" => "1"
+        "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
       }
     end
 
@@ -453,20 +456,22 @@ describe ImmunisationImportRow, type: :model do
   describe "#dose_sequence" do
     subject(:dose_sequence) { immunisation_import_row.dose_sequence }
 
+    let(:campaign) { create(:campaign, :hpv) }
+
     context "without a value" do
-      let(:data) { {} }
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil" } }
 
       it { should be_nil }
     end
 
     context "with an invalid value" do
-      let(:data) { { "DOSE_SEQUENCE" => "abc" } }
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil", "DOSE_SEQUENCE" => "abc" } }
 
       it { should be_nil }
     end
 
     context "with a valid value" do
-      let(:data) { { "DOSE_SEQUENCE" => "1" } }
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil", "DOSE_SEQUENCE" => "1" } }
 
       it { should eq(1) }
     end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -28,7 +28,7 @@ describe ImmunisationImport, type: :model do
     create(:immunisation_import, campaign:, csv:, user:)
   end
 
-  let(:campaign) { create(:campaign) }
+  let(:campaign) { create(:campaign, :flu) }
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
   let(:team) { create(:team, ods_code: "R1L") }
@@ -115,7 +115,7 @@ describe ImmunisationImport, type: :model do
           .and change(immunisation_import.patients, :count).by(11)
           .and change(immunisation_import.sessions, :count).by(4)
           .and change(PatientSession, :count).by(11)
-          .and change(Batch, :count).by(2)
+          .and change(Batch, :count).by(4)
 
         # Second import should not duplicate the vaccination records if they're
         # identical.
@@ -143,7 +143,7 @@ describe ImmunisationImport, type: :model do
           .and change(immunisation_import.patients, :count).by(7)
           .and change(immunisation_import.sessions, :count).by(1)
           .and change(PatientSession, :count).by(7)
-          .and change(Batch, :count).by(2)
+          .and change(Batch, :count).by(5)
 
         # Second import should not duplicate the vaccination records if they're
         # identical.

--- a/spec/models/nivs_report_row_spec.rb
+++ b/spec/models/nivs_report_row_spec.rb
@@ -49,7 +49,7 @@ describe NivsReportRow do
 
       expect(subject[9..17]).to eq [
            "20200101",
-           "Gardasil 9",
+           "Cervarix",
            "AB1234",
            "20210101",
            "Left Upper Arm",

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -44,7 +44,7 @@ describe VaccinationRecord do
   it "validates that the vaccine and the batch vaccines match" do
     patient_session = create(:patient_session)
     vaccine = patient_session.campaign.vaccines.first
-    different_vaccine = create(:vaccine, :flu)
+    different_vaccine = create(:vaccine)
     batch = create(:batch, vaccine: different_vaccine)
 
     subject =


### PR DESCRIPTION
This updates the immunisation import code to import vaccines from the `VACCINE_GIVEN` column, matching them with the `nivs_name` column we added in #1568.

See individual commits for more details.