### PR TITLE
Persist/discard changes to vaccinations when importing

### DIFF
--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class AppVaccinationRecordDetailsComponent < ViewComponent::Base
-  def initialize(vaccination_record)
+  def initialize(vaccination_record, change_links: false)
     super
 
     @vaccination_record = vaccination_record
     @vaccine = vaccination_record.vaccine
     @batch = vaccination_record.batch
+    @change_links = change_links
   end
 
   def dose_number
@@ -102,15 +103,17 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
         summary_list.with_row do |row|
           row.with_key { "Vaccination date" }
           row.with_value { administered_at.to_fs(:long) }
-          row.with_action(
-            text: "Change",
-            visually_hidden_text: "vaccination date",
-            href:
-              programme_vaccination_record_edit_date_and_time_path(
-                @vaccination_record.programme,
-                @vaccination_record
-              )
-          )
+          if @change_links
+            row.with_action(
+              text: "Change",
+              visually_hidden_text: "vaccination date",
+              href:
+                programme_vaccination_record_edit_date_and_time_path(
+                  @vaccination_record.programme,
+                  @vaccination_record
+                )
+            )
+          end
         end
       end
 

--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -10,6 +10,153 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
     @change_links = change_links
   end
 
+  def call
+    govuk_summary_list(
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
+    ) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Outcome" }
+        row.with_value { outcome_value }
+      end
+
+      if @vaccine.present?
+        summary_list.with_row do |row|
+          row.with_key { "Vaccine" }
+          row.with_value { vaccine_value }
+        end
+      end
+
+      if @vaccination_record.delivery_method.present?
+        summary_list.with_row do |row|
+          row.with_key { "Method" }
+          row.with_value { delivery_method_value }
+        end
+      end
+
+      if @vaccination_record.delivery_site.present?
+        summary_list.with_row do |row|
+          row.with_key { "Site" }
+          row.with_value { delivery_site_value }
+        end
+      end
+
+      if @vaccine.present?
+        summary_list.with_row do |row|
+          row.with_key { "Dose volume" }
+          row.with_value { dose_volume_value }
+        end
+      end
+
+      if dose_number.present?
+        summary_list.with_row do |row|
+          row.with_key { "Dose number" }
+          row.with_value { dose_number_value }
+        end
+      end
+
+      if @batch.present?
+        summary_list.with_row do |row|
+          row.with_key { "Batch ID" }
+          row.with_value(classes: ["app-u-monospace"]) { batch_id_value }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "Batch expiry date" }
+          row.with_value { batch_expiry_value }
+        end
+      end
+
+      if @vaccination_record.session.location.present?
+        summary_list.with_row do |row|
+          row.with_key { "Location" }
+          row.with_value { location_value }
+        end
+      end
+
+      if @vaccination_record.administered_at.present?
+        summary_list.with_row do |row|
+          row.with_key { "Vaccination date" }
+          row.with_value { vaccination_date_value }
+          if @change_links
+            row.with_action(
+              text: "Change",
+              visually_hidden_text: "vaccination date",
+              href:
+                programme_vaccination_record_edit_date_and_time_path(
+                  @vaccination_record.programme,
+                  @vaccination_record
+                )
+            )
+          end
+        end
+      end
+
+      if @vaccination_record.performed_by.present?
+        summary_list.with_row do |row|
+          row.with_key { "Nurse" }
+          row.with_value { nurse_value }
+        end
+      end
+
+      if @vaccination_record.notes.present?
+        summary_list.with_row do |row|
+          row.with_key { "Notes" }
+          row.with_value { notes_value }
+        end
+      end
+    end
+  end
+
+  private
+
+  def outcome_value
+    @vaccination_record.administered? ? "Vaccinated" : "Not vaccinated"
+  end
+
+  def vaccine_value
+    helpers.vaccine_heading(@vaccine)
+  end
+
+  def delivery_method_value
+    @vaccination_record.human_enum_name(:delivery_method)
+  end
+
+  def delivery_site_value
+    @vaccination_record.human_enum_name(:delivery_site)
+  end
+
+  def dose_volume_value
+    "#{@vaccination_record.dose} ml"
+  end
+
+  def batch_id_value
+    @batch.name
+  end
+
+  def batch_expiry_value
+    @batch.expiry.to_fs(:long)
+  end
+
+  def location_value
+    @vaccination_record.session.location.name
+  end
+
+  def vaccination_date_value
+    @vaccination_record.administered_at.to_fs(:long)
+  end
+
+  def nurse_value
+    @vaccination_record.performed_by.full_name
+  end
+
+  def notes_value
+    @vaccination_record.notes
+  end
+
+  def dose_number_value
+    dose_number
+  end
+
   def dose_number
     return nil if @vaccine.nil? || @vaccine.seasonal?
 
