### PR TITLE
Send text messages

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -3,17 +3,19 @@
 module ConsentFormMailerConcern
   extend ActiveSupport::Concern
 
-  def send_record_mail(consent_form)
+  def send_consent_form_confirmation(consent_form)
     mailer = ConsentMailer.with(consent_form:)
 
     if consent_form.contact_injection?
       mailer.confirmation_injection.deliver_later
     elsif consent_form.consent_refused?
       mailer.confirmation_refused.deliver_later
+      TextDeliveryJob.perform_later(:consent_refused, consent_form:)
     elsif consent_form.needs_triage?
       mailer.confirmation_needs_triage.deliver_later
     else
       mailer.confirmation.deliver_later
+      TextDeliveryJob.perform_later(:consent_given, consent_form:)
     end
 
     mailer.give_feedback.deliver_later(wait: 1.hour)

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -3,21 +3,22 @@
 module TriageMailerConcern
   extend ActiveSupport::Concern
 
-  def send_triage_mail(patient_session, consent)
+  def send_triage_confirmation(patient_session, consent)
     session = patient_session.session
 
-    if send_vaccination_will_happen_email?(patient_session, consent)
+    if vaccination_will_happen?(patient_session, consent)
       TriageMailer
         .with(consent:, session:)
         .vaccination_will_happen
         .deliver_later
-    elsif send_vaccination_wont_happen_email?(patient_session, consent)
+    elsif vaccination_wont_happen?(patient_session, consent)
       TriageMailer
         .with(consent:, session:)
         .vaccination_wont_happen
         .deliver_later
     elsif consent.response_refused?
       ConsentMailer.with(consent:, session:).confirmation_refused.deliver_later
+      TextDeliveryJob.perform_later(:consent_refused, consent:, session:)
     elsif consent.triage_needed?
       ConsentMailer
         .with(consent:, session:)
@@ -25,14 +26,17 @@ module TriageMailerConcern
         .deliver_later
     else
       ConsentMailer.with(consent:, session:).confirmation.deliver_later
+      TextDeliveryJob.perform_later(:consent_given, consent:, session:)
     end
   end
 
-  def send_vaccination_will_happen_email?(patient_session, consent)
+  private
+
+  def vaccination_will_happen?(patient_session, consent)
     consent.triage_needed? && patient_session.triaged_ready_to_vaccinate?
   end
 
