### PR TITLE
Simplify campaign factory

### DIFF
--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -29,7 +29,7 @@ describe AppActivityLogComponent, type: :component do
   end
   let(:component) { described_class.new(patient_session) }
   let(:user) { create(:user, teams: [team], full_name: "Nurse Joy") }
-  let(:campaign) { create(:campaign, team:) }
+  let(:campaign) { create(:campaign, :hpv, team:) }
   let(:location) { create(:location, :school, name: "Hogwarts") }
   let(:session) { create(:session, campaign:, location:) }
   let(:patient) { create(:patient, school: location) }

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -87,7 +87,7 @@ describe AppActivityLogComponent, type: :component do
   end
 
   include_examples "card",
-                   title: "Vaccinated with Cervarix (HPV)",
+                   title: "Vaccinated with Gardasil 9 (HPV)",
                    date: "31 May 2024 at 12:00pm",
                    notes: "Some notes",
                    by: "Nurse Joy"

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -30,7 +30,17 @@ describe AppOutcomeBannerComponent, type: :component do
   end
 
   context "state is vaccinated" do
-    let(:patient_session) { create :patient_session, :vaccinated, user: }
+    let(:campaign) { create(:campaign, :hpv) }
+    let(:patient_session) do
+      create(
+        :patient_session,
+        :vaccinated,
+        user:,
+        session_attributes: {
+          campaign:
+        }
+      )
+    end
     let(:vaccination_record) { patient_session.vaccination_records.first }
     let(:vaccine) { patient_session.session.campaign.vaccines.first }
     let(:location) { patient_session.session.location }

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -13,7 +13,7 @@ describe AppPatientPageComponent, type: :component do
     # rubocop:enable RSpec/AnyInstance
   end
 
-  let(:campaign) { create(:campaign) }
+  let(:campaign) { create(:campaign, :hpv) }
   let(:vaccine) { campaign.vaccines.first }
 
   let(:component) do

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -21,12 +21,13 @@ FactoryBot.define do
   factory :campaign do
     transient { batch_count { 1 } }
 
+    name { "Campaign" }
     academic_year { Time.zone.today.year }
     start_date { Date.new(academic_year, 9, 1) }
     end_date { Date.new(academic_year + 1, 7, 31) }
 
     team
-    hpv
+    vaccines { [association(:vaccine, batch_count:)] }
 
     trait :hpv do
       name { "HPV" }
@@ -40,7 +41,7 @@ FactoryBot.define do
     end
 
     trait :hpv_no_batches do
-      transient { batch_count { 0 } }
+      batch_count { 0 }
       hpv
     end
 

--- a/spec/factories/campaigns.rb
+++ b/spec/factories/campaigns.rb
@@ -31,11 +31,16 @@ FactoryBot.define do
 
     trait :hpv do
       name { "HPV" }
+      vaccines { [association(:vaccine, :gardasil_9, batch_count:)] }
+    end
+
+    trait :hpv_all_vaccines do
+      hpv
       vaccines do
         [
-          create(:vaccine, :cervarix, batch_count:),
-          create(:vaccine, :gardasil, batch_count:),
-          create(:vaccine, :gardasil_9, batch_count:)
+          association(:vaccine, :cervarix, batch_count:),
+          association(:vaccine, :gardasil, batch_count:),
+          association(:vaccine, :gardasil_9, batch_count:)
         ]
       end
     end
@@ -49,21 +54,35 @@ FactoryBot.define do
       name { "Flu" }
       vaccines do
         [
-          create(:vaccine, :adjuvanted_quadrivalent, batch_count:),
-          create(:vaccine, :cell_quadrivalent, batch_count:),
-          create(:vaccine, :fluad_tetra, batch_count:),
-          create(:vaccine, :flucelvax_tetra, batch_count:),
-          create(:vaccine, :fluenz_tetra, batch_count:),
-          create(:vaccine, :quadrivalent_influenza, batch_count:),
-          create(:vaccine, :quadrivalent_influvac_tetra, batch_count:),
-          create(:vaccine, :supemtek, batch_count:)
+          association(:vaccine, :adjuvanted_quadrivalent, batch_count:),
+          association(:vaccine, :cell_quadrivalent, batch_count:),
+          association(:vaccine, :fluenz_tetra, batch_count:),
+          association(:vaccine, :quadrivalent_influenza, batch_count:),
+          association(:vaccine, :quadrivalent_influvac_tetra, batch_count:),
+          association(:vaccine, :supemtek, batch_count:)
+        ]
+      end
+    end
+
+    trait :flu_all_vaccines do
+      flu
+      vaccines do
+        [
+          association(:vaccine, :adjuvanted_quadrivalent, batch_count:),
+          association(:vaccine, :cell_quadrivalent, batch_count:),
+          association(:vaccine, :fluad_tetra, batch_count:),
+          association(:vaccine, :flucelvax_tetra, batch_count:),
+          association(:vaccine, :fluenz_tetra, batch_count:),
+          association(:vaccine, :quadrivalent_influenza, batch_count:),
+          association(:vaccine, :quadrivalent_influvac_tetra, batch_count:),
+          association(:vaccine, :supemtek, batch_count:)
         ]
       end
     end
 
     trait :flu_nasal_only do
       name { "Flu" }
