### PR TITLE
Improve logic related to importing session locations

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -61,6 +61,14 @@ class ImmunisationImportRow
             },
             unless: :administered
 
+  CARE_SETTING_SCHOOL = 1
+  CARE_SETTING_COMMUNITY = 2
+
+  validates :care_setting,
+            inclusion: [CARE_SETTING_SCHOOL, CARE_SETTING_COMMUNITY],
+            allow_nil: true
+  validates :care_setting, presence: true, if: :requires_care_setting?
+
   def initialize(data:, campaign:, user:, imported_from:)
     @data = data
     @campaign = campaign
@@ -236,6 +244,12 @@ class ImmunisationImportRow
     parse_date("DATE_OF_VACCINATION")
   end
 
+  def care_setting
+    Integer(@data["CARE_SETTING"])
+  rescue ArgumentError, TypeError
+    nil
+  end
+
   private
 
   attr_reader :imported_from
@@ -308,6 +322,10 @@ class ImmunisationImportRow
 
   def maximum_dose_sequence
     vaccine.maximum_dose_sequence
+  end
+
+  def requires_care_setting?
+    vaccine&.type == "hpv"
   end
 
   def parse_date(key)

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -31,8 +31,20 @@ class ImmunisationImportRow
             },
             if: :administered
 
-  validates :school_name, presence: true
-  validates :school_urn, presence: true
+  SCHOOL_URN_HOME_EDUCATED = "999999"
+  SCHOOL_URN_UNKNOWN = "888888"
+
+  validates :school_name,
+            presence: true,
+            if: -> { school_urn == SCHOOL_URN_UNKNOWN }
+  validates :school_urn,
+            presence: true,
+            inclusion: {
+              in: -> do
+                Location.school.pluck(:urn) +
+                  [SCHOOL_URN_HOME_EDUCATED, SCHOOL_URN_UNKNOWN]
+              end
+            }
 
   validates :patient_first_name, presence: true
   validates :patient_last_name, presence: true
@@ -237,7 +249,7 @@ class ImmunisationImportRow
   end
 
   def home_educated
-    school_urn == "999999"
+    school_urn == SCHOOL_URN_HOME_EDUCATED
   end
 
   def session_date

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -95,6 +95,7 @@ class ImmunisationImportRow
 
     VaccinationRecord.create_with(
       imported_from: @imported_from,
+      notes:,
       recorded_at:
     ).find_or_create_by!(
       administered:,
@@ -138,6 +139,10 @@ class ImmunisationImportRow
           location:,
           time_of_day: :all_day
         )
+  end
+
+  def notes
+    "Vaccinated at #{school_name}" if school_name.present? && location.nil?
   end
 
   def administered

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -89,6 +89,8 @@ en:
               blank: is required but missing
             patient_postcode:
               blank: is required but missing
+            school_urn:
+              inclusion: The school URN is not recognised. If you’ve checked the URN, and you believe it’s valid, contact our support team.
   activerecord:
     attributes:
       consent:

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -6,6 +6,7 @@ describe "Immunisation imports" do
   scenario "User uploads a file and views vaccination records" do
     given_i_am_signed_in
     and_an_hpv_campaign_is_underway
+    and_school_locations_exist
 
     when_i_go_to_the_reports_page
     then_i_should_see_the_upload_link
@@ -41,6 +42,12 @@ describe "Immunisation imports" do
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school)
     @session = create(:session, campaign:, location:)
+  end
+
+  def and_school_locations_exist
+    create(:location, :school, urn: "110158")
+    create(:location, :school, urn: "120026")
+    create(:location, :school, urn: "144012")
   end
 
   def when_i_go_to_the_reports_page

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -608,6 +608,28 @@ describe ImmunisationImportRow, type: :model do
     it { should_not be_nil }
   end
 
+  describe "#care_setting" do
+    subject(:care_setting) { immunisation_import_row.care_setting }
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with a valid value" do
+      let(:data) { { "CARE_SETTING" => "1" } }
+
+      it { should eq(1) }
+    end
+
+    context "with an invalid value" do
+      let(:data) { { "CARE_SETTING" => "School" } }
+
+      it { should be_nil }
+    end
+  end
+
   describe "#to_vaccination_record" do
     subject(:vaccination_record) do
       immunisation_import_row.to_vaccination_record

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -377,6 +377,71 @@ describe ImmunisationImportRow, type: :model do
     end
   end
 
+  describe "#notes" do
+    subject(:notes) { immunisation_import_row.notes }
+
+    context "without data" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with a school" do
+      let(:data) { valid_data }
+
+      it { should be_nil }
+    end
+
+    context "when home educated and community care setting" do
+      let(:data) do
+        valid_data.merge("SCHOOL_URN" => "999999", "CARE_SETTING" => "2")
+      end
+
+      it { should be_nil }
+    end
+
+    context "when home educated and unknown care setting" do
+      let(:data) { valid_data.merge("SCHOOL_URN" => "999999") }
+
+      it { should be_nil }
+    end
+
+    context "with an unknown school and school care setting" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "888888",
+          "SCHOOL_NAME" => "Waterloo Road",
+          "CARE_SETTING" => "1"
+        )
+      end
+
+      it { should eq("Vaccinated at Waterloo Road") }
+    end
+
+    context "with an unknown school and community care setting" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "888888",
+          "SCHOOL_NAME" => "Waterloo Road",
+          "CARE_SETTING" => "2"
+        )
+      end
+
+      it { should be_nil }
+    end
+
+    context "with an unknown school and unknown case setting" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "888888",
+          "SCHOOL_NAME" => "Waterloo Road"
+        )
+      end
+
+      it { should eq("Vaccinated at Waterloo Road") }
+    end
+  end
+
   describe "#administered" do
     subject(:administered) { immunisation_import_row.administered }
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -42,6 +42,8 @@ describe ImmunisationImportRow, type: :model do
     }
   end
 
+  before { create(:location, :school, urn: "123456") }
+
   describe "validations" do
     context "with an empty row" do
       let(:data) { {} }

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -28,6 +28,12 @@ describe ImmunisationImport, type: :model do
     create(:immunisation_import, campaign:, csv:, user:)
   end
 
+  before do
+    create(:location, :school, urn: "110158")
+    create(:location, :school, urn: "120026")
+    create(:location, :school, urn: "144012")
+  end
+
   let(:campaign) { create(:campaign, :flu) }
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
@@ -111,7 +117,7 @@ describe ImmunisationImport, type: :model do
         # stree-ignore
         expect { process! }
           .to change(immunisation_import.vaccination_records, :count).by(7)
-          .and change(immunisation_import.locations, :count).by(1)
+          .and not_change(immunisation_import.locations, :count)
           .and change(immunisation_import.patients, :count).by(7)
           .and change(immunisation_import.sessions, :count).by(1)
           .and change(PatientSession, :count).by(7)
@@ -143,7 +149,7 @@ describe ImmunisationImport, type: :model do
         # stree-ignore
         expect { process! }
           .to change(immunisation_import.vaccination_records, :count).by(7)
-          .and change(immunisation_import.locations, :count).by(1)
+          .and not_change(immunisation_import.locations, :count)
           .and change(immunisation_import.patients, :count).by(7)
           .and change(immunisation_import.sessions, :count).by(1)
           .and change(PatientSession, :count).by(7)


### PR DESCRIPTION
This implements the logic related to importing session locations to correctly handle home educated patients, and vaccination records where we don't have the school URN. See individual commits for more details.