### PR TITLE
Switch to ActiveSupport::Testing::TimeHelpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,5 @@ group :test do
   gem "rspec-html-matchers"
   gem "shoulda-matchers"
   gem "simplecov", require: false
-  gem "timecop"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -593,7 +593,6 @@ GEM
     temple (0.10.0)
     thor (1.3.1)
     tilt (2.3.0)
-    timecop (0.9.10)
     timeout (0.4.1)
     turbo-rails (2.0.6)
       actionpack (>= 6.0.0)
@@ -710,7 +709,6 @@ DEPENDENCIES
   syntax_tree
   syntax_tree-haml
   syntax_tree-rbs
-  timecop
   turbo-rails
   tzinfo-data
   uk_postcode

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -16,7 +16,7 @@ describe AppTriageNotesComponent, type: :component do
 
   context "a single triage note is present" do
     around do |example|
-      Timecop.freeze(Time.zone.local(2023, 12, 4, 10, 4)) { example.run }
+      travel_to(Time.zone.local(2023, 12, 4, 10, 4)) { example.run }
     end
 
     let(:performed_by) { create(:user, family_name: "Gear", given_name: "Joe") }

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -5,9 +5,7 @@ require "rails_helper"
 describe "HPV Vaccination" do
   include EmailExpectations
 
-  around do |example|
-    Timecop.freeze(Time.zone.local(2024, 2, 1)) { example.run }
-  end
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Administered" do
     given_i_am_signed_in

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -3,9 +3,7 @@
 require "rails_helper"
 
 describe "HPV Vaccination" do
-  around do |example|
-    Timecop.freeze(Time.zone.local(2024, 2, 1)) { example.run }
-  end
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Default batch" do
     given_i_am_signed_in

--- a/spec/features/manage_vaccines_batches_spec.rb
+++ b/spec/features/manage_vaccines_batches_spec.rb
@@ -3,8 +3,7 @@
 require "rails_helper"
 
 describe "Batches" do
-  before { Timecop.freeze(Time.zone.local(2024, 2, 29)) }
-  after { Timecop.return }
+  around { |example| travel_to(Time.zone.local(2024, 2, 29)) { example.run } }
 
   scenario "Adding and editing batches" do
     given_my_team_is_running_an_hpv_vaccination_campaign

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -4,9 +4,7 @@ require "rails_helper"
 require "csv"
 
 describe "Pilot journey" do
-  around do |example|
-    Timecop.freeze(Time.zone.local(2024, 2, 1)) { example.run }
-  end
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Cohorting, session creation, verbal consent, vaccination" do
     # Cohorting
@@ -171,7 +169,7 @@ describe "Pilot journey" do
   end
 
   def given_the_day_of_the_session_comes
-    Timecop.travel(2024, 3, 1)
+    travel_to(Time.zone.local(2024, 3, 1))
     sign_in @team.users.first
   end
 

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "Self-consent" do
-  after { Timecop.return }
+  after { travel_back }
 
   scenario "No consent from parent, the child is Gillick competent so can self-consent" do
     given_an_hpv_campaign_is_underway
@@ -29,7 +29,7 @@ describe "Self-consent" do
   end
 
   def and_it_is_the_day_of_a_vaccination_session
-    Timecop.freeze(@session.date)
+    travel_to(@session.date)
   end
 
   def and_there_is_a_child_without_parental_consent

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe "Not Gillick competent" do
-  after { Timecop.return }
+  after { travel_back }
 
   scenario "No consent from parent, the child is not Gillick competent" do
     given_an_hpv_campaign_is_underway
@@ -24,7 +24,7 @@ describe "Not Gillick competent" do
   end
 
   def and_it_is_the_day_of_a_vaccination_session
-    Timecop.freeze(@session.date)
+    travel_to(@session.date)
   end
 
   def and_there_is_a_child_without_parental_consent

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 describe "Session management" do
   include EmailExpectations
 
-  before { Timecop.freeze(Time.zone.local(2024, 2, 29)) }
-  after { Timecop.return }
+  around { |example| travel_to(Time.zone.local(2024, 2, 29)) { example.run } }
 
   scenario "Adding a new session, closing consent" do
     given_my_team_is_running_an_hpv_vaccination_campaign
@@ -140,7 +139,7 @@ describe "Session management" do
   end
 
   def when_the_deadline_has_passed
-    Timecop.travel(2024, 3, 10)
+    travel_to(Time.zone.local(2024, 3, 10))
   end
 
   def then_they_can_no_longer_give_consent

--- a/spec/lib/mesh_spec.rb
+++ b/spec/lib/mesh_spec.rb
@@ -141,7 +141,7 @@ describe MESH do
     it "returns the correct string" do
       # Test authorisation header generated with
       # https://nhsdigital.github.io/mesh_validate_auth_header/
-      Timecop.freeze(Time.zone.local(2022, 2, 22, 22, 22, 22)) do
+      travel_to(Time.zone.local(2022, 2, 22, 22, 22, 22)) do
         allow(SecureRandom).to receive(:uuid).and_return(
           "deadbeef-dead-beef-dead-beef00031337"
         )

--- a/spec/models/concerns/age_concern_spec.rb
+++ b/spec/models/concerns/age_concern_spec.rb
@@ -32,8 +32,7 @@ describe AgeConcern do
       it { should eq 10 }
 
       context "today is a leap day" do
-        before { Timecop.freeze(Date.new(2020, 2, 29)) }
-        after { Timecop.return }
+        around { |example| travel_to(Date.new(2020, 2, 29)) { example.run } }
 
         it { should eq 10 }
       end
@@ -45,8 +44,7 @@ describe AgeConcern do
       it { should eq 10 }
 
       context "today is a leap day" do
-        before { Timecop.freeze(Date.new(2020, 2, 29)) }
-        after { Timecop.return }
+        around { |example| travel_to(Date.new(2020, 2, 29)) { example.run } }
 
         it { should eq 10 }
       end
@@ -58,8 +56,7 @@ describe AgeConcern do
       it { should eq 9 }
 
       context "today is a leap day" do
-        before { Timecop.freeze(Date.new(2020, 2, 29)) }
-        after { Timecop.return }
+        around { |example| travel_to(Date.new(2020, 2, 29)) { example.run } }
 
         it { should eq 9 }
       end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -65,8 +65,7 @@ describe Patient, type: :model do
   describe "#year_group" do
     subject { patient.year_group }
 
-    before { Timecop.freeze(date) }
-    after { Timecop.return }
+    around { |example| travel_to(date) { example.run } }
 
     let(:patient) { described_class.new(date_of_birth: dob) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -100,6 +100,7 @@ RSpec.configure do |config|
 
   config.after(:each, type: :system) { WebMock.enable! }
 
+  config.include ActiveSupport::Testing::TimeHelpers
   config.include ActiveJob::TestHelper, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :system


### PR DESCRIPTION
This replaces all uses of Timecop with the built-in time helpers provided by Rails directly, to reduce the number of third party libraries.