### PR TITLE
Validate vaccination record administered at date

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -58,7 +58,8 @@ class ImmunisationImportRow
   validates :session_date,
             presence: true,
             comparison: {
-              less_than_or_equal_to: -> { Date.current }
+              greater_than_or_equal_to: :campaign_start_date,
+              less_than_or_equal_to: :campaign_end_date_or_today
             }
   validates :reason,
             inclusion: {
@@ -350,6 +351,14 @@ class ImmunisationImportRow
 
   def maximum_dose_sequence
     vaccine.maximum_dose_sequence
+  end
+
+  def campaign_start_date
+    @campaign.start_date
+  end
+
+  def campaign_end_date_or_today
+    [@campaign.end_date, Date.current].min
   end
 
   def requires_care_setting?

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -117,6 +117,14 @@ class VaccinationRecord < ApplicationRecord
 
   validates :notes, length: { maximum: 1000 }
 
+  validates :administered_at,
+            comparison: {
+              greater_than_or_equal_to: :first_possible_administered_at,
+              less_than: :last_possible_administered_at,
+              allow_nil: true
+            },
+            if: :campaign
+
   validates :delivery_site,
             inclusion: {
               in: delivery_sites.keys
@@ -192,6 +200,14 @@ class VaccinationRecord < ApplicationRecord
   end
 
   private
+
+  def first_possible_administered_at
+    campaign.start_date.in_time_zone
+  end
+
+  def last_possible_administered_at
+    (campaign.end_date + 1.day).in_time_zone
+  end
 
   def maximum_dose_sequence
     vaccine&.maximum_dose_sequence || 1

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -7,10 +7,16 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
 
   let(:component) { described_class.new(vaccination_record) }
 
-  let(:administered_at) { Time.zone.local(2023, 6, 9, 12) }
+  let(:administered_at) { Time.zone.local(2024, 9, 6, 12) }
   let(:location) { create(:location, :school, name: "Hogwarts") }
   let(:campaign) do
-    create(:campaign, type: vaccine&.type || :hpv, vaccines: [vaccine].compact)
+    create(
+      :campaign,
+      :active,
+      academic_year: 2024,
+      type: vaccine&.type || :hpv,
+      vaccines: [vaccine].compact
+    )
   end
   let(:session) { create(:session, campaign:, location:) }
   let(:patient_session) { create(:patient_session, session:) }
@@ -166,7 +172,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
     it do
       expect(rendered).to have_css(
         ".nhsuk-summary-list__row",
-        text: "Date\n9 June 2023"
+        text: "Date\n6 September 2024"
       )
     end
   end

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -12,9 +12,7 @@ describe VaccinationMailerConcern do
     let(:consent) { create(:consent, campaign:, route:) }
     let(:patient) { create(:patient, consents: [consent]) }
     let(:patient_session) { create(:patient_session, session:, patient:) }
-    let(:vaccination_record) do
-      create(:vaccination_record, patient_session:, administered:)
-    end
+    let(:vaccination_record) { create(:vaccination_record, patient_session:) }
     let(:administered_mail) { double(deliver_later: true) }
     let(:not_administered_mail) { double(deliver_later: true) }
 
@@ -28,8 +26,6 @@ describe VaccinationMailerConcern do
     end
 
     context "when the vaccination has taken place" do
-      let(:administered) { true }
-
       it "calls hpv_vaccination_has_taken_place" do
         expect(VaccinationMailer).to have_received(
           :hpv_vaccination_has_taken_place
@@ -42,7 +38,9 @@ describe VaccinationMailerConcern do
     end
 
     context "when the vaccination hasn't taken place" do
-      let(:administered) { false }
+      let(:vaccination_record) do
+        create(:vaccination_record, :not_administered, patient_session:)
+      end
 
       it "calls hpv_vaccination_has_not_taken_place" do
         expect(VaccinationMailer).to have_received(

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -142,14 +142,15 @@ FactoryBot.define do
         ]
       end
       vaccination_records do
-        create_list(
-          :vaccination_record,
-          1,
-          reason: :already_had,
-          administered: false,
-          user:,
-          patient_session: instance
-        )
+        [
+          association(
+            :vaccination_record,
+            :not_administered,
+            reason: :already_had,
+            user:,
+            patient_session: instance
+          )
+        ]
       end
     end
 
@@ -195,13 +196,7 @@ FactoryBot.define do
         ]
       end
       vaccination_records do
-        create_list(
-          :vaccination_record,
-          1,
-          administered: true,
-          user:,
-          patient_session: instance
-        )
+        [association(:vaccination_record, user:, patient_session: instance)]
       end
     end
 

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -53,7 +53,14 @@ FactoryBot.define do
     vaccine { patient_session.session.campaign.vaccines.first }
     batch { vaccine.batches.first }
     user { create :user }
-    administered_at { Time.zone.now }
+
+    administered_at do
+      Faker::Time.between(
+        from: patient_session.session.campaign.start_date,
+        to: patient_session.session.campaign.end_date
+      )
+    end
+
     dose_sequence { 1 }
     uuid { SecureRandom.uuid }
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 describe "HPV Vaccination" do
   include EmailExpectations
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2024, 2, 1)) { example.run }
+  end
+
   scenario "Administered" do
     given_i_am_signed_in
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
@@ -24,7 +28,7 @@ describe "HPV Vaccination" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     location = create(:location, :school)
-    campaign = create(:campaign, :hpv, team:)
+    campaign = create(:campaign, :hpv, academic_year: 2023, team:)
     @batch = campaign.batches.first
     @session = create(:session, campaign:, location:)
     @patient =

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 describe "HPV Vaccination" do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2024, 2, 1)) { example.run }
+  end
+
   scenario "Default batch" do
     given_i_am_signed_in
     when_i_vaccinate_a_patient
