### PR TITLE
Further improvements to import error handling

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -171,7 +171,7 @@ class ImmunisationImportRow
   }.freeze
 
   def delivery_site
-    DELIVERY_SITES[@data["ANATOMICAL_SITE"]&.downcase]
+    DELIVERY_SITES[@data["ANATOMICAL_SITE"]&.strip&.downcase]
   end
 
   def delivery_method

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -6,7 +6,6 @@ class ImmunisationImportRow
   validates :administered, inclusion: [true, false]
   validates :batch_expiry_date, presence: true, if: :administered
   validates :batch_number, presence: true, if: :administered
-  validates :delivery_method, presence: true, if: :administered
   validates :delivery_site, presence: true, if: :administered
   validates :dose_sequence,
             comparison: {

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -51,11 +51,7 @@ class ImmunisationImportRow
               greater_than_or_equal_to: :campaign_start_date,
               less_than_or_equal_to: :campaign_end_date_or_today
             }
-  validates :reason,
-            inclusion: {
-              in: VaccinationRecord.reasons.keys.map(&:to_sym)
-            },
-            unless: :administered
+  validates :reason, presence: true, if: -> { administered == false }
 
   CARE_SETTING_SCHOOL = 1
   CARE_SETTING_COMMUNITY = 2
@@ -149,14 +145,14 @@ class ImmunisationImportRow
     @data["BATCH_NUMBER"]&.strip
   end
 
+  REASONS = {
+    "did not attend" => :absent_from_session,
+    "vaccination contraindicated" => :contraindications,
+    "unwell" => :not_well
+  }.freeze
+
   def reason
-    {
-      "Did Not Attend" => :absent_from_session,
-      "Vaccination Contraindicated" => :contraindications,
-      "Unwell" => :not_well
-    }[
-      @data["REASON_NOT_VACCINATED"]&.strip
-    ]
+    REASONS[@data["REASON_NOT_VACCINATED"]&.strip&.downcase]
   end
 
   DELIVERY_SITES = {

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -9,7 +9,6 @@ class ImmunisationImportRow
   validates :delivery_method, presence: true, if: :administered
   validates :delivery_site, presence: true, if: :administered
   validates :dose_sequence,
-            presence: true,
             comparison: {
               greater_than_or_equal_to: 1,
               less_than_or_equal_to: :maximum_dose_sequence
@@ -41,7 +40,6 @@ class ImmunisationImportRow
   validates :patient_first_name, presence: true
   validates :patient_last_name, presence: true
   validates :patient_date_of_birth,
-            presence: true,
             comparison: {
               less_than_or_equal_to: -> { Date.current }
             }
@@ -50,7 +48,6 @@ class ImmunisationImportRow
   validate :zero_or_one_existing_patient
 
   validates :session_date,
-            presence: true,
             comparison: {
               greater_than_or_equal_to: :campaign_start_date,
               less_than_or_equal_to: :campaign_end_date_or_today

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,8 @@ en:
               inclusion: Choose an answer
         immunisation_import_row:
           attributes:
+            administered:
+              inclusion: Unable to determine if the vaccination was administered or not.
             patient:
               multiple_duplicate_match: Two or more possible patients match the patient first name, last name, date of birth or postcode.
             school_urn:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -51,7 +51,7 @@ describe ImmunisationImportRow, type: :model do
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:administered]).to include(
-          "is not included in the list"
+          "Unable to determine if the vaccination was administered or not."
         )
         expect(immunisation_import_row.errors[:organisation_code]).to include(
           "can't be blank"

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -73,9 +73,6 @@ describe ImmunisationImportRow, type: :model do
         expect(immunisation_import_row.errors[:delivery_site]).to eq(
           ["can't be blank"]
         )
-        expect(immunisation_import_row.errors[:delivery_method]).to eq(
-          ["can't be blank"]
-        )
         expect(immunisation_import_row.errors[:organisation_code]).to eq(
           ["can't be blank"]
         )


### PR DESCRIPTION
This follows up from #1644 with further improvements to the error handling for the immunisation import to make the error messages clearer and more consistent, see individual commits for more details.