### PR TITLE
Ensure location URL is a URL

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -40,6 +40,7 @@ class Location < ApplicationRecord
   enum :type, %w[school generic_clinic]
 
   validates :name, presence: true
+  validates :url, url: true, allow_nil: true
 
   validates :urn, presence: true, if: :school?
   validates :urn, uniqueness: true, allow_nil: true


### PR DESCRIPTION
This adds validation using the standard Rails validation to ensure that location URLs are correctly formatted as valid URLs.