### PR TITLE
Handle session location being nil

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -51,7 +51,7 @@ class AppActivityLogComponent < ViewComponent::Base
     [
       {
         title:
-          "Invited to session at #{@patient_session.session.location.name}",
+          "Invited to session at #{helpers.session_location(@patient_session.session, part_of_sentence: true)}",
         time: @patient_session.created_at,
         by: @patient_session.created_by.full_name
       }

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -27,7 +27,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
           ["Site", vaccination_record.human_enum_name(:delivery_site)],
           ["Date", date_summary],
           ["Time", last_action_time.to_fs(:time)],
-          ["Location", @patient_session.session.location.name],
+          ["Location", helpers.session_location(@patient_session.session)],
           ["Vaccinator", clinician_name],
           ["Notes", notes]
         ]
@@ -38,7 +38,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
           ["Time", last_action_time.to_fs(:time)],
           (
             if show_location?
-              ["Location", @patient_session.session.location.name]
+              ["Location", helpers.session_location(@patient_session.session)]
             end
           ),
           ["Decided by", clinician_name],

--- a/app/components/app_session_details_component.rb
+++ b/app/components/app_session_details_component.rb
@@ -8,7 +8,7 @@ class AppSessionDetailsComponent < ViewComponent::Base
   end
 
   def school
-    @session.location.name
+    helpers.session_location(@session)
   end
 
   def vaccine

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,6 @@
 
 class SessionsController < ApplicationController
   before_action :set_session, except: %i[index create]
-  before_action :set_school, only: %i[show]
 
   layout "two_thirds", except: %i[index show]
 
@@ -52,9 +51,5 @@ class SessionsController < ApplicationController
 
   def set_session
     @session = policy_scope(Session).find(params[:id])
-  end
-
-  def set_school
-    @school = @session.location
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -4,4 +4,16 @@ module SessionsHelper
   def pluralize_child(count)
     count.zero? ? "No children" : pluralize(count, "child")
   end
+
+  def session_location(session, part_of_sentence: false)
+    if (location = session.location).present?
+      location.name
+    else
+      part_of_sentence ? "unknown location" : "Unknown location"
+    end
+  end
+
+  def session_name(session)
+    "#{session.campaign.name} session at #{session_location(session, part_of_sentence: true)}"
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -54,8 +54,6 @@ class Session < ApplicationRecord
 
   default_scope { active }
 
-  delegate :name, to: :location
-
   after_initialize :set_timeline_attributes
   after_validation :set_timeline_timestamps
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -163,10 +163,6 @@ class VaccinationRecord < ApplicationRecord
     validates :batch_id, presence: true
   end
 
-  def location_name
-    patient_session.session.location&.name
-  end
-
   def administered?
     administered_at != nil
   end

--- a/app/views/campaigns/sessions.html.erb
+++ b/app/views/campaigns/sessions.html.erb
@@ -60,9 +60,10 @@
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Location</span>
               <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
-                <%= link_to session.location.name, session_path(session) %>
-                <br>
-                <%= session.location.address %>
+                <%= link_to session_location(session), session_path(session) %>
+                <% if (address = session.location&.address).present? %>
+                  <br /><%= address %>
+                <% end %>
               </p>
             <% end %>
               <% row.with_cell do %>

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                          { text: session_name(@session), href: session_path(@session) },
                                           { text: "Check consent responses", href: session_consents_path(@session) },
                                           { text: page_title },
                                         ]) %>

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
-                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                          { text: session_name(@session), href: session_path(@session) },
                                         ]) %>
 <% end %>
 

--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -17,8 +17,10 @@
               colour: "blue",
             ) %><br>
       <% end %>
-      <%= link_to session.location.name, edit_session_path(session), "data-testid": "session-link" %><br>
-      <%= session.location.town %>, <%= session.location.postcode %>
+      <%= link_to session_location(session), edit_session_path(session), "data-testid": "session-link" %>
+      <% if (location = session.location).present? %>
+        <br /><%= location.town %>, <%= location.postcode %>
+      <% end %>
     </p>
   </td>
 </tr>

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
-                                          { text: @session.name, active: true },
+                                          { text: session_name(@session), active: true },
                                         ]) %>
 <% end %>
 

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -30,9 +30,10 @@
               <% row.with_cell do %>
                 <span class="nhsuk-table-responsive__heading">Location</span>
                 <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
-                  <%= link_to session.location.name, session_path(session) %>
-                  <br>
-                  <%= session.location.address %>
+                  <%= link_to session_location(session), session_path(session) %>
+                  <% if (address = session.location&.address).present? %>
+                    <br /><%= address %>
+                  <% end %>
                 </p>
               <% end %>
               <% row.with_cell do %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -1,4 +1,4 @@
-<% page_title = "#{@session.name}" %>
+<% page_title = session_name(@session) %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
-                                          { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+                                          { text: session_name(@session), href: session_path(@session) },
                                         ]) %>
 <% end %>
 

--- a/app/views/vaccinations/batch.html.erb
+++ b/app/views/vaccinations/batch.html.erb
@@ -13,7 +13,7 @@
 
   <%= f.govuk_radio_buttons_fieldset(
         :batch_id,
-        caption: { text: @session.location.name, size: "l" },
+        caption: { text: session_location(@session), size: "l" },
         legend: { size: "l", tag: "h1", text: page_title },
       ) do %>
     <% @batches.each_with_index do |batch, idx| %>

--- a/app/views/vaccinations/edit/confirm.html.erb
+++ b/app/views/vaccinations/edit/confirm.html.erb
@@ -74,7 +74,7 @@
         
           summary_list.with_row do |row|
             row.with_key { "Location" }
-            row.with_value { @session.location.name }
+            row.with_value { session_location(@session) }
           end
         
           summary_list.with_row do |row|

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -3,8 +3,7 @@
         items: [
           { text: "Home", href: dashboard_path },
           { text: t("sessions.index.title"), href: sessions_path },
-          { text: "#{@session.campaign.name} session at #{@session.name}",
-            href: session_path(@session) },
+          { text: session_name(@session), href: session_path(@session) },
         ],
       ) %>
 <% end %>

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SessionsHelper, type: :helper do
+  let(:campaign) { build(:campaign, name: "Flu") }
+  let(:location) { build(:location, name: "Waterloo Road") }
+  let(:session) { build(:session, campaign:, location:) }
+
+  describe "#session_location" do
+    subject(:session_location) { helper.session_location(session) }
+
+    it { should eq("Waterloo Road") }
+
+    context "when location is nil" do
+      let(:location) { nil }
+
+      it { should eq("Unknown location") }
+
+      context "when part of a sentence" do
+        subject(:session_location) do
+          helper.session_location(session, part_of_sentence: true)
+        end
+
+        it { should eq("unknown location") }
+      end
+    end
+  end
+
+  describe "#session_name" do
+    subject(:session_name) { helper.session_name(session) }
+
+    it { should eq("Flu session at Waterloo Road") }
+
+    context "when location is nil" do
+      let(:location) { nil }
+
+      it { should eq("Flu session at unknown location") }
+    end
+  end
+end


### PR DESCRIPTION
This is now a valid state for sessions that have been imported as some of the rows won't match with a known location. I've updated most cases where we show the session location to use a new helper that handles the value being `nil`.

I haven't updated all places as there are many parts of the service that require the location to be present, and for records created in the service this will always be true, it's only those that were imported where it's possible.