### PR TITLE
Remove unneeded presence validations

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -89,7 +89,7 @@ class Consent < ApplicationRecord
             if: -> { recorded_at.present? && !via_self_consent? }
 
   on_wizard_step :route do
-    validates :route, inclusion: { in: Consent.routes.keys }, presence: true
+    validates :route, inclusion: { in: Consent.routes.keys }
   end
 
   on_wizard_step :who, exact: true do
@@ -101,19 +101,14 @@ class Consent < ApplicationRecord
   end
 
   on_wizard_step :agree do
-    validates :response,
-              inclusion: {
-                in: Consent.responses.keys
-              },
-              presence: true
+    validates :response, inclusion: { in: Consent.responses.keys }
   end
 
   on_wizard_step :reason do
     validates :reason_for_refusal,
               inclusion: {
                 in: Consent.reason_for_refusals.keys
-              },
-              presence: true
+              }
   end
 
   on_wizard_step :reason_notes do

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -124,11 +124,7 @@ class ConsentForm < ApplicationRecord
   end
 
   on_wizard_step :school, exact: true do
-    validates :is_this_their_school,
-              presence: true,
-              inclusion: {
-                in: %w[yes no]
-              }
+    validates :is_this_their_school, inclusion: { in: %w[yes no] }
   end
 
   on_wizard_step :consent do

--- a/app/models/health_answer.rb
+++ b/app/models/health_answer.rb
@@ -13,7 +13,7 @@ class HealthAnswer
 
   validates :notes, length: { maximum: 1000 }
 
-  validates :response, presence: true, inclusion: { in: %w[yes no] }
+  validates :response, inclusion: { in: %w[yes no] }
   validates :notes, presence: true, if: -> { response == "yes" }
 
   def attributes

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -25,7 +25,6 @@ class ImmunisationImportRow
             }
   validates :recorded_at, presence: true
   validates :vaccine_given,
-            presence: true,
             inclusion: {
               in: :valid_given_vaccines
             },
@@ -38,7 +37,6 @@ class ImmunisationImportRow
             presence: true,
             if: -> { school_urn == SCHOOL_URN_UNKNOWN }
   validates :school_urn,
-            presence: true,
             inclusion: {
               in: -> do
                 Location.school.pluck(:urn) +
@@ -53,11 +51,7 @@ class ImmunisationImportRow
             comparison: {
               less_than_or_equal_to: -> { Date.current }
             }
-  validates :patient_gender_code,
-            presence: true,
-            inclusion: {
-              in: Patient.gender_codes.values
-            }
+  validates :patient_gender_code, inclusion: { in: Patient.gender_codes.values }
   validates :patient_postcode, presence: true, postcode: true
   validate :zero_or_one_existing_patient
 
@@ -67,7 +61,6 @@ class ImmunisationImportRow
               less_than_or_equal_to: -> { Date.current }
             }
   validates :reason,
-            presence: true,
             inclusion: {
               in: VaccinationRecord.reasons.keys.map(&:to_sym)
             },

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -37,11 +37,7 @@ class Parent < ApplicationRecord
   validates :name, presence: true
   validates :phone, phone: true, if: -> { phone.present? }
   validates :email, presence: true, notify_safe_email: true
-  validates :relationship,
-            inclusion: {
-              in: Parent.relationships.keys
-            },
-            presence: true
+  validates :relationship, inclusion: { in: Parent.relationships.keys }
   validates :relationship_other, presence: true, if: -> { relationship_other? }
   validate :has_parental_responsibility, if: -> { relationship_other? }
   validates :contact_method_other,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -60,7 +60,6 @@ class Session < ApplicationRecord
   after_validation :set_timeline_timestamps
 
   validates :time_of_day,
-            presence: true,
             inclusion: {
               in: time_of_days.keys
             },
@@ -73,11 +72,7 @@ class Session < ApplicationRecord
   on_wizard_step :when, exact: true do
     validates :date, presence: true
 
-    validates :time_of_day,
-              presence: true,
-              inclusion: {
-                in: Session.time_of_days.keys
-              }
+    validates :time_of_day, inclusion: { in: Session.time_of_days.keys }
   end
 
   on_wizard_step :cohort, exact: true do
@@ -92,11 +87,7 @@ class Session < ApplicationRecord
                 less_than_or_equal_to: ->(object) { object.date }
               }
 
-    validates :reminder_days_after,
-              presence: true,
-              inclusion: {
-                in: %w[default custom]
-              }
+    validates :reminder_days_after, inclusion: { in: %w[default custom] }
     validates :reminder_days_after_custom,
               presence: true,
               numericality: {
@@ -105,11 +96,7 @@ class Session < ApplicationRecord
               },
               if: -> { reminder_days_after == "custom" }
 
