### PR TITLE
Add check and confirm page for cohort imports

### DIFF
--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -18,9 +18,9 @@ class AppPatientTableComponent < ViewComponent::Base
 
   def outcome_for(patient:)
     patient_session = patient_session_for(patient:)
-    if patient_session.vaccination_administered?
+    if patient_session&.vaccination_administered?
       govuk_tag(text: "Vaccinated", colour: "green")
-    elsif patient_session.vaccination_not_administered?
+    elsif patient_session&.vaccination_not_administered?
       govuk_tag(text: "Could not vaccinate", colour: "red")
     else
       govuk_tag(text: "No outcome yet", colour: "grey")
@@ -29,6 +29,8 @@ class AppPatientTableComponent < ViewComponent::Base
 
   def href_for(patient:)
     patient_session = patient_session_for(patient:)
+    return nil if patient_session.nil?
+
     session = patient_session.session
 
     tab =

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
 class CohortImportsController < ApplicationController
-  skip_after_action :verify_policy_scoped, only: %i[new create success]
-
-  before_action :set_team, only: %i[new create]
-  before_action :set_programme, only: %i[new create]
+  before_action :set_programme
 
   def new
     @cohort_import = CohortImport.new
@@ -38,15 +35,11 @@ class CohortImportsController < ApplicationController
 
   private
 
+  def set_programme
+    @programme = policy_scope(Programme).active.find(params[:programme_id])
+  end
+
   def cohort_import_params
     params.fetch(:cohort_import, {}).permit(:csv)
-  end
-
-  def set_team
-    @team = current_user.team
-  end
-
-  def set_programme
-    @programme = policy_scope(Programme).find(params[:programme_id])
   end
 end

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -25,6 +25,11 @@ class CohortImportsController < ApplicationController
 
     @cohort_import.process!
 
+    if @cohort_import.processed_only_exact_duplicates?
+      render :duplicates
+      return
+    end
+
     @cohort_import.record!
 
     redirect_to action: :success

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -2,8 +2,8 @@
 
 class CohortImportsController < ApplicationController
   before_action :set_programme
-  before_action :set_cohort_import, only: %i[show]
-  before_action :set_patients, only: %i[show]
+  before_action :set_cohort_import, only: %i[show edit update]
+  before_action :set_patients, only: %i[show edit]
 
   def new
     @cohort_import = CohortImport.new
@@ -15,29 +15,34 @@ class CohortImportsController < ApplicationController
 
     @cohort_import.load_data!
     if @cohort_import.invalid?
-      render :new, status: :unprocessable_entity
-      return
+      render :new, status: :unprocessable_entity and return
     end
 
     @cohort_import.parse_rows!
     if @cohort_import.invalid?
-      render :errors, status: :unprocessable_entity
-      return
+      render :errors, status: :unprocessable_entity and return
     end
 
     @cohort_import.process!
 
     if @cohort_import.processed_only_exact_duplicates?
-      render :duplicates
-      return
+      render :duplicates and return
     end
 
-    @cohort_import.record!
-
-    redirect_to programme_cohort_import_path(@programme, @cohort_import)
+    redirect_to edit_programme_cohort_import_path(@programme, @cohort_import)
   end
 
   def show
+  end
+
+  def edit
+    render layout: "full"
+  end
+
+  def update
+    @cohort_import.record!
+
+    redirect_to programme_cohort_import_path(@programme, @cohort_import)
   end
 
   private

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -2,6 +2,8 @@
 
 class CohortImportsController < ApplicationController
   before_action :set_programme
+  before_action :set_cohort_import, only: %i[show]
+  before_action :set_patients, only: %i[show]
 
   def new
     @cohort_import = CohortImport.new
@@ -32,16 +34,25 @@ class CohortImportsController < ApplicationController
 
     @cohort_import.record!
 
-    redirect_to action: :success
+    redirect_to programme_cohort_import_path(@programme, @cohort_import)
   end
 
-  def success
+  def show
   end
 
   private
 
   def set_programme
     @programme = policy_scope(Programme).active.find(params[:programme_id])
