### PR TITLE
Refactor PatientSession and associated factories

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -46,8 +46,8 @@ class PatientSession < ApplicationRecord
   has_many :triage, -> { order(:updated_at) }
   has_many :vaccination_records
   has_many :consents,
-           ->(patient) do
-             Consent.submitted_for_campaign(patient.campaign).includes(:parent)
+           ->(patient_session) do
+             submitted_for_campaign(patient_session.campaign).includes(:parent)
            end,
            through: :patient,
            class_name: "Consent"

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -8,7 +8,7 @@ class PatientPolicy
     end
 
     def resolve
-      @scope.joins(:school)
+      @scope.includes(:school)
     end
   end
 end

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -30,14 +30,7 @@ describe AppOutcomeBannerComponent, type: :component do
   context "state is vaccinated" do
     let(:campaign) { create(:campaign, :hpv) }
     let(:patient_session) do
-      create(
-        :patient_session,
-        :vaccinated,
-        created_by: user,
-        session_attributes: {
-          campaign:
-        }
-      )
+      create(:patient_session, :vaccinated, created_by: user, campaign:)
     end
     let(:vaccination_record) { patient_session.vaccination_records.first }
     let(:vaccine) { patient_session.session.campaign.vaccines.first }

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -30,9 +30,7 @@ describe AppPatientPageComponent, type: :component do
         :patient_session,
         :consent_given_triage_needed,
         :session_in_progress,
-        session_attributes: {
-          campaign:
-        }
+        campaign:
       )
     end
 
@@ -63,9 +61,7 @@ describe AppPatientPageComponent, type: :component do
         :patient_session,
         :triaged_ready_to_vaccinate,
         :session_in_progress,
-        session_attributes: {
-          campaign:
-        }
+        campaign:
       )
     end
 

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -11,9 +11,7 @@ describe AppPatientTableComponent, type: :component do
 
   let(:section) { :consent }
   let(:campaign) { create(:campaign) }
-  let(:patient_sessions) do
-    create_list(:patient_session, 2, session_attributes: { campaign: })
-  end
+  let(:patient_sessions) { create_list(:patient_session, 2, campaign:) }
   let(:columns) { %i[name dob] }
   let(:params) { { session_id: 1, section:, tab: :needed } }
   let(:args) do
@@ -38,16 +36,13 @@ describe AppPatientTableComponent, type: :component do
 
   describe "when the patient has a common name" do
     let(:patient_sessions) do
-      create_list(
-        :patient_session,
-        2,
-        session_attributes: {
-          campaign:
-        },
-        patient_attributes: {
-          common_name: "Bobby"
-        }
-      )
+      [
+        create(
+          :patient_session,
+          campaign:,
+          patient: create(:patient, common_name: "Bobby")
+        )
+      ]
     end
 
     it "includes the patient's common name" do

--- a/spec/components/app_session_details_component_spec.rb
+++ b/spec/components/app_session_details_component_spec.rb
@@ -29,9 +29,7 @@ describe AppSessionDetailsComponent, type: :component do
   end
 
   context "for a session with only 1 patient" do
-    let(:session) do
-      create(:session, date:, close_consent_at:, patients_in_session: 1)
-    end
+    before { create(:patient, session:) }
 
     it "pluralizes 'child' correctly" do
       expect(component.cohort).to eq "1 child"
@@ -39,9 +37,7 @@ describe AppSessionDetailsComponent, type: :component do
   end
 
   context "for a session with more than 1 patient" do
-    let(:session) do
-      create(:session, date:, close_consent_at:, patients_in_session: 2)
-    end
+    before { create_list(:patient, 2, session:) }
 
     it "pluralizes 'child' correctly" do
       expect(component.cohort).to eq "2 children"

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -11,27 +11,19 @@ describe AppVaccinationRecordTableComponent, type: :component do
       create(
         :vaccination_record,
         administered_at: Time.zone.local(2020, 9, 1),
-        patient_attributes: {
-          first_name: "John",
-          last_name: "Smith",
-          nhs_number: "9999999999",
-          date_of_birth: Date.new(2000, 5, 28),
-          address_postcode: "SW1A 2AA"
-        },
-        session_attributes: {
-          date: Date.new(2020, 9, 1),
-          campaign:
-        }
+        patient:
+          create(
+            :patient,
+            first_name: "John",
+            last_name: "Smith",
+            nhs_number: "9999999999",
+            date_of_birth: Date.new(2000, 5, 28),
+            address_postcode: "SW1A 2AA"
+          ),
+        session: create(:session, campaign:, date: Date.new(2020, 9, 1))
       )
