### PR TITLE
Allow seeing draft vaccination records

### DIFF
--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -2,7 +2,7 @@
 
 class VaccinationRecordsController < ApplicationController
   def index
-    @vaccination_records = vaccination_records
+    @vaccination_records = vaccination_records.recorded
 
     render layout: "full"
   end
@@ -38,12 +38,12 @@ class VaccinationRecordsController < ApplicationController
         .includes(
           :batch,
           :campaign,
+          :imported_from,
           :performed_by_user,
           :vaccine,
           patient: :school,
           session: :location
         )
-        .recorded
         .where(campaign:)
         .order(:recorded_at)
         .strict_loading

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -1,9 +1,19 @@
 <% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: t("campaigns.index.title"), href: campaigns_path },
-                                          { text: @campaign.name, href: campaign_vaccination_records_path(@campaign) },
-                                          { text: t("vaccination_records.index.title"), href: campaign_vaccination_records_path(@campaign) },
-                                        ]) %>
+  <% if @vaccination_record.recorded? %>
+    <%= render AppBreadcrumbComponent.new(items: [
+                                            { text: t("campaigns.index.title"), href: campaigns_path },
+                                            { text: @campaign.name, href: campaign_vaccination_records_path(@campaign) },
+                                            { text: t("vaccination_records.index.title"), href: campaign_vaccination_records_path(@campaign) },
+                                          ]) %>
+  <% elsif (immunisation_import = @vaccination_record.imported_from) %>
+    <%= render AppBacklinkComponent.new(
+          href: edit_campaign_immunisation_import_path(
+            @campaign,
+            immunisation_import
+          ),
+          name: "check and confirm upload",
+        ) %>
+  <% end %>
 <% end %>
 
 <%= h1 @patient.full_name %>

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -23,7 +23,11 @@ describe "Immunisation imports" do
     then_i_should_see_the_success_heading
     and_i_should_see_the_vaccination_records
 
-    when_i_click_on_upload_records
+    when_i_click_on_a_vaccination_record
+    then_i_should_see_the_vaccination_record
+
+    when_i_go_back
+    and_i_click_on_upload_records
     then_i_should_see_the_upload
     and_i_should_see_the_vaccination_records
 
@@ -126,7 +130,11 @@ describe "Immunisation imports" do
     expect(page).to have_content("Vaccination date 14 May 2024")
   end
 
-  def when_i_click_on_upload_records
+  def when_i_go_back
+    click_on "Back to check and confirm upload"
+  end
+
+  def and_i_click_on_upload_records
     click_on "Upload records"
   end
 
@@ -149,7 +157,7 @@ describe "Immunisation imports" do
     expect(page).to have_content("Chyna Pickle")
     expect(page).to have_content("Child record")
     expect(page).to have_content("NameChyna Pickle")
-    expect(page).to have_content("Vaccination record")
+    expect(page).to have_content("Vaccination details")
     expect(page).to have_content("OutcomeVaccinated")
   end
 


### PR DESCRIPTION
This makes it possible to see the information about a vaccination record before it's recorded by updating the controller to see all vaccination records.