+  end
+
+  def set_cohort_import
+    # TODO: @programme.cohort_imports.find
+    @cohort_import = CohortImport.find(params[:id])
+  end
+
+  def set_patients
+    @patients = @cohort_import.patients
   end
 
   def cohort_import_params

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -3,7 +3,7 @@
 class ImmunisationImportsController < ApplicationController
   before_action :set_programme
   before_action :set_immunisation_import, only: %i[show edit update]
-  before_action :set_vaccination_records, only: %i[edit show]
+  before_action :set_vaccination_records, only: %i[show edit]
   before_action :set_patients_with_changes, only: %i[edit]
 
   def index
@@ -32,21 +32,18 @@ class ImmunisationImportsController < ApplicationController
 
     @immunisation_import.load_data!
     if @immunisation_import.invalid?
-      render :new, status: :unprocessable_entity
-      return
+      render :new, status: :unprocessable_entity and return
     end
 
     @immunisation_import.parse_rows!
     if @immunisation_import.invalid?
-      render :errors, status: :unprocessable_entity
-      return
+      render :errors, status: :unprocessable_entity and return
     end
 
     @immunisation_import.process!
 
     if @immunisation_import.processed_only_exact_duplicates?
-      render :duplicates
-      return
+      render :duplicates and return
     end
 
     redirect_to edit_programme_immunisation_import_path(

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -44,8 +44,7 @@ class ImmunisationImportsController < ApplicationController
 
     @immunisation_import.process!
 
-    if @immunisation_import.new_record_count.zero? &&
-         @immunisation_import.exact_duplicate_record_count != 0
+    if @immunisation_import.processed_only_exact_duplicates?
       render :duplicates
       return
     end

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -31,6 +31,11 @@ class CohortImport < ApplicationRecord
   has_and_belongs_to_many :parents
   has_and_belongs_to_many :patients
 
+  def processed_only_exact_duplicates?
+    new_record_count.zero? && changed_record_count.zero? &&
+      exact_duplicate_record_count != 0
+  end
+
   private
 
   def required_headers

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -40,6 +40,10 @@ class ImmunisationImport < ApplicationRecord
   has_and_belongs_to_many :sessions
   has_and_belongs_to_many :vaccination_records
 
+  def processed_only_exact_duplicates?
+    new_record_count.zero? && exact_duplicate_record_count != 0
+  end
+
   private
 
   def required_headers

--- a/app/views/cohort_imports/duplicates.html.erb
+++ b/app/views/cohort_imports/duplicates.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: new_programme_cohort_import_path(@programme),
+        name: @programme.name,
+      ) %>
+<% end %>
+
+<% title = "Cohort records already uploaded" %>
+
+<%= h1 title, page_title: "#{@programme.name} – #{title}" %>
+
+<p>
+  All records in this CSV file have been uploaded.
+</p>
+
+<p>
+  <%= govuk_link_to "Upload new cohort records", new_programme_cohort_import_path %>
+</p>

--- a/app/views/cohort_imports/edit.html.erb
+++ b/app/views/cohort_imports/edit.html.erb
@@ -1,0 +1,43 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: new_programme_cohort_import_path(@programme),
+        name: @programme.name,
+      ) %>
+<% end %>
+
+<% title = "Check and confirm" %>
+
+<span class="nhsuk-caption-l"><%= @programme.name %></span>
+<%= h1 title, page_title: "#{@programme.name} – #{title}" %>
+
+<% if @cohort_import.exact_duplicate_record_count > 1 ||
+      @cohort_import.changed_record_count > 1 %>
+  <div class="nhsuk-warning-callout">
+    <h3 class="nhsuk-warning-callout__label">
+      <span class="nhsuk-u-visually-hidden">Important: </span>
+      Uploaded records will differ from the file
+    </h3>
+
+    <ul class="nhsuk-list nhsuk-list--bullet">
+      <% if @cohort_import.exact_duplicate_record_count > 1 %>
+        <li>
+          <%= @cohort_import.exact_duplicate_record_count %> previously
+          uploaded records were omitted
+        </li>
+      <% end %>
+
+      <% if @cohort_import.changed_record_count > 1 %>
+        <li>
+          <%= @cohort_import.changed_record_count %> previously uploaded records were updated
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= govuk_button_to "Upload records", programme_cohort_import_path(
+      @programme,
+      @cohort_import
+    ), method: :put %>
+
+<%= render AppPatientTableComponent.new(@patients, programme: @programme) %>

