### PR TITLE
Use secondary style for upload buttons

### DIFF
--- a/app/assets/stylesheets/_button.scss
+++ b/app/assets/stylesheets/_button.scss
@@ -4,11 +4,6 @@ $app-cis2-button-active-color: #003087;
 $app-cis2-button-shadow-color: #003087;
 $button-shadow-size: 4px;
 
-.app-button--small {
-  @include nhsuk-typography-responsive(16);
-  padding: nhsuk-spacing(1) 12px;
-}
-
 .nhsuk-button {
   .nhsuk-table & {
     margin-bottom: 0;
@@ -44,5 +39,69 @@ $button-shadow-size: 4px;
     box-shadow: none;
     color: $nhsuk-button-text-color;
     top: $button-shadow-size;
+  }
+}
+
+// Proposed secondary button style
+// See https://github.com/nhsuk/nhsapp-frontend/issues/12
+// See https://github.com/nhsuk/nhs-app-design-styles-components-patterns
+@mixin app-button-secondary($button-color) {
+  background-color: transparent;
+  border-bottom: 0;
+  border-color: $button-color;
+  box-shadow: 0 4px 0 $button-color;
+  color: $button-color;
+  // Adjust padding to account for removal of 2px bottom border
+  padding-bottom: 13px;
+  padding-top: 13px;
+
+  &:link,
+  &:visited {
+    color: $button-color;
+  }
+
+  &:hover {
+    background-color: rgba($button-color, 10%);
+    color: $button-color;
+  }
+
+  &:focus {
+    background-color: $nhsuk-focus-color;
+    border-color: $nhsuk-focus-color;
+    color: $nhsuk-focus-text-color;
+  }
+
+  &:active {
+    background-color: rgba($button-color, 15%);
+    border-color: $button-color;
+    border-bottom: 2px solid; // Reintroduce 2px bottom border
+    color: $button-color;
+    // Revert padding to account for reintroduction of 2px bottom border
+    padding-bottom: 12px;
+    padding-top: 12px;
+  }
+
+  &:focus:visited:active {
+    // Override .nhsuk-button turning colour white
+    color: $button-color;
+  }
+}
+
+.app-button--secondary {
+  @include app-button-secondary($nhsuk-link-color);
+}
+
+.app-button--secondary-warning {
+  @include app-button-secondary($nhsuk-warning-button-color);
+}
+
+.app-button--small {
+  @include nhsuk-typography-responsive(16);
+  padding: nhsuk-spacing(1) 12px;
+
+  &.app-button--secondary,
+  &.app-button--secondary-warning {
+    padding-bottom: #{nhsuk-spacing(1) + 1px};
+    padding-top: #{nhsuk-spacing(1) + 1px};
   }
 }

--- a/app/views/immunisation_imports/index.html.erb
+++ b/app/views/immunisation_imports/index.html.erb
@@ -11,9 +11,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :immunisation_imports) %>
 
-<p class="app-action-list">
-  <%= govuk_link_to "Upload new vaccination records", new_programme_immunisation_import_path %>
-</p>
+<%= govuk_button_link_to "Import vaccination records", new_programme_immunisation_import_path, class: "app-button--secondary" %>
 
 <% if @immunisation_imports.any? %>
   <div class="nhsuk-table__panel-with-heading-tab">

--- a/app/views/programmes/patients.html.erb
+++ b/app/views/programmes/patients.html.erb
@@ -11,8 +11,6 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :patients) %>
 
-<p class="app-action-list">
-  <%= link_to "Add children to programme cohort", new_programme_cohort_import_path(@programme) %>
-</p>
+<%= govuk_button_link_to "Import child records", new_programme_cohort_import_path(@programme), class: "app-button--secondary" %>
 
 <%= render AppPatientTableComponent.new(@patients, programme: @programme) %>

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -56,7 +56,7 @@ describe "Cohort imports" do
   end
 
   def and_i_start_adding_children_to_the_cohort
-    click_on "Add children to programme cohort"
+    click_on "Import child records"
   end
 
   def then_i_should_see_the_upload_cohort_page

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -83,7 +83,7 @@ describe "End-to-end journey" do
     click_on "Vaccination programmes", match: :first
     click_on "HPV"
     click_on "Cohort"
-    click_on "Add children to programme cohort"
+    click_on "Import child records"
     attach_file "cohort_import[csv]", csv_file.path
     click_on "Continue"
     click_on "Upload records"

--- a/spec/features/immunisation_imports_upload_duplicates_spec.rb
+++ b/spec/features/immunisation_imports_upload_duplicates_spec.rb
@@ -140,7 +140,7 @@ describe "Immunisation imports duplicates" do
   end
 
   def and_i_click_on_the_upload_link
-    click_on "Upload new vaccination records"
+    click_on "Import vaccination records"
   end
 
   def and_i_upload_a_file_with_duplicate_records

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -75,11 +75,11 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_upload_link
-    expect(page).to have_link("Upload new vaccination records")
+    expect(page).to have_link("Import vaccination records")
   end
 
   def when_i_click_on_the_upload_link
-    click_on "Upload new vaccination records"
+    click_on "Import vaccination records"
   end
 
   def then_i_should_see_the_upload_page


### PR DESCRIPTION
This is to match the designs in the prototype, using a newer button style that's currently being tested but not yet part of the NHS frontend.

See https://github.com/nhsuk/nhsapp-frontend/issues/12 for more details.

## Screenshots

<img width="335" alt="Screenshot 2024-09-18 at 11 20 55" src="https://github.com/user-attachments/assets/d4ec868e-e088-4e49-85ce-03a352bbfe1c">
<img width="285" alt="Screenshot 2024-09-18 at 11 20 51" src="https://github.com/user-attachments/assets/7fa047b5-3f45-4990-8243-6b060ab549ae">
