### PR TITLE
Skip importing duplicate records

### DIFF
--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -37,10 +37,24 @@ class ImmunisationImportsController < ApplicationController
 
     result = @immunisation_import.process!
 
-    flash[:success] = "#{result[:count]} vaccinations uploaded"
+    if result[:new_count].zero? && result[:duplicate_count] != 0
+      render :duplicates
+      return
+    end
+
+    flash[:success] = "#{result[:new_count]} vaccinations uploaded"
+
+    # TODO: Move to "Check and confirm" page
+    if (duplicate_count = result[:duplicate_count]) > 1
+      flash[
+        :info
+      ] = "#{duplicate_count} previously uploaded records were omitted"
+    end
 
     if (ignored_count = result[:ignored_count]) > 1
-      flash[:info] = "#{ignored_count} un-administered vaccinations ignored"
+      flash[
+        :info
+      ] = "#{ignored_count} records for children who were not vaccinated were omitted"
     end
 
     redirect_to campaign_immunisation_import_path(

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -82,7 +82,7 @@ class ImmunisationImportRow
       imported_from: @imported_from,
       notes:,
       recorded_at:
-    ).find_or_create_by!(
+    ).find_or_initialize_by(
       administered_at:,
       batch:,
       delivery_method:,

--- a/app/views/immunisation_imports/duplicates.html.erb
+++ b/app/views/immunisation_imports/duplicates.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: new_campaign_immunisation_import_path(@campaign),
+        name: @campaign.name,
+      ) %>
+<% end %>
+
+<% title = "Vaccination records already uploaded" %>
+
+<%= h1 title, page_title: "#{@campaign.name} – #{title}" %>
+
+<p>
+  All records in this CSV file have been uploaded.
+</p>
+
+<p>
+  <%= govuk_link_to "Upload new vaccination records", new_campaign_immunisation_import_path %>
+</p>

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -31,6 +31,13 @@ describe "Immunisation imports" do
 
     when_i_click_on_vaccination_records
     and_i_should_see_the_vaccination_records
+
+    when_i_click_on_the_uploads_tab
+    and_i_click_on_the_upload_link
+    then_i_should_see_the_upload_page
+
+    when_i_upload_a_valid_file
+    then_i_should_see_the_duplicates_page
   end
 
   def given_i_am_signed_in
@@ -140,5 +147,17 @@ describe "Immunisation imports" do
     expect(page).to have_content("NameChyna Pickle")
     expect(page).to have_content("Vaccination record")
     expect(page).to have_content("OutcomeVaccinated")
+  end
+
+  def when_i_click_on_the_uploads_tab
+    click_on "Uploads"
+  end
+
+  alias_method :and_i_click_on_the_upload_link, :when_i_click_on_the_upload_link
+
+  def then_i_should_see_the_duplicates_page
+    expect(page).to have_content(
+      "All records in this CSV file have been uploaded."
+    )
   end
 end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -138,7 +138,13 @@ describe ImmunisationImport, type: :model do
       end
 
       it "returns statistics on the import" do
-        expect(process!).to eq({ count: 7, ignored_count: 4 })
+        expect(process!).to eq(
+          { duplicate_count: 0, ignored_count: 4, new_count: 7 }
+        )
+
+        expect(immunisation_import.process!).to eq(
+          { duplicate_count: 7, ignored_count: 4, new_count: 0 }
+        )
       end
     end
 
@@ -170,7 +176,13 @@ describe ImmunisationImport, type: :model do
       end
 
       it "returns statistics on the import" do
-        expect(process!).to eq({ count: 7, ignored_count: 0 })
+        expect(process!).to eq(
+          { duplicate_count: 0, ignored_count: 0, new_count: 7 }
+        )
+
+        expect(immunisation_import.process!).to eq(
+          { duplicate_count: 7, ignored_count: 0, new_count: 0 }
+        )
       end
 
       it "creates a new session for each date" do


### PR DESCRIPTION
This updates the importer to skip duplicate records and show the number of records skipped to the user. If all the records are duplicates we show a page that explains there's nothing to do, otherwise we include a banner at the top of the page showing how many were duplicates.