### PR TITLE
Add missing campaign error message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,7 @@ en:
             start_date:
               blank: Enter a start date
             type:
+              blank: Choose a programme type
               inclusion: Choose a programme type
         consent:
           attributes:


### PR DESCRIPTION
This adds a missing error message to the campaign creation page when the programme type is not selected.