-  def send_vaccination_wont_happen_email?(patient_session, consent)
+  def vaccination_wont_happen?(patient_session, consent)
     consent.triage_needed? &&
       (
         patient_session.triaged_do_not_vaccinate? ||

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -3,21 +3,29 @@
 module VaccinationMailerConcern
   extend ActiveSupport::Concern
 
-  def send_vaccination_mail(vaccination_record)
+  def send_vaccination_confirmation(vaccination_record)
     patient_session = vaccination_record.patient_session
 
-    action_name =
+    mailer_action =
       if vaccination_record.administered?
         :hpv_vaccination_has_taken_place
       else
         :hpv_vaccination_has_not_taken_place
       end
 
+    text_template_name =
+      if vaccination_record.administered?
+        :vaccination_has_taken_place
+      else
+        :vaccination_didnt_happen
+      end
+
     patient_session.consents_to_send_communication.each do |consent|
-      VaccinationMailer
-        .with(consent:, vaccination_record:)
-        .public_send(action_name)
-        .deliver_later
+      params = { consent:, vaccination_record: }
+
+      VaccinationMailer.with(params).public_send(mailer_action).deliver_later
+
+      TextDeliveryJob.perform_later(text_template_name, **params)
     end
   end
 end

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -109,7 +109,7 @@ class ManageConsentsController < ApplicationController
       if @triage.persisted?
         @patient_session.do_consent!
         @patient_session.do_triage!
-        send_triage_mail(@patient_session, @consent)
+        send_triage_confirmation(@patient_session, @consent)
       else
         # We need to discard the draft triage record so that the patient
         # session can be saved.

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -45,7 +45,7 @@ module ParentInterface
 
       session.delete(:consent_form_id)
 
-      send_record_mail(@consent_form)
+      send_consent_form_confirmation(@consent_form)
 
       ConsentFormMatchingJob.perform_later(@consent_form)
     end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -49,7 +49,9 @@ class TriageController < ApplicationController
     @triage.assign_attributes(triage_params.merge(performed_by: current_user))
     if @triage.save(context: :consent)
       @patient_session.do_triage!
-      @patient.consents.recorded.each { send_triage_mail(@patient_session, _1) }
+      @patient.consents.recorded.each do
+        send_triage_confirmation(@patient_session, _1)
+      end
       flash[:success] = {
         heading: "Triage outcome updated for",
         heading_link_text: @patient.full_name,

--- a/app/controllers/vaccinations/edit_controller.rb
+++ b/app/controllers/vaccinations/edit_controller.rb
@@ -38,7 +38,7 @@ class Vaccinations::EditController < ApplicationController
     )
 
     if @draft_vaccination_record.save
-      send_vaccination_mail(@draft_vaccination_record)
+      send_vaccination_confirmation(@draft_vaccination_record)
       @patient_session.do_vaccination!
 
       session.delete(:delivery_site_other)

--- a/app/jobs/consent_reminders_session_batch_job.rb
+++ b/app/jobs/consent_reminders_session_batch_job.rb
@@ -17,6 +17,12 @@ class ConsentRemindersSessionBatchJob < ApplicationJob
     session.patients.needing_consent_reminder.each do |patient|
       patient.parents.each do |parent|
         ConsentMailer.with(parent:, patient:, session:).reminder.deliver_now
+        TextDeliveryJob.perform_later(
+          :consent_reminder,
+          parent:,
+          patient:,
+          session:
+        )
       end
 
       patient.update!(consent_reminder_sent_at: Time.zone.now)

--- a/app/jobs/consent_requests_session_batch_job.rb
+++ b/app/jobs/consent_requests_session_batch_job.rb
@@ -17,6 +17,12 @@ class ConsentRequestsSessionBatchJob < ApplicationJob
     session.patients.consent_request_not_sent.each do |patient|
       patient.parents.each do |parent|
         ConsentMailer.with(parent:, patient:, session:).request.deliver_now
+        TextDeliveryJob.perform_later(
+          :consent_request,
+          parent:,
+          patient:,
+          session:
+        )
       end
 
       patient.update!(consent_request_sent_at: Time.zone.now)

--- a/app/jobs/session_reminders_job.rb
+++ b/app/jobs/session_reminders_job.rb
@@ -9,6 +9,11 @@ class SessionRemindersJob < ApplicationJob
     patient_sessions.each do |patient_session|
       patient_session.consents_to_send_communication.each do |consent|
         SessionMailer.with(consent:, patient_session:).reminder.deliver_later
+        TextDeliveryJob.perform_later(
+          :session_reminder,
+          consent:,
+          patient_session:
+        )
       end
 
       patient_session.update!(reminder_sent_at: Time.zone.now)

--- a/app/jobs/text_delivery_job.rb
+++ b/app/jobs/text_delivery_job.rb
@@ -5,20 +5,22 @@ class TextDeliveryJob < ApplicationJob
 
   def perform(
     template_name,
-    session:,
     consent: nil,
     consent_form: nil,
     parent: nil,
     patient: nil,
+    patient_session: nil,
+    session: nil,
     vaccination_record: nil
   )
     template_id = GOVUK_NOTIFY_TEXT_TEMPLATES[template_name.to_sym]
     raise UnknownTemplate if template_id.nil?
 
-    phone_number = consent_form&.parent_phone || parent&.phone
+    phone_number =
+      consent_form&.parent_phone || consent&.parent&.phone || parent&.phone
     return if phone_number.nil?
 
-    unless consent_form&.parent_phone_receive_updates ||
+    unless consent_form&.parent_phone_receive_updates || consent&.parent ||
              parent&.phone_receive_updates
       return
     end
@@ -30,6 +32,7 @@ class TextDeliveryJob < ApplicationJob
         consent_form:,
         parent:,
         patient:,
+        patient_session:,
         vaccination_record:
       )
 

--- a/app/jobs/text_delivery_job.rb
+++ b/app/jobs/text_delivery_job.rb
@@ -38,6 +38,8 @@ class TextDeliveryJob < ApplicationJob
 
     if self.class.send_via_notify?
       self.class.client.send_sms(phone_number:, template_id:, personalisation:)
+    elsif self.class.send_via_test?
+      self.class.deliveries << { phone_number:, template_id:, personalisation: }
     else
       Rails.logger.info "Sending text message to #{phone_number} with template #{template_id}"
     end
@@ -50,8 +52,16 @@ class TextDeliveryJob < ApplicationJob
       )
   end
 