--- a/app/views/cohort_imports/errors.html.erb
+++ b/app/views/cohort_imports/errors.html.erb
@@ -1,15 +1,17 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
         href: new_programme_cohort_import_path(@programme),
-        name: "cohort upload page",
+        name: @programme.name,
       ) %>
 <% end %>
 
-<%= h1 "The cohort list could not be added" %>
+<% title = "Cohort records cannot be uploaded" %>
 
-<p>
-  It wasn’t possible to add a cohort list due to the following errors in the
-  uploaded CSV file:
+<%= h1 title, page_title: "#{@programme.name} – #{title}" %>
+
+<p class="nhsuk-body">
+  The records cannot be uploaded due to errors in the CSV file.
+  When fixing these errors, note that the header does not count as a row.
 </p>
 
 <% @cohort_import.errors.each do |error| %>
@@ -20,6 +22,7 @@
       <%= error.attribute.to_s.humanize %>
     <% end %>
   </h2>
+
   <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-font-size-16">
     <% if error.type.is_a?(Array) %>
       <% error.type.each do |type| %>
@@ -30,9 +33,3 @@
     <% end %>
   </ul>
 <% end %>
-
-<hr />
-
-<p>
-  <%= link_to "Upload a new cohort list", new_programme_cohort_import_path(@programme) %>
-</p>

--- a/app/views/cohort_imports/errors.html.erb
+++ b/app/views/cohort_imports/errors.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: new_programme_cohort_path(@programme),
+        href: new_programme_cohort_import_path(@programme),
         name: "cohort upload page",
       ) %>
 <% end %>
@@ -34,5 +34,5 @@
 <hr />
 
 <p>
-  <%= link_to "Upload a new cohort list", new_programme_cohort_path(@programme) %>
+  <%= link_to "Upload a new cohort list", new_programme_cohort_import_path(@programme) %>
 </p>

--- a/app/views/cohort_imports/new.html.erb
+++ b/app/views/cohort_imports/new.html.erb
@@ -10,7 +10,7 @@
                                         ]) %>
 <% end %>
 
-<%= form_with model: @cohort_import, url: programme_cohort_path(@programme) do |f| %>
+<%= form_with model: @cohort_import, url: programme_cohort_imports_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :csv,

--- a/app/views/cohort_imports/new.html.erb
+++ b/app/views/cohort_imports/new.html.erb
@@ -1,20 +1,22 @@
-<% page_title = "Upload the cohort list" %>
-<% content_for(:page_title, page_title) %>
-
 <% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
-                                          { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
-                                          { text: page_title },
-                                        ]) %>
+  <%= render AppBacklinkComponent.new(
+        href: patients_programme_path(@programme),
+        name: @programme.name,
+      ) %>
 <% end %>
+
+<% title = "Upload cohort records" %>
+<% hint = "Make sure the CSV you upload has the same format as your standard cohort template. " %>
+
+<% content_for :page_title, title %>
 
 <%= form_with model: @cohort_import, url: programme_cohort_imports_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :csv,
-                         label: { text: page_title, tag: "h1", size: "l" } %>
+                         caption: { text: @programme.name, size: "l" },
+                         label: { text: title, tag: "h1", size: "l" },
+                         hint: { text: hint } %>
 
-  <%= f.govuk_submit "Upload the cohort list" %>
+  <%= f.govuk_submit %>
 <% end %>

--- a/app/views/cohort_imports/show.html.erb
+++ b/app/views/cohort_imports/show.html.erb
@@ -2,14 +2,14 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_path(@programme) },
-                                          { text: t("immunisation_imports.index.title"), href: programme_immunisation_imports_path(@programme) },
+                                          { text: t("programmes.patients.title"), href: patients_programme_path(@programme) },
                                         ]) %>
 <% end %>
 
-<%= h1 "Vaccination report (uploaded #{@immunisation_import.created_at.to_fs(:long)})" %>
+<%= h1 "Cohort report (uploaded #{@cohort_import.created_at.to_fs(:long)})" %>
 
 <%= render AppCardComponent.new do |card| %>
