### PR TITLE
Immunisation importer: don't set the import user as vaccinator

### DIFF
--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -96,9 +96,11 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
         row.with_value { @vaccination_record.recorded_at.to_fs(:long) }
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Nurse" }
-        row.with_value { @vaccination_record.user.full_name }
+      if @vaccination_record.user.present?
+        summary_list.with_row do |row|
+          row.with_key { "Nurse" }
+          row.with_value { @vaccination_record.user.full_name }
+        end
       end
 
       summary_list.with_row do |row|

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -75,8 +75,7 @@ class ImmunisationImportRow
 
     VaccinationRecord.create_with(
       imported_from: @imported_from,
-      recorded_at:,
-      user: @user
+      recorded_at:
     ).find_or_create_by!(
       administered:,
       delivery_method:,

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -70,7 +70,7 @@ class VaccinationRecord < ApplicationRecord
   belongs_to :patient_session
   belongs_to :imported_from, class_name: "ImmunisationImport", optional: true
   belongs_to :batch, optional: true
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :vaccine, optional: true
   has_one :session, through: :patient_session
   has_one :patient, through: :patient_session

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -170,7 +170,20 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
   end
 
   describe "nurse row" do
-    it { should have_css(".nhsuk-summary-list__row", text: "Nurse\nTest User") }
+    context "when the user is present" do
+      it do
+        expect(subject).to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Nurse\nTest User"
+        )
+      end
+    end
+
+    context "when the user is not present" do
+      let(:vaccination_record) { create(:vaccination_record, user: nil) }
+
+      it { should_not have_css(".nhsuk-summary-list__row", text: "Nurse") }
+    end
   end
 
   describe "location row" do

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -602,6 +602,8 @@ describe ImmunisationImportRow, type: :model do
   end
 
   describe "#recorded_at" do
+    subject(:recorded_at) { immunisation_import_row.recorded_at }
+
     let(:data) { {} }
 
     it { should_not be_nil }

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -17,6 +17,31 @@ describe ImmunisationImportRow, type: :model do
   let(:user) { create(:user, teams: [team]) }
   let(:immunisation_import) { create(:immunisation_import, campaign:, user:) }
 
+  let(:nhs_number) { "1234567890" }
+  let(:first_name) { "Harry" }
+  let(:last_name) { "Potter" }
+  let(:date_of_birth) { "20120101" }
+  let(:address_postcode) { "SW1A 1AA" }
+  let(:valid_data) do
+    {
+      "ORGANISATION_CODE" => "abc",
+      "VACCINATED" => "Yes",
+      "ANATOMICAL_SITE" => "nasal",
+      "BATCH_EXPIRY_DATE" => "20210101",
+      "BATCH_NUMBER" => "123",
+      "SCHOOL_NAME" => "Hogwarts",
+      "SCHOOL_URN" => "123456",
+      "PERSON_FORENAME" => first_name,
+      "PERSON_SURNAME" => last_name,
+      "PERSON_DOB" => date_of_birth,
+      "PERSON_POSTCODE" => address_postcode,
+      "PERSON_GENDER_CODE" => "Male",
+      "NHS_NUMBER" => nhs_number,
+      "DATE_OF_VACCINATION" => "20240101",
+      "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
+    }
+  end
+
   describe "validations" do
     context "with an empty row" do
       let(:data) { {} }
@@ -181,32 +206,6 @@ describe ImmunisationImportRow, type: :model do
 
   describe "#patient" do
     subject(:patient) { immunisation_import_row.patient }
-
-    let(:nhs_number) { "1234567890" }
-    let(:first_name) { "Harry" }
-    let(:last_name) { "Potter" }
-    let(:date_of_birth) { "20120101" }
-    let(:address_postcode) { "SW1A 1AA" }
-
-    let(:valid_data) do
-      {
-        "ORGANISATION_CODE" => "abc",
-        "VACCINATED" => "Yes",
-        "ANATOMICAL_SITE" => "nasal",
-        "BATCH_EXPIRY_DATE" => "20210101",
-        "BATCH_NUMBER" => "123",
-        "SCHOOL_NAME" => "Hogwarts",
-        "SCHOOL_URN" => "123456",
-        "PERSON_FORENAME" => first_name,
-        "PERSON_SURNAME" => last_name,
-        "PERSON_DOB" => date_of_birth,
-        "PERSON_POSTCODE" => address_postcode,
-        "PERSON_GENDER_CODE" => "Male",
-        "NHS_NUMBER" => nhs_number,
-        "DATE_OF_VACCINATION" => "20240101",
-        "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
-      }
-    end
 
     context "without patient data" do
       let(:data) { {} }
@@ -607,5 +606,17 @@ describe ImmunisationImportRow, type: :model do
     let(:data) { {} }
 
     it { should_not be_nil }
+  end
+
+  describe "#to_vaccination_record" do
+    subject(:vaccination_record) do
+      immunisation_import_row.to_vaccination_record
+    end
+
+    let(:data) { valid_data }
+
+    it "does not have a vaccinator as that isn't provided in the import" do
+      expect(vaccination_record.user).to be_nil
+    end
   end
 end


### PR DESCRIPTION
It's very likely that the person who is uploading the vaccinations **isn't** the vaccinator, so we can't make that assumption.

* Allow `VaccinationRecord#user` to be `nil`
* Don't populate `VaccinationRecord#user` when importing
* Don't break when showing a vaccination record without a `user`