### PR TITLE
Add interface for creating campaigns

### DIFF
--- a/app/controllers/campaigns/new_controller.rb
+++ b/app/controllers/campaigns/new_controller.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class Campaigns::NewController < ApplicationController
+  include Wicked::Wizard
+
+  before_action :set_campaign
+  before_action :set_steps
+  before_action :setup_wizard
+
+  skip_after_action :verify_policy_scoped
+
+  layout "two_thirds"
+
+  def show
+    render_wizard
+  end
+
+  def update
+    params = send("#{current_step}_params")
+
+    @campaign.assign_attributes(form_step: current_step, **params)
+
+    render_wizard(@campaign)
+  end
+
+  private
+
+  def set_campaign
+    @campaign =
+      policy_scope(Campaign).where(
+        active: params[:id] == Wicked::FINISH_STEP
+      ).find(params[:campaign_id])
+  end
+
+  def set_steps
+    self.steps = @campaign.form_steps
+  end
+
+  def finish_wizard_path
+    campaign_path(@campaign)
+  end
+
+  def current_step
+    @current_step ||= wizard_value(step).to_sym
+  end
+
+  def details_params
+    params.require(:campaign).permit(:name, :academic_year, :type)
+  end
+
+  def dates_params
+    params.require(:campaign).permit(:start_date, :end_date)
+  end
+
+  def confirm_params
+    { active: true, vaccines: Vaccine.active.where(type: @campaign.type) }
+  end
+end

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -1,10 +1,21 @@
 # frozen_string_literal: true
 
 class CampaignsController < ApplicationController
-  before_action :set_campaign, except: :index
+  before_action :set_campaign, only: %i[show sessions]
+
+  skip_after_action :verify_policy_scoped, only: :create
 
   def index
     @campaigns = campaigns
+  end
+
+  def create
+    campaign = Campaign.create!(team: current_user.team)
+
+    redirect_to campaign_new_path(
+                  campaign_id: campaign.id,
+                  id: campaign.form_steps.first
+                )
   end
 
   def show

--- a/app/helpers/campaigns_helper.rb
+++ b/app/helpers/campaigns_helper.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module CampaignsHelper
-  def campaign_academic_year(campaign)
-    year_1 = campaign.academic_year.to_s
-    year_2 = (campaign.academic_year + 1).to_s
+  def campaign_academic_year(value)
+    academic_year = value.is_a?(Campaign) ? value.academic_year : value
+
+    year_1 = academic_year.to_s
+    year_2 = (academic_year + 1).to_s
     "#{year_1}/#{year_2[2..3]}"
   end
 end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -45,6 +45,8 @@ class Vaccine < ApplicationRecord
   enum :method, %i[injection nasal], validate: true
   enum :type, { flu: "flu", hpv: "hpv" }, validate: true
 
+  scope :active, -> { where(discontinued: false) }
+
   delegate :first_health_question, to: :health_questions
 
   def contains_gelatine?

--- a/app/views/campaigns/index.html.erb
+++ b/app/views/campaigns/index.html.erb
@@ -1,4 +1,8 @@
-<%= h1 t(".title"), size: "xl" %>
+<div class="app-heading-group">
+  <%= h1 t(".title"), size: "xl" %>
+
+  <%= govuk_button_to "Create a new vaccination programme", campaigns_path, secondary: true %>
+</div>
 
 <div class="nhsuk-table__panel-with-heading-tab">
   <h3 class="nhsuk-table__heading-tab">Active campaigns</h3>
@@ -18,7 +22,10 @@
             <span class="nhsuk-table-responsive__heading">Name</span>
             <%= link_to campaign.name, campaign_path(campaign) %>
           <% end %>
-          <% row.with_cell(text: campaign_academic_year(campaign)) %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Academic year</span>
+            <%= campaign_academic_year(campaign) %>
+          <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccines</span>
             <%= campaign.vaccines

--- a/app/views/campaigns/new/confirm.html.erb
+++ b/app/views/campaigns/new/confirm.html.erb
@@ -1,0 +1,45 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: previous_wizard_path,
+        name: "#{@previous_step} page of programme creation",
+      ) %>
+<% end %>
+
+<%= h1 "Check and confirm" %>
+
+<%= form_with model: @campaign, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render AppCardComponent.new do |card| %>
+    <% card.with_heading { "New programme details" } %>
+
+    <%= govuk_summary_list do |summary_list| %>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key { "Name" } %>
+        <%= row.with_value { @campaign.name } %>
+      <% end %>
+
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key { "Type" } %>
+        <%= row.with_value { @campaign.human_enum_name(:type) } %>
+      <% end %>
+
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key { "Academic year" } %>
+        <%= row.with_value { campaign_academic_year(@campaign) } %>
+      <% end %>
+
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key { "Start date" } %>
+        <%= row.with_value { @campaign.start_date.to_fs(:long) } %>
+      <% end %>
+
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key { "End date" } %>
+        <%= row.with_value { @campaign.end_date.to_fs(:long) } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit "Save changes" %>
+<% end %>