-  <% card.with_heading { "Vaccination report" } %>
+  <% card.with_heading { "Cohort report" } %>
 
   <%= govuk_summary_list(
         classes: %w[app-summary-list--no-bottom-border
@@ -17,12 +17,12 @@
       ) do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key { "Uploaded on" } %>
-      <%= row.with_value { @immunisation_import.created_at.to_fs(:long) } %>
+      <%= row.with_value { @cohort_import.created_at.to_fs(:long) } %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
       <%= row.with_key { "Uploaded by" } %>
-      <%= row.with_value { @immunisation_import.uploaded_by.full_name } %>
+      <%= row.with_value { @cohort_import.uploaded_by.full_name } %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -32,6 +32,4 @@
   <% end %>
 <% end %>
 
-<%= render AppVaccinationRecordTableComponent.new(
-      @immunisation_import.recorded? ? @vaccination_records.recorded : @vaccination_records.draft
-    ) %>
+<%= render AppPatientTableComponent.new(@patients, programme: @programme) %>

--- a/app/views/cohort_imports/success.html.erb
+++ b/app/views/cohort_imports/success.html.erb
@@ -1,9 +1,0 @@
-<% page_title = "Cohort data uploaded" %>
-<% content_for :page_title, page_title %>
-
-<%= govuk_panel(title_text: page_title, classes: "nhsuk-u-margin-bottom-6") do %>
-  <%= pluralize(@count, "child") %> <%= @count == 1 ? "has" : "have" %>
-  been added to the pilot cohort
-<% end %>
-
-<p>You can select children from this cohort when adding a new session.</p>

--- a/app/views/immunisation_imports/_breadcrumbs.html.erb
+++ b/app/views/immunisation_imports/_breadcrumbs.html.erb
@@ -1,7 +1,0 @@
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
-                                          { text: t("immunisation_imports.index.title"), href: programme_immunisation_imports_path(@programme) },
-                                        ]) %>
-<% end %>

--- a/app/views/programmes/patients.html.erb
+++ b/app/views/programmes/patients.html.erb
@@ -34,6 +34,7 @@
     end %>
 
 <p class="app-action-list">
-  <%= link_to "Add children to programme cohort", new_programme_cohort_path(@programme) %>
+  <%= link_to "Add children to programme cohort", new_programme_cohort_import_path(@programme) %>
 </p>
+
 <%= render AppPatientTableComponent.new(@patients, programme: @programme) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
                 controller: "immunisation_imports/patients"
     end
 
-    resources :cohort_imports, path: "cohort-imports", only: %i[new create show]
+    resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]
 
     resources :vaccination_records,
               path: "vaccination-records",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,9 +74,7 @@ Rails.application.routes.draw do
                 controller: "immunisation_imports/patients"
     end
 
-    resources :cohort_imports, path: "cohort-imports", only: %i[new create] do
-      get "success", on: :collection
-    end
+    resources :cohort_imports, path: "cohort-imports", only: %i[new create show]
 
     resources :vaccination_records,
               path: "vaccination-records",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,10 @@ Rails.application.routes.draw do
                 controller: "immunisation_imports/patients"
     end
 
+    resources :cohort_imports, path: "cohort-imports", only: %i[new create] do
+      get "success", on: :collection
+    end
+
     resources :vaccination_records,
               path: "vaccination-records",
               only: %i[index show] do
@@ -88,10 +92,6 @@ Rails.application.routes.draw do
       put "edit/date-and-time",
           controller: "vaccination_records/edit",
           action: "update_date_and_time"
-    end
-
-    resource :cohort_import, as: :cohort, only: %i[new create] do
-      get "success", on: :collection
     end
   end
 

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -23,7 +23,8 @@ describe "Cohort imports" do
     and_i_go_back_to_the_upload_page
 
     when_i_upload_a_valid_file
-    then_i_should_see_the_success_page
+    then_i_should_see_the_upload
+    and_i_should_see_the_patients
 
     when_i_visit_the_cohort_page_for_the_hpv_programme
     and_i_start_adding_children_to_the_cohort
@@ -67,8 +68,18 @@ describe "Cohort imports" do
     click_on "Continue"
   end
 
