### PR TITLE
Handle duplicate patient records during immunisation import

### DIFF
--- a/app/controllers/immunisation_imports/patients_controller.rb
+++ b/app/controllers/immunisation_imports/patients_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class ImmunisationImports::PatientsController < ApplicationController
+  before_action :set_campaign
+  before_action :set_immunisation_import
+  before_action :set_patient
+
+  def show
+    render layout: "full"
+  end
+
+  def update
+  end
+
+  private
+
+  def set_campaign
+    @campaign =
+      policy_scope(Campaign)
+        .active
+        .includes(:immunisation_imports)
+        .find(params[:campaign_id])
+  end
+
+  def set_immunisation_import
+    @immunisation_import =
+      @campaign.immunisation_imports.find(params[:immunisation_import_id])
+  end
+
+  def set_patient
+    @patient =
+      Patient
+        .joins(patient_sessions: :vaccination_records)
+        .where(
+          patient_sessions: {
+            vaccination_records: {
+              imported_from: @immunisation_import
+            }
+          }
+        )
+        .find(params[:id])
+  end
+end

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -54,6 +54,7 @@ class ImmunisationImportsController < ApplicationController
   end
 
   def edit
+    render layout: "full"
   end
 
   def update

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -4,6 +4,7 @@ class ImmunisationImportsController < ApplicationController
   before_action :set_campaign
   before_action :set_immunisation_import, only: %i[show edit update]
   before_action :set_vaccination_records, only: %i[edit show]
+  before_action :set_patients_with_changes, only: %i[edit]
 
   def index
     @immunisation_imports =
@@ -87,6 +88,14 @@ class ImmunisationImportsController < ApplicationController
         :patient,
         :session
       )
+  end
+
+  def set_patients_with_changes
+    @patients =
+      @vaccination_records
+        .map(&:patient)
+        .select { _1.pending_changes.present? }
+        .uniq
   end
 
   def immunisation_import_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -32,6 +32,8 @@ class SessionsController < ApplicationController
 
     @counts =
       SessionStats.new(patient_sessions: @patient_sessions, session: @session)
+
+    render layout: "full"
   end
 
   def edit

--- a/app/views/immunisation_imports/edit.html.erb
+++ b/app/views/immunisation_imports/edit.html.erb
@@ -41,7 +41,7 @@
       @immunisation_import
     ), method: :put %>
 
-<% if @patients.present? %>
+<% if @patients.present? && Flipper.enabled?(:import_review) %>
   <div class="nhsuk-table__panel-with-heading-tab">
     <h3 class="nhsuk-table__heading-tab">
       <%= pluralize(@patients.count, "duplicate record") %>

--- a/app/views/immunisation_imports/edit.html.erb
+++ b/app/views/immunisation_imports/edit.html.erb
@@ -10,7 +10,8 @@
 <span class="nhsuk-caption-l"><%= @campaign.name %></span>
 <%= h1 title, page_title: "#{@campaign.name} – #{title}" %>
 
-<% if @immunisation_import.exact_duplicate_record_count > 1 || @immunisation_import.not_administered_record_count > 1 %>
+<% if @immunisation_import.exact_duplicate_record_count > 1 ||
+      @immunisation_import.not_administered_record_count > 1 %>
   <div class="nhsuk-warning-callout">
     <h3 class="nhsuk-warning-callout__label">
       <span class="nhsuk-u-visually-hidden">Important: </span>
@@ -19,11 +20,17 @@
 
     <ul class="nhsuk-list nhsuk-list--bullet">
       <% if @immunisation_import.exact_duplicate_record_count > 1 %>
-        <li><%= @immunisation_import.exact_duplicate_record_count %> previously uploaded records were omitted</li>
+        <li>
+          <%= @immunisation_import.exact_duplicate_record_count %> previously
+          uploaded records were omitted
+        </li>
       <% end %>
 
       <% if @immunisation_import.not_administered_record_count > 1 %>
-        <li><%= @immunisation_import.not_administered_record_count %> records for children who were not vaccinated were omitted</li>
+        <li>
+          <%= @immunisation_import.not_administered_record_count %> records for
+          children who were not vaccinated were omitted
+        </li>
       <% end %>
     </ul>
   </div>
@@ -34,4 +41,58 @@
       @immunisation_import
     ), method: :put %>
 