+  def self.deliveries
+    @deliveries ||= []
+  end
+
   def self.send_via_notify?
     Rails.configuration.action_mailer.delivery_method == :notify
+  end
+
+  def self.send_via_test?
+    Rails.configuration.action_mailer.delivery_method == :test
   end
 
   class UnknownTemplate < StandardError

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -4,18 +4,21 @@ class GovukNotifyPersonalisation
   include Rails.application.routes.url_helpers
 
   def initialize(
-    session:,
     consent: nil,
     consent_form: nil,
     parent: nil,
     patient: nil,
+    patient_session: nil,
+    session: nil,
     vaccination_record: nil
   )
+    patient_session ||= vaccination_record&.patient_session
+
     @consent = consent
     @consent_form = consent_form
-    @parent = parent
-    @patient = patient
-    @session = session
+    @parent = parent || consent&.parent
+    @patient = patient || consent&.patient || patient_session&.patient
+    @session = session || consent_form&.session || patient_session&.session
     @vaccination_record = vaccination_record
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -25,30 +25,31 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def patient_session
-    @patient_session ||=
-      params[:patient_session] || vaccination_record&.patient_session
+    @patient_session ||= params[:patient_session]
   end
 
   def patient
-    @patient ||=
-      params[:patient] || consent&.patient || patient_session&.patient
+    @patient ||= params[:patient]
   end
 
   def parent
-    @parent ||= params[:parent] || consent&.parent
+    @parent ||= params[:parent]
   end
 
   def session
-    @session ||=
-      params[:session] || consent_form&.session || patient_session&.session
+    @session ||= params[:session]
   end
 
   def to
-    consent_form&.parent_email || parent.email
+    consent_form&.parent_email || consent&.parent&.email || parent.email
   end
 
   def reply_to_id
-    session.programme.team.reply_to_id
+    programme =
+      session&.programme || consent&.programme ||
+        consent_form&.session&.programme || patient_session&.programme
+
+    programme.team.reply_to_id
   end
 
   def personalisation
@@ -57,6 +58,7 @@ class ApplicationMailer < Mail::Notify::Mailer
       consent_form:,
       parent:,
       patient:,
+      patient_session:,
       session:,
       vaccination_record:
     )

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -5,33 +5,49 @@ describe ConsentFormMailerConcern do
 
   let(:consent_form) { create(:consent_form) }
 
-  describe "#send_record_mail" do
-    subject(:send_record_mail) { sample.send_record_mail(consent_form) }
+  describe "#send_consent_form_confirmation" do
+    subject(:send_consent_form_confirmation) do
+      sample.send_consent_form_confirmation(consent_form)
+    end
 
     it "sends a confirmation email" do
