### PR TITLE
Keep user on login page when they fail auth

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -11,8 +11,11 @@ module AuthenticationConcern
         if request.path != start_path
           store_location_for(:user, request.fullpath)
         end
-        flash[:info] = "You must be logged in to access this page."
-        redirect_to start_path
+
+        unless request.path == new_user_session_path
+          flash[:info] = "You must be logged in to access this page."
+          redirect_to start_path
+        end
       elsif cis2_session?
         if !selected_cis2_org_is_registered?
           redirect_to users_team_not_found_path

--- a/spec/features/user_authentication_failure_spec.rb
+++ b/spec/features/user_authentication_failure_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "User authentication failure" do
+  scenario "user enters wrong username or password" do
+    given_that_i_have_an_account
+    when_i_go_to_the_start_page
+    and_i_click_on_start_now
+    and_i_click_on_log_in
+    then_i_see_the_sign_in_form
+  end
+
+  def given_that_i_have_an_account
+    @user = create :user, password: "rosebud123"
+  end
+
+  def when_i_go_to_the_start_page
+    visit start_path
+  end
+
+  def and_i_click_on_start_now
+    click_link "Start now"
+  end
+
+  def and_i_click_on_log_in
+    click_button "Log in"
+  end
+
+  def then_i_see_the_sign_in_form
+    expect(page).to have_selector :heading, "Log in"
+  end
+end


### PR DESCRIPTION
This was sending users back to the start page which can be confusing. Worth noting, users will probably not see this journey because they'll be using CIS2, but it's still a qol issue in development.