@@ -20,7 +24,7 @@ describe "HPV Vaccination" do
   end
 
   def given_i_am_signed_in
-    campaign = create(:example_campaign, :in_progress)
+    campaign = create(:example_campaign, :in_progress, academic_year: 2023)
     team = campaign.team
     @batch = campaign.batches.first
     @batch2 = campaign.batches.second

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -39,7 +39,8 @@ describe "Immunisation imports" do
   end
 
   def and_an_hpv_campaign_is_underway
-    campaign = create(:campaign, :hpv_all_vaccines, team: @team)
+    campaign =
+      create(:campaign, :hpv_all_vaccines, academic_year: 2023, team: @team)
     location = create(:location, :school)
     @session = create(:session, campaign:, location:)
   end

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 require "csv"
 
 describe "Pilot journey" do
-  before { Timecop.freeze(Time.zone.local(2024, 2, 1)) }
-  after { Timecop.return }
+  around do |example|
+    Timecop.freeze(Time.zone.local(2024, 2, 1)) { example.run }
+  end
 
   scenario "Cohorting, session creation, verbal consent, vaccination" do
     # Cohorting
@@ -46,7 +47,7 @@ describe "Pilot journey" do
 
   def given_an_hpv_campaign_is_underway
     @team = create(:team, :with_one_nurse)
-    @campaign = create(:campaign, :hpv, team: @team)
+    @campaign = create(:campaign, :hpv, academic_year: 2023, team: @team)
     @school = create(:location, :school, name: "Pilot School")
   end
 

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -9,7 +9,7 @@ describe DPSExportRow do
   let(:team) { create(:team) }
   let(:vaccine) { create(:vaccine, :gardasil_9, dose: 0.5) }
   let(:campaign) do
-    create(:campaign, type: vaccine.type, team:, vaccines: [vaccine])
+    create(:campaign, :active, type: vaccine.type, team:, vaccines: [vaccine])
   end
   let(:location) { create(:location, :school) }
   let(:school) { create(:location, :school) }

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -815,11 +815,11 @@ describe ImmunisationImportRow, type: :model do
     end
 
     context "with a daylight saving time date" do
-      let(:data) { valid_data.merge("DATE_OF_VACCINATION" => "20230701") }
+      let(:data) { valid_data.merge("DATE_OF_VACCINATION" => "20230901") }
 
       it "sets the administered at time" do
         expect(vaccination_record.administered_at).to eq(
-          Time.new(2023, 7, 1, 12, 0, 0, "+01:00")
+          Time.new(2023, 9, 1, 12, 0, 0, "+01:00")
         )
       end
     end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -12,7 +12,7 @@ describe ImmunisationImportRow, type: :model do
     )
   end
 
-  let(:campaign) { create(:campaign, :flu) }
+  let(:campaign) { create(:campaign, :flu, academic_year: 2023) }
   let(:team) { create(:team, ods_code: "abc") }
   let(:user) { create(:user, teams: [team]) }
   let(:immunisation_import) { create(:immunisation_import, campaign:, user:) }
@@ -181,7 +181,7 @@ describe ImmunisationImportRow, type: :model do
     end
 
     context "with valid fields for Flu" do
-      let(:campaign) { create(:campaign, :flu) }
+      let(:campaign) { create(:campaign, :flu, academic_year: 2023) }
 
       let(:data) do
         {

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -34,7 +34,8 @@ describe ImmunisationImport, type: :model do
     create(:location, :school, urn: "144012")
   end
 
-  let(:campaign) { create(:campaign, :flu_all_vaccines) }
+  let(:academic_year) { 2023 }
+  let(:campaign) { create(:campaign, :flu_all_vaccines, academic_year:) }
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
   let(:team) { create(:team, ods_code: "R1L") }
@@ -77,7 +78,7 @@ describe ImmunisationImport, type: :model do
     before { immunisation_import.parse_rows! }
 
     context "with valid Flu rows" do
-      let(:campaign) { create(:campaign, :flu_all_vaccines) }
+      let(:campaign) { create(:campaign, :flu_all_vaccines, academic_year:) }
       let(:file) { "valid_flu.csv" }
 
       it "populates the rows" do
@@ -87,7 +88,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with valid HPV rows" do
-      let(:campaign) { create(:campaign, :hpv_all_vaccines) }
+      let(:campaign) { create(:campaign, :hpv_all_vaccines, academic_year:) }
       let(:file) { "valid_hpv.csv" }
 
       it "populates the rows" do
@@ -110,7 +111,7 @@ describe ImmunisationImport, type: :model do
     subject(:process!) { immunisation_import.process! }
 
     context "with valid Flu rows" do
-      let(:campaign) { create(:campaign, :flu_all_vaccines) }
+      let(:campaign) { create(:campaign, :flu_all_vaccines, academic_year:) }
       let(:file) { "valid_flu.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -142,7 +143,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with valid HPV rows" do
-      let(:campaign) { create(:campaign, :hpv_all_vaccines) }
+      let(:campaign) { create(:campaign, :hpv_all_vaccines, academic_year:) }
       let(:file) { "valid_hpv.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -184,7 +185,7 @@ describe ImmunisationImport, type: :model do
     end
 
     context "with an existing patient matching the name" do
-      let(:campaign) { create(:campaign, :flu_all_vaccines) }
+      let(:campaign) { create(:campaign, :flu_all_vaccines, academic_year:) }
       let(:file) { "valid_flu.csv" }
 
       let!(:patient) do


### PR DESCRIPTION
This validates the `administered_at` column to ensure that it's always within the start and end date of the campaign. We need this to ensure that we're only recording vaccinations that are part of the campaign.