### PR TITLE
Refactor administered_at test

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -286,7 +286,7 @@ class ImmunisationImportRow
   attr_reader :imported_from
 
   def administered_at
-    administered ? session_date.to_time : nil
+    administered ? (session_date.in_time_zone + 12.hours) : nil
   end
 
   def location

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -808,10 +808,20 @@ describe ImmunisationImportRow, type: :model do
       expect(vaccination_record.user).to be_nil
     end
 
-    it "sets the administered at time to the session date" do
+    it "sets the administered at time" do
       expect(vaccination_record.administered_at).to eq(
-        Time.zone.local(2024, 1, 1)
+        Time.new(2024, 1, 1, 12, 0, 0, "+00:00")
       )
+    end
+
+    context "with a daylight saving time date" do
+      let(:data) { valid_data.merge("DATE_OF_VACCINATION" => "20230701") }
+
+      it "sets the administered at time" do
+        expect(vaccination_record.administered_at).to eq(
+          Time.new(2023, 7, 1, 12, 0, 0, "+01:00")
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This improves the test by explicitly checking the time zone to ensure that we're correctly choosing GMT or BST according to the date of the vaccination.

We've also decided to change the time of day to be midday rather than midnight.