### PR TITLE
Add ability to edit vaccination record date/time

### DIFF
--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -91,10 +91,17 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
         end
       end
 
+      if (location = @vaccination_record.session.location).present?
+        summary_list.with_row do |row|
+          row.with_key { "Location" }
+          row.with_value { location.name }
+        end
+      end
+
       if (administered_at = @vaccination_record.administered_at).present?
         summary_list.with_row do |row|
-          row.with_key { "Date" }
-          row.with_value { administered_at.to_date.to_fs(:long) }
+          row.with_key { "Vaccination date" }
+          row.with_value { administered_at.to_fs(:long) }
         end
       end
 
@@ -102,13 +109,6 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
         summary_list.with_row do |row|
           row.with_key { "Nurse" }
           row.with_value { user.full_name }
-        end
-      end
-
-      if (location = @vaccination_record.session.location).present?
-        summary_list.with_row do |row|
-          row.with_key { "Location" }
-          row.with_value { location.name }
         end
       end
 

--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -102,6 +102,15 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
         summary_list.with_row do |row|
           row.with_key { "Vaccination date" }
           row.with_value { administered_at.to_fs(:long) }
+          row.with_action(
+            text: "Change",
+            visually_hidden_text: "vaccination date",
+            href:
+              campaign_vaccination_record_edit_date_and_time_path(
+                @vaccination_record.campaign,
+                @vaccination_record
+              )
+          )
         end
       end
 

--- a/app/components/app_vaccination_record_table_component.html.erb
+++ b/app/components/app_vaccination_record_table_component.html.erb
@@ -27,9 +27,12 @@
             <span class="nhsuk-table-responsive__heading">Date of birth</span>
             <%= vaccination_record.patient.date_of_birth.to_fs(:long) %>
           <% end %>
+
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccination date</span>
-            <%= vaccination_record.administered_at.to_date.to_fs(:long) %>
+            <% if (administered_at = vaccination_record.administered_at).present? %>
+              <%= administered_at.to_date.to_fs(:long) %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/app_vaccination_record_table_component.rb
+++ b/app/components/app_vaccination_record_table_component.rb
@@ -13,10 +13,9 @@ class AppVaccinationRecordTableComponent < ViewComponent::Base
   attr_reader :vaccination_records, :new_records
 
   def heading
-    [
-      vaccination_records.count.to_s,
-      new_records ? "new" : nil,
-      "vaccination records"
-    ].compact.join(" ")
+    pluralize(
+      vaccination_records.count,
+      new_records ? "new vaccination record" : "vaccination record"
+    )
   end
 end

--- a/app/controllers/vaccination_records/edit_controller.rb
+++ b/app/controllers/vaccination_records/edit_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class VaccinationRecords::EditController < ApplicationController
+  before_action :set_vaccination_record
+  before_action :set_campaign
+
+  def edit_date_and_time
+    render :date_and_time
+  end
+
+  def update_date_and_time
+    @vaccination_record.assign_attributes(vaccination_record_params)
+
+    if @vaccination_record.administered_at.nil?
+      @vaccination_record.errors.add(:administered_at, :blank)
+      render :date_and_time, status: :unprocessable_entity
+    elsif @vaccination_record.save
+      redirect_to campaign_vaccination_record_path(
+                    @campaign,
+                    @vaccination_record
+                  )
+    else
+      render :date_and_time, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_vaccination_record
+    @vaccination_record =
+      policy_scope(VaccinationRecord)
+        .where(campaign: params[:campaign_id])
+        .includes(:campaign)
+        .find(params[:vaccination_record_id])
+  end
+
+  def set_campaign
+    @campaign = @vaccination_record.campaign
+  end
+
+  def vaccination_record_params
+    params.require(:vaccination_record).permit(:administered_at)
+  end
+end

--- a/app/views/vaccination_records/edit/date_and_time.html.erb
+++ b/app/views/vaccination_records/edit/date_and_time.html.erb
@@ -1,0 +1,40 @@
+<% patient = @vaccination_record.patient %>
+
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: campaign_vaccination_record_path(@campaign, @vaccination_record),
+        name: patient.full_name,
+      ) %>
+<% end %>
+
+<%= form_with model: @vaccination_record, url: campaign_vaccination_record_edit_date_and_time_path(@campaign, @vaccination_record), method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="nhsuk-caption-l"><%= patient.full_name %></span>
+  <%= h1 "When was the vaccination given?" %>
+
+  <%= f.govuk_date_field :administered_at,
+                         legend: { text: "Date" },
+                         hint: { text: "For example, 27 3 2017" } %>
+
+  <% form_group_class = ["nhsuk-form-group", @vaccination_record.errors[:administered_at].present? ? "nhsuk-form-group--error" : nil].compact %>
+  <% date_input_class = ["nhsuk-date-input__input", @vaccination_record.errors[:administered_at].present? ? "nhsuk-input--error" : nil].compact %>
+
+  <%= tag.div(class: form_group_class) do %>
+    <%= f.govuk_fieldset legend: { text: "Time" }, hint: { text: "For example, 13 15" } do %>
+      <div class="nhsuk-date-input">
+        <div class="nhsuk-date-input__item">
+          <%= f.govuk_text_field :"administered_at(4i)", class: date_input_class, label: { text: "Hour", class: "nhsuk-date-input__label" }, value: @vaccination_record.administered_at&.hour, width: 2 %>
+        </div>
+
+        <div class="nhsuk-date-input__item">
+          <%= f.govuk_text_field :"administered_at(5i)", class: date_input_class, label: { text: "Minute", class: "nhsuk-date-input__label" }, value: @vaccination_record.administered_at&.min, width: 2 %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,6 +403,10 @@ en:
           attributes:
             administered:
               inclusion: Choose if they got the vaccine
