### PR TITLE
Pass phone_receive_updates when creating form

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -208,6 +208,7 @@ class ManageConsentsController < ApplicationController
         email: @parent.email,
         name: @parent.name,
         phone: @parent.phone,
+        phone_receive_updates: @parent.phone_receive_updates,
         relationship_type: @parent_relationship&.type,
         relationship_other_name: @parent_relationship&.other_name
       )


### PR DESCRIPTION
This ensures that if we're editing an existing parent we have the value that they already provided.