### PR TITLE
Update DPSExportJob with error handling

### DIFF
--- a/app/jobs/dps_export_job.rb
+++ b/app/jobs/dps_export_job.rb
@@ -5,8 +5,10 @@ class DPSExportJob < ApplicationJob
 
   def perform
     Campaign.active.find_each do |campaign|
-      data = DPSExport.create!(campaign:).csv
-      MESH.send_file(data:, to: Settings.mesh.dps_mailbox)
+      if campaign.vaccination_records.recorded.administered.unexported.any?
+        data = DPSExport.create!(campaign:).csv
+        MESH.send_file(data:, to: Settings.mesh.dps_mailbox)
+      end
     end
   end
 end

--- a/app/jobs/dps_export_job.rb
+++ b/app/jobs/dps_export_job.rb
@@ -4,6 +4,8 @@ class DPSExportJob < ApplicationJob
   queue_as :default
 
   def perform
+    return unless Flipper.enabled? :mesh_jobs
+
     Campaign.active.find_each do |campaign|
       if campaign.vaccination_records.recorded.administered.unexported.any?
         dps_export = DPSExport.create!(campaign:)

--- a/app/jobs/dps_export_job.rb
+++ b/app/jobs/dps_export_job.rb
@@ -6,8 +6,30 @@ class DPSExportJob < ApplicationJob
   def perform
     Campaign.active.find_each do |campaign|
       if campaign.vaccination_records.recorded.administered.unexported.any?
-        data = DPSExport.create!(campaign:).csv
-        MESH.send_file(data:, to: Settings.mesh.dps_mailbox)
+        dps_export = DPSExport.create!(campaign:)
+        response =
+          MESH.send_file(data: dps_export.csv, to: Settings.mesh.dps_mailbox)
+
+        if response.success?
+          mesh_reply = JSON.parse(response.body)
+          message_id = mesh_reply.fetch("message_id")
+          dps_export.update!(status: "sent", message_id:)
+
+          Rails.logger.info(
+            "DPS export (#{dps_export.id}) for campaign (#{campaign.id}) sent: " \
+              "#{response.status} - #{response.body}"
+          )
+        else
+          dps_export.update!(status: "failed")
+          Rails.logger.error(
+            "DPS export (#{dps_export.id}) for campaign (#{campaign.id}) send failed: " \
+              " #{response.status} - #{response.body}"
+          )
+        end
+      else
+        Rails.logger.info(
+          "No vaccination records to export for campaign #{campaign.id}"
+        )
       end
     end
   end

--- a/app/lib/mesh.rb
+++ b/app/lib/mesh.rb
@@ -40,7 +40,7 @@ module MESH
 
   def self.send_file(to:, data:)
     headers = {
-      "Content-Type" => "text/csv",
+      "Content-Type" => "application/octet-stream",
       "Content-Encoding" => "gzip",
       "mex-to" => to,
       "mex-workflowid" => "dps export"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -136,11 +136,6 @@ Rails.application.configure do
       cron: "every day at 9am",
       class: "SessionRemindersJob",
       description: "Send session reminder emails to parents"
-    },
-    dps_export: {
-      cron: "every day at 9am",
-      class: "DPSExportJob",
-      description: "Export DPS data via MESH"
     }
   }
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -9,6 +9,11 @@ Rails.application.configure do
       cron: "every day at 1am",
       class: "MESHValidateMailboxJob",
       description: "Validate MESH mailbox"
+    },
+    dps_export: {
+      cron: "every day at 2am",
+      class: "DPSExportJob",
+      description: "Export DPS data via MESH"
     }
   }
 end

--- a/lib/tasks/mesh.rake
+++ b/lib/tasks/mesh.rake
@@ -2,7 +2,9 @@
 
 namespace :mesh do
   desc "Export DPS data via MESH"
-  task dps_export: :environment do
+  task "dps_export" => :environment do
+    Rails.logger = Logger.new($stdout)
+    Rails.logger.level = Logger::DEBUG
     DPSExportJob.perform_now
   end
 

--- a/lib/tasks/mesh.rake
+++ b/lib/tasks/mesh.rake
@@ -40,6 +40,19 @@ namespace :mesh do
 
     response = MESH.connection.put("inbox/#{message}/status/acknowledged")
 
+    puts response.body
+    warn response.status unless response.status == 200
+  end
+
+  desc "Send a file to a mailbox via MESH"
+  task "send_file", %i[to file] => :environment do |_, args|
+    to = args[:to]
+    file = args[:file]
+
+    data = File.read(file)
+    response = MESH.send_file(to:, data:)
+
+    puts response.body
     warn response.status unless response.status == 200
   end
 end

--- a/spec/factories/dps_exports.rb
+++ b/spec/factories/dps_exports.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: dps_exports
+#
+#  id          :bigint           not null, primary key
+#  filename    :string           not null
+#  sent_at     :datetime
+#  status      :string           default("pending"), not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  campaign_id :bigint           not null
+#  message_id  :string
+#
+# Indexes
+#
+#  index_dps_exports_on_campaign_id  (campaign_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (campaign_id => campaigns.id)
+#
+FactoryBot.define do
+  factory :dps_export do
+    campaign { association :campaign, :active }
+  end
+end

--- a/spec/lib/mesh_spec.rb
+++ b/spec/lib/mesh_spec.rb
@@ -45,7 +45,7 @@ describe MESH do
         ).with(
           headers: {
             "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-            "Content-Type" => "text/csv",
+            "Content-Type" => "application/octet-stream",
             "Content-Encoding" => "gzip",
             "Mex-To" => "TESTBOX",
             "Mex-Workflowid" => "dps export",


### PR DESCRIPTION
Adds error handling and a few other tidbits to the DPS export:

- only create DPS exports for campaigns that have unexported `vaccination_records`
- use `mesh_jobs` feature flag to control whether the job runs
- change `Content-Type` to `application/octet-stream` when sending files to MESH
- disable cron in production and enable in staging
- add logging to $stdout to `mesh:dps_export` rake task for dev purposes
- add `mesh:send_file` rake task for dev purposes

Sorry for packing them all into one, but they're all on a similar topic and a few of these are quite small. Can break these out into separate PRs if they're too much here.

Short example of using the cli to trigger the DPS export job:

```
$ rails mesh:dps_export
D, [2024-08-22T00:36:18.776567 #71193] DEBUG -- :   Flipper feature(mesh_jobs) enabled? true (5.2ms)  [ actors=nil gate_name=boolean ]
I, [2024-08-22T00:36:19.806113 #71193]  INFO -- : DPS export (1) for campaign (1) sent: 202 - {"message_id":"20240821223619601139_F8E657"}
```