-      vaccines { [create(:vaccine, :fluenz_tetra, batch_count:)] }
+      vaccines { [association(:vaccine, :fluenz_tetra, batch_count:)] }
     end
   end
 end

--- a/spec/factories/example_campaigns.rb
+++ b/spec/factories/example_campaigns.rb
@@ -2,6 +2,8 @@
 
 FactoryBot.define do
   factory :example_campaign, parent: :campaign do
+    hpv
+
     transient do
       user { create(:user) }
       # this name and URN matches the data in spec/fixtures/cohort_list/valid_cohort.csv

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -99,6 +99,7 @@ FactoryBot.define do
       trait key do
         send(data["type"])
         brand { data["brand"] }
+        discontinued { data.fetch("discontinued", false) }
         dose { data["dose"] }
         manufacturer { data["manufacturer"] }
         add_attribute(:method) { data["method"] }

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -39,7 +39,7 @@ describe "Immunisation imports" do
   end
 
   def and_an_hpv_campaign_is_underway
-    campaign = create(:campaign, :hpv, team: @team)
+    campaign = create(:campaign, :hpv_all_vaccines, team: @team)
     location = create(:location, :school)
     @session = create(:session, campaign:, location:)
   end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -708,7 +708,12 @@ describe ConsentForm, type: :model do
   end
 
   it "seeds the health questions when the parent gives consent" do
-    consent_form = create(:consent_form, response: "refused")
+    consent_form =
+      create(
+        :consent_form,
+        campaign: create(:campaign, :hpv),
+        response: "refused"
+      )
 
     consent_form.update!(
       response: "given",

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -161,6 +161,7 @@ describe Consent do
     consent =
       build(
         :consent,
+        campaign: create(:campaign, :hpv),
         health_answers: [],
         response: "refused",
         reason_for_refusal: "contains_gelatine",

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -170,7 +170,7 @@ describe ImmunisationImportRow, type: :model do
     context "with an invalid dose sequence" do
       let(:campaign) { create(:campaign, :hpv) }
 
-      let(:data) { { "VACCINE_GIVEN" => "Gardasil", "DOSE_SEQUENCE" => "4" } }
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil9", "DOSE_SEQUENCE" => "4" } }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -632,19 +632,21 @@ describe ImmunisationImportRow, type: :model do
     let(:campaign) { create(:campaign, :hpv) }
 
     context "without a value" do
-      let(:data) { { "VACCINE_GIVEN" => "Gardasil" } }
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil9" } }
 
       it { should be_nil }
     end
 
     context "with an invalid value" do
-      let(:data) { { "VACCINE_GIVEN" => "Gardasil", "DOSE_SEQUENCE" => "abc" } }
+      let(:data) do
+        { "VACCINE_GIVEN" => "Gardasil9", "DOSE_SEQUENCE" => "abc" }
+      end
 
       it { should be_nil }
     end
 
     context "with a valid value" do
-      let(:data) { { "VACCINE_GIVEN" => "Gardasil", "DOSE_SEQUENCE" => "1" } }
+      let(:data) { { "VACCINE_GIVEN" => "Gardasil9", "DOSE_SEQUENCE" => "1" } }
 
       it { should eq(1) }
     end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -34,7 +34,7 @@ describe ImmunisationImport, type: :model do
     create(:location, :school, urn: "144012")
   end
 
-  let(:campaign) { create(:campaign, :flu) }
+  let(:campaign) { create(:campaign, :flu_all_vaccines) }
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
   let(:team) { create(:team, ods_code: "R1L") }
@@ -77,7 +77,7 @@ describe ImmunisationImport, type: :model do
     before { immunisation_import.parse_rows! }
 
     context "with valid Flu rows" do
-      let(:campaign) { create(:campaign, :flu) }
+      let(:campaign) { create(:campaign, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       it "populates the rows" do
@@ -87,7 +87,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with valid HPV rows" do
-      let(:campaign) { create(:campaign, :hpv) }
+      let(:campaign) { create(:campaign, :hpv_all_vaccines) }
       let(:file) { "valid_hpv.csv" }
 
       it "populates the rows" do
@@ -110,7 +110,7 @@ describe ImmunisationImport, type: :model do
     subject(:process!) { immunisation_import.process! }
 
     context "with valid Flu rows" do
-      let(:campaign) { create(:campaign, :flu) }
+      let(:campaign) { create(:campaign, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -142,7 +142,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with valid HPV rows" do
-      let(:campaign) { create(:campaign, :hpv) }
+      let(:campaign) { create(:campaign, :hpv_all_vaccines) }
       let(:file) { "valid_hpv.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -184,7 +184,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with an existing patient matching the name" do
-      let(:campaign) { create(:campaign, :flu) }
+      let(:campaign) { create(:campaign, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       let!(:patient) do


### PR DESCRIPTION
This makes a number of changes to the campaign factory to simplify the default set up (reducing the number of associations) and updates the tests to only use a specific trait when required. Locally this has improved the performance of the tests by about 15 seconds:

## Before

```
Executed in   71.39 secs    fish           external
   usr time   47.79 secs    0.09 millis   47.79 secs
   sys time    3.35 secs    2.15 millis    3.35 secs
```

## After

```
Executed in   56.78 secs    fish           external
   usr time   38.35 secs    0.09 millis   38.35 secs
   sys time    2.64 secs    2.07 millis    2.63 secs

```