-  def then_i_should_see_the_success_page
-    expect(page).to have_content("Cohort data uploaded")
+  def then_i_should_see_the_upload
+    expect(page).to have_content("Uploaded on")
+    expect(page).to have_content("Uploaded byTest User")
+    expect(page).to have_content("ProgrammeHPV")
+  end
+
+  def and_i_should_see_the_patients
+    expect(page).to have_content("Full nameNHS numberDate of birthOutcome")
+    expect(page).to have_content("Jimmy Smith")
+    expect(page).to have_content(/NHS number.*123.*456.*7890/)
+    expect(page).to have_content("Date of birth 1 January 2010")
+    expect(page).to have_content("Outcome No outcome yet")
   end
 
   def when_i_continue_without_uploading_a_file

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-describe "Cohort upload" do
-  scenario "User uploads a cohort list" do
+describe "Cohort imports" do
+  scenario "User uploads a file" do
     given_the_app_is_setup
     and_an_hpv_programme_is_underway
 
@@ -20,7 +20,7 @@ describe "Cohort upload" do
 
     when_i_upload_a_cohort_file_with_invalid_fields
     then_i_should_the_errors_page_with_invalid_fields
-    and_i_should_be_able_to_go_to_the_upload_page
+    and_i_go_back_to_the_upload_page
 
     when_i_upload_the_cohort_file
     then_i_should_see_the_success_page
@@ -49,7 +49,7 @@ describe "Cohort upload" do
   end
 
   def then_i_should_see_the_upload_cohort_page
-    expect(page).to have_content("Upload the cohort list")
+    expect(page).to have_content("Upload cohort records")
   end
 
   def when_i_upload_the_cohort_file
@@ -57,7 +57,7 @@ describe "Cohort upload" do
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/valid_cohort.csv"
     )
-    click_on "Upload the cohort list"
+    click_on "Continue"
   end
 
   def then_i_should_see_the_success_page
@@ -65,7 +65,7 @@ describe "Cohort upload" do
   end
 
   def when_i_continue_without_uploading_a_file
-    click_on "Upload the cohort list"
+    click_on "Continue"
   end
 
   def then_i_should_see_an_error
@@ -77,7 +77,7 @@ describe "Cohort upload" do
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/malformed.csv"
     )
-    click_on "Upload the cohort list"
+    click_on "Continue"
   end
 
   def when_i_upload_a_cohort_file_with_invalid_headers
@@ -85,7 +85,7 @@ describe "Cohort upload" do
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/invalid_headers.csv"
     )
-    click_on "Upload the cohort list"
+    click_on "Continue"
   end
 
   def then_i_should_the_errors_page_with_invalid_headers
@@ -97,15 +97,15 @@ describe "Cohort upload" do
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/invalid_fields.csv"
     )
-    click_on "Upload the cohort list"
+    click_on "Continue"
   end
 
   def then_i_should_the_errors_page_with_invalid_fields
-    expect(page).to have_content("The cohort list could not be added")
+    expect(page).to have_content("Cohort records cannot be uploaded")
     expect(page).to have_content("Row 2")
   end
 
-  def and_i_should_be_able_to_go_to_the_upload_page
-    click_on "Upload a new cohort list"
+  def and_i_go_back_to_the_upload_page
+    click_on "Back"
   end
 end

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -15,15 +15,22 @@ describe "Cohort imports" do
     when_i_upload_a_malformed_csv
     then_i_should_see_an_error
 
-    when_i_upload_a_cohort_file_with_invalid_headers
+    when_i_upload_a_file_with_invalid_headers
     then_i_should_the_errors_page_with_invalid_headers
 
-    when_i_upload_a_cohort_file_with_invalid_fields
+    when_i_upload_a_file_with_invalid_fields
     then_i_should_the_errors_page_with_invalid_fields
     and_i_go_back_to_the_upload_page
 
-    when_i_upload_the_cohort_file
+    when_i_upload_a_valid_file
     then_i_should_see_the_success_page
+
+    when_i_visit_the_cohort_page_for_the_hpv_programme
+    and_i_start_adding_children_to_the_cohort
+    then_i_should_see_the_upload_cohort_page
+
+    when_i_upload_a_valid_file
+    then_i_should_see_the_duplicates_page
   end
 
   def given_the_app_is_setup
@@ -52,7 +59,7 @@ describe "Cohort imports" do
     expect(page).to have_content("Upload cohort records")
   end
 
