### PR TITLE
Seed vaccines from an initialiser configuration 

### DIFF
--- a/config/vaccines.yml
+++ b/config/vaccines.yml
@@ -1,0 +1,130 @@
+fluenz_tetra:
+  brand: Fluenz Tetra - LAIV
+  type: flu
+  method: nasal
+  manufacturer: AstraZeneca
+  nivs_name: AstraZeneca Fluenz Tetra LAIV
+  dose: 0.2
+  snomed_product_code: 27114211000001105
+  snomed_product_term: Fluenz Tetra vaccine nasal suspension 0.2ml unit dose
+    (AstraZeneca UK Ltd) (product)
+
+cervarix:
+  brand: Cervarix
+  type: hpv
+  method: injection
+  manufacturer: GlaxoSmithKline
+  nivs_name: Cervarix
+  dose: 0.5
+  snomed_product_code: 12238911000001100
+  snomed_product_term:
+    Cervarix vaccine suspension for injection 0.5ml pre-filled
+    syringes (GlaxoSmithKline) (product)
+
+gardasil_9:
+  brand: Gardasil 9
+  type: hpv
+  method: injection
+  manufacturer: Merck Sharp & Dohme
+  nivs_name: Gardasil9
+  dose: 0.5
+  snomed_product_code: 33493111000001108
+  snomed_product_term:
+    Gardasil 9 vaccine suspension for injection 0.5ml pre-filled
+    syringes (Merck Sharp & Dohme (UK) Ltd) (product)
+
+gardasil:
+  brand: Gardasil
+  type: hpv
+  method: injection
+  manufacturer: Merck Sharp & Dohme
+  nivs_name: Gardasil
+  dose: 0.5
+  snomed_product_code: 10880211000001104
+  snomed_product_term:
+    Gardasil vaccine suspension for injection 0.5ml pre-filled
+    syringes (Merck Sharp & Dohme (UK) Ltd) (product)
+
+quadrivalent_influvac_tetra:
+  brand: Quadrivalent Influvac sub-unit Tetra - QIVe
+  type: flu
+  method: injection
+  manufacturer: Mylan
+  nivs_name: Mylan Influvac QIVe
+  dose: 0.5
+  snomed_product_code: 35727111000001109
+  snomed_product_term:
+    Influvac sub-unit Tetra vaccine suspension for injection 0.5ml
+    pre-filled syringes (Viatris UK Healthcare Ltd) (product)
+
+supemtek:
+  brand: Supemtek - QIVr
+  type: flu
+  method: injection
+  manufacturer: Sanofi
+  nivs_name: Sanofi Pasteur  Supemtek QIVr
+  dose: 0.5
+  snomed_product_code: 39566211000001103
+  snomed_product_term: Supemtek Quadrivalent vaccine (recombinant) solution for
+    injection 0.5ml pre-filled syringes (Sanofi) (product)
+
+quadrivalent_influenza:
+  brand: Quadrivalent Influenza vaccine - QIVe
+  type: flu
+  method: injection
+  manufacturer: Sanofi
+  nivs_name: Sanofi Pasteur QIVe
+  dose: 0.5
+  snomed_product_code: 34680411000001107
+  snomed_product_term:
+    Quadrivalent influenza vaccine (split virion, inactivated)
+    suspension for injection 0.5ml pre-filled syringes (Sanofi) (product)
+
+fluad_tetra:
+  brand: Fluad Tetra - aQIV
+  type: flu
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Fluad Tetra AQIV
+  dose: 0.5
+  snomed_product_code: 38973211000001108
+  snomed_product_term:
+    Fluad Tetra vaccine suspension for injection 0.5ml pre-filled
+    syringes (Seqirus UK Ltd) (product)
+
+flucelvax_tetra:
+  brand: Flucelvax Tetra - QIVc
+  type: flu
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Flucelvax Tetra QIVC
+  dose: 0.5
+  snomed_product_code: 36509011000001106
+  snomed_product_term: Flucelvax Tetra vaccine suspension for injection 0.5ml
+    pre-filled syringes (Seqirus UK Ltd) (product)
+
+cell_quadrivalent:
+  brand: Cell-based Quadrivalent - QIVc
+  type: flu
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Cell based Quadrivalent QIVc
+  dose: 0.5
+  snomed_product_code: 40085011000001101
+  snomed_product_term:
+    Cell-based quadrivalent influenza vaccine (surface antigen,
+    inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK
+    Ltd) (product)
+
+adjuvanted_quadrivalent:
+  brand: Adjuvanted Quadrivalent - aQIV
+  type: flu
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Adjuvanted Quadrivalent aQIV
+  dose: 0.5
+  snomed_product_code: 40085311000001103
+  snomed_product_term:
+    Adjuvanted quadrivalent influenza vaccine (surface antigen,
+    inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK
+    Ltd) (product)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,3 +34,5 @@ Audited
 
 Team.find_by(ods_code: "Y51") ||
   FactoryBot.create(:team, name: "NMEPFIT SAIS Team", ods_code: "Y51")
+
+Rake::Task["vaccines:seed"].execute

