### PR TITLE
Remove dps exports on reset

### DIFF
--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -17,12 +17,9 @@ class VaccinationRecordsController < ApplicationController
   end
 
   def reset_dps_export
-    campaign.dps_exports.each { _1.vaccination_records = [] }
+    campaign.dps_exports.destroy_all
 
-    flash[:success] = {
-      heading:
-        "DPS export status has been reset for vaccination records in this campaign"
-    }
+    flash[:success] = { heading: "DPS exports have been reset for campaign" }
 
     redirect_to campaign_immunisation_imports_path(campaign)
   end

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -68,6 +68,6 @@
 <% content_for :after_main do %>
   <%= render(AppDevToolsComponent.new) do %>
     <%= govuk_button_to "Download DPS export", export_dps_campaign_vaccination_records_path(@campaign) %>
-    <%= govuk_button_to "Reset vaccination records for DPS export", reset_dps_export_campaign_vaccination_records_path(@campaign) %>
+    <%= govuk_button_to "Reset DPS export for campaign", reset_dps_export_campaign_vaccination_records_path(@campaign) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
When we just unassociate the vaccination records with the dps exports, as we were doing before, this leaves behind the dps exports with no vaccination records associated with them. These just end up being noisy and unnecessary.