### PR TITLE
Remove unused controller action

### DIFF
--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -52,9 +52,6 @@ class ImmunisationImportsController < ApplicationController
       )
   end
 
-  def success
-  end
-
   private
 
   def set_campaign


### PR DESCRIPTION
The success action of the immunisation imports controller used to be used but now we show a flash banner so it can be safely removed.