-      expect { send_record_mail }.to have_enqueued_mail(
+      expect { send_consent_form_confirmation }.to have_enqueued_mail(
         ConsentMailer,
         :confirmation
       ).with(params: { consent_form: }, args: [])
     end
 
+    it "sends a conset given text" do
+      expect { send_consent_form_confirmation }.to have_enqueued_text(
+        :consent_given
+      ).with(consent_form:)
+    end
+
     it "sends a feedback email" do
       today = Time.zone.local(2024, 1, 1)
 
-      expect { travel_to(today) { send_record_mail } }.to have_enqueued_mail(
-        ConsentMailer,
-        :give_feedback
-      ).with(params: { consent_form: }, args: []).at(today + 1.hour)
+      expect {
+        travel_to(today) { send_consent_form_confirmation }
+      }.to have_enqueued_mail(ConsentMailer, :give_feedback).with(
+        params: {
+          consent_form:
+        },
+        args: []
+      ).at(today + 1.hour)
     end
 
     context "when user agrees to be contacted about injections" do
       before { consent_form.contact_injection = true }
 
       it "sends an injection confirmation email" do
-        expect { send_record_mail }.to have_enqueued_mail(
+        expect { send_consent_form_confirmation }.to have_enqueued_mail(
           ConsentMailer,
           :confirmation_injection
         ).with(params: { consent_form: }, args: [])
+      end
+
+      it "doesn't send a text" do
+        expect { send_consent_form_confirmation }.not_to have_enqueued_text
       end
     end
 
@@ -39,10 +55,16 @@ describe ConsentFormMailerConcern do
       before { consent_form.response = :refused }
 
       it "sends an confirmation refused email" do
-        expect { send_record_mail }.to have_enqueued_mail(
+        expect { send_consent_form_confirmation }.to have_enqueued_mail(
           ConsentMailer,
           :confirmation_refused
         ).with(params: { consent_form: }, args: [])
+      end
+
+      it "sends a consent refused text" do
+        expect { send_consent_form_confirmation }.to have_enqueued_text(
+          :consent_refused
+        ).with(consent_form:)
       end
     end
 
@@ -50,10 +72,14 @@ describe ConsentFormMailerConcern do
       before { consent_form.health_answers.last.response = "yes" }
 
       it "sends an confirmation needs triage email" do
-        expect { send_record_mail }.to have_enqueued_mail(
+        expect { send_consent_form_confirmation }.to have_enqueued_mail(
           ConsentMailer,
           :confirmation_needs_triage
         ).with(params: { consent_form: }, args: [])
+      end
+
+      it "doesn't send a text" do
+        expect { send_consent_form_confirmation }.not_to have_enqueued_text
       end
     end
   end

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -61,9 +61,7 @@ FactoryBot.define do
     parent_email { Faker::Internet.email }
     parent_name { "#{Faker::Name.first_name}} #{last_name}" }
     parent_phone { "07700 900#{rand(0..999).to_s.rjust(3, "0")}" }
-    parent_phone_receive_updates do
-      parent_phone.present? ? [true, false].sample : false
-    end
+    parent_phone_receive_updates { parent_phone.present? }
     parent_relationship_other_name do
       parent_relationship_type == "other" ? "Other" : nil
     end

--- a/spec/factories/parents.rb
+++ b/spec/factories/parents.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
     name { "#{first_name} #{last_name}" }
     email { Faker::Internet.email }
     phone { "07700 900#{rand(0..999).to_s.rjust(3, "0")}" }
-    phone_receive_updates { phone.present? ? [true, false].sample : false }
+    phone_receive_updates { phone.present? }
 
     trait :contact_method_any do
       contact_method_type { "any" }

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -17,6 +17,7 @@ describe "HPV Vaccination" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_vaccinated
     and_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    and_a_text_is_sent_to_the_parent_confirming_the_vaccination
   end
 
   def given_i_am_signed_in
@@ -83,6 +84,13 @@ describe "HPV Vaccination" do
     expect_email_to(
       @patient.consents.last.parent.email,
       :confirmation_the_hpv_vaccination_has_taken_place
+    )
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+    expect_text_to(
+      @patient.consents.last.parent.phone,
+      :vaccination_has_taken_place
     )
   end
 end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -14,6 +14,7 @@ describe "HPV Vaccination" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_delayed
     and_an_email_is_sent_to_the_parent_confirming_the_delay
+    and_a_text_is_sent_to_the_parent_confirming_the_delay
   end
 
   def given_i_am_signed_in
@@ -73,6 +74,13 @@ describe "HPV Vaccination" do
     expect_email_to(
       @patient.consents.last.parent.email,
       :confirmation_the_hpv_vaccination_didnt_happen
+    )
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_the_delay
+    expect_text_to(
+      @patient.consents.last.parent.phone,
+      :vaccination_didnt_happen
     )
   end
 end

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -15,6 +15,7 @@ describe "HPV Vaccination" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_could_not_vaccinate
     and_an_email_is_sent_saying_the_vaccination_didnt_happen
+    and_a_text_is_sent_saying_the_vaccination_didnt_happen
   end
 
   def given_i_am_signed_in
@@ -76,6 +77,13 @@ describe "HPV Vaccination" do
     expect_email_to(
       @patient.consents.last.parent.email,
       :confirmation_the_hpv_vaccination_didnt_happen
+    )
+  end
+
+  def and_a_text_is_sent_saying_the_vaccination_didnt_happen
+    expect_text_to(
+      @patient.consents.last.parent.phone,
+      :vaccination_didnt_happen
     )
   end
 end

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -17,6 +17,7 @@ describe "Parental consent" do
     when_i_confirm_my_answers
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirming_that_my_child_wont_be_vaccinated
+    and_i_receive_a_text_confirming_that_my_child_wont_be_vaccinated
     and_i_receive_an_email_prompting_me_to_give_feedback
 
     when_the_nurse_checks_the_consent_responses
@@ -82,6 +83,7 @@ describe "Parental consent" do
     choose "Mum" # Your relationship to the child
     fill_in "Email address", with: "jane@example.com"
     fill_in "Phone number", with: "07123456789"
+    check "Tick this box if you’d like to get updates by text message"
     click_on "Continue"
 
     expect(page).to have_content("Phone contact method")
@@ -110,10 +112,14 @@ describe "Parental consent" do
   def and_i_receive_an_email_confirming_that_my_child_wont_be_vaccinated
     expect(enqueued_jobs.first["scheduled_at"]).to be_nil
     expect(
-      Time.zone.parse(enqueued_jobs.second["scheduled_at"]).to_i
+      Time.zone.parse(enqueued_jobs.third["scheduled_at"]).to_i
     ).to be_within(1.second).of(1.hour.from_now.to_i)
 
     expect_email_to "jane@example.com", :parental_consent_confirmation_refused
+  end
+
+  def and_i_receive_a_text_confirming_that_my_child_wont_be_vaccinated
+    expect_text_to "07123456789", :consent_refused
   end
 
   def and_i_receive_an_email_prompting_me_to_give_feedback

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -20,6 +20,7 @@ describe "Parental consent" do
 
     when_i_submit_the_consent_form
     then_i_get_a_confirmation_email_and_scheduled_survey_email
+    and_i_get_a_confirmation_text
 
     when_the_nurse_checks_the_consent_responses
     then_they_see_that_the_child_has_consent
@@ -146,6 +147,10 @@ describe "Parental consent" do
       :parental_consent_give_feedback,
       :second
     )
+  end
+
+  def and_i_get_a_confirmation_text
+    expect_text_to("07123456789", :consent_given)
   end
 
   def when_the_nurse_checks_the_consent_responses

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -123,6 +123,7 @@ describe "Session management" do
   def and_the_parents_should_receive_a_consent_request
     @patient.parents.each do |parent|
       expect_email_to(parent.email, :hpv_session_consent_request, :any)
+      expect_text_to(parent.phone, :consent_request, :any)
     end
   end
 

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -81,4 +81,8 @@ describe "Verbal consent" do
   def then_an_email_is_sent_to_the_parent_confirming_their_consent
     expect_email_to("jsmith@example.com", :parental_consent_confirmation)
   end
+
+  def and_i_a_text_is_sent_to_the_parent_confirming_their_consent
+    expect_text_to("07987654321", :consent_given)
+  end
 end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -5,8 +5,8 @@ describe "Verbal consent" do
     given_i_am_signed_in
 
     when_i_record_that_verbal_consent_was_given
-
     then_an_email_is_sent_to_the_parent_confirming_their_consent
+    and_a_text_is_sent_to_the_parent_confirming_their_consent
     and_the_patients_status_is_safe_to_vaccinate
     and_i_can_see_the_consent_response_details
   end
@@ -111,5 +111,9 @@ describe "Verbal consent" do
       @patient.parents.first.email,
       :parental_consent_confirmation
     )
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_their_consent
+    expect_text_to(@patient.parents.first.phone, :consent_given)
   end
 end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -78,6 +78,10 @@ feature "Verbal consent" do
     expect_email_to(@refusing_parent.email, :parental_consent_confirmation)
   end
 
+  def and_a_text_is_sent_to_the_parent_confirming_their_consent
+    expect_text_to(@refusing_parent.phone, :consent_given)
+  end
+
   def and_the_child_is_shown_as_having_consent_given
     click_on "Given"
     expect(page).to have_content(@child.full_name)

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -7,6 +7,7 @@ describe "Verbal consent" do
     when_i_record_the_consent_refusal_and_reason
 
     then_an_email_is_sent_to_the_parent_confirming_the_refusal
+    and_a_text_is_sent_to_the_parent_confirming_the_refusal
     and_the_patients_status_is_do_not_vaccinate
     and_i_can_see_the_consent_response_details
   end
@@ -95,5 +96,9 @@ describe "Verbal consent" do
   def then_an_email_is_sent_to_the_parent_confirming_the_refusal
     expect_email_to @patient.parents.first.email,
                     :parental_consent_confirmation_refused
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_the_refusal
+    expect_text_to @patient.parents.first.phone, :consent_refused
   end
 end

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -35,9 +35,7 @@ describe TextDeliveryJob do
 
     let(:template_name) { GOVUK_NOTIFY_TEXT_TEMPLATES.keys.first }
     let(:session) { create(:session) }
-    let(:parent) do
-      create(:parent, phone: "01234567890", phone_receive_updates: true)
-    end
+    let(:parent) { create(:parent, phone: "01234567890") }
     let(:consent) { nil }
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
@@ -83,13 +81,7 @@ describe TextDeliveryJob do
     end
 
     context "with a consent form" do
-      let(:consent_form) do
-        create(
-          :consent_form,
-          parent_phone: "01234567890",
-          parent_phone_receive_updates: true
-        )
-      end
+      let(:consent_form) { create(:consent_form, parent_phone: "01234567890") }
       let(:parent) { nil }
       let(:patient) { nil }
 

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -28,6 +28,7 @@ describe TextDeliveryJob do
         consent_form:,
         parent:,
         patient:,
+        patient_session:,
         vaccination_record:
       )
     end
@@ -40,6 +41,7 @@ describe TextDeliveryJob do
     let(:consent) { nil }
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
+    let(:patient_session) { nil }
     let(:vaccination_record) { nil }
 
     after { perform }
@@ -51,6 +53,7 @@ describe TextDeliveryJob do
         consent_form:,
         parent:,
         patient:,
+        patient_session:,
         vaccination_record:
       )
     end

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -3,12 +3,13 @@
 describe VaccinationMailer do
   let(:programme) { create(:programme, :active) }
   let(:session) { create(:session, programme:) }
