### PR TITLE
Refactor DPSExport

### DIFF
--- a/app/jobs/dps_export_job.rb
+++ b/app/jobs/dps_export_job.rb
@@ -4,11 +4,7 @@ class DPSExportJob < ApplicationJob
   queue_as :default
 
   def perform
-    dps_export =
-      DPSExport.new(
-        VaccinationRecord.recorded.where(exported_to_dps_at: nil)
-      ).export_csv
-
-    MESH.send_file(data: dps_export, to: Settings.mesh.dps_mailbox)
+    data = DPSExport.new(campaigns: Campaign.all).export!
+    MESH.send_file(data:, to: Settings.mesh.dps_mailbox)
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -20,8 +20,10 @@ class Campaign < ApplicationRecord
   belongs_to :team
   has_and_belongs_to_many :vaccines
   has_many :batches, through: :vaccines
-  has_many :sessions, dependent: :destroy
-  has_many :triage, dependent: :destroy
   has_many :consents, dependent: :destroy
   has_many :immunisation_imports, dependent: :destroy
+  has_many :patient_sessions, through: :sessions
+  has_many :sessions, dependent: :destroy
+  has_many :triage, dependent: :destroy
+  has_many :vaccination_records, through: :patient_sessions
 end

--- a/app/models/dps_export.rb
+++ b/app/models/dps_export.rb
@@ -3,21 +3,67 @@
 require "csv"
 
 class DPSExport
-  def initialize(vaccinations)
-    @vaccinations = vaccinations
-  end
-
-  def to_csv
-    CSV.generate(headers: true, force_quotes: true) do |csv|
-      csv << DPSExportRow::FIELDS.map(&:upcase)
-
-      @vaccinations.each { csv << DPSExportRow.new(_1).to_a }
+  def initialize(campaign: nil, campaigns: nil)
+    if campaign.present? && campaigns.blank?
+      @campaigns = [campaign]
+    elsif campaigns.present? && campaign.blank?
+      @campaigns = campaigns
+    else
+      raise "Must provide a campaign"
     end
   end
 
-  def export_csv
-    csv = to_csv
-    @vaccinations.update_all(exported_to_dps_at: Time.zone.now)
-    csv
+  def csv
+    @csv ||=
+      CSV.generate(headers: true, force_quotes: true) do |csv|
+        csv << DPSExportRow::FIELDS.map(&:upcase)
+
+        unexported_vaccination_records.each { csv << DPSExportRow.new(_1).to_a }
+      end
+  end
+
+  def export!
+    csv.tap do
+      unexported_vaccination_records.update_all(
+        exported_to_dps_at: Time.zone.now
+      )
+    end
+  end
+
+  def filename
+    raise "More than one campaign provided" if campaigns.count > 1
+
+    date = Time.zone.today.strftime("%Y-%m-%d")
+    campaign_name = campaigns.first.name.parameterize(preserve_case: true)
+    "Vaccinations-#{campaign_name}-#{date}.csv"
+  end
+
+  def reset!
+    exported_vaccination_records.update_all(exported_to_dps_at: nil)
+  end
+
+  private
+
+  attr_reader :campaigns
+
+  def vaccination_records
+    @vaccination_records ||=
+      VaccinationRecord
+        .includes(:batch, :location, :patient, :session, :team, :vaccine)
+        .where(sessions: { campaign: campaigns })
+        .recorded
+        .administered
+        .order(:recorded_at)
+        .strict_loading
+  end
+
+  def unexported_vaccination_records
+    @unexported_vaccination_records ||=
+      vaccination_records.where(exported_to_dps_at: nil)
+  end
+
+  def exported_vaccination_records
+    @exported_vaccination_records ||=
+      vaccination_records.where.not(exported_to_dps_at: nil)
   end
 end

--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -51,10 +51,10 @@ class DPSExportRow
   attr_reader :vaccination_record
 
   delegate :batch,
-           :campaign,
            :delivery_site,
            :location,
            :patient,
+           :team,
            :user,
            :vaccine,
            to: :vaccination_record
@@ -88,7 +88,7 @@ class DPSExportRow
   end
 
   def site_code
-    campaign.team.ods_code
+    team.ods_code
   end
 
   def site_code_type_uri
@@ -185,7 +185,7 @@ class DPSExportRow
   end
 
   def location_code
-    location.present? ? location.urn : campaign.team.ods_code
+    location.present? ? location.urn : team.ods_code
   end
 
   def location_code_type_uri

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -64,7 +64,7 @@
 
 <% content_for :after_main do %>
   <%= render(AppDevToolsComponent.new) do %>
-    <%= govuk_button_to "Download DPS export", dps_export_campaign_vaccination_records_path(@campaign) %>
-    <%= govuk_button_to "Reset vaccination records for DPS export", dps_export_reset_campaign_vaccination_records_path(@campaign) %>
+    <%= govuk_button_to "Download DPS export", export_dps_campaign_vaccination_records_path(@campaign) %>
+    <%= govuk_button_to "Reset vaccination records for DPS export", reset_dps_export_campaign_vaccination_records_path(@campaign) %>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,9 +73,9 @@ Rails.application.routes.draw do
     resources :vaccination_records,
               path: "vaccination-records",
               only: %i[index show] do
-      post "dps-export", on: :collection
+      post "export-dps", on: :collection
       constraints -> { Flipper.enabled?(:dev_tools) } do
-        post "dps-export-reset", on: :collection
+        post "reset-dps-export", on: :collection
       end
     end
   end

--- a/spec/jobs/dps_export_job_spec.rb
+++ b/spec/jobs/dps_export_job_spec.rb
@@ -5,29 +5,11 @@ require "rails_helper"
 describe DPSExportJob, type: :job do
   before { allow(MESH).to receive(:send_file) }
 
-  let(:patient_session) { create(:patient_session) }
-
-  it "generates an export with vaccination records that haven't been exported yet" do
-    create(
-      :vaccination_record,
-      exported_to_dps_at: 2.hours.ago,
-      patient_session:
-    )
-    vaccination2 =
-      create(:vaccination_record, exported_to_dps_at: nil, patient_session:)
-
+  it "sends the DPS export to MESH" do
     allow(DPSExport).to receive(:new).and_return(
-      instance_double(DPSExport, export_csv: "csv")
+      instance_double(DPSExport, export!: "csv")
     )
-    described_class.perform_now
 
-    expect(DPSExport).to have_received(:new).with([vaccination2])
-  end
-
-  it "sets the correct body" do
-    allow(DPSExport).to receive(:new).and_return(
-      instance_double(DPSExport, export_csv: "csv")
-    )
     described_class.perform_now
 
     expect(MESH).to have_received(:send_file).with(hash_including(data: "csv"))


### PR DESCRIPTION
This refactors the DPSExport class to encapsulate everything related to the DPS export (fetching the correct vaccination records with SQL joins for performance, exporting only new records, and resetting exported records) so it can be used in multiple places with the same logic applied each time.

A few things this improves:

- The send to MESH job was exporting unadminstered records, unlike via the UI
- The send to MESH job had N+1 query performance issues
- The logic around which records have already been exported was found separately in the controller and job