### PR TITLE
Refactor models related to CSV imports

### DIFF
--- a/app/controllers/cohort_lists_controller.rb
+++ b/app/controllers/cohort_lists_controller.rb
@@ -6,7 +6,7 @@ class CohortListsController < ApplicationController
   before_action :set_team, only: %i[new create]
 
   def new
-    @cohort_list = CohortList.new(team: @team)
+    @cohort_list = CohortList.new
   end
 
   def create
@@ -20,11 +20,12 @@ class CohortListsController < ApplicationController
 
     @cohort_list.parse_rows!
     if @cohort_list.invalid?
-      render :errors, status: :unprocessable_entity, layout: "application"
+      render :errors, status: :unprocessable_entity
       return
     end
 
-    @cohort_list.generate_patients!
+    @cohort_list.process!
+
     session[:last_cohort_upload_count] = @cohort_list.rows.count
 
     redirect_to action: :success
@@ -37,7 +38,7 @@ class CohortListsController < ApplicationController
   private
 
   def cohort_list_params
-    params.fetch(:cohort_list, {}).permit(:csv).merge(team: @team)
+    params.fetch(:cohort_list, {}).permit(:csv)
   end
 
   def set_team

--- a/app/models/cohort_list.rb
+++ b/app/models/cohort_list.rb
@@ -4,65 +4,9 @@ require "csv"
 
 class CohortList
   include ActiveModel::Model
+  include CSVImportable
 
-  attr_accessor :csv_data, :csv_is_malformed, :data, :rows
-
-  REQUIRED_HEADERS = %w[
-    SCHOOL_URN
-    SCHOOL_NAME
-    PARENT_NAME
-    PARENT_RELATIONSHIP
-    PARENT_EMAIL
-    PARENT_PHONE
-    CHILD_FIRST_NAME
-    CHILD_LAST_NAME
-    CHILD_COMMON_NAME
-    CHILD_DATE_OF_BIRTH
-    CHILD_ADDRESS_LINE_1
-    CHILD_ADDRESS_LINE_2
-    CHILD_ADDRESS_TOWN
-    CHILD_ADDRESS_POSTCODE
-    CHILD_NHS_NUMBER
-  ].freeze
-
-  validates :csv, presence: true
-
-  validate :csv_is_valid
-  validate :csv_has_records
-  validate :headers_are_valid
-  validate :rows_are_valid
-
-  def csv=(file)
-    self.csv_data = file&.read
-  end
-
-  # Needed so that validations match the form field name.
-  def csv
-    csv_data
-  end
-
-  def load_data!
-    return if invalid?
-
-    self.data ||= CSV.parse(csv_data, headers: true, skip_blanks: true)
-  rescue CSV::MalformedCSVError
-    self.csv_is_malformed = true
-  end
-
-  def parse_rows!
-    load_data! if data.nil?
-    return if invalid?
-
-    self.rows =
-      data.map do |raw_row|
-        CohortListRow.new(
-          raw_row
-            .to_h
-            .slice(*REQUIRED_HEADERS) # Remove extra columns
-            .transform_keys { _1.downcase.to_sym }
-        )
-      end
-  end
+  attr_accessor :csv_data, :csv_filename
 
   def process!
     parse_rows! if rows.nil?
@@ -80,32 +24,32 @@ class CohortList
 
   private
 
-  def csv_is_valid
-    return unless csv_is_malformed
-
-    errors.add(:csv, :invalid)
+  def required_headers
+    %w[
+      SCHOOL_URN
+      SCHOOL_NAME
+      PARENT_NAME
+      PARENT_RELATIONSHIP
+      PARENT_EMAIL
+      PARENT_PHONE
+      CHILD_FIRST_NAME
+      CHILD_LAST_NAME
+      CHILD_COMMON_NAME
+      CHILD_DATE_OF_BIRTH
+      CHILD_ADDRESS_LINE_1
+      CHILD_ADDRESS_LINE_2
+      CHILD_ADDRESS_TOWN
+      CHILD_ADDRESS_POSTCODE
+      CHILD_NHS_NUMBER
+    ]
   end
 