--- a/app/views/campaigns/new/dates.html.erb
+++ b/app/views/campaigns/new/dates.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: previous_wizard_path,
+        name: "#{@previous_step} page of programme creation",
+      ) %>
+<% end %>
+
+<%= h1 "When does this programme run?" %>
+
+<%= form_with model: @campaign, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_date_field :start_date, legend: { text: "Start date" } %>
+
+  <%= f.govuk_date_field :end_date, legend: { text: "End date" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/campaigns/new/details.html.erb
+++ b/app/views/campaigns/new/details.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(href: campaigns_path, name: "programme") %>
+<% end %>
+
+<%= h1 "Programme details" %>
+
+<%= form_with model: @campaign, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_field :name, label: { size: "m" } %>
+
+  <%= f.govuk_collection_radio_buttons :type, Campaign.types.keys.map { [_1, Campaign.human_enum_name(:type, _1)] }, :first, :second, legend: { text: "Programme type" } %>
+
+  <%= f.govuk_radio_buttons_fieldset :academic_year, legend: { text: "Academic year" } do %>
+    <% today_year = Time.zone.today.year %>
+    <% [today_year - 1, today_year, today_year + 1].each_with_index do |academic_year, index| %>
+      <%= f.govuk_radio_button(
+            :academic_year, academic_year.to_s,
+            label: { text: campaign_academic_year(academic_year) },
+            link_errors: index.zero?,
+          ) %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,10 @@ en:
               inclusion: The school URN is not recognised. If you’ve checked the URN, and you believe it’s valid, contact our support team.
   activerecord:
     attributes:
+      campaign:
+        types:
+          flu: Flu
+          hpv: HPV
       consent:
         reason_for_refusals:
           already_vaccinated: Vaccine already received
@@ -198,6 +202,18 @@ en:
               missing_year: Enter a year
             name:
               blank: Enter a batch
+        campaign:
+          attributes:
+            academic_year:
+              blank: Choose an academic year
+            end_date:
+              blank: Enter an end date
+            name:
+              blank: Enter a name
+            start_date:
+              blank: Enter a start date
+            type:
+              inclusion: Choose a programme type
         consent:
           attributes:
             new_or_existing_parent:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,8 +63,13 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :campaigns, only: %i[index show] do
+  resources :campaigns, only: %i[index create show] do
     get "sessions", on: :member
+
+    resource :new,
+             controller: "campaigns/new",
+             only: %i[show update],
+             path: "new/:id"
 
     resources :immunisation_imports,
               path: "immunisation-imports",

--- a/spec/features/create_campaign_spec.rb
+++ b/spec/features/create_campaign_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Create campaign" do
+  before do
+    given_i_am_signed_in
+    and_active_and_discontinued_vaccines_exist
+  end
+
+  scenario "User creates a Flu campaign" do
+    when_i_go_to_the_campaigns_page
+    and_i_click_on_the_new_campaign_button
+    then_i_should_see_the_details_page
+
+    when_i_fill_in_flu_details
+    and_i_click_continue
+    then_i_should_see_the_dates_page
+
+    when_i_fill_in_the_dates
+    and_i_click_continue
+    then_i_should_see_the_confirm_page
+
+    when_i_confirm_the_campaign
+    then_i_should_see_the_campaign_page
+    and_i_should_see_the_flu_campaign
+
+    when_i_go_to_the_campaigns_page
+    then_i_should_see_the_flu_campaign_and_vaccines
+  end
+
+  scenario "User creates an HPV campaign" do
+    when_i_go_to_the_campaigns_page
+    and_i_click_on_the_new_campaign_button
+    then_i_should_see_the_details_page
+
+    when_i_fill_in_hpv_details
+    and_i_click_continue
+    then_i_should_see_the_dates_page
+
+    when_i_fill_in_the_dates
+    and_i_click_continue
+    then_i_should_see_the_confirm_page
+
+    when_i_confirm_the_campaign
+    then_i_should_see_the_campaign_page
+    and_i_should_see_the_hpv_campaign
+
+    when_i_go_to_the_campaigns_page
+    then_i_should_see_the_hpv_campaign_and_vaccines
+  end
+
+  def given_i_am_signed_in
+    @team = create(:team, :with_one_nurse, ods_code: "R1L")
+    sign_in @team.users.first
+  end
+
+  def and_active_and_discontinued_vaccines_exist
+    create(:vaccine, :gardasil_9)
+    create(:vaccine, :gardasil)
+
+    create(:vaccine, :fluenz_tetra)
+    create(:vaccine, :fluad_tetra)
+  end
+
+  def when_i_go_to_the_campaigns_page
+    visit "/dashboard"
+    click_on "Vaccination programmes", match: :first
+  end
+
+  def and_i_click_on_the_new_campaign_button
+    click_on "Create a new vaccination programme"
+  end
+
+  def then_i_should_see_the_details_page
+    expect(page).to have_content("Programme details")
+  end
+
+  def when_i_fill_in_flu_details
+    fill_in "Name", with: "Flu"
+    choose "Flu"
+    choose "2025/26"
+  end
+
+  def when_i_fill_in_hpv_details
+    fill_in "Name", with: "HPV"
+    choose "HPV"
+    choose "2025/26"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def then_i_should_see_the_dates_page
+    expect(page).to have_content("When does this programme run?")
+  end
+
+  def when_i_fill_in_the_dates
+    within all(".nhsuk-fieldset")[0] do
+      fill_in "Day", with: "1"
+      fill_in "Month", with: "09"
+      fill_in "Year", with: "2025"
+    end
+
+    within all(".nhsuk-fieldset")[1] do
+      fill_in "Day", with: "31"
+      fill_in "Month", with: "05"
+      fill_in "Year", with: "2026"
+    end
+  end
+
+  def then_i_should_see_the_confirm_page
+    expect(page).to have_content("Check and confirm")
+  end
+
+  def when_i_confirm_the_campaign
+    click_on "Save changes"
+  end
+
+  def then_i_should_see_the_campaign_page
+    expect(page).to have_content("Vaccination programmes")
+  end
+
+  def and_i_should_see_the_flu_campaign
+    expect(page).to have_content("Flu\n2025/26")
+  end
+
+  def and_i_should_see_the_hpv_campaign
+    expect(page).to have_content("HPV\n2025/26")
+  end
+
+  def then_i_should_see_the_flu_campaign_and_vaccines
+    expect(page).to have_content(
+      "Name Flu Academic year 2025/26 Vaccines Fluenz Tetra - LAIV"
+    )
+  end
+
+  def then_i_should_see_the_hpv_campaign_and_vaccines
+    expect(page).to have_content(
+      "Name HPV Academic year 2025/26 Vaccines Gardasil 9"
+    )
+  end
+end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -26,21 +26,19 @@
 require "rails_helper"
 
 describe Campaign, type: :model do
+  subject(:campaign) do
+    build(:campaign, academic_year: 2024, start_date: Date.new(2024, 6, 1))
+  end
+
   it { should normalize(:name).from(" abc ").to("abc") }
 
   describe "validations" do
-    subject(:campaign) do
-      build(
-        :campaign,
-        :active,
-        academic_year: 2024,
-        start_date: Date.new(2024, 6, 1)
-      )
-    end
+    it { should validate_presence_of(:name).on(:update) }
 
-    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:type).on(:update) }
     it { should validate_inclusion_of(:type).in_array(%w[flu hpv]) }