-  let(:parent) { patient.consents.last.parent }
+  let(:consent) { patient.consents.last }
+  let(:parent) { consent.parent }
 
   describe "#hpv_vaccination_has_taken_place" do
     subject(:mail) do
       described_class.with(
-        parent:,
+        consent:,
         vaccination_record:
       ).hpv_vaccination_has_taken_place
     end
@@ -86,7 +87,7 @@ describe VaccinationMailer do
   describe "#hpv_vaccination_has_not_place" do
     subject(:mail) do
       described_class.with(
-        parent:,
+        consent:,
         vaccination_record:
       ).hpv_vaccination_has_not_taken_place
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -198,7 +198,10 @@ RSpec.configure do |config|
 
   config.after(:each, type: :system) { WebMock.enable! }
 
-  config.before { ActionMailer::Base.deliveries.clear }
+  config.before do
+    ActionMailer::Base.deliveries.clear
+    TextDeliveryJob.deliveries.clear
+  end
 
   config.include ActiveJob::TestHelper, type: :feature
   config.include ActiveSupport::Testing::TimeHelpers
@@ -207,5 +210,6 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :system
   config.include EmailExpectations, type: :feature
   config.include FactoryBot::Syntax::Methods
+  config.include TextExpectations, type: :feature
   config.include ViewComponent::TestHelpers, type: :component
 end

