### PR TITLE
Add Programme#year_groups

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -105,6 +105,12 @@ class Programme < ApplicationRecord
     self.vaccines = Vaccine.where(id: ids)
   end
 
+  YEAR_GROUPS_BY_TYPE = { "flu" => (4..11).to_a, "hpv" => (8..11).to_a }.freeze
+
+  def year_groups
+    YEAR_GROUPS_BY_TYPE.fetch(type)
+  end
+
   private
 
   def first_possible_start_date

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -82,4 +82,20 @@ describe Programme, type: :model do
       end
     end
   end
+
+  describe "#year_groups" do
+    subject(:year_groups) { programme.year_groups }
+
+    context "with a Flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should eq([4, 5, 6, 7, 8, 9, 10, 11]) }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should eq([8, 9, 10, 11]) }
+    end
+  end
 end


### PR DESCRIPTION
This adds a method for determining the year groups that a programme is relevant to, for now this is hard coded based on the type but we might want to change this in the future.