@@ -29,107 +176,6 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
       numbers_to_words[@vaccination_record.dose_sequence]
     else
       @vaccination_record.dose_sequence.ordinalize
-    end
-  end
-
-  def call
-    govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { "Outcome" }
-        row.with_value do
-          @vaccination_record.administered? ? "Vaccinated" : "Not vaccinated"
-        end
-      end
-
-      if @vaccine.present?
-        summary_list.with_row do |row|
-          row.with_key { "Vaccine" }
-          row.with_value { helpers.vaccine_heading(@vaccine) }
-        end
-      end
-
-      if @vaccination_record.delivery_method.present?
-        summary_list.with_row do |row|
-          row.with_key { "Method" }
-          row.with_value do
-            @vaccination_record.human_enum_name(:delivery_method)
-          end
-        end
-      end
-
-      if @vaccination_record.delivery_site.present?
-        summary_list.with_row do |row|
-          row.with_key { "Site" }
-          row.with_value { @vaccination_record.human_enum_name(:delivery_site) }
-        end
-      end
-
-      if @vaccine.present?
-        summary_list.with_row do |row|
-          row.with_key { "Dose volume" }
-          row.with_value { "#{@vaccination_record.dose} ml" }
-        end
-      end
-
-      if dose_number.present?
-        summary_list.with_row do |row|
-          row.with_key { "Dose number" }
-          row.with_value { dose_number }
-        end
-      end
-
-      if @batch.present?
-        summary_list.with_row do |row|
-          row.with_key { "Batch ID" }
-          row.with_value(classes: ["app-u-monospace"]) { @batch.name }
-        end
-
-        summary_list.with_row do |row|
-          row.with_key { "Batch expiry date" }
-          row.with_value { @batch.expiry.to_fs(:long) }
-        end
-      end
-
-      if (location = @vaccination_record.session.location).present?
-        summary_list.with_row do |row|
-          row.with_key { "Location" }
-          row.with_value { location.name }
-        end
-      end
-
-      if (administered_at = @vaccination_record.administered_at).present?
-        summary_list.with_row do |row|
-          row.with_key { "Vaccination date" }
-          row.with_value { administered_at.to_fs(:long) }
-          if @change_links
-            row.with_action(
-              text: "Change",
-              visually_hidden_text: "vaccination date",
-              href:
-                programme_vaccination_record_edit_date_and_time_path(
-                  @vaccination_record.programme,
-                  @vaccination_record
-                )
-            )
-          end
-        end
-      end
-
-      if (user = @vaccination_record.performed_by).present?
-        summary_list.with_row do |row|
-          row.with_key { "Nurse" }
-          row.with_value { user.full_name }
-        end
-      end
-
-      if (notes = @vaccination_record.notes).present?
-        summary_list.with_row do |row|
-          row.with_key { "Notes" }
-          row.with_value { notes }
-        end
-      end
     end
   end
 end

--- a/app/components/app_vaccination_record_details_component.rb
+++ b/app/components/app_vaccination_record_details_component.rb
@@ -110,19 +110,31 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
   private
 
   def outcome_value
