### PR TITLE
Temporarily limit locations when creating sessions

### DIFF
--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -95,7 +95,8 @@ class Sessions::EditController < ApplicationController
   end
 
   def set_locations
-    @locations = policy_scope(Location).order(:name)
+    # TODO: Use an autocomplete instead.
+    @locations = policy_scope(Location).order(:name).limit(100)
   end
 
   def set_patients


### PR DESCRIPTION
There are 51k+ locations in the database after running the GIAS import. We can't display all of them at the same time, and instead should use something like an autocomplete that fetches locations from the server.