### PR TITLE
Ensure campaign name is present

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -34,6 +34,8 @@ class Campaign < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
+  validates :name, presence: true
+
   validates :academic_year,
             comparison: {
               greater_than_or_equal_to: 2000,

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -26,6 +26,7 @@ describe Campaign, type: :model do
   end
 
   describe "validations" do
+    it { should validate_presence_of(:name) }
     it { should validate_presence_of(:academic_year) }
 
     it do


### PR DESCRIPTION
This adds validation on the campaign name to ensure that it's provided. The field is already marked as not null, but this adds user-facing errors to the model.