-    @vaccination_record.administered? ? "Vaccinated" : "Not vaccinated"
+    highlight_if(
+      @vaccination_record.administered? ? "Vaccinated" : "Not vaccinated",
+      @vaccination_record.administered_at_changed?
+    )
   end
 
   def vaccine_value
-    helpers.vaccine_heading(@vaccine)
+    highlight_if(
+      helpers.vaccine_heading(@vaccine),
+      @vaccination_record.vaccine_id_changed?
+    )
   end
 
   def delivery_method_value
-    @vaccination_record.human_enum_name(:delivery_method)
+    highlight_if(
+      @vaccination_record.human_enum_name(:delivery_method),
+      @vaccination_record.delivery_method_changed?
+    )
   end
 
   def delivery_site_value
-    @vaccination_record.human_enum_name(:delivery_site)
+    highlight_if(
+      @vaccination_record.human_enum_name(:delivery_site),
+      @vaccination_record.delivery_site_changed?
+    )
   end
 
   def dose_volume_value
@@ -130,11 +142,14 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
   end
 
   def batch_id_value
-    @batch.name
+    highlight_if(@batch.name, @vaccination_record.batch_id_changed?)
   end
 
   def batch_expiry_value
-    @batch.expiry.to_fs(:long)
+    highlight_if(
+      @batch.expiry.to_fs(:long),
+      @vaccination_record.batch_id_changed?
+    )
   end
 
   def location_value
@@ -142,19 +157,25 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
   end
 
   def vaccination_date_value
-    @vaccination_record.administered_at.to_fs(:long)
+    highlight_if(
+      @vaccination_record.administered_at.to_fs(:long),
+      @vaccination_record.administered_at_changed?
+    )
   end
 
   def nurse_value
-    @vaccination_record.performed_by.full_name
+    highlight_if(
+      @vaccination_record.performed_by.full_name,
+      @vaccination_record.performed_by_user_id_changed?
+    )
   end
 
   def notes_value
-    @vaccination_record.notes
+    highlight_if(@vaccination_record.notes, @vaccination_record.notes_changed?)
   end
 
   def dose_number_value
-    dose_number
+    highlight_if(dose_number, @vaccination_record.dose_sequence_changed?)
   end
 
   def dose_number
@@ -177,5 +198,9 @@ class AppVaccinationRecordDetailsComponent < ViewComponent::Base
     else
       @vaccination_record.dose_sequence.ordinalize
     end
+  end
+
+  def highlight_if(value, condition)
+    condition ? tag.span(value, class: "app-highlight") : value
   end
 end

--- a/app/controllers/immunisation_imports/duplicates_controller.rb
+++ b/app/controllers/immunisation_imports/duplicates_controller.rb
@@ -50,8 +50,13 @@ class ImmunisationImports::DuplicatesController < ApplicationController
   end
 
   def set_form
-    apply_changes = params.dig(:patient_changes_form, :apply_changes)
+    apply_changes =
+      params.dig(:immunisation_import_duplicate_form, :apply_changes)
 
-    @form = PatientChangesForm.new(patient: @patient, apply_changes:)
+    @form =
+      ImmunisationImportDuplicateForm.new(
+        vaccination_record: @vaccination_record,
+        apply_changes:
+      )
   end
 end

--- a/app/controllers/immunisation_imports/duplicates_controller.rb
+++ b/app/controllers/immunisation_imports/duplicates_controller.rb
@@ -3,6 +3,7 @@
 class ImmunisationImports::DuplicatesController < ApplicationController
   before_action :set_programme
   before_action :set_immunisation_import
+  before_action :set_vaccination_record
   before_action :set_patient
   before_action :set_form
 
@@ -39,8 +40,13 @@ class ImmunisationImports::DuplicatesController < ApplicationController
       @programme.immunisation_imports.find(params[:immunisation_import_id])
   end
 
