### PR TITLE
Remove N+1 query from vaccines index

### DIFF
--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -6,11 +6,17 @@ class VaccinesController < ApplicationController
   layout "two_thirds"
 
   def index
-    @vaccines = policy_scope(Vaccine).order(:name)
+    @vaccines = vaccines
     @todays_batch_id = todays_batch_id
   end
 
   def show
-    @vaccine = policy_scope(Vaccine).find(params[:id])
+    @vaccine = vaccines.find(params[:id])
+  end
+
+  private
+
+  def vaccines
+    @vaccines ||= policy_scope(Vaccine).includes(:batches).order(:name)
   end
 end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -33,7 +33,7 @@ class Vaccine < ApplicationRecord
 
   has_and_belongs_to_many :campaigns
   has_many :health_questions, dependent: :destroy
-  has_many :batches
+  has_many :batches, -> { order(:name) }
 
   validates :brand, presence: true, uniqueness: { scope: :manufacturer }
   validates :dose, presence: true

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -12,7 +12,7 @@
       <%= link_to "Add a batch", new_vaccine_batch_path(vaccine) %>
     </p>
 
-    <% if vaccine.batches.any? %>
+    <% if (batches = vaccine.batches).present? %>
       <%= govuk_table do |table| %>
         <%= table.with_head do |head| %>
           <%= head.with_row do |row| %>
@@ -24,7 +24,7 @@
         <% end %>
 
         <%= table.with_body do |body| %>
-          <% vaccine.batches.order(:name).each do |batch| %>
+          <% batches.each do |batch| %>
             <% body.with_row do |row| %>
               <% row.with_cell(text: batch.name) do %>
                 <%= batch.name %>


### PR DESCRIPTION
When we're displaying the vaccines index page we also display the batches, currently this performs a separate query for each vaccine rather than pre-fetching the batches for all the vaccines.