### PR TITLE
Support sessions without locations

### DIFF
--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -105,9 +105,11 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
         end
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Location" }
-        row.with_value { @vaccination_record.session.location.name }
+      if (location = @vaccination_record.session.location).present?
+        summary_list.with_row do |row|
+          row.with_key { "Location" }
+          row.with_value { location.name }
+        end
       end
     end
   end

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -201,5 +201,11 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
         text: "Location\nHogwarts"
       )
     end
+
+    context "when the location is not present" do
+      let(:location) { nil }
+
+      it { should_not have_css(".nhsuk-summary-list__row", text: "Location") }
+    end
   end
 end


### PR DESCRIPTION
Sometimes sessions won't have a location associated with them (in particular as part of the import process where we're unable to identify exactly where a vaccination event happened), at the moment the page shows an error by trying to get access to the name of a `nil` location.