-    ] + create_list(:vaccination_record, 4, session_attributes: { campaign: }) +
-      create_list(
-        :vaccination_record,
-        5,
-        :not_administered,
-        session_attributes: {
-          campaign:
-        }
-      )
+    ] + create_list(:vaccination_record, 4, campaign:) +
+      create_list(:vaccination_record, 5, :not_administered, campaign:)
   end
 
   it "renders a heading tab" do

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -59,6 +59,6 @@ class AppConsentComponentPreview < ViewComponent::Preview
 
   def setup
     @campaign = create(:campaign, :hpv, team: Team.first || create(:team))
-    @session = create(:session, patients_in_session: 0, campaign:)
+    @session = create(:session, campaign:)
   end
 end

--- a/spec/components/previews/app_health_questions_component_preview.rb
+++ b/spec/components/previews/app_health_questions_component_preview.rb
@@ -68,6 +68,6 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
 
   def setup
     @campaign = create(:campaign, :hpv, team: Team.first || create(:team))
-    @session = create(:session, patients_in_session: 0, campaign:)
+    @session = create(:session, campaign:)
   end
 end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -24,13 +24,10 @@
 #
 FactoryBot.define do
   factory :patient_session do
-    transient do
-      patient_attributes { {} }
-      session_attributes { {} }
-    end
+    transient { campaign { association :campaign, :active } }
 
-    session { association :session, **session_attributes }
-    patient { association :patient, session:, **patient_attributes }
+    session { association :session, campaign: }
+    patient { association :patient }
     created_by { association :user }
 
     active { session.active }
@@ -43,48 +40,57 @@ FactoryBot.define do
       active { false }
     end
 
-    trait :added_to_session do
-      active
-      patient { association :patient, consents: [] }
-    end
+    trait :added_to_session
 
     trait :consent_given_triage_not_needed do
-      active
       patient do
-        association :patient, :consent_given_triage_not_needed, session:
+        association :patient,
+                    :consent_given_triage_not_needed,
+                    campaign: session.campaign
       end
     end
 
     trait :consent_given_triage_needed do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
+      end
     end
 
     trait :consent_refused do
-      active
-      patient { association :patient, :consent_refused, session: }
+      patient do
+        association :patient, :consent_refused, campaign: session.campaign
+      end
     end
 
     trait :consent_refused_with_notes do
-      active
-      patient { association :patient, :consent_refused_with_notes, session: }
+      patient do
+        association :patient,
+                    :consent_refused_with_notes,
+                    campaign: session.campaign
+      end
     end
 
     trait :consent_conflicting do
-      active
-      patient { association :patient, :consent_conflicting, session: }
+      patient do
+        association :patient, :consent_conflicting, campaign: session.campaign
+      end
     end
 
     trait :triaged_ready_to_vaccinate do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
+      end
+
       triage do
         [
           association(
             :triage,
             :ready_to_vaccinate,
             notes: "Okay to vaccinate",
-            patient_session: instance,
             performed_by: created_by
           )
         ]
@@ -92,47 +98,38 @@ FactoryBot.define do
     end
 
     trait :triaged_do_not_vaccinate do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
+      end
+
       triage do
-        [
-          association(
-            :triage,
-            :do_not_vaccinate,
-            patient_session: instance,
-            performed_by: created_by
-          )
-        ]
+        [association(:triage, :do_not_vaccinate, performed_by: created_by)]
       end
     end
 
     trait :triaged_kept_in_triage do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
+      end
+
       triage do
-        [
-          association(
-            :triage,
-            :needs_follow_up,
-            patient_session: instance,
-            performed_by: created_by
-          )
-        ]
+        [association(:triage, :needs_follow_up, performed_by: created_by)]
       end
     end
 
     trait :delay_vaccination do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
+      end
+
       triage do
-        [
-          association(
-            :triage,
-            :delay_vaccination,
-            patient_session: instance,
-            performed_by: created_by
-          )
-        ]
+        [association(:triage, :delay_vaccination, performed_by: created_by)]
       end
 
       vaccination_records do
@@ -149,25 +146,24 @@ FactoryBot.define do
     end
 
     trait :did_not_need_triage do
-      active
       patient do