+            administered_at:
+              blank: Enter a date and time
+              greater_than_or_equal_to: Date and time must be after the campaign started
+              less_than: Date and time must be before the campaign ended
             batch_id:
               blank: Choose a batch
               incorrect_vaccine: Choose a batch of the %{vaccine_brand} vaccine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,13 @@ Rails.application.routes.draw do
       constraints -> { Flipper.enabled?(:dev_tools) } do
         post "reset-dps-export", on: :collection
       end
+
+      get "edit/date-and-time",
+          controller: "vaccination_records/edit",
+          action: "edit_date_and_time"
+      put "edit/date-and-time",
+          controller: "vaccination_records/edit",
+          action: "update_date_and_time"
     end
   end
 

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -172,7 +172,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
     it do
       expect(rendered).to have_css(
         ".nhsuk-summary-list__row",
-        text: "Date\n6 September 2024"
+        text: "Vaccination date\n6 September 2024 at 12:00pm"
       )
     end
   end

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -23,7 +23,15 @@ describe AppVaccinationRecordTableComponent, type: :component do
           campaign:
         }
       )
-    ] + create_list(:vaccination_record, 9, session_attributes: { campaign: })
+    ] + create_list(:vaccination_record, 4, session_attributes: { campaign: }) +
+      create_list(
+        :vaccination_record,
+        5,
+        :not_administered,
+        session_attributes: {
+          campaign:
+        }
+      )
   end
 
   it "renders a heading tab" do

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+describe "Edit vaccination record" do
+  scenario "User edits the date/time" do
+    given_i_am_signed_in
+    and_an_hpv_campaign_is_underway
+    and_a_vaccination_record_exists
+
+    when_i_go_to_the_vaccination_records_page
+    then_i_should_see_the_vaccination_records
+
+    when_i_click_on_the_vaccination_record
+    then_i_should_see_the_vaccination_record
+
+    when_i_click_on_the_change_link
+    then_i_should_see_the_date_time_form
+
+    when_i_fill_in_the_date
+    and_i_fill_in_the_time
+    and_i_click_continue
+    then_i_should_see_the_vaccination_record
+    and_i_should_see_the_updated_date_time
+  end
+
+  def given_i_am_signed_in
+    @team = create(:team, :with_one_nurse, ods_code: "R1L")
+    sign_in @team.users.first
+  end
+
+  def and_an_hpv_campaign_is_underway
+    campaign = create(:campaign, :hpv, academic_year: 2023, team: @team)
+    location = create(:location, :school)
+    @session = create(:session, campaign:, location:)
+  end
+
+  def and_a_vaccination_record_exists
+    patient = create(:patient, first_name: "John", last_name: "Smith")
+
+    create(
+      :vaccination_record,
+      patient_session: create(:patient_session, patient:, session: @session)
+    )
+  end
+
+  def when_i_go_to_the_vaccination_records_page
+    visit "/dashboard"
+
+    click_on "Vaccination programmes", match: :first
+    click_on "HPV"
+    click_on "Vaccination records"
+  end
+
+  def then_i_should_see_the_vaccination_records
+    expect(page).to have_content("1 vaccination record")
+    expect(page).to have_content("John Smith")
+  end
+
+  def when_i_click_on_the_vaccination_record
+    click_on "John Smith"
+  end
+
+  def then_i_should_see_the_vaccination_record
+    expect(page).to have_content("NameJohn Smith")
+  end
+
+  def when_i_click_on_the_change_link
+    click_on "Change"
+  end
+
+  def then_i_should_see_the_date_time_form
+    expect(page).to have_content("Date")
+    expect(page).to have_content("Time")
+  end
+
+  def when_i_fill_in_the_date
+    fill_in "Year", with: "2023"
+    fill_in "Month", with: "9"
+    fill_in "Day", with: "1"
+  end
+
+  def and_i_fill_in_the_time
+    fill_in "Hour", with: "12"
+    fill_in "Minute", with: "00"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def and_i_should_see_the_updated_date_time
+    expect(page).to have_content("Vaccination date1 September 2023 at 12:00pm")
+  end
+end

--- a/spec/jobs/remove_immunisation_import_csv_job_spec.rb
+++ b/spec/jobs/remove_immunisation_import_csv_job_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "rails_helper"
-
 describe RemoveImmunisationImportCSVJob, type: :job do
   let(:immunisation_import_to_remove) do
     create(:immunisation_import, created_at: Time.zone.now - 90.days)


### PR DESCRIPTION
This adds the ability to edit the date and time an existing vaccination record.

I've decided to add these actions to a new controller as it's likely we'll need to edit different parts of the vaccination records in the future. I've also set up the controller in a similar way to how we handle wizards as I imagine we'll likely need that functionality in the future.

The `govuk_form_builder` Gem doesn't currently support time fields (and there's no mention of how they should work in the design system) so I've had to re-create it myself in the form.

If the user is on this page we should expect the date/time to always be set, whereas we allow the field to be optional on the model. One way to solve this could be to use a form object, however for this page I've decided to add some validation logic to the controller. We could refactor this in to a form object in the future.

I've opened this PR to discuss whether a form object would be suitable here, I will also need to integrate with the `DateParamsValidator` before marking this as ready for review.

This PR doesn't implement the feature exactly as designed, where multiple changes can be made to vaccination records and then committed together in one go, this could be implemented later as we add more fields to change.

## Screenshots

<img width="786" alt="Screenshot 2024-08-26 at 17 21 20" src="https://github.com/user-attachments/assets/444f4f2e-43db-4f8a-920c-8377459d9245">
<img width="568" alt="Screenshot 2024-08-26 at 17 21 16" src="https://github.com/user-attachments/assets/c87b9be7-27b3-47ca-bf17-7d60e0dc0e26">
