### PR TITLE
Use pipe to separate the DPS csv fields

### DIFF
--- a/app/models/dps_export.rb
+++ b/app/models/dps_export.rb
@@ -32,7 +32,7 @@ class DPSExport < ApplicationRecord
 
   def csv
     @csv ||=
-      CSV.generate(headers: true, force_quotes: true) do |csv|
+      CSV.generate(headers: true, force_quotes: true, col_sep: "|") do |csv|
         csv << DPSExportRow::FIELDS.map(&:upcase)
 
         vaccination_records

--- a/spec/models/dps_export_spec.rb
+++ b/spec/models/dps_export_spec.rb
@@ -41,7 +41,7 @@ describe DPSExport, type: :model do
       subject(:header) { csv.split("\n").first }
 
       it "has all the fields in the correct order" do
-        expect(header.split(",")).to eq %w[
+        expect(header.split("|")).to eq %w[
              "NHS_NUMBER"
              "PERSON_FORENAME"
              "PERSON_SURNAME"


### PR DESCRIPTION
Despite being described as a CSV file, the spec for this DPS export wants a pipe field separator. Is this really still called a CSV file??