### PR TITLE
Don't crash on parental consent form for backfilled sessions

### DIFF
--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -58,7 +58,7 @@ module ParentInterface
     end
 
     def check_if_past_deadline
-      return if @session.close_consent_at.future?
+      return if @session.open_for_consent?
 
       redirect_to action: :deadline_passed
     end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -122,6 +122,10 @@ class Session < ApplicationRecord
     consent_forms.unmatched.recorded.order(:recorded_at)
   end
 
+  def open_for_consent?
+    close_consent_at&.future?
+  end
+
   private
 
   def set_timeline_attributes

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -59,5 +59,11 @@ FactoryBot.define do
     trait :in_past do
       date { Time.zone.now - 1.week }
     end
+
+    trait :minimal do
+      send_consent_at { nil }
+      send_reminders_at { nil }
+      close_consent_at { nil }
+    end
   end
 end

--- a/spec/features/parental_consent_backfilled_session_spec.rb
+++ b/spec/features/parental_consent_backfilled_session_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe "Parental consent for a backfilled session" do
+  scenario "Consent form is shown as closed" do
+    given_an_hpv_programme_is_underway_with_a_backfilled_session
+    when_i_go_to_the_consent_form
+    then_i_see_that_consent_is_closed
+  end
+
+  def given_an_hpv_programme_is_underway_with_a_backfilled_session
+    @team = create(:team, :with_one_nurse)
+    programme = create(:programme, :hpv, team: @team)
+    location = create(:location, :school, name: "Pilot School")
+    @session = create(:session, :in_past, :minimal, programme:, location:)
+  end
+
+  def when_i_go_to_the_consent_form
+    visit start_session_parent_interface_consent_forms_path(@session)
+  end
+
+  def then_i_see_that_consent_is_closed
+    expect(page).to have_content("The deadline for responding has passed")
+  end
+end


### PR DESCRIPTION
If a session has been backfilled by the immunisations importer, it won't have timestamps for when consent requests were sent, when reminders were sent and when consent closed. 

For such sessions, trying to give consent should show that the session is closed and not crash.