### PR TITLE
Refactor immunisation import processed validation

### DIFF
--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -48,6 +48,12 @@ describe ImmunisationImport, type: :model do
 
   it { should validate_presence_of(:csv) }
 
+  it "raises if processed without updating the statistics" do
+    expect {
+      immunisation_import.update!(processed_at: Time.zone.now)
+    }.to raise_error(/Count statistics must be set/)
+  end
+
   describe "#load_data!" do
     before { immunisation_import.load_data! }
 


### PR DESCRIPTION
This refactors the validation added in 64a51954efaa4e462c94aa377c41498c7cb7fe05 to replace it with a `before_save` callback which raises an exception if the state is invalid which makes the intention clearer and hopefully easier to read and understand.