### PR TITLE
Remove default scopes

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -6,7 +6,7 @@
   </p>
 <% end %>
 
-<% if patient_session.consents.present? %>
+<% if consents.present? %>
   <%= govuk_table(classes: "nhsuk-u-margin-bottom-4") do |table| %>
     <%= table.with_head do |head| %>
       <%= head.with_row do |row| %>

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -15,6 +15,6 @@ class AppConsentComponent < ViewComponent::Base
   delegate :session, to: :patient_session
 
   def consents
-    patient_session.consents.order(recorded_at: :desc)
+    patient_session.consents.recorded.order(recorded_at: :desc)
   end
 end

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -52,7 +52,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
 
   def show_location?
     # location only makes sense if an attempt to vaccinate on site was made
-    @patient_session.vaccination_records.any?
+    @patient_session.vaccination_records.any?(&:recorded?)
   end
 
   def vaccine_summary

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -59,7 +59,7 @@
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "All answers to health questions" } %>
     <%= render AppHealthQuestionsComponent.new(
-          consents: @patient_session.consents,
+          consents: @patient_session.consents.recorded,
         ) %>
   <% end %>
 <% end %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -27,7 +27,7 @@ class AppPatientPageComponent < ViewComponent::Base
   delegate :session, to: :patient_session
 
   def display_health_questions?
-    @patient_session.consents.any?(&:response_given?)
+    @patient_session.consents.recorded.any?(&:response_given?)
   end
 
   def gillick_assessment_applicable?

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -17,7 +17,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def most_recent_vaccination
     @most_recent_vaccination ||=
-      @patient_session.vaccination_records.order(:created_at).last
+      @patient_session.vaccination_records.recorded.order(:created_at).last
   end
 
   def who_refused

--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -22,9 +22,9 @@ class CampaignsController < ApplicationController
   end
 
   def sessions
-    @in_progress_sessions = @campaign.sessions.in_progress
-    @future_sessions = @campaign.sessions.future
-    @past_sessions = @campaign.sessions.past
+    @in_progress_sessions = @campaign.sessions.active.in_progress
+    @future_sessions = @campaign.sessions.active.future
+    @past_sessions = @campaign.sessions.active.past
   end
 
   private

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -47,7 +47,7 @@ class ConsentsController < ApplicationController
   end
 
   def show
-    @consent = @session.campaign.consents.find(params[:consent_id])
+    @consent = @session.campaign.consents.recorded.find(params[:consent_id])
   end
 
   private

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -178,7 +178,7 @@ class ManageConsentsController < ApplicationController
     @parent_options =
       (
         [@patient.parent] +
-          @patient_session.consents.includes(:parent).map(&:parent)
+          @patient_session.consents.recorded.includes(:parent).map(&:parent)
       ).compact.uniq.sort_by(&:name)
   end
 

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -89,7 +89,7 @@ class TriageController < ApplicationController
     @triage.assign_attributes(triage_params.merge(performed_by: current_user))
     if @triage.save(context: :consent)
       @patient_session.do_triage!