-    it { should validate_presence_of(:academic_year) }
+
+    it { should validate_presence_of(:academic_year).on(:update) }
 
     it do
       expect(campaign).to validate_comparison_of(
@@ -50,7 +48,7 @@ describe Campaign, type: :model do
       )
     end
 
-    it { should validate_presence_of(:start_date) }
+    it { should validate_presence_of(:start_date).on(:update) }
 
     it do
       expect(campaign).to validate_comparison_of(
@@ -58,7 +56,7 @@ describe Campaign, type: :model do
       ).is_greater_than_or_equal_to(Date.new(2024, 1, 1))
     end
 
-    it { should validate_presence_of(:end_date) }
+    it { should validate_presence_of(:end_date).on(:update) }
 
     it do
       expect(campaign).to validate_comparison_of(


### PR DESCRIPTION
This adds a new step-by-step interface for creating new campaigns based on the designs in the prototype. I've introduced a new controller which handles all the logic related to the steps using the Wicked Gem that we're using in other places.

## Screenshots

<img width="1141" alt="Screenshot 2024-08-16 at 15 13 08" src="https://github.com/user-attachments/assets/82529e51-e964-4261-a68c-26d1087e9db0">

![Screenshot 2024-08-16 at 10 11 22](https://github.com/user-attachments/assets/debc7aad-4632-4a8a-86fc-9b344c6c0b1a)

<img width="761" alt="Screenshot 2024-08-16 at 14 37 47" src="https://github.com/user-attachments/assets/1b203985-11d3-455a-9005-4313017e96d7">

<img width="804" alt="Screenshot 2024-08-16 at 14 46 38" src="https://github.com/user-attachments/assets/15281ec9-177d-45a1-9053-47069d12bdc2">