+  def set_vaccination_record
+    @vaccination_record =
+      @immunisation_import.vaccination_records.find(params[:id])
+  end
+
   def set_patient
-    @patient = @immunisation_import.patients.find(params[:id])
+    @patient = @vaccination_record.patient
   end
 
   def set_form

--- a/app/controllers/immunisation_imports/duplicates_controller.rb
+++ b/app/controllers/immunisation_imports/duplicates_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ImmunisationImports::PatientsController < ApplicationController
+class ImmunisationImports::DuplicatesController < ApplicationController
   before_action :set_programme
   before_action :set_immunisation_import
   before_action :set_patient

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -93,10 +93,7 @@ class ImmunisationImportsController < ApplicationController
 
   def set_patients_with_changes
     @patients =
-      @vaccination_records
-        .map(&:patient)
-        .select { _1.pending_changes.present? }
-        .uniq
+      @immunisation_import.patients.where.not(pending_changes: {}).uniq
   end
 
   def immunisation_import_params

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -93,7 +93,13 @@ class ImmunisationImportsController < ApplicationController
 
   def set_patients_with_changes
     @patients =
-      @immunisation_import.patients.where.not(pending_changes: {}).uniq
+      @immunisation_import
+        .patients
+        .left_joins(:vaccination_records)
+        .where(
+          "patients.pending_changes != '{}' OR vaccination_records.pending_changes != '{}'"
+        )
+        .distinct
   end
 
   def immunisation_import_params

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -4,7 +4,7 @@ class ImmunisationImportsController < ApplicationController
   before_action :set_programme
   before_action :set_immunisation_import, only: %i[show edit update]
   before_action :set_vaccination_records, only: %i[show edit]
-  before_action :set_patients_with_changes, only: %i[edit]
+  before_action :set_vaccination_records_with_pending_changes, only: %i[edit]
 
   def index
     @immunisation_imports =
@@ -91,11 +91,10 @@ class ImmunisationImportsController < ApplicationController
       )
   end
 
-  def set_patients_with_changes
-    @patients =
-      @immunisation_import
-        .patients
-        .left_joins(:vaccination_records)
+  def set_vaccination_records_with_pending_changes
+    @vaccination_records_with_pending_changes =
+      @vaccination_records
+        .left_joins(:patient)
         .where(
           "patients.pending_changes != '{}' OR vaccination_records.pending_changes != '{}'"
         )

--- a/app/forms/immunisation_import_duplicate_form.rb
+++ b/app/forms/immunisation_import_duplicate_form.rb
@@ -13,7 +13,9 @@ class ImmunisationImportDuplicateForm
     ActiveRecord::Base.transaction do
       if apply_changes == "apply"
         vaccination_record.patient.apply_pending_changes!
+        vaccination_record.apply_pending_changes!
       elsif apply_changes == "discard"
+        vaccination_record.patient.discard_pending_changes!
         vaccination_record.discard_pending_changes!
       end
     end

--- a/app/forms/immunisation_import_duplicate_form.rb
+++ b/app/forms/immunisation_import_duplicate_form.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class PatientChangesForm
+class ImmunisationImportDuplicateForm
   include ActiveModel::Model
 
-  attr_accessor :patient, :apply_changes
+  attr_accessor :vaccination_record, :apply_changes
 
   validates :apply_changes, inclusion: { in: %w[apply discard] }
 
@@ -12,9 +12,9 @@ class PatientChangesForm
 
     ActiveRecord::Base.transaction do
       if apply_changes == "apply"
-        patient.apply_pending_changes!
+        vaccination_record.patient.apply_pending_changes!
       elsif apply_changes == "discard"
-        patient.discard_pending_changes!
+        vaccination_record.discard_pending_changes!
       end
     end
 

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -75,20 +75,32 @@ class ImmunisationImportRow
 
     return unless administered
 
