### PR TITLE
Ignore db/schema.rb code duplication

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.cpd.exclusions=db/schema.rb,spec/**/*,tests/**/*


### PR DESCRIPTION
This is an automatically generated file so it doesn't make sense to run Sonar code checking on it as we wouldn't be able to fix any of the issues.

I've also added `spec` and `tests`, which is already configured in Sonar Cloud, but now replicated here too.