-<%= render AppVaccinationRecordTableComponent.new(@vaccination_records, new_records: true) %>
+<% if @patients.present? %>
+  <div class="nhsuk-table__panel-with-heading-tab">
+    <h3 class="nhsuk-table__heading-tab">
+      <%= pluralize(@patients.count, "duplicate record") %>
+      <%= @patients.count == 1 ? "needs" : "need" %> review
+    </h3>
+    <%= govuk_table(html_attributes: {
+                      class: "nhsuk-table-responsive",
+                    }) do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Child record") %>
+          <% row.with_cell(text: "Issue to review") %>
+          <% row.with_cell(text: "Actions") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% @patients.each do |patient| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Child record</span>
+              <%= patient.full_name %>
+            <% end %>
+
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">
+                Issue to review
+              </span>
+              A field in a duplicate record does not match a previously uploaded
+              record
+            <% end %>
+
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Actions</span>
+              <%= govuk_link_to campaign_immunisation_import_patient_path(
+                    @campaign,
+                    @immunisation_import,
+                    patient
+                  ) do %>
+                Review
+                <span class="nhsuk-u-visually-hidden">
+                  <%= patient.full_name %>
+                </span>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>
+
+<%= render AppVaccinationRecordTableComponent.new(@vaccination_records,
+                                                  new_records: true) %>

--- a/app/views/immunisation_imports/patients/show.html.erb
+++ b/app/views/immunisation_imports/patients/show.html.erb
@@ -1,0 +1,111 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: campaign_immunisation_import_path(@campaign, @immunisation_import),
+        name: @campaign.name,
+      ) %>
+<% end %>
+
+<% title = "Review duplicate vaccination record" %>
+
+<span class="nhsuk-caption-l"><%= @patient.full_name %></span>
+<%= h1 title, page_title: "#{@patient.full_name} – #{title}" %>
+
+<div class="nhsuk-warning-callout">
+  <h3 class="nhsuk-warning-callout__label">
+    <span class="nhsuk-u-visually-hidden">Important: </span>
+    This record needs reviewing
+  </h3>
+
+  <p>
+    A field in a duplicate record does not match that in a previously uploaded
+    record
+  </p>
+</div>
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-one-half">
+    <%= render AppCardComponent.new(colour: "blue") do |c| %>
+      <% c.with_heading { "Duplicate record" } %>
+      <h3 class="nhsuk-heading-s">Duplicate child record</h3>
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "NHS number" } %>
+          <% row.with_value { format_nhs_number(@patient.nhs_number) } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Full name" } %>
+          <% row.with_value { @patient.full_name } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Date of birth" } %>
+          <% row.with_value { @patient.date_of_birth.to_fs(:long) } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Sex" } %>
+          <% row.with_value { @patient.gender_code.humanize } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Postcode" } %>
+          <% row.with_value { @patient.address_postcode } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "School" } %>
+          <% row.with_value { @patient.school&.name } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="nhsuk-grid-column-one-half">
+    <%= render AppCardComponent.new(colour: "blue") do |c| %>
+      <% c.with_heading { "Previously uploaded record" } %>
+      <h3 class="nhsuk-heading-s">Previously uploaded child record</h3>
+      <%= govuk_summary_list do |summary_list| %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "NHS number" } %>
+          <% row.with_value { format_nhs_number(@patient.nhs_number) } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Full name" } %>
+          <% row.with_value { @patient.full_name } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Date of birth" } %>
+          <% row.with_value { @patient.date_of_birth.to_fs(:long) } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Sex" } %>
+          <% row.with_value { @patient.gender_code.humanize } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "Postcode" } %>
+          <% row.with_value { @patient.address_postcode } %>
+        <% end %>
+        <% summary_list.with_row do |row| %>
+          <% row.with_key { "School" } %>
+          <% row.with_value { @patient.school&.name } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<%= form_with(
+      model: @immunisation_import,
+      url: campaign_immunisation_import_patient_path(@campaign,
+                                                     @immunisation_import),
+      method: :put,
+      class: "nhsuk-u-width-one-half",
+    ) do |f| %>
+  <%= f.govuk_radio_buttons_fieldset(:keep_record,
+                                     legend: { text: "Which record do you want to keep?" }) do %>
+    <%= f.govuk_radio_button :keep_record, "duplicate",
+                             label: { text: "Use duplicate record" },
+                             hint: { text: "The duplicate record will replace the previously uploaded record." } %>
+    <%= f.govuk_radio_button :keep_record, "previous",
+                             label: { text: "Keep previously uploaded record" },
+                             hint: { text: "The previously uploaded record will be kept and the duplicate record will be discarded." } %>
+  <% end %>
+
+  <%= f.govuk_submit "Resolve duplicate" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,11 @@ Rails.application.routes.draw do
 
     resources :immunisation_imports,
               path: "immunisation-imports",