-  def when_i_upload_the_cohort_file
+  def when_i_upload_a_valid_file
     attach_file(
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/valid_cohort.csv"
@@ -80,7 +87,7 @@ describe "Cohort imports" do
     click_on "Continue"
   end
 
-  def when_i_upload_a_cohort_file_with_invalid_headers
+  def when_i_upload_a_file_with_invalid_headers
     attach_file(
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/invalid_headers.csv"
@@ -92,7 +99,7 @@ describe "Cohort imports" do
     expect(page).to have_content("The file is missing the following headers")
   end
 
-  def when_i_upload_a_cohort_file_with_invalid_fields
+  def when_i_upload_a_file_with_invalid_fields
     attach_file(
       "cohort_import[csv]",
       "spec/fixtures/cohort_import/invalid_fields.csv"
@@ -107,5 +114,11 @@ describe "Cohort imports" do
 
   def and_i_go_back_to_the_upload_page
     click_on "Back"
+  end
+
+  def then_i_should_see_the_duplicates_page
+    expect(page).to have_content(
+      "All records in this CSV file have been uploaded."
+    )
   end
 end

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -23,6 +23,9 @@ describe "Cohort imports" do
     and_i_go_back_to_the_upload_page
 
     when_i_upload_a_valid_file
+    and_i_should_see_the_patients
+
+    when_i_click_on_upload_records
     then_i_should_see_the_upload
     and_i_should_see_the_patients
 
@@ -68,18 +71,22 @@ describe "Cohort imports" do
     click_on "Continue"
   end
 
-  def then_i_should_see_the_upload
-    expect(page).to have_content("Uploaded on")
-    expect(page).to have_content("Uploaded byTest User")
-    expect(page).to have_content("ProgrammeHPV")
-  end
-
   def and_i_should_see_the_patients
     expect(page).to have_content("Full nameNHS numberDate of birthOutcome")
     expect(page).to have_content("Jimmy Smith")
     expect(page).to have_content(/NHS number.*123.*456.*7890/)
     expect(page).to have_content("Date of birth 1 January 2010")
     expect(page).to have_content("Outcome No outcome yet")
+  end
+
+  def when_i_click_on_upload_records
+    click_on "Upload records"
+  end
+
+  def then_i_should_see_the_upload
+    expect(page).to have_content("Uploaded on")
+    expect(page).to have_content("Uploaded byTest User")
+    expect(page).to have_content("ProgrammeHPV")
   end
 
   def when_i_continue_without_uploading_a_file

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -86,6 +86,7 @@ describe "End-to-end journey" do
     click_on "Add children to programme cohort"
     attach_file "cohort_import[csv]", csv_file.path
     click_on "Continue"
+    click_on "Upload records"
   end
 
   def then_i_see_that_the_cohort_has_been_uploaded

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -89,7 +89,7 @@ describe "End-to-end journey" do
   end
 
   def then_i_see_that_the_cohort_has_been_uploaded
-    expect(page).to have_content("Cohort data uploaded")
+    expect(page).to have_content("Cohort report")
   end
 
   def when_i_start_creating_a_new_session_by_choosing_school_and_time

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -85,7 +85,7 @@ describe "End-to-end journey" do
     click_on "Cohort"
     click_on "Add children to programme cohort"
     attach_file "cohort_import[csv]", csv_file.path
-    click_on "Upload the cohort list"
+    click_on "Continue"
   end
 
   def then_i_see_that_the_cohort_has_been_uploaded

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -147,7 +147,7 @@ describe "Immunisation imports" do
   def then_i_should_see_the_upload
     expect(page).to have_content("Uploaded on")
     expect(page).to have_content("Uploaded byTest User")
-    expect(page).to have_content("CampaignHPV")
+    expect(page).to have_content("ProgrammeHPV")
   end
 
   def when_i_click_on_a_vaccination_record


### PR DESCRIPTION
This updates the various pages related to cohort imports to match the designs we have for immunisation imports, specifically added a two-stage process where the user has to "Check and confirm" the records before they are recorded.

The implementation is based on the existing designs for immunisation import, but I expect these will need to change slightly when the designs for cohorts are finalised. I think once we know more about the similarities and differences between cohort and immunisation imports we could refactor these views in to shared components.