### PR TITLE
Display highlighted changes to patients 

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class AppPatientSummaryComponent < ViewComponent::Base
+  def initialize(patient:)
+    super
+
+    @patient = patient
+  end
+
+  def call
+    govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "NHS number" }
+        row.with_value { format_nhs_number }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Full name" }
+        row.with_value { format_full_name }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Date of birth" }
+        row.with_value { format_date_of_birth }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Sex" }
+        row.with_value { format_gender_code }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Postcode" }
+        row.with_value { format_postcode }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "School" }
+        row.with_value { format_school }
+      end
+    end
+  end
+
+  private
+
+  def format_nhs_number
+    highlight_if(
+      helpers.format_nhs_number(@patient.nhs_number),
+      @patient.nhs_number_changed?
+    )
+  end
+
+  def format_full_name
+    highlight_if(
+      @patient.full_name,
+      @patient.first_name_changed? || @patient.last_name_changed?
+    )
+  end
+
+  def format_date_of_birth
+    highlight_if(
+      @patient.date_of_birth.to_date.to_fs(:long),
+      @patient.date_of_birth_changed?
+    )
+  end
+
+  def format_gender_code
+    highlight_if(
+      @patient.gender_code.to_s.humanize,
+      @patient.gender_code_changed?
+    )
+  end
+
+  def format_postcode
+    highlight_if(@patient.address_postcode, @patient.address_postcode_changed?)
+  end
+
+  def format_school
+    highlight_if(@patient.school.name, @patient.school_id_changed?)
+  end
+
+  def highlight_if(value, condition)
+    condition ? tag.span(value, class: "app-highlight") : value
+  end
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -118,6 +118,19 @@ class Patient < ApplicationRecord
     update!(pending_changes:) if pending_changes.any?
   end
 
+  def with_pending_changes
+    return self if pending_changes.blank?
+
+    dup.tap do |patient|
+      patient.clear_changes_information
+      pending_changes.each do |attr, value|
+        if patient.respond_to?("#{attr}=")
+          patient.public_send("#{attr}=", value)
+        end
+      end
+    end
+  end
+
   private
 
   def remove_spaces_from_nhs_number

--- a/app/views/immunisation_imports/patients/show.html.erb
+++ b/app/views/immunisation_imports/patients/show.html.erb
@@ -27,32 +27,9 @@
     <%= render AppCardComponent.new(colour: "blue") do |c| %>
       <% c.with_heading { "Duplicate record" } %>
       <h3 class="nhsuk-heading-s">Duplicate child record</h3>
-      <%= govuk_summary_list do |summary_list| %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "NHS number" } %>
-          <% row.with_value { format_nhs_number(@patient.nhs_number) } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Full name" } %>
-          <% row.with_value { @patient.full_name } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Date of birth" } %>
-          <% row.with_value { @patient.date_of_birth.to_fs(:long) } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Sex" } %>
-          <% row.with_value { @patient.gender_code.humanize } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Postcode" } %>
-          <% row.with_value { @patient.address_postcode } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "School" } %>
-          <% row.with_value { @patient.school&.name } %>
-        <% end %>
-      <% end %>
+      <%= render AppPatientSummaryComponent.new(
+            patient: @patient.with_pending_changes,
+          ) %>
     <% end %>
   </div>
 
@@ -60,32 +37,9 @@
     <%= render AppCardComponent.new(colour: "blue") do |c| %>
       <% c.with_heading { "Previously uploaded record" } %>
       <h3 class="nhsuk-heading-s">Previously uploaded child record</h3>
-      <%= govuk_summary_list do |summary_list| %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "NHS number" } %>
-          <% row.with_value { format_nhs_number(@patient.nhs_number) } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Full name" } %>
-          <% row.with_value { @patient.full_name } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Date of birth" } %>
-          <% row.with_value { @patient.date_of_birth.to_fs(:long) } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Sex" } %>
-          <% row.with_value { @patient.gender_code.humanize } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "Postcode" } %>
-          <% row.with_value { @patient.address_postcode } %>
-        <% end %>
-        <% summary_list.with_row do |row| %>
-          <% row.with_key { "School" } %>
-          <% row.with_value { @patient.school&.name } %>
-        <% end %>
-      <% end %>
+      <%= render AppPatientSummaryComponent.new(
+            patient: @patient,
+          ) %>
     <% end %>
   </div>
 </div>

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe AppPatientSummaryComponent, type: :component do
+  subject { page }
+
+  before { render_inline(component) }
+
+  let(:component) { described_class.new(patient:) }
+  let(:school) { create(:location, :school, name: "Test School") }
+  let(:other_school) { create(:location, :school, name: "Other School") }
+  let(:patient) do
+    create(
+      :patient,
+      nhs_number: "1234567890",
+      first_name: "John",
+      last_name: "Doe",
+      date_of_birth: Date.new(2000, 1, 1),
+      gender_code: "male",
+      address_postcode: "SW1A 1AA",
+      school:,
+      pending_changes: {
+        first_name: "Jane",
+        date_of_birth: Date.new(2001, 1, 1),
+        address_postcode: "SW1A 2AA",
+        school_id: other_school.id
+      }
+    )
+  end
+
+  it { should have_content("NHS number") }
+  it { should have_content("123\u00A0\u200D456\u00A0\u200D7890") }
+
+  it { should have_content("Full name") }
+  it { should have_content("John Doe") }
+
+  it { should have_content("Date of birth") }
+  it { should have_content("1 January 2000") }
+
+  it { should have_content("Sex") }
+  it { should have_content("Male") }
+
+  it { should have_content("Postcode") }
+  it { should have_content("SW1A 1AA") }
+
+  it { should have_content("School") }
+  it { should have_content("Test School") }
+
+  it { should_not have_css(".app-highlight") }
+
+  context "with pending changes" do
+    let(:component) do
+      described_class.new(patient: patient.with_pending_changes)
+    end
+
+    it { should have_css(".app-highlight", text: "Jane Doe") }
+    it { should have_css(".app-highlight", text: "1 January 2001") }
+    it { should have_css(".app-highlight", text: "SW1A 2AA") }
+    it { should_not have_css(".app-highlight", text: "Male") }
+    it { should_not have_css(".app-highlight", text: "Test School") }
+    it { should have_css(".app-highlight", text: "Other School") }
+  end
+end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -146,4 +146,18 @@ describe Patient, type: :model do
       )
     end
   end
+
+  describe "#with_pending_changes" do
+    let(:patient) { create(:patient) }
+
+    it "returns the patient with pending changes applied" do
+      patient.stage_changes(first_name: "Jane")
+      expect(patient.first_name_changed?).to be(false)
+
+      changed_patient = patient.with_pending_changes
+      expect(changed_patient.first_name_changed?).to be(true)
+      expect(changed_patient.last_name_changed?).to be(false)
+      expect(changed_patient.first_name).to eq("Jane")
+    end
+  end
 end


### PR DESCRIPTION
Refactor the duplicate patient summary to use a component.

Add a `with_pending_changes` method to patients that assigns all the attributes, allowing us to check whether they're changed using [ActiveModel::Dirty](https://api.rubyonrails.org/classes/ActiveModel/Dirty.html) built-ins.

### Screenshots

![image](https://github.com/user-attachments/assets/67ab4e29-729d-48ee-acac-b3995a5bd746)
