### PR TITLE
Avoid layout with only constraint

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -6,8 +6,6 @@ class ConsentsController < ApplicationController
 
   before_action :set_session
 
-  layout "full", only: :index
-
   def index
     all_patient_sessions =
       @session
@@ -44,6 +42,8 @@ class ConsentsController < ApplicationController
     sort_and_filter_patients!(@patient_sessions)
 
     session[:current_section] = "consents"
+
+    render layout: "full"
   end
 
   def show

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -5,8 +5,6 @@ class ImmunisationImportsController < ApplicationController
   before_action :set_immunisation_import, only: %i[show edit update]
   before_action :set_vaccination_records, only: %i[edit show]
 
-  layout "full", except: :new
-
   def index
     @immunisation_imports =
       @campaign
@@ -15,6 +13,8 @@ class ImmunisationImportsController < ApplicationController
         .includes(:user)
         .order(:created_at)
         .strict_loading
+
+    render layout: "full"
   end
 
   def new

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,8 +3,6 @@
 class SessionsController < ApplicationController
   before_action :set_session, except: %i[index create]
 
-  layout "full", only: :edit
-
   def create
     skip_policy_scope
 
@@ -18,6 +16,8 @@ class SessionsController < ApplicationController
   def index
     @sessions_by_type =
       policy_scope(Session).active.in_progress.group_by(&:type)
+
+    render layout: "full"
   end
 
   def show

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -13,8 +13,6 @@ class TriageController < ApplicationController
 
   after_action :verify_policy_scoped, only: %i[index create new]
 
-  layout "full", only: :index
-
   def index
     all_patient_sessions =
       @session
@@ -39,6 +37,8 @@ class TriageController < ApplicationController
     sort_and_filter_patients!(@patient_sessions)
 
     session[:current_section] = "triage"
+
+    render layout: "full"
   end
 
   def new
@@ -56,9 +56,7 @@ class TriageController < ApplicationController
       }
       redirect_to redirect_path
     else
-      render "patients/show",
-             layout: "two_thirds",
-             status: :unprocessable_entity
+      render "patients/show", status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -3,6 +3,8 @@
 class VaccinationRecordsController < ApplicationController
   def index
     @vaccination_records = vaccination_records
+
+    render layout: "full"
   end
 
   def show

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -15,8 +15,6 @@ class VaccinationsController < ApplicationController
   before_action :set_batches, only: %i[batch update_batch]
   before_action :set_section_and_tab, only: %i[create]
 
-  layout "full", only: :index
-
   def index
     all_patient_sessions =
       @session
@@ -43,7 +41,7 @@ class VaccinationsController < ApplicationController
     @patient_sessions = grouped_patient_sessions.fetch(@current_tab, [])
 
     respond_to do |format|
-      format.html
+      format.html { render layout: "full" }
       format.json { render json: @patient_outcomes.map(&:first).index_by(&:id) }
     end
 
@@ -66,9 +64,7 @@ class VaccinationsController < ApplicationController
                     id: @draft_vaccination_record.form_steps.first
                   )
     else
-      render "patients/show",
-             layout: "two_thirds",
-             status: :unprocessable_entity
+      render "patients/show", status: :unprocessable_entity
     end
   end
 


### PR DESCRIPTION
A statement such as `layout "full", only: :index` reads like this uses the default layout for all actions, except the `index` action where instead we use `full`.

This doesn't work like this, instead the call to `layout` replaces the call to `layout` in the `ApplicationController` and instead we end up with `layout "full"` only been called for `index`, and no layout is specified for the the other actions, which then ends up being the `application` layout.

This improves upon f82d2771f4a85e095a251eb23ae2147a78ee2065 which first introduced the default two thirds layout.

See https://stackoverflow.com/a/1576165 for more details.