-  def csv_has_records
-    return unless data
-
-    errors.add(:csv, :empty) if data.empty?
-  end
-
-  def headers_are_valid
-    return unless data
-
-    missing_headers = REQUIRED_HEADERS - data.headers
-    errors.add(:csv, :missing_headers, missing_headers:) if missing_headers.any?
-  end
-
-  def rows_are_valid
-    return unless rows
-
-    rows.each.with_index do |row, index|
-      if row.invalid?
-        errors.add("row_#{index + 1}".to_sym, row.errors.full_messages)
-      end
-    end
+  def parse_row(row_data)
+    CohortListRow.new(
+      row_data
+        .to_h
+        .slice(*required_headers) # Remove extra columns
+        .transform_keys { _1.downcase.to_sym }
+    )
   end
 end

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module CSVImportable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_accessor :csv_is_malformed, :data, :rows
+
+    validates :csv,
+              absence: {
+                if: -> { try(:csv_removed?) || false }
+              },
+              presence: {
+                unless: -> { try(:csv_removed?) || false }
+              }
+    validates :csv_filename, presence: true
+
+    validate :csv_is_valid
+    validate :csv_has_records
+    validate :headers_are_valid
+    validate :rows_are_valid
+  end
+
+  def csv=(file)
+    self.csv_data = file&.read
+    self.csv_filename = file&.original_filename
+  end
+
+  # Needed so that validations match the form field name.
+  def csv
+    csv_data
+  end
+
+  def load_data!
+    return if invalid?
+
+    self.data ||= CSV.parse(csv_data, headers: true, skip_blanks: true)
+  rescue CSV::MalformedCSVError
+    self.csv_is_malformed = true
+  end
+
+  def parse_rows!
+    load_data! if data.nil?
+    return if invalid?
+
+    self.rows = data.map { |row_data| parse_row(row_data) }
+  end
+
+  def csv_is_valid
+    return unless csv_is_malformed
+
+    errors.add(:csv, :invalid)
+  end
+
+  def csv_has_records
+    return unless data
+
+    errors.add(:csv, :empty) if data.empty?
+  end
+
+  def headers_are_valid
+    return unless data
+
+    missing_headers = required_headers - data.headers
+    errors.add(:csv, :missing_headers, missing_headers:) if missing_headers.any?
+  end
+
+  def rows_are_valid
+    return unless rows
+
+    rows.each.with_index do |row, index|
+      if row.invalid?
+        errors.add("row_#{index + 1}".to_sym, row.errors.full_messages)
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,8 +23,9 @@ en:
           attributes:
             csv:
               blank: Choose a file
+              empty: Choose a CSV file with at least one record
               invalid: Choose a CSV file in the correct format
-              too_large: Choose a CSV with %{remaining} or fewer rows
+              missing_headers: "The file is missing the following headers: %{missing_headers}"
         cohort_list_row:
           attributes:
             child_address_line_1:

--- a/spec/features/pilot_upload_cohort_spec.rb
+++ b/spec/features/pilot_upload_cohort_spec.rb
@@ -17,7 +17,6 @@ describe "Pilot - upload cohort" do
 
     when_i_upload_a_cohort_file_with_invalid_headers
     then_i_should_the_errors_page_with_invalid_headers
-    and_i_should_be_able_to_go_back_to_the_upload_page
 
     when_i_upload_a_cohort_file_with_invalid_fields
     then_i_should_the_errors_page_with_invalid_fields
@@ -84,12 +83,7 @@ describe "Pilot - upload cohort" do
   end
 
   def then_i_should_the_errors_page_with_invalid_headers
-    expect(page).to have_content("The cohort list could not be added")
-    expect(page).to have_content("CSV")
-  end
-
-  def and_i_should_be_able_to_go_back_to_the_upload_page
-    click_on "Back to cohort upload page"
+    expect(page).to have_content("The file is missing the following headers")
   end
 
   def when_i_upload_a_cohort_file_with_invalid_fields