--- a/spec/support/matchers/have_enqueued_text.rb
+++ b/spec/support/matchers/have_enqueued_text.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.matcher :have_enqueued_text do |template_name = nil|
+  supports_block_expectations
+
+  chain :with do |params|
+    @params = params
+  end
+
+  match do |actual|
+    expect { actual.call }.to have_enqueued_job(TextDeliveryJob).with(
+      *[template_name].compact,
+      **(@params || {})
+    )
+  end
+
+  match_when_negated do |actual|
+    expect { actual.call }.not_to have_enqueued_job(TextDeliveryJob).with(
+      *[template_name].compact,
+      **(@params || {})
+    )
+  end
+end

--- a/spec/support/text_expectations.rb
+++ b/spec/support/text_expectations.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module TextExpectations
+  def expect_text_to(phone_number, template_name, nth = :first)
+    template_id = GOVUK_NOTIFY_TEXT_TEMPLATES[template_name]
+
+    text =
+      if nth == :any
+        sent_texts.find do |t|
+          t[:phone_number] == phone_number && t[:template_id] == template_id
+        end
+      else
+        sent_texts.send(nth)
+      end
+
+    expect(text).not_to be_nil
+    expect(text[:phone_number]).to eq(phone_number)
+    expect(text[:template_id]).to eq(template_id)
+  end
+
+  def sent_texts
+    perform_enqueued_jobs
+
+    TextDeliveryJob.deliveries
+  end
+end


### PR DESCRIPTION
This adds the ability to send text messages as well as emails for certain updates to a vaccination, consent or session. Specifically this adds 7 new text messages using templates that already exist in GOV.UK Notify:

- Consent has been given
- Consent has been refused
- A reminder that consent is required
- A request for consent
- A reminder that a session is happening
- The vaccination didn't happen
- The vaccination did happen

Updates are already sent to parents for all of these via email, but they have the choice to also receive these via text.