### PR TITLE
Bigfix: set session time of day during imms import

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -251,7 +251,11 @@ class ImmunisationImportRow
       @campaign
         .sessions
         .create_with(imported_from:)
-        .find_or_create_by!(date: session_date, location:)
+        .find_or_create_by!(
+          date: session_date,
+          location:,
+          time_of_day: :all_day
+        )
   end
 
   def patient_session

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -59,6 +59,13 @@ class Session < ApplicationRecord
   after_initialize :set_timeline_attributes
   after_validation :set_timeline_timestamps
 
+  validates :time_of_day,
+            presence: true,
+            inclusion: {
+              in: time_of_days.keys
+            },
+            unless: -> { draft? }
+
   on_wizard_step :location, exact: true do
     validates :location_id, presence: true
   end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -157,6 +157,16 @@ describe ImmunisationImport, type: :model do
           .and not_change(PatientSession, :count)
           .and not_change(Batch, :count)
       end
+
+      it "creates a new session for each date" do
+        process!
+
+        expect(immunisation_import.sessions.count).to eq(1)
+
+        session = immunisation_import.sessions.first
+        expect(session.date).to eq(Date.new(2024, 5, 14))
+        expect(session.time_of_day).to eq("all_day")
+      end
     end
 
     context "with an existing patient matching the name" do


### PR DESCRIPTION
Also validate that it's set on for non-draft sessions.