--- a/spec/models/cohort_list_spec.rb
+++ b/spec/models/cohort_list_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 describe CohortList, type: :model do
-  subject(:cohort_list) { described_class.new(csv:, team:) }
+  subject(:cohort_list) { described_class.new(csv:) }
 
-  let(:team) { create(:team) }
   # Ensure location URN matches the URN in our fixture files
   let!(:location) do
     Location.find_by(urn: "123456") || create(:location, :school, urn: "123456")
@@ -11,12 +10,14 @@ describe CohortList, type: :model do
   let(:csv) { fixture_file_upload("spec/fixtures/cohort_list/#{file}") }
 
   describe "#load_data!" do
+    subject(:load_data!) { cohort_list.load_data! }
+
+    before { load_data! }
+
     describe "with missing CSV" do
       let(:csv) { nil }
 
       it "is invalid" do
-        cohort_list.load_data!
-
         expect(cohort_list).to be_invalid
         expect(cohort_list.errors[:csv]).to include(/Choose/)
       end
@@ -26,8 +27,6 @@ describe CohortList, type: :model do
       let(:file) { "malformed.csv" }
 
       it "is invalid" do
-        cohort_list.load_data!
-
         expect(cohort_list).to be_invalid
         expect(cohort_list.errors[:csv]).to include(/correct format/)
       end
@@ -35,13 +34,14 @@ describe CohortList, type: :model do
   end
 
   describe "#parse_rows!" do
+    subject(:parse_rows!) { cohort_list.parse_rows! }
+
+    before { parse_rows! }
+
     describe "with invalid headers" do
       let(:file) { "invalid_headers.csv" }
 
       it "populates header errors" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_invalid
         expect(cohort_list.errors[:csv]).to include(/missing.*headers/)
       end
@@ -51,9 +51,6 @@ describe CohortList, type: :model do
       let(:file) { "invalid_fields.csv" }
 
       it "populates rows" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_invalid
         expect(cohort_list.rows).not_to be_empty
       end
@@ -63,9 +60,6 @@ describe CohortList, type: :model do
       let(:file) { "valid_cohort_extra_fields.csv" }
 
       it "populates rows" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_valid
       end
     end
@@ -74,16 +68,10 @@ describe CohortList, type: :model do
       let(:file) { "valid_cohort.csv" }
 
       it "is valid" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_valid
       end
 
       it "accepts NHS numbers with spaces, removes spaces" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_valid
         expect(cohort_list.rows.second.to_patient[:nhs_number]).to eq(
           "1234567891"
@@ -91,9 +79,6 @@ describe CohortList, type: :model do
       end
 
       it "parses dates in the ISO8601 format" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_valid
         expect(cohort_list.rows.first.to_patient[:date_of_birth]).to eq(
           Date.new(2010, 1, 1)
@@ -101,9 +86,6 @@ describe CohortList, type: :model do
       end
 
       it "parses dates in the DD/MM/YYYY format" do
-        cohort_list.load_data!
-        cohort_list.parse_rows!
-
         expect(cohort_list).to be_valid
         expect(cohort_list.rows.second.to_patient[:date_of_birth]).to eq(
           Date.new(2010, 1, 2)
@@ -112,14 +94,13 @@ describe CohortList, type: :model do
     end
   end
 
-  describe "#generate_patients!" do
+  describe "#process!" do
+    subject(:process!) { cohort_list.process! }
+
     let(:file) { "valid_cohort.csv" }
 
     it "creates patients" do
-      cohort_list.load_data!
-      cohort_list.parse_rows!
-
-      expect { cohort_list.generate_patients! }.to change(Patient, :count).by(2)
+      expect { process! }.to change(Patient, :count).by(2)
 
       expect(Patient.first).to have_attributes(
         nhs_number: "1234567890",


### PR DESCRIPTION
This refactors the `ImmunisationImport` and `CohortList` models to use a common `CSVImportable` concern which encapsulates the logic of both classes and ensure the behaviour is consistent across the two.