-    VaccinationRecord.create_with(
-      notes:,
-      recorded_at: nil
-    ).find_or_initialize_by(
-      administered_at:,
-      batch:,
-      delivery_method:,
-      delivery_site:,
-      dose_sequence:,
-      patient_session:,
-      performed_by_family_name:,
-      performed_by_given_name:,
-      vaccine:
-    )
+    vaccination_record =
+      VaccinationRecord.create_with(
+        notes:,
+        recorded_at: nil
+      ).find_or_initialize_by(
+        administered_at:,
+        dose_sequence:,
+        patient_session:,
+        performed_by_family_name:,
+        performed_by_given_name:,
+        vaccine:
+      )
+
+    if vaccination_record.persisted?
+      vaccination_record.stage_changes(
+        batch_id: batch.id,
+        delivery_method:,
+        delivery_site:
+      )
+    else
+      vaccination_record.batch = batch
+      vaccination_record.delivery_method = delivery_method
+      vaccination_record.delivery_site = delivery_site
+    end
+
+    vaccination_record
   end
 
   def patient

--- a/app/views/immunisation_imports/duplicates/show.html.erb
+++ b/app/views/immunisation_imports/duplicates/show.html.erb
@@ -55,9 +55,9 @@
 
 <%= form_with(
       model: @form,
-      url: programme_immunisation_import_patient_path(@programme,
-                                                      @immunisation_import,
-                                                      @patient),
+      url: programme_immunisation_import_duplicate_path(@programme,
+                                                        @immunisation_import,
+                                                        @patient),
       method: :put,
       class: "nhsuk-u-width-one-half",
     ) do |f| %>

--- a/app/views/immunisation_imports/duplicates/show.html.erb
+++ b/app/views/immunisation_imports/duplicates/show.html.erb
@@ -57,7 +57,7 @@
       model: @form,
       url: programme_immunisation_import_duplicate_path(@programme,
                                                         @immunisation_import,
-                                                        @patient),
+                                                        @vaccination_record),
       method: :put,
       class: "nhsuk-u-width-one-half",
     ) do |f| %>

