### PR TITLE
Add patients to cohorts when importing

### DIFF
--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -69,7 +69,7 @@ class CohortImport < ApplicationRecord
   end
 
   def parse_row(row_data)
-    CohortImportRow.new(data: row_data)
+    CohortImportRow.new(data: row_data, team:)
   end
 
   def process_row(row)

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -73,6 +73,7 @@ class CohortImport < ApplicationRecord
   end
 
   def process_row(row)
+    cohort = row.to_cohort
     parent = row.to_parent
     patient = row.to_patient
     parent_relationship = row.to_parent_relationship(parent, patient)
@@ -90,9 +91,12 @@ class CohortImport < ApplicationRecord
         end
       )
 
+    cohort.save!
     parent.save!
     patient.save!
     parent_relationship.save!
+
+    cohort.patients << patient unless cohort.patients.include?(patient)
 
     link_records(parent, patient, parent_relationship)
 

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -26,6 +26,18 @@ class CohortImportRow
     @team = team
   end
 
+  def to_cohort
+    return unless valid?
+
+    # Children normally start school the September after their 4th birthday.
+    # https://www.gov.uk/schools-admissions/school-starting-age
+
+    reception_starting_year =
+      date_of_birth.year + (date_of_birth.month >= 9 ? 5 : 4)
+
+    Cohort.find_or_initialize_by(team: @team, reception_starting_year:)
+  end
+
   def to_parent
     return unless valid?
 

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -21,8 +21,9 @@ class CohortImportRow
 
   validate :zero_or_one_existing_patient
 
-  def initialize(data:)
+  def initialize(data:, team:)
     @data = data
+    @team = team
   end
 
   def to_parent

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -20,8 +20,9 @@
 #  index_teams_on_ods_code  (ods_code) UNIQUE
 #
 class Team < ApplicationRecord
-  has_many :programmes
   has_many :cohort_imports
+  has_many :cohorts
+  has_many :programmes
 
   has_and_belongs_to_many :users
 

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -27,6 +27,24 @@ describe CohortImportRow do
 
   before { create(:location, :school, urn: "123456") }
 
+  describe "#to_cohort" do
+    subject(:cohort) { cohort_import_row.to_cohort }
+
+    let(:data) { valid_data.merge("CHILD_DATE_OF_BIRTH" => date_of_birth) }
+
+    context "with a date of birth before September" do
+      let(:date_of_birth) { "2000-08-31" }
+
+      it { should have_attributes(team:, reception_starting_year: 2004) }
+    end
+
+    context "with a date of birth after September" do
+      let(:date_of_birth) { "2000-09-01" }
+
+      it { should have_attributes(team:, reception_starting_year: 2005) }
+    end
+  end
+
   describe "#to_parent" do
     subject(:parent) { cohort_import_row.to_parent }
 

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-describe CohortImportRow, type: :model do
-  subject(:cohort_import_row) { described_class.new(data:) }
+describe CohortImportRow do
+  subject(:cohort_import_row) { described_class.new(data:, team:) }
+
+  let(:team) { create(:team) }
 
   let(:valid_data) do
     {


### PR DESCRIPTION
This adds the functionality to ensure that patients are added to the correct cohort when they're imported. The cohort is determined based on the date of birth of the patient.