### PR TITLE
Don't import un-administered records

### DIFF
--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -29,11 +29,14 @@ class ImmunisationImportsController < ApplicationController
     end
 
     @immunisation_import.save!
-    @immunisation_import.process!
 
-    flash[
-      :success
-    ] = "#{@immunisation_import.vaccination_records.count} vaccinations uploaded"
+    result = @immunisation_import.process!
+
+    flash[:success] = "#{result[:count]} vaccinations uploaded"
+
+    if (ignored_count = result[:ignored_count]) > 1
+      flash[:info] = "#{ignored_count} un-administered vaccinations ignored"
+    end
 
     redirect_to campaign_immunisation_import_path(
                   @campaign,

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -93,7 +93,13 @@ class ImmunisationImport < ApplicationRecord
     parse_rows! if rows.nil?
     return if invalid?
 
-    ActiveRecord::Base.transaction { rows.map(&:to_vaccination_record) }
+    vaccination_records =
+      ActiveRecord::Base.transaction { rows.map(&:to_vaccination_record) }
+
+    {
+      count: vaccination_records.compact.count,
+      ignored_count: vaccination_records.count(&:nil?)
+    }
   end
 
   private

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -71,6 +71,8 @@ class ImmunisationImportRow
   def to_vaccination_record
     return unless valid?
 
+    return unless administered
+
     VaccinationRecord.create_with(
       imported_from: @imported_from,
       recorded_at:,

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -110,11 +110,11 @@ describe ImmunisationImport, type: :model do
       it "creates locations, patients, and vaccination records" do
         # stree-ignore
         expect { process! }
-          .to change(immunisation_import.vaccination_records, :count).by(11)
-          .and change(immunisation_import.locations, :count).by(4)
-          .and change(immunisation_import.patients, :count).by(11)
-          .and change(immunisation_import.sessions, :count).by(4)
-          .and change(PatientSession, :count).by(11)
+          .to change(immunisation_import.vaccination_records, :count).by(7)
+          .and change(immunisation_import.locations, :count).by(1)
+          .and change(immunisation_import.patients, :count).by(7)
+          .and change(immunisation_import.sessions, :count).by(1)
+          .and change(PatientSession, :count).by(7)
           .and change(Batch, :count).by(4)
 
         # Second import should not duplicate the vaccination records if they're
@@ -128,6 +128,10 @@ describe ImmunisationImport, type: :model do
           .and not_change(immunisation_import.sessions, :count)
           .and not_change(PatientSession, :count)
           .and not_change(Batch, :count)
+      end
+
+      it "returns statistics on the import" do
+        expect(process!).to eq({ count: 7, ignored_count: 4 })
       end
     end
 
@@ -158,6 +162,10 @@ describe ImmunisationImport, type: :model do
           .and not_change(Batch, :count)
       end
 
+      it "returns statistics on the import" do
+        expect(process!).to eq({ count: 7, ignored_count: 0 })
+      end
+
       it "creates a new session for each date" do
         process!
 
@@ -185,7 +193,7 @@ describe ImmunisationImport, type: :model do
 
       it "doesn't create an additional patient" do
         expect { process! }.to change(immunisation_import.patients, :count).by(
-          10
+          6
         )
       end
 


### PR DESCRIPTION
When importing data for the immunisation import we want to ignore records where the vaccine wasn't administered, rather than importing them. This is to match the Mavis reporting specification.

For now we should another flash banner with the number of ignored records, but we might want to improve the UI in the future.