-        association :patient, :consent_given_triage_not_needed, session:
+        association :patient,
+                    :consent_given_triage_not_needed,
+                    campaign: session.campaign
       end
     end
 
     trait :unable_to_vaccinate do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
-      triage do
-        [
-          association(
-            :triage,
-            :ready_to_vaccinate,
-            patient_session: instance,
-            performed_by: created_by
-          )
-        ]
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
       end
+
+      triage do
+        [association(:triage, :ready_to_vaccinate, performed_by: created_by)]
+      end
+
       vaccination_records do
         [
           association(
@@ -182,24 +178,16 @@ FactoryBot.define do
     end
 
     trait :unable_to_vaccinate_not_gillick_competent do
-      active
+      gillick_assessment { association :gillick_assessment, :not_competent }
 
-      gillick_assessment do
-        association :gillick_assessment,
-                    :not_competent,
-                    patient_session: instance
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
       end
 
-      patient { association :patient, :consent_given_triage_needed, session: }
       triage do
-        [
-          association(
-            :triage,
-            :ready_to_vaccinate,
-            patient_session: instance,
-            performed_by: created_by
-          )
-        ]
+        [association(:triage, :ready_to_vaccinate, performed_by: created_by)]
       end
 
       vaccination_records do
@@ -216,18 +204,16 @@ FactoryBot.define do
     end
 
     trait :vaccinated do
-      active
-      patient { association :patient, :consent_given_triage_needed, session: }
-      triage do
-        [
-          association(
-            :triage,
-            :ready_to_vaccinate,
-            patient_session: instance,
-            performed_by: created_by
-          )
-        ]
+      patient do
+        association :patient,
+                    :consent_given_triage_needed,
+                    campaign: session.campaign
       end
+
+      triage do
+        [association(:triage, :ready_to_vaccinate, performed_by: created_by)]
+      end
+
       vaccination_records do
         [
           association(
@@ -240,17 +226,11 @@ FactoryBot.define do
     end
 
     trait :session_in_progress do
-      active
-      session { association :session, :in_progress, **session_attributes }
+      session { association :session, :in_progress, campaign: }
     end
 
     trait :not_gillick_competent do
-      active
-      gillick_assessment do
-        association :gillick_assessment,
-                    :not_competent,
-                    patient_session: instance
-      end
+      gillick_assessment { association :gillick_assessment, :not_competent }
     end
   end
 end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -64,63 +64,51 @@ FactoryBot.define do
     address_town { Faker::Address.city }
     address_postcode { Faker::Address.postcode }
 
+    after(:create) do |patient, evaluator|
+      if evaluator.session
+        create(:patient_session, patient:, session: evaluator.session)
+      end
+    end
+
     trait :home_educated do
       school { nil }
       home_educated { true }
     end
 
     trait :consent_given_triage_not_needed do
-      consents do
-        create_list(:consent, 1, :given, campaign:, patient: instance)
-      end
+      consents { [association(:consent, :given, campaign:)] }
     end
 
     trait :consent_given_triage_needed do
       consents do
-        create_list(
-          :consent,
-          1,
-          :given,
-          :health_question_notes,
-          campaign:,
-          patient: instance
-        )
+        [association(:consent, :given, :health_question_notes, campaign:)]
       end
     end
 
     trait :consent_refused do
-      consents do
-        create_list(
-          :consent,
-          1,
-          :refused,
-          :from_mum,
-          campaign:,
-          patient: instance
-        )
-      end
+      consents { [association(:consent, :refused, :from_mum, campaign:)] }
     end
 
     trait :consent_refused_with_notes do
       consents do
-        create_list(
-          :consent,
-          1,
-          :refused,
-          :from_mum,
-          campaign:,
-          reason_for_refusal: "already_vaccinated",
-          reason_for_refusal_notes: "Already had the vaccine at the GP",
-          patient: instance
-        )
+        [
+          association(
+            :consent,
+            :refused,
+            :from_mum,
+            campaign:,
+            reason_for_refusal: "already_vaccinated",
+            reason_for_refusal_notes: "Already had the vaccine at the GP"
+          )
+        ]
       end
     end
 
     trait :consent_conflicting do
       consents do
         [
-          create(:consent, :refused, :from_mum, campaign:, patient: instance),
-          create(:consent, :given, :from_dad, campaign:, patient: instance)
+          association(:consent, :refused, :from_mum, campaign:),
+          association(:consent, :given, :from_dad, campaign:)
         ]
       end
     end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -28,8 +28,6 @@
 #
 FactoryBot.define do
   factory :session do
-    transient { patients_in_session { 0 } }
-
     campaign { association :campaign, :active }
     location { association :location, :school }
 
@@ -60,16 +58,6 @@ FactoryBot.define do
 
     trait :in_past do
       date { Time.zone.now - 1.week }
-    end
-
-    patients do
-      Array.new(patients_in_session) do
-        association(
-          :patient,
-          school: instance.location,
-          patient_sessions: [association(:patient_session, session: instance)]
-        )
-      end
     end
   end
 end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -42,13 +42,13 @@
 FactoryBot.define do
   factory :vaccination_record do
     transient do
-      patient_attributes { {} }
-      session_attributes { {} }
+      campaign { association :campaign, :active }
+      session { association :session, campaign: }
+      patient { association :patient }
     end
 
-    patient_session do
-      association :patient_session, patient_attributes:, session_attributes:
-    end
+    patient_session { association :patient_session, patient:, session: }
+
     recorded_at { "2023-06-09" }
     delivery_site { "left_arm_upper_position" }
     delivery_method { "intramuscular" }

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -28,11 +28,7 @@ describe "HPV Vaccination" do
     @batch = campaign.batches.first
     @session = create(:session, campaign:, location:)
     @patient =
-      create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session: @session
-      ).patient
+      create(:patient, :consent_given_triage_not_needed, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -25,11 +25,7 @@ describe "HPV Vaccination" do
     @batch = campaign.batches.first
     @session = create(:session, campaign:, location:)
     @patient =
-      create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session: @session
-      ).patient
+      create(:patient, :consent_given_triage_not_needed, session: @session)
 
     sign_in @team.users.first
   end

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -26,11 +26,7 @@ describe "HPV Vaccination" do
     @batch = campaign.batches.first
     @session = create(:session, campaign:, location:)
     @patient =
-      create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        session: @session
-      ).patient
+      create(:patient, :consent_given_triage_not_needed, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/parental_consent_authentication_spec.rb
+++ b/spec/features/parental_consent_authentication_spec.rb
@@ -27,9 +27,8 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -75,9 +75,8 @@ RSpec.feature "Parental consent change answers" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :flu, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def when_i_go_to_a_prefilled_consent_form

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -23,9 +23,8 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :flu, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -30,9 +30,8 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -35,9 +35,8 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def when_a_nurse_checks_consent_responses

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -59,10 +59,8 @@ describe "Patient sorting and filtering" do
     location = create(:location, :school)
     @user = @team.users.first
     @campaign = create(:campaign, :hpv, team: @team)
-    @session =
-      create(:session, campaign: @campaign, location:, patients_in_session: 4)
-    @session
-      .patients
+    @session = create(:session, campaign: @campaign, location:)
+    create_list(:patient, 4, session: @session)
       .zip(
         %w[Alex Blair Casey Cassidy],
         %w[2000-01-01 2001-01-01 2002-01-01 2002-01-02]

--- a/spec/features/response_matching_spec.rb
+++ b/spec/features/response_matching_spec.rb
@@ -26,15 +26,9 @@ describe "Response matching" do
     @user = @team.users.first
     @campaign = create(:campaign, :hpv, team: @team)
     @school = create(:location, :school, name: "Pilot School")
-    @session =
-      create(
-        :session,
-        location: @school,
-        campaign: @campaign,
-        patients_in_session: 1
-      )
+    @session = create(:session, location: @school, campaign: @campaign)
     @consent_form = create(:consent_form, :recorded, session: @session)
-    @patient = @session.patients.first
+    @patient = create(:patient, session: @session)
   end
 
   def when_i_go_to_the_campaigns_page

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -21,9 +21,8 @@ describe "Self-consent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def and_it_is_the_day_of_a_vaccination_session

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -16,9 +16,8 @@ describe "Not Gillick competent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
-    @child = @session.patients.first
+    @session = create(:session, :in_future, campaign:, location:)
+    @child = create(:patient, session: @session)
   end
 
   def and_it_is_the_day_of_a_vaccination_session

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -26,18 +26,16 @@ describe "User authorisation" do
       create(:campaign, :hpv, team: @other_team, vaccines: [vaccine])
     location = create(:location, :school, name: "Pilot School")
     other_location = create(:location, :school, name: "Other School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
+    @session = create(:session, :in_future, campaign:, location:)
     @other_session =
       create(
         :session,
         :in_future,
         campaign: other_campaign,
-        location: other_location,
-        patients_in_session: 1
+        location: other_location
       )
-    @child = @session.patients.first
-    @other_child = @other_session.patients.first
+    @child = create(:patient, session: @session)
+    @other_child = create(:patient, session: @other_session)
   end
 
   def when_i_sign_in_as_a_nurse_from_one_team

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -16,8 +16,8 @@ describe "Verbal consent" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team:)
-    @session = create(:session, campaign:, patients_in_session: 1)
-    @patient = @session.patients.first
+    @session = create(:session, campaign:)
+    @patient = create(:patient, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -15,8 +15,8 @@ describe "Verbal consent" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team:)
-    @session = create(:session, campaign:, patients_in_session: 1)
-    @patient = @session.patients.first
+    @session = create(:session, campaign:)
+    @patient = create(:patient, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -15,8 +15,8 @@ describe "Verbal consent" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team:)
-    @session = create(:session, campaign:, patients_in_session: 1)
-    @patient = @session.patients.first
+    @session = create(:session, campaign:)
+    @patient = create(:patient, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -15,8 +15,8 @@ describe "Verbal consent" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team:)
-    @session = create(:session, campaign:, patients_in_session: 1)
-    @patient = @session.patients.first
+    @session = create(:session, campaign:)
+    @patient = create(:patient, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -16,8 +16,8 @@ describe "Verbal consent" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team:)
-    @session = create(:session, campaign:, patients_in_session: 1)
-    @patient = @session.patients.first
+    @session = create(:session, campaign:)
+    @patient = create(:patient, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -18,8 +18,7 @@ feature "Verbal consent" do
     @team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session =
-      create(:session, :in_future, campaign:, location:, patients_in_session: 0)
+    @session = create(:session, :in_future, campaign:, location:)
   end
 
   def and_a_parent_has_refused_consent_for_their_child

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -16,8 +16,8 @@ describe "Verbal consent" do
   def given_i_am_signed_in
     team = create(:team, :with_one_nurse)
     campaign = create(:campaign, :hpv, team:)
-    @session = create(:session, campaign:, patients_in_session: 1)
-    @patient = @session.patients.first
+    @session = create(:session, campaign:)
+    @patient = create(:patient, session: @session)
 
     sign_in team.users.first
   end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -592,7 +592,7 @@ describe ConsentForm, type: :model do
       create_list(
         :patient,
         patients_in_session,
-        sessions: [session],
+        session:,
         address_postcode: "SW1A 1AA"
       )
     end

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -12,19 +12,11 @@ describe DPSExportRow do
   end
   let(:location) { create(:location, :school) }
   let(:school) { create(:location, :school) }
-  let(:patient_session) do
-    create(
-      :patient_session,
-      patient_attributes: {
-        date_of_birth: "2012-12-29",
-        school:
-      },
-      session_attributes: {
-        campaign:,
-        location:
-      }
-    )
+  let(:patient) do
+    create(:patient, date_of_birth: Date.new(2012, 12, 29), school:)
   end
+  let(:session) { create(:session, campaign:, location:) }
+  let(:patient_session) { create(:patient_session, patient:, session:) }
   let(:performed_by) { create(:user, family_name: "Doe", given_name: "Jane") }
   let(:performed_by_given_name) { nil }
   let(:performed_by_family_name) { nil }

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -50,9 +50,7 @@ describe PatientSession do
     subject { patient_session.latest_consents }
 
     let(:campaign) { create(:campaign) }
-    let(:patient_session) do
-      create(:patient_session, patient:, session_attributes: { campaign: })
-    end
+    let(:patient_session) { create(:patient_session, campaign:, patient:) }
 
     context "multiple consent given responses from different parents" do
       let(:consents) { build_list(:consent, 2, campaign:, response: :given) }

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -41,13 +41,7 @@
 #
 
 describe VaccinationRecord, type: :model do
-  subject(:vaccination_record) do
-    create(
-      :vaccination_record,
-      patient_session:
-        create(:patient_session, session_attributes: { campaign: })
-    )
-  end
+  subject(:vaccination_record) { create(:vaccination_record, campaign:) }
 
   let(:campaign) do
     create(


### PR DESCRIPTION
This refactors the factories related to patient sessions, and therefore sessions and patients too, to simplify their use and improve the code readability.

The main changes are automatic creation of patient sessions if a session is passed to the patient when created, which simplifies a number of other factories; and the use of association in the factories.