### PR TITLE
Fix school importer

### DIFF
--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -100,11 +100,11 @@ namespace :schools do
         )
 
         if locations.size >= batch_size
-          Location.import locations,
-                          on_duplicate_key_update: {
-                            conflict_target: [:urn],
-                            columns: %i[name address town county postcode url]
-                          }
+          Location.import! locations,
+                           on_duplicate_key_update: {
+                             conflict_target: [:urn],
+                             columns: %i[name address town county postcode url]
+                           }
           locations.clear
         end
 
@@ -113,11 +113,11 @@ namespace :schools do
 
       # Import remaining locations in the last incomplete batch
       unless locations.empty?
-        Location.import locations,
-                        on_duplicate_key_update: {
-                          conflict_target: [:urn],
-                          columns: %i[name address town county postcode url]
-                        }
+        Location.import! locations,
+                         on_duplicate_key_update: {
+                           conflict_target: [:urn],
+                           columns: %i[name address town county postcode url]
+                         }
       end
     end
 

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -79,6 +79,16 @@ namespace :schools do
         )
       # rubocop:enable Rails/SaveBang
 
+      # Some URLs from the GIAS CSV are missing the protocol.
+      process_url = ->(url) do
+        return nil if url.blank?
+        url.start_with?("http://", "https://") ? url : "https://#{url}"
+
+        # Legh Vale school has a URL of http:www.leghvale.st-helens.sch.uk
+        # which is not a valid URL.
+        url.gsub!("http:www", "http://www")
+      end
+
       CSV.parse(
         csv_content,
         headers: true,
@@ -96,7 +106,7 @@ namespace :schools do
           town: row["Town"],
           county: row["County (name)"],
           postcode: row["Postcode"],
-          url: row["SchoolWebsite"]
+          url: process_url.call(row["SchoolWebsite"].presence)
         )
 
         if locations.size >= batch_size


### PR DESCRIPTION
Use `import!` which causes the import to fail if any locations don't pass validations.

The GIAS CSV contains some school addresses that don't have a protocol. As such, they are not valid URLs according to validate_url.

To work around this, we can force prepend `https://`, which assumes that the school websites have HTTPS setup. This isn't a given, but it feels like the better default, since HTTPS is pretty strongly pushed by browser vendors.

The URL for Legh Vale Primary School is also malformed and starts with `http:www`. It's the only instance of this, but we have to work around it.