--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :vaccines do
+  desc "Seed the vaccine table from the built-in vaccine data."
+  task seed: :environment do
+    all_data = YAML.load_file(Rails.root.join("config/vaccines.yml"))
+
+    all_data.each_value do |data|
+      vaccine =
+        Vaccine.find_or_initialize_by(
+          snomed_product_code: data["snomed_product_code"]
+        )
+
+      vaccine.brand = data["brand"]
+      vaccine.dose = data["dose"]
+      vaccine.manufacturer = data["manufacturer"]
+      vaccine.method = data["method"]
+      vaccine.nivs_name = data["nivs_name"]
+      vaccine.snomed_product_term = data["snomed_product_term"]
+      vaccine.type = data["type"]
+
+      vaccine.save!
+    end
+  end
+end

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
       name { "HPV" }
       vaccines do
         [
-          create(:vaccine, :cervaris, batch_count:),
+          create(:vaccine, :cervarix, batch_count:),
           create(:vaccine, :gardasil, batch_count:),
           create(:vaccine, :gardasil_9, batch_count:)
         ]
@@ -41,9 +41,14 @@ FactoryBot.define do
       name { "Flu" }
       vaccines do
         [
+          create(:vaccine, :adjuvanted_quadrivalent, batch_count:),
+          create(:vaccine, :cell_quadrivalent, batch_count:),
+          create(:vaccine, :fluad_tetra, batch_count:),
           create(:vaccine, :flucelvax_tetra, batch_count:),
           create(:vaccine, :fluenz_tetra, batch_count:),
-          create(:vaccine, :quadrivalent_influenza, batch_count:)
+          create(:vaccine, :quadrivalent_influenza, batch_count:),
+          create(:vaccine, :quadrivalent_influvac_tetra, batch_count:),
+          create(:vaccine, :supemtek, batch_count:)
         ]
       end
     end

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -74,48 +74,6 @@ FactoryBot.define do
       end
     end
 
-    trait :flucelvax_tetra do
-      flu
-      injection
-      brand { "Flucelvax Tetra - QIVc" }
-      manufacturer { "Seqirus" }
-      nivs_name { "Seqirus Flucelvax Tetra QIVC" }
-      snomed_product_code { "36509011000001106" }
-      snomed_product_term do
-        "Flucelvax Tetra vaccine suspension for injection 0.5ml" \
-          " pre-filled syringes (Seqirus UK Ltd) (product)"
-      end
-      dose { 0.5 }
-    end
-
-    trait :fluenz_tetra do
-      flu
-      nasal
-      type { "flu" }
-      brand { "Fluenz Tetra - LAIV" }
-      manufacturer { "AstraZeneca" }
-      nivs_name { "AstraZeneca Fluenz Tetra LAIV" }
-      snomed_product_code { "27114211000001105" }
-      snomed_product_term do
-        "Fluenz Tetra vaccine nasal suspension 0.2ml unit dose (AstraZeneca UK Ltd) (product)"
-      end
-      dose { 0.2 }
-    end
-
-    trait :quadrivalent_influenza do
-      flu
-      injection
-      brand { "Quadrivalent Influenza vaccine - QIVe" }
-      manufacturer { "Sanofi" }
-      nivs_name { "Sanofi Pasteur QIVe" }
-      snomed_product_code { "34680411000001107" }
-      snomed_product_term do
-        "Quadrivalent influenza vaccine (split virion, inactivated) suspension" \
-          " for injection 0.5ml pre-filled syringes (Sanofi) (product)"
-      end
-      dose { 0.5 }
-    end
-
     trait :hpv do
       type { "hpv" }
 
@@ -130,43 +88,19 @@ FactoryBot.define do
       end
     end
 
-    trait :cervaris do
-      hpv
-      injection
-      brand { "Cervarix" }
-      manufacturer { "GlaxoSmithKline" }
-      nivs_name { "Cervarix" }
-      snomed_product_code { "12238911000001100" }
-      snomed_product_term do
-        "Cervarix vaccine suspension for injection 0.5ml pre-filled syringes (GlaxoSmithKline) (product)"
-      end
-      dose { 0.5 }
-    end
+    all_data = YAML.load_file(Rails.root.join("config/vaccines.yml"))
 
-    trait :gardasil do
-      hpv
-      injection
-      brand { "Gardasil" }
-      manufacturer { "Merck Sharp & Dohme" }
-      nivs_name { "Gardasil" }
-      snomed_product_code { "10880211000001104" }
-      snomed_product_term do
-        "Gardasil vaccine suspension for injection 0.5ml pre-filled syringes (Merck Sharp & Dohme (UK) Ltd) (product)"
+    all_data.each do |key, data|
+      trait key do
+        send(data["type"])
+        brand { data["brand"] }
+        dose { data["dose"] }
+        manufacturer { data["manufacturer"] }
+        add_attribute(:method) { data["method"] }
+        nivs_name { data["nivs_name"] }
+        snomed_product_code { data["snomed_product_code"] }
+        snomed_product_term { data["snomed_product_term"] }
       end
-      dose { 0.5 }
-    end
-
-    trait :gardasil_9 do
-      hpv
-      injection
-      brand { "Gardasil 9" }
-      manufacturer { "Merck Sharp & Dohme" }
-      nivs_name { "Gardasil9" }
-      snomed_product_code { "33493111000001108" }
-      snomed_product_term do
-        "Gardasil 9 vaccine suspension for injection 0.5ml pre-filled syringes (Merck Sharp & Dohme (UK) Ltd) (product)"
-      end
-      dose { 0.5 }
     end
   end
 end


### PR DESCRIPTION
This builds on top of #1550 to use the configuration in a number of ways:

- automatically define factory traits that we can use in our tests
- populate vaccines as part of running `db:seed`
- provide a Rake task (`vaccines:seed`) that can be used to populate only the vaccines in deployed environments 