### PR TITLE
Get patient year group from cohort

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -101,6 +101,8 @@ class Patient < ApplicationRecord
 
   before_save :remove_spaces_from_nhs_number
 
+  delegate :year_group, to: :cohort
+
   def self.find_existing(
     nhs_number:,
     first_name:,
@@ -130,10 +132,6 @@ class Patient < ApplicationRecord
 
   def as_json(options = {})
     super.merge("full_name" => full_name, "age" => age)
-  end
-
-  def year_group
-    Time.zone.today.academic_year - (date_of_birth.academic_year + 5)
   end
 
   def address_fields

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -129,42 +129,6 @@ describe Patient do
     end
   end
 
-  describe "#year_group" do
-    subject { patient.year_group }
-
-    around { |example| travel_to(date) { example.run } }
-
-    let(:patient) { described_class.new(date_of_birth: dob) }
-
-    context "child born BEFORE 1 Sep 2016, date is BEFORE 1 Sep 2024" do
-      let(:dob) { Date.new(2016, 8, 31) }
-      let(:date) { Date.new(2024, 8, 31) }
-
-      it { should eq 3 }
-    end
-
-    context "child born BEFORE 1 Sep 2016, date is AFTER 1 Sep 2024" do
-      let(:dob) { Date.new(2016, 8, 31) }
-      let(:date) { Date.new(2024, 9, 1) }
-
-      it { should eq 4 }
-    end
-
-    context "child born AFTER 1 Sep 2016, date is BEFORE 1 Sep 2024" do
-      let(:dob) { Date.new(2016, 9, 1) }
-      let(:date) { Date.new(2024, 8, 31) }
-
-      it { should eq 2 }
-    end
-
-    context "child born AFTER 1 Sep 2016, date is AFTER 1 Sep 2024" do
-      let(:dob) { Date.new(2016, 9, 1) }
-      let(:date) { Date.new(2024, 9, 1) }
-
-      it { should eq 3 }
-    end
-  end
-
   describe "#stage_changes" do
     let(:patient) { create(:patient, first_name: "John", last_name: "Doe") }
 


### PR DESCRIPTION
This is a more accurate value for the patient's year group as the patient might move between cohorts in certain special cases.