### PR TITLE
Fix alignment of text on file upload button

### DIFF
--- a/app/assets/stylesheets/_file-upload.scss
+++ b/app/assets/stylesheets/_file-upload.scss
@@ -1,12 +1,17 @@
 .nhsuk-file-upload {
-  @extend .govuk-file-upload;
+  @include nhsuk-font(19, $line-height: 60px);
 
   &::file-selector-button {
     @extend .nhsuk-button;
     @extend .nhsuk-button--secondary;
 
     color: $color_nhsuk-white;
-    font-weight: bold;
+    font-family: inherit;
     margin-bottom: 0;
+  }
+
+  // Button receives focus
+  &:focus {
+    outline: 0;
   }
 }


### PR DESCRIPTION
Fix alignment of file selector text in Firefox and Chrome. Also remove unsoiled focus ring, which is fine as the button already receives focus styles. 

| Before | After |
| - | - |
| <img width="300" alt="Before screenshot" src="https://github.com/user-attachments/assets/e6c8b626-9d9f-45d3-97f8-623b0d2b77ec"> | <img width="300" alt="After screenshot" src="https://github.com/user-attachments/assets/66ee7d6b-3a9c-4a37-ae6d-9483fbf5bcd6"> |

