### PR TITLE
Prevent detection of NHS numbers as telephone numbers

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+# Replace each space in NHS number with a non-breaking space and
+# zero-width word joiner to prevent telephone format detection
 module PatientsHelper
   def format_nhs_number(nhs_number)
     if nhs_number.present?
       tag.span(class: "app-u-monospace") do
-        nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
+        nhs_number
+          .to_s
+          .gsub(/(\d{3})(\d{3})(\d{4})/, "\\1&nbsp;&zwj;\\2&nbsp;&zwj;\\3")
+          .html_safe
       end
     else
       "Not provided"

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -60,7 +60,7 @@ describe AppPatientDetailsComponent, type: :component do
       expect(page).to(
         have_css(
           ".nhsuk-summary-list__row .app-u-monospace",
-          text: "123 456 7890"
+          text: "123\u00A0\u200D456\u00A0\u200D7890"
         )
       )
     end

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -59,7 +59,10 @@ describe AppVaccinationRecordTableComponent, type: :component do
     )
     expect(rendered).to have_css(".nhsuk-table__cell", text: "John Smith")
     expect(rendered).to have_link("John Smith")
-    expect(rendered).to have_css(".nhsuk-table__cell", text: "999 999 9999")
+    expect(rendered).to have_css(
+      ".nhsuk-table__cell",
+      text: "999\u00A0\u200D999\u00A0\u200D9999"
+    )
     expect(rendered).to have_css(".nhsuk-table__cell", text: "SW1A 2AA")
     expect(rendered).to have_css(".nhsuk-table__cell", text: "28 May 2000")
     expect(rendered).to have_css(".nhsuk-table__cell", text: "1 January 2020")

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -110,10 +110,11 @@ describe "Immunisation imports" do
     expect(page).to have_content(
       "Full nameNHS numberDate of birthPostcodeVaccinated date"
     )
-    expect(page).to have_content(
-      "Full name Chyna Pickle NHS number 742 018 0008 Date of birth 12 September 2012 " \
-        "Postcode LE3 2DA Vaccinated date 14 May 2024"
-    )
+    expect(page).to have_content("Full name Chyna Pickle")
+    expect(page).to have_content(/NHS number.*742.*018.*0008/)
+    expect(page).to have_content("Date of birth 12 September 2012")
+    expect(page).to have_content("Postcode LE3 2DA")
+    expect(page).to have_content("Vaccinated date 14 May 2024")
   end
 
   def when_i_click_on_a_vaccination_record

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -166,7 +166,7 @@ describe "Pilot journey" do
   end
 
   def then_i_see_the_childs_details_including_the_updated_nhs_number
-    expect(page).to have_content("NHS number999 888 6666")
+    expect(page).to have_content(/NHS number.*999.*888.*6666/)
   end
 
   def given_the_day_of_the_session_comes

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe PatientsHelper, type: :helper do
       let(:nhs_number) { "0123456789" }
 
       it { should be_html_safe }
-      it { should eq("<span class=\"app-u-monospace\">012 345 6789</span>") }
+
+      it do
+        expect(subject).to eq(
+          "<span class=\"app-u-monospace\">012&nbsp;&zwj;345&nbsp;&zwj;6789</span>"
+        )
+      end
     end
 
     context "when the NHS number is not present" do


### PR DESCRIPTION
Currently, in certain scenarios (notably iOS Safari, perhaps other user agents), NHS numbers get detected as being phone numbers and are linked to accordingly. Trying to copy an NHS number, or accidentally clicking on a linked NHS number may initiate a phone call.

We can prevent numbers from being detected as phone numbers by adding the following meta tag:

```html
<meta name="format-detection" content="telephone=no">
```

However, that prevents actual telephone numbers from being linked as well, which is useful. We could revert this behaviour by adding a link with the `tel:` protocol to telephone numbers, but linked phone numbers may not make sense on desktop browsers where there is less likelihood of there being a telephony function.

What we need to do is opt-out NHS numbers from being detected as phone numbers.

In my experimentation, replacing a space (`U+0020`) with any space-like character doesn’t prevent format detection from happening. However, adding a ZWJ (zero-width joiner, `U+200D`) does.

Replacing a space with a ZWJ removes the space between number groups; adding a non-breaking space plus the ZWJ recreates the previous appearance. (It doesn’t need to be a non-breaking space, but as the number shouldn’t wrap where there’s a space, this makes sense to use).

Am using `&zwj;` as this entity was introduced in HTML 4.0, so hopefully has near universal browser support.

💅

> [!NOTE]
> I mostly got the tests to pass, but am having trouble getting Capybara’s `have_content` method detect the special characters correctly. I tried using HTML entities and Unicode references, and `have_text`, but none of these seemed to work). 