-    validates :close_consent_on,
-              presence: true,
-              inclusion: {
-                in: %w[default custom]
-              }
+    validates :close_consent_on, inclusion: { in: %w[default custom] }
     validates :close_consent_at,
               presence: true,
               if: -> { close_consent_on == "custom" }

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -32,13 +32,17 @@ class Triage < ApplicationRecord
   has_one :campaign, through: :session
 
   enum :status,
-       %i[ready_to_vaccinate do_not_vaccinate needs_follow_up delay_vaccination]
+       %i[
+         ready_to_vaccinate
+         do_not_vaccinate
+         needs_follow_up
+         delay_vaccination
+       ],
+       validate: true
 
   encrypts :notes
 
   validates :notes, length: { maximum: 1000 }
-
-  validates :status, presence: true, inclusion: { in: statuses.keys }
 
   def triage_complete?
     ready_to_vaccinate? || do_not_vaccinate?

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -118,13 +118,11 @@ class VaccinationRecord < ApplicationRecord
   validates :notes, length: { maximum: 1000 }
 
   validates :delivery_site,
-            presence: true,
             inclusion: {
               in: delivery_sites.keys
             },
             if: -> { administered? && !delivery_site_other }
   validates :delivery_method,
-            presence: true,
             inclusion: {
               in: delivery_methods.keys
             },
@@ -140,12 +138,10 @@ class VaccinationRecord < ApplicationRecord
 
   on_wizard_step :"delivery-site", exact: true do
     validates :delivery_site,
-              presence: true,
               inclusion: {
                 in: VaccinationRecord.delivery_sites.keys
               }
     validates :delivery_method,
-              presence: true,
               inclusion: {
                 in: VaccinationRecord.delivery_methods.keys
               }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,7 +67,6 @@ en:
               blank: Enter details
               too_long: Enter details that are less than 1000 characters long
             response:
-              blank: Choose an answer
               inclusion: Choose an answer
         immunisation_import_row:
           attributes:
@@ -86,7 +85,7 @@ en:
             patient_first_name:
               multiple_duplicate_match: two or more possible patients match
             patient_gender_code:
-              blank: is required but missing
+              inclusion: is required but missing
             patient_postcode:
               blank: is required but missing
             school_urn:
@@ -267,7 +266,6 @@ en:
             gp_response:
               blank: Choose if your child is registered with a GP
             is_this_their_school:
-              blank: Tell us if this is their school
               inclusion: Tell us if this is their school
             last_name:
               blank: Enter a last name
@@ -283,7 +281,6 @@ en:
               invalid: Enter a valid phone number, like 07700 900 000
               too_long: Enter a phone number that is less than 300 characters long
             parent_relationship:
-              blank: Choose your relationship
               inclusion: Choose a relationship
             parent_relationship_other:
               blank: Enter your relationship
@@ -345,7 +342,6 @@ en:
               invalid: Enter a valid phone number, like 07700 900 000
               too_long: Enter a phone number that is less than 300 characters long
             relationship:
-              blank: Choose a relationship
               inclusion: Choose a relationship
             relationship_other:
               blank: Enter a relationship
@@ -355,7 +351,6 @@ en:
             close_consent_at:
               blank: Choose a date for the deadline
             close_consent_on:
-              blank: Choose a deadline for responses
               inclusion: Choose a deadline for responses
             date:
               blank: Enter a date
@@ -368,7 +363,6 @@ en:
             patients:
               blank: You must choose a cohort to continue
             reminder_days_after:
-              blank: Choose when to send reminders
               inclusion: Choose when to send reminders
             reminder_days_after_custom:
               blank: Choose the number of days after the session to send reminders
@@ -382,7 +376,6 @@ en:
               missing_month: Enter a month
               missing_year: Enter a year
             time_of_day:
-              blank: Select a time of day
               inclusion: Select a time of day
         triage:
           attributes:
@@ -422,9 +415,9 @@ en:
               blank: Choose a batch
               incorrect_vaccine: Choose a batch of the %{vaccine_brand} vaccine
             delivery_method:
-              blank: Choose a method of delivery
+              inclusion: Choose a method of delivery
             delivery_site:
-              blank: Choose a delivery site
+              inclusion: Choose a delivery site
             notes:
               too_long: Enter notes that are less than 1000 characters long
             reason:

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -110,8 +110,6 @@ describe ConsentForm, type: :model do
         it { should validate_presence_of(:date_of_birth).on(:update) }
       end
 
-      it { should validate_presence_of(:is_this_their_school).on(:update) }
-
       it do
         expect(subject).to validate_inclusion_of(
           :is_this_their_school


### PR DESCRIPTION
When a presence validation is paired with an inclusion validation there's often no need to have both. The inclusion implicitly checks whether the value is present by requiring it to match the list of valid values, and we often don't need to present the user with two error messages (one for presence and one for inclusion).