### PR TITLE
Don't require a not vaccinated reason

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -50,7 +50,6 @@ class ImmunisationImportRow
               greater_than_or_equal_to: :campaign_start_date,
               less_than_or_equal_to: :campaign_end_date_or_today
             }
-  validates :reason, presence: true, if: -> { administered == false }
 
   CARE_SETTING_SCHOOL = 1
   CARE_SETTING_COMMUNITY = 2
@@ -90,7 +89,6 @@ class ImmunisationImportRow
         patient_session:,
         performed_by_family_name:,
         performed_by_given_name:,
-        reason:,
         vaccine:
       )
   end
@@ -145,16 +143,6 @@ class ImmunisationImportRow
 
   def batch_number
     @data["BATCH_NUMBER"]&.strip
-  end
-
-  REASONS = {
-    "did not attend" => :absent_from_session,
-    "vaccination contraindicated" => :contraindications,
-    "unwell" => :not_well
-  }.freeze
-
-  def reason
-    REASONS[@data["REASON_NOT_VACCINATED"]&.strip&.downcase]
   end
 
   DELIVERY_SITES = {

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -581,32 +581,6 @@ describe ImmunisationImportRow, type: :model do
     end
   end
 
-  describe "#reason" do
-    subject(:reason) { immunisation_import_row.reason }
-
-    context "without a reason" do
-      let(:data) { { "VACCINATED" => "N" } }
-
-      it { expect(immunisation_import_row).to be_invalid }
-    end
-
-    context "without an unknown reason" do
-      let(:data) do
-        { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => "Unknown" }
-      end
-
-      it { expect(immunisation_import_row).to be_invalid }
-    end
-
-    context "with a reason" do
-      let(:data) do
-        { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => "Did Not Attend" }
-      end
-
-      it { should eq(:absent_from_session) }
-    end
-  end
-
   describe "#delivery_method" do
     subject(:delivery_method) { immunisation_import_row.delivery_method }
 


### PR DESCRIPTION
We won't be importing records which haven't been vaccinated so we don't need the CSV file to include a `NOT_VACCINATED_REASON` column, and instead we can simply ignore it.