### PR TITLE
Import and export performing professional names

### DIFF
--- a/app/models/dps_export.rb
+++ b/app/models/dps_export.rb
@@ -36,7 +36,15 @@ class DPSExport < ApplicationRecord
         csv << DPSExportRow::FIELDS.map(&:upcase)
 
         vaccination_records
-          .includes(:batch, :location, :patient, :session, :team, :vaccine)
+          .includes(
+            :batch,
+            :location,
+            :patient,
+            :performed_by_user,
+            :session,
+            :team,
+            :vaccine
+          )
           .order(:recorded_at)
           .strict_loading
           .find_each { csv << DPSExportRow.new(_1).to_a }

--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -108,11 +108,11 @@ class DPSExportRow
   end
 
   def performing_professional_forename
-    # is not required
+    vaccination_record.performed_by&.given_name
   end
 
   def performing_professional_surname
-    # is not required
+    vaccination_record.performed_by&.family_name
   end
 
   def recorded_date

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -26,6 +26,9 @@ describe DPSExportRow do
       }
     )
   end
+  let(:performed_by) { create(:user, family_name: "Doe", given_name: "Jane") }
+  let(:performed_by_given_name) { nil }
+  let(:performed_by_family_name) { nil }
   let(:vaccination_record) do
     create(
       :vaccination_record,
@@ -35,7 +38,9 @@ describe DPSExportRow do
       delivery_site: :left_arm_upper_position,
       dose_sequence: 1,
       patient_session:,
-      performed_by: create(:user, family_name: "Doe", given_name: "Jane"),
+      performed_by:,
+      performed_by_given_name:,
+      performed_by_family_name:,
       recorded_at: Time.zone.local(2024, 7, 23, 19, 31, 47),
       uuid: "ea4860a5-6d97-4f31-b640-f5c50f43bfd2",
       vaccine:
@@ -101,12 +106,40 @@ describe DPSExportRow do
       expect(array[11]).to eq "new"
     end
 
-    it "has performing_professional_forename" do
-      expect(array[12]).to be_nil
+    describe "performing_professional_forename" do
+      subject(:performing_professional_forename) { array[12] }
+
+      it { should eq("Jane") }
+
+      context "without a user" do
+        let(:performed_by) { nil }
+
+        it { should be_nil }
+
+        context "with a name" do
+          let(:performed_by_given_name) { "Jane" }
+
+          it { should eq("Jane") }
+        end
+      end
     end
 
-    it "has performing_professional_surname" do
-      expect(array[13]).to be_nil
+    describe "performing_professional_surname" do
+      subject(:performing_professional_surname) { array[13] }
+
+      it { should eq("Doe") }
+
+      context "without a user" do
+        let(:performed_by) { nil }
+
+        it { should be_nil }
+
+        context "with a name" do
+          let(:performed_by_family_name) { "Doe" }
+
+          it { should eq("Doe") }
+        end
+      end
     end
 
     it "has recorded_date" do

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -38,7 +38,9 @@ describe ImmunisationImportRow, type: :model do
       "PERSON_GENDER_CODE" => "Male",
       "NHS_NUMBER" => nhs_number,
       "DATE_OF_VACCINATION" => "20240101",
-      "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
+      "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV",
+      "PERFORMING_PROFESSIONAL_FORENAME" => "John",
+      "PERFORMING_PROFESSIONAL_SURNAME" => "Smith"
     }
   end
 
@@ -218,7 +220,35 @@ describe ImmunisationImportRow, type: :model do
           "PERSON_POSTCODE" => "SW1A 1AA",
           "PERSON_GENDER_CODE" => "Male",
           "DATE_OF_VACCINATION" => "20240101",
-          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
+          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV",
+          "PERFORMING_PROFESSIONAL_FORENAME" => "John",
+          "PERFORMING_PROFESSIONAL_SURNAME" => "Smith"
+        }
+      end
+
+      it { should be_valid }
+    end
+
+    context "with valid fields for HPV" do
+      let(:campaign) { create(:campaign, :hpv, academic_year: 2023) }
+
+      let(:data) do
+        {
+          "ORGANISATION_CODE" => "abc",
+          "BATCH_EXPIRY_DATE" => "20210101",
+          "BATCH_NUMBER" => "123",
+          "ANATOMICAL_SITE" => "left thigh",
+          "SCHOOL_NAME" => "Hogwarts",
+          "SCHOOL_URN" => "123456",
+          "PERSON_FORENAME" => "Harry",
+          "PERSON_SURNAME" => "Potter",
+          "PERSON_DOB" => "20120101",
+          "PERSON_POSTCODE" => "SW1A 1AA",
+          "PERSON_GENDER_CODE" => "Male",
+          "DATE_OF_VACCINATION" => "20240101",
+          "VACCINE_GIVEN" => "Gardasil9",
+          "DOSE_SEQUENCE" => "1",
+          "CARE_SETTING" => "1"
         }
       end
 
@@ -829,6 +859,42 @@ describe ImmunisationImportRow, type: :model do
     end
   end
 
+  describe "#performed_by_given_name" do
+    subject(:performed_by_given_name) do
+      immunisation_import_row.performed_by_given_name
+    end
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with a value" do
+      let(:data) { { "PERFORMING_PROFESSIONAL_FORENAME" => "John" } }
+
+      it { should eq("John") }
+    end
+  end
+
+  describe "#performed_by_family_name" do
+    subject(:performed_by_family_name) do
+      immunisation_import_row.performed_by_family_name
+    end
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with a value" do
+      let(:data) { { "PERFORMING_PROFESSIONAL_SURNAME" => "Smith" } }
+
+      it { should eq("Smith") }
+    end
+  end
+
   describe "#to_vaccination_record" do
     subject(:vaccination_record) do
       immunisation_import_row.to_vaccination_record
@@ -836,8 +902,10 @@ describe ImmunisationImportRow, type: :model do
 
     let(:data) { valid_data }
 
-    it "does not have a vaccinator as that isn't provided in the import" do
-      expect(vaccination_record.performed_by).to be_nil
+    it "has a vaccinator" do
+      expect(vaccination_record.performed_by).to have_attributes(
+        full_name: "John Smith"
+      )
     end
 
     it "sets the administered at time" do


### PR DESCRIPTION
This stores the performing professional names on the vaccination record (if the information is available) and again exports it to DPS (if the information is available).

These values must be provided by Flu, and may be provided for HPV.