--- a/app/views/immunisation_imports/edit.html.erb
+++ b/app/views/immunisation_imports/edit.html.erb
@@ -76,7 +76,7 @@
 
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Actions</span>
-              <%= govuk_link_to programme_immunisation_import_patient_path(
+              <%= govuk_link_to programme_immunisation_import_duplicate_path(
                     @programme,
                     @immunisation_import,
                     patient

--- a/app/views/immunisation_imports/edit.html.erb
+++ b/app/views/immunisation_imports/edit.html.erb
@@ -41,11 +41,14 @@
       @immunisation_import
     ), method: :put %>
 
-<% if @patients.present? && Flipper.enabled?(:import_review) %>
+<% if @vaccination_records_with_pending_changes.present? &&
+      Flipper.enabled?(:import_review) %>
   <div class="nhsuk-table__panel-with-heading-tab">
     <h3 class="nhsuk-table__heading-tab">
-      <%= pluralize(@patients.count, "duplicate record") %>
-      <%= @patients.count == 1 ? "needs" : "need" %> review
+      <%= pluralize(@vaccination_records_with_pending_changes.count,
+                    "duplicate record") %>
+      <%= @vaccination_records_with_pending_changes.count == 1 ?
+            "needs" : "need" %> review
     </h3>
     <%= govuk_table(html_attributes: {
                       class: "nhsuk-table-responsive",
@@ -59,11 +62,11 @@
       <% end %>
 
       <% table.with_body do |body| %>
-        <% @patients.each do |patient| %>
+        <% @vaccination_records_with_pending_changes.each do |vaccination_record| %>
           <% body.with_row do |row| %>
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Child record</span>
-              <%= patient.full_name %>
+              <%= vaccination_record.patient.full_name %>
             <% end %>
 
             <% row.with_cell do %>
@@ -79,11 +82,11 @@
               <%= govuk_link_to programme_immunisation_import_duplicate_path(
                     @programme,
                     @immunisation_import,
-                    patient
+                    vaccination_record
                   ) do %>
                 Review
                 <span class="nhsuk-u-visually-hidden">
-                  <%= patient.full_name %>
+                  <%= vaccination_record.patient.full_name %>
                 </span>
               <% end %>
             <% end %>

--- a/app/views/immunisation_imports/patients/show.html.erb
+++ b/app/views/immunisation_imports/patients/show.html.erb
@@ -31,6 +31,10 @@
       <%= render AppPatientSummaryComponent.new(
             patient: @patient.with_pending_changes,
           ) %>
+      <h3 class="nhsuk-heading-s">Duplicate vaccination record</h3>
+      <%= render AppVaccinationRecordDetailsComponent.new(
+            @vaccination_record.with_pending_changes
+          ) %>
     <% end %>
   </div>
 
@@ -40,6 +44,10 @@
       <h3 class="nhsuk-heading-s">Previously uploaded child record</h3>
       <%= render AppPatientSummaryComponent.new(
             patient: @patient,
+          ) %>
+      <h3 class="nhsuk-heading-s">Previously uploaded vaccination record</h3>
+      <%= render AppVaccinationRecordDetailsComponent.new(
+            @vaccination_record
           ) %>
     <% end %>
   </div>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -25,5 +25,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Vaccination details" } %>
-  <%= render AppVaccinationRecordDetailsComponent.new(@vaccination_record) %>
+  <%= render AppVaccinationRecordDetailsComponent.new(
+        @vaccination_record, change_links: true,
+      ) %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,9 +69,9 @@ Rails.application.routes.draw do
     resources :immunisation_imports,
               path: "immunisation-imports",
               except: :destroy do
-      resources :patients,
+      resources :duplicates,
                 only: %i[show update],
-                controller: "immunisation_imports/patients"
+                controller: "immunisation_imports/duplicates"
     end
 
     resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]

--- a/spec/components/app_vaccination_record_details_component_spec.rb
+++ b/spec/components/app_vaccination_record_details_component_spec.rb
@@ -22,6 +22,9 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
   let(:batch) do
     create(:batch, name: "ABC", expiry: Date.new(2020, 1, 1), vaccine:)
   end
+  let(:other_batch) do
+    create(:batch, name: "DEF", expiry: Date.new(2021, 1, 1), vaccine:)
+  end
   let(:notes) { "Some notes." }
 
   let(:vaccination_record) do
@@ -31,7 +34,14 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
       batch:,
       vaccine:,
       patient_session:,
-      notes:
+      delivery_method: :intramuscular,
+      delivery_site: :left_arm_upper_position,
+      notes:,
+      pending_changes: {
+        batch_id: other_batch&.id,
+        delivery_method: :nasal_spray,
+        delivery_site: :nose
+      }
     )
   end
 
@@ -66,6 +76,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
     context "without a vaccine" do
       let(:vaccine) { nil }
       let(:batch) { nil }
+      let(:other_batch) { nil }
 
       it { should_not have_css(".nhsuk-summary-list__row", text: "Vaccine") }
     end
@@ -100,6 +111,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
     context "without a vaccine" do
       let(:vaccine) { nil }
       let(:batch) { nil }
+      let(:other_batch) { nil }
 
       it do
         expect(subject).not_to have_css(
@@ -142,6 +154,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
     context "without a vaccine" do
       let(:vaccine) { nil }
       let(:batch) { nil }
+      let(:other_batch) { nil }
 
       it { should_not have_css(".nhsuk-summary-list__row", text: "Batch ID") }
     end
@@ -158,6 +171,7 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
     context "without a vaccine" do
       let(:vaccine) { nil }
       let(:batch) { nil }
+      let(:other_batch) { nil }
 
       it do
         expect(rendered).not_to have_css(
@@ -233,6 +247,19 @@ describe AppVaccinationRecordDetailsComponent, type: :component do
       let(:notes) { nil }
 
       it { should_not have_css(".nhsuk-summary-list__row", text: "Notes") }
+    end
+  end
+
+  describe "with pending changes" do
+    let(:component) do
+      described_class.new(vaccination_record.with_pending_changes)
+    end
+
+    it "highlights changed fields" do
+      expect(rendered).to have_css(".app-highlight", text: "Nasal spray")
+      expect(rendered).to have_css(".app-highlight", text: "Nose")
+      expect(rendered).to have_css(".app-highlight", text: "DEF")
+      expect(rendered).to have_css(".app-highlight", text: "1 January 2021")
     end
   end
 end

--- a/spec/features/immunisation_imports_upload_duplicates_spec.rb
+++ b/spec/features/immunisation_imports_upload_duplicates_spec.rb
@@ -26,6 +26,11 @@ describe "Immunisation imports duplicates" do
 
     when_i_review_the_second_duplicate_record
     then_i_should_see_the_second_duplicate_record
+
+    when_i_choose_to_keep_the_duplicate_record
+    and_i_confirm_my_selection
+    then_i_should_see_a_success_message
+    and_the_second_record_should_be_updated
   end
 
   def given_i_am_signed_in
@@ -165,5 +170,12 @@ describe "Immunisation imports duplicates" do
 
   def when_i_review_the_second_duplicate_record
     click_on "Review Caden Attwater"
+  end
+
+  def and_the_second_record_should_be_updated
+    @previous_vaccination_record.reload
+    expect(@previous_vaccination_record.delivery_method).to eq("intramuscular")
+    expect(@previous_vaccination_record.delivery_site).to eq("left_thigh")
+    expect(@previous_vaccination_record.pending_changes).to eq({})
   end
 end

--- a/spec/features/immunisation_imports_upload_duplicates_spec.rb
+++ b/spec/features/immunisation_imports_upload_duplicates_spec.rb
@@ -13,16 +13,19 @@ describe "Immunisation imports duplicates" do
     and_i_upload_a_file_with_duplicate_records
     then_i_should_see_the_edit_page_with_duplicate_records
 
-    when_i_review_the_duplicate_record
-    then_i_should_see_the_duplicate_record
+    when_i_review_the_first_duplicate_record
+    then_i_should_see_the_first_duplicate_record
 
     when_i_submit_the_form_without_choosing_anything
     then_i_should_see_a_validation_error
 
-    when_i_select_the_duplicate_record
+    when_i_choose_to_keep_the_duplicate_record
     and_i_confirm_my_selection
     then_i_should_see_a_success_message
-    and_the_record_should_be_updated
+    and_the_first_record_should_be_updated
+
+    when_i_review_the_second_duplicate_record
+    then_i_should_see_the_second_duplicate_record
   end
 
   def given_i_am_signed_in
@@ -78,8 +81,8 @@ describe "Immunisation imports duplicates" do
       create(
         :batch,
         vaccine: @vaccine,
-        expiry: Date.new(2022, 7, 30),
-        name: "123013325"
+        expiry: Date.new(2024, 7, 30),
+        name: "Something else"
       )
     @previous_vaccination_record =
       create(
@@ -88,8 +91,8 @@ describe "Immunisation imports duplicates" do
         notes: "Foo",
         recorded_at: Time.zone.yesterday,
         batch: @batch,
-        delivery_method: :intramuscular,
-        delivery_site: :left_thigh,
+        delivery_method: :nasal_spray,
+        delivery_site: :nose,
         dose_sequence: 1,
         patient_session: @patient_session,
         vaccine: @vaccine
@@ -116,10 +119,10 @@ describe "Immunisation imports duplicates" do
   end
 
   def then_i_should_see_the_edit_page_with_duplicate_records
-    expect(page).to have_content("1 duplicate record needs review")
+    expect(page).to have_content("2 duplicate records need review")
   end
 
-  def when_i_select_the_duplicate_record
+  def when_i_choose_to_keep_the_duplicate_record
     choose "Use duplicate record"
   end
 
@@ -133,15 +136,23 @@ describe "Immunisation imports duplicates" do
     expect(page).to have_content("Vaccination record updated")
   end
 
-  def when_i_review_the_duplicate_record
+  def when_i_review_the_first_duplicate_record
     click_on "Review Esmae O'Connell"
   end
 
-  def then_i_should_see_the_duplicate_record
+  def then_i_should_see_the_first_duplicate_record
     expect(page).to have_content("This record needs reviewing")
+    expect(page).to have_content("PostcodeLE3 2DA")
+    expect(page).to have_content("PostcodeQG53 3OA")
   end
 
-  def and_the_record_should_be_updated
+  def then_i_should_see_the_second_duplicate_record
+    expect(page).to have_content("This record needs reviewing")
+    expect(page).to have_content("MethodIntramuscular")
+    expect(page).to have_content("MethodNasal spray")
+  end
+
+  def and_the_first_record_should_be_updated
     @existing_patient.reload
     expect(@existing_patient.first_name).to eq("Chyna")
     expect(@existing_patient.last_name).to eq("Pickle")
@@ -150,5 +161,9 @@ describe "Immunisation imports duplicates" do
 
   def then_i_should_see_a_validation_error
     expect(page).to have_content("There is a problem")
+  end
+
+  def when_i_review_the_second_duplicate_record
+    click_on "Review Caden Attwater"
   end
 end

--- a/spec/features/immunisation_imports_upload_duplicates_spec.rb
+++ b/spec/features/immunisation_imports_upload_duplicates_spec.rb
@@ -34,7 +34,14 @@ describe "Immunisation imports duplicates" do
     @programme =
       create(:programme, :hpv_all_vaccines, academic_year: 2023, team: @team)
     @location = create(:location, :school, urn: "110158")
-    @session = create(:session, programme: @programme, location: @location)
+    @session =
+      create(
+        :session,
+        programme: @programme,
+        location: @location,
+        date: Date.new(2024, 5, 14),
+        time_of_day: :all_day
+      )
   end
 
   def and_an_existing_patient_record_exists
@@ -48,6 +55,44 @@ describe "Immunisation imports duplicates" do
         gender_code: :female,
         address_postcode: "QG53 3OA",
         school: @location
+      )
+    @already_vaccinated_patient =
+      create(
+        :patient,
+        first_name: "Caden",
+        last_name: "Attwater",
+        nhs_number: "4146825652", # Third row of valid_hpv.csv
+        date_of_birth: Date.new(2012, 9, 14),
+        gender_code: :male,
+        address_postcode: "LE1 2DA",
+        school: @location
+      )
+    @patient_session =
+      create(
+        :patient_session,
+        patient: @already_vaccinated_patient,
+        session: @session
+      )
+    @vaccine = @programme.vaccines.find_by(nivs_name: "Gardasil9")
+    @batch =
+      create(
+        :batch,
+        vaccine: @vaccine,
+        expiry: Date.new(2022, 7, 30),
+        name: "123013325"
+      )
+    @previous_vaccination_record =
+      create(
+        :vaccination_record,
+        administered_at: @session.date.in_time_zone + 12.hours,
+        notes: "Foo",
+        recorded_at: Time.zone.yesterday,
+        batch: @batch,
+        delivery_method: :intramuscular,
+        delivery_site: :left_thigh,
+        dose_sequence: 1,
+        patient_session: @patient_session,
+        vaccine: @vaccine
       )
   end
 


### PR DESCRIPTION
This stages changes to vaccination records during the immunisation import process, allowing users to then persist or discard the changes.

TODO:

- [x] Get the right vaccination record instead of the last one
- [x] Add highlighting
- [x] Update the form to update the vaccination record as well

### Screenshots

![image](https://github.com/user-attachments/assets/0bc54db6-fb5f-4c61-86f7-5b350c4ef309)