-      @patient.consents.each { send_triage_mail(@patient_session, _1) }
+      @patient.consents.recorded.each { send_triage_mail(@patient_session, _1) }
       flash[:success] = {
         heading: "Triage outcome updated for",
         heading_link_text: @patient.full_name,

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -18,7 +18,7 @@ class VaccinationMailer < ApplicationMailer
   private
 
   def consent
-    @patient_session.patient.consents.order(:created_at).last
+    @patient_session.patient.consents.recorded.order(:created_at).last
   end
 
   def to

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -43,7 +43,7 @@ class Consent < ApplicationRecord
   attr_accessor :triage
 
   has_one :consent_form
-  belongs_to :parent, optional: true
+  belongs_to :parent, -> { recorded }, optional: true
   belongs_to :draft_parent,
              -> { draft },
              class_name: "Parent",
@@ -56,12 +56,10 @@ class Consent < ApplicationRecord
              optional: true,
              foreign_key: :recorded_by_user_id
 
-  default_scope { recorded }
-
   scope :submitted_for_campaign,
         ->(campaign) { where(campaign:).where.not(recorded_at: nil) }
   scope :recorded, -> { where.not(recorded_at: nil) }
-  scope :draft, -> { rewhere(recorded_at: nil) }
+  scope :draft, -> { where(recorded_at: nil) }
 
   enum :response, %w[given refused not_provided], prefix: true
   enum :reason_for_refusal,

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -58,7 +58,7 @@ class ConsentForm < ApplicationRecord
 
   belongs_to :consent, optional: true
   belongs_to :session
-  belongs_to :parent, optional: true
+  belongs_to :parent, -> { recorded }, optional: true
   belongs_to :draft_parent,
              -> { draft },
              class_name: "Parent",

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -32,9 +32,8 @@ class GillickAssessment < ApplicationRecord
 
   encrypts :notes
 
-  scope :draft, -> { rewhere(recorded_at: nil) }
+  scope :draft, -> { where(recorded_at: nil) }
   scope :recorded, -> { where.not(recorded_at: nil) }
-  default_scope { recorded }
 
   on_wizard_step :gillick do
     validates :gillick_competent, inclusion: { in: [true, false] }

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -24,8 +24,7 @@ class Parent < ApplicationRecord
   has_one :patient
 
   scope :recorded, -> { where.not(recorded_at: nil) }
-  scope :draft, -> { rewhere(recorded_at: nil) }
-  default_scope { recorded }
+  scope :draft, -> { where(recorded_at: nil) }
 
   attr_accessor :parental_responsibility
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -35,7 +35,7 @@ class PatientSession < ApplicationRecord
              class_name: "User",
              optional: true,
              foreign_key: :created_by_user_id
-  has_one :gillick_assessment
+  has_one :gillick_assessment, -> { recorded }
   has_one :draft_gillick_assessment,
           -> { draft },
           class_name: "GillickAssessment"

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -52,8 +52,6 @@ class Session < ApplicationRecord
   scope :in_progress, -> { where(date: Time.zone.today) }
   scope :future, -> { where(date: Time.zone.tomorrow..) }
 
-  default_scope { active }
-
   after_initialize :set_timeline_attributes
   after_validation :set_timeline_timestamps
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -83,10 +83,8 @@ class VaccinationRecord < ApplicationRecord
 
   scope :administered, -> { where.not(administered_at: nil) }
   scope :recorded, -> { where.not(recorded_at: nil) }
-  scope :draft, -> { rewhere(recorded_at: nil) }
+  scope :draft, -> { where(recorded_at: nil) }
   scope :unexported, -> { where.missing(:dps_exports) }
-
-  default_scope { recorded }
 
   enum :delivery_method,
        %w[intramuscular subcutaneous nasal_spray],

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -27,7 +27,7 @@ class SessionPolicy
         Session.where(campaign: nil).or(
           Session.where(campaign: @user.team.campaigns)
         )
-      ).rewhere(draft: true)
+      ).draft
     end
   end
 end

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -26,7 +26,7 @@ task :performance, [] => :environment do |_task, _args|
     VaccinationRecord
       .joins(:team)
       .where(session: { campaigns: { team: teams } })
-      .and(VaccinationRecord.where.not(recorded_at: nil))
+      .and(VaccinationRecord.recorded)
       .count
   puts "#{vaccination_records_total} *Vaccination records (total)*"
 

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -115,19 +115,6 @@ describe Consent do
     end
   end
 
-  describe "default scope" do
-    let(:patient) { create(:patient) }
-    let(:campaign) { create(:campaign) }
-
-    it "uses the recorded scope" do
-      consent =
-        create(:consent, patient:, recorded_at: Time.zone.now, campaign:)
-      create(:consent, :draft, patient:, campaign:)
-
-      expect(patient.consents).to eq([consent])
-    end
-  end
-
   describe "#recorded scope" do
     let(:patient) { create(:patient) }
     let(:campaign) { create(:campaign) }


### PR DESCRIPTION
A number of models use default scopes to automatically only show "active" or "recorded" instances. This can be useful, but as the codebase grows it can start to cause unexpected behaviour and the need to override the default scope becomes more common.

I've attempted to find all the places where the default scopes were being used and update them in this commit, but it's possible some of them may have been missed and will need to be updated in the future.