### PR TITLE
Show vaccination record notes

### DIFF
--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -111,6 +111,13 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
           row.with_value { location.name }
         end
       end
+
+      if (notes = @vaccination_record.notes).present?
+        summary_list.with_row do |row|
+          row.with_key { "Notes" }
+          row.with_value { notes }
+        end
+      end
     end
   end
 end

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -24,6 +24,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
   let(:batch) do
     create(:batch, name: "ABC", expiry: Date.new(2020, 1, 1), vaccine:)
   end
+  let(:notes) { "Some notes." }
 
   let(:vaccination_record) do
     create(
@@ -31,7 +32,8 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
       administered_at:,
       batch:,
       vaccine:,
-      patient_session:
+      patient_session:,
+      notes:
     )
   end
 
@@ -206,6 +208,21 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
       let(:location) { nil }
 
       it { should_not have_css(".nhsuk-summary-list__row", text: "Location") }
+    end
+  end
+
+  describe "notes row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Notes\nSome notes."
+      )
+    end
+
+    context "when the notes are not present" do
+      let(:notes) { nil }
+
+      it { should_not have_css(".nhsuk-summary-list__row", text: "Notes") }
     end
   end
 end


### PR DESCRIPTION
We store the school name in the notes on the vaccination record if we're unable to link it with a stored location, so it makes sense that we'd want to show these notes back to users.