-              except: :destroy
+              except: :destroy do
+      resources :patients,
+                only: %i[show update],
+                controller: "immunisation_imports/patients"
+    end
 
     resources :vaccination_records,
               path: "vaccination-records",

--- a/spec/features/immunisation_imports_upload_duplicates_spec.rb
+++ b/spec/features/immunisation_imports_upload_duplicates_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Immunisation imports duplicates" do
+  before { Flipper.enable(:import_review) }
+
   scenario "User reviews and selects between duplicate records" do
     given_i_am_signed_in
     and_an_hpv_campaign_is_underway

--- a/spec/features/immunisation_imports_upload_duplicates_spec.rb
+++ b/spec/features/immunisation_imports_upload_duplicates_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+describe "Immunisation imports duplicates" do
+  scenario "User reviews and selects between duplicate records" do
+    given_i_am_signed_in
+    and_an_hpv_campaign_is_underway
+    and_an_existing_patient_record_exists
+
+    when_i_go_to_the_reports_page
+    and_i_click_on_the_upload_link
+    and_i_upload_a_file_with_duplicate_records
+    then_i_should_see_the_edit_page_with_duplicate_records
+
+    when_i_review_the_duplicate_record
+    then_i_should_see_the_duplicate_record
+
+    # when_i_select_the_new_record
+    # and_i_confirm_my_selection
+    # then_i_should_see_a_success_message
+  end
+
+  def given_i_am_signed_in
+    @team = create(:team, :with_one_nurse, ods_code: "R1L")
+    sign_in @team.users.first
+  end
+
+  def and_an_hpv_campaign_is_underway
+    @campaign =
+      create(:campaign, :hpv_all_vaccines, academic_year: 2023, team: @team)
+    @location = create(:location, :school, urn: "110158")
+    @session = create(:session, campaign: @campaign, location: @location)
+  end
+
+  def and_an_existing_patient_record_exists
+    @existing_patient =
+      create(
+        :patient,
+        first_name: "Esmae",
+        last_name: "O'Connell",
+        nhs_number: "7420180008", # First row of valid_hpv.csv
+        date_of_birth: Date.new(2014, 3, 29),
+        gender_code: :female,
+        address_postcode: "QG53 3OA",
+        school: @location
+      )
+  end
+
+  def when_i_go_to_the_reports_page
+    visit "/dashboard"
+    click_on "Vaccination programmes", match: :first
+    click_on "HPV"
+    click_on "Uploads"
+  end
+
+  def and_i_click_on_the_upload_link
+    click_on "Upload new vaccination records"
+  end
+
+  def and_i_upload_a_file_with_duplicate_records
+    attach_file(
+      "immunisation_import[csv]",
+      "spec/fixtures/immunisation_import/valid_hpv.csv"
+    )
+    click_on "Continue"
+  end
+
+  def then_i_should_see_the_edit_page_with_duplicate_records
+    expect(page).to have_content("1 duplicate record needs review")
+  end
+
+  def when_i_select_the_new_record
+    choose "Use new record"
+  end
+
+  def and_i_confirm_my_selection
+    click_on "Confirm"
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content("Duplicate record reviewed successfully")
+  end
+
+  def when_i_review_the_duplicate_record
+    click_on "Review Esmae O'Connell"
+  end
+
+  def then_i_should_see_the_duplicate_record
+    expect(page).to have_content("This record needs reviewing")
+  end
+end


### PR DESCRIPTION
This implements the design that allows users to apply the `pending_changes` that are added to patient records when matching records that match on NHS Number are uploaded a second time.

TODO in follow-up PRs:

- [ ] Implement the diffing correctly
- [ ] Implement the form to keep or overwrite changes
- [ ] Vaccination record review
- [ ] Breadcrumbs
- [ ] Send an updated record to MESH if the user chooses to use the duplicate record
- [ ] If the duplicate records aren't reviewed and resolved before uploading the batch, then they appear in the "Upload issues" area (see prototype)
- [ ] Test 2+ patients, not just 1 record

### Screenshots

(Font is wrong because these are taken from tests)

![image](https://github.com/user-attachments/assets/ced6fd05-e411-4614-83bb-8481da9beed9)

![image](https://github.com/user-attachments/assets/0c71819c-3f11-4008-a802-e16606a00589)
