### PR TITLE
Formalise vaccine types

### DIFF
--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -38,11 +38,10 @@ class Vaccine < ApplicationRecord
   validates :dose, presence: true
   validates :gtin, uniqueness: true, allow_nil: true
   validates :manufacturer, presence: true
-  validates :method, presence: true
   validates :snomed_product_code, presence: true, uniqueness: true
   validates :snomed_product_term, presence: true, uniqueness: true
 
-  enum :method, %i[injection nasal]
+  enum :method, %i[injection nasal], validate: true
   enum :type, { flu: "flu", hpv: "hpv" }, validate: true
 
   delegate :first_health_question, to: :health_questions
@@ -66,16 +65,15 @@ class Vaccine < ApplicationRecord
 
   alias_method :seasonal?, :flu?
 
-  def available_delivery_sites
-    if injection?
+  AVAILABLE_DELIVERY_SITES_BY_METHOD = {
+    "injection" =>
       VaccinationRecord.delivery_sites.keys -
-        %w[left_buttock right_buttock nose]
-    elsif nasal?
-      %w[nose]
-    else
-      raise NotImplementedError,
-            "Available delivery sites not implemented for #{method} vaccine."
-    end
+        %w[left_buttock right_buttock nose],
+    "nasal" => %w[nose]
+  }.freeze
+
+  def available_delivery_sites
+    AVAILABLE_DELIVERY_SITES_BY_METHOD.fetch(method)
   end
 
   AVAILABLE_DELIVERY_METHODS_BY_TYPE = {

--- a/spec/models/health_question_spec.rb
+++ b/spec/models/health_question_spec.rb
@@ -29,9 +29,7 @@
 require "rails_helper"
 
 describe HealthQuestion do
-  let(:vaccine) do
-    create :vaccine, type: "tester", brand: "Tester", method: "injection"
-  end
+  let(:vaccine) { create(:vaccine, brand: "Tester", method: "injection") }
   let!(:hqs) { create_list :health_question, 3, vaccine: }
 
   describe ".first_health_question" do

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -30,6 +30,7 @@ require "rails_helper"
 
 describe Vaccine, type: :model do
   describe "validation" do
+    it { should validate_inclusion_of(:method).in_array(%w[injection nasal]) }
     it { should validate_inclusion_of(:type).in_array(%w[flu hpv]) }
   end
 

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -29,6 +29,10 @@
 require "rails_helper"
 
 describe Vaccine, type: :model do
+  describe "validation" do
+    it { should validate_inclusion_of(:type).in_array(%w[flu hpv]) }
+  end
+
   describe "#contains_gelatine?" do
     it "returns true if the vaccine is a nasal flu vaccine" do
       vaccine = build(:vaccine, :fluenz_tetra)
@@ -63,19 +67,18 @@ describe Vaccine, type: :model do
   end
 
   describe "#seasonal?" do
-    it "returns true if the vaccine is a flu vaccine" do
-      vaccine = build(:vaccine, :flu)
-      expect(vaccine.seasonal?).to be true
+    subject(:seasonal?) { vaccine.seasonal? }
+
+    context "with a Flu vaccine" do
+      let(:vaccine) { build(:vaccine, :flu) }
+
+      it { should be(true) }
     end
 
-    it "returns false for HPV" do
-      vaccine = build(:vaccine, :gardasil_9)
-      expect(vaccine.seasonal?).to be false
-    end
+    context "with an HPV vaccine" do
+      let(:vaccine) { build(:vaccine, :hpv) }
 
-    it "raises an error for an unknown vaccine type" do
-      vaccine = build(:vaccine, type: "unknown")
-      expect { vaccine.seasonal? }.to raise_error(NotImplementedError)
+      it { should be(false) }
     end
   end
 end


### PR DESCRIPTION
This adds an enum definition to vaccines to formalise the types of vaccines we support. This will support the creation of new campaigns as we can use the list from the enum to decide the campaign type (either Flu or HPV).