### PR TITLE
Fix Docker build missing GOV.UK Notify API key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY --link . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 MAVIS__GOVUK_NOTIFY__API_KEY=dummy ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base


### PR DESCRIPTION
In 917d436723231751b9360c801460e104fe4f2223 we ensured that a GOV.UK Notify API key is set in production, but this broke the Docker builds as we need a value to be set when precompiling the assets.