### PR TITLE
Show empty cohorts

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -6,11 +6,20 @@ class CohortsController < ApplicationController
   layout "full"
 
   def index
-    @cohorts =
+    cohorts =
       policy_scope(Cohort)
+        .select("cohorts.*", "COUNT(patients.id) AS patient_count")
         .for_year_groups(@programme.year_groups)
-        .order(:reception_starting_year)
-        .includes(:recorded_patients)
+        .left_outer_joins(:patients)
+        .merge(Patient.recorded)
+        .group("cohorts.id")
+        .index_by(&:year_group)
+
+    @programme.year_groups.each do |year_group|
+      cohorts[year_group] ||= OpenStruct.new(year_group:, patient_count: 0)
+    end
+
+    @cohorts = cohorts.sort.map { _2 }
   end
 
   def show

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -23,7 +23,6 @@ class Cohort < ApplicationRecord
   belongs_to :team
 
   has_many :patients
-  has_many :recorded_patients, -> { recorded }, class_name: "Patient"
 
   validates :reception_starting_year,
             comparison: {

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -16,9 +16,9 @@
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <% @cohorts.each do |cohort| %>
     <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
-      <%= render AppCardComponent.new(link_to: programme_cohort_path(@programme, cohort)) do |card| %>
+      <%= render AppCardComponent.new(link_to: cohort.patient_count > 0 ? programme_cohort_path(@programme, cohort) : nil) do |card| %>
         <% card.with_heading { format_year_group(cohort.year_group) } %>
-        <% card.with_description { pluralize(cohort.recorded_patients.count, "child") } %>
+        <% card.with_description { pluralize(cohort.patient_count, "child") } %>
       <% end %>
     </li>
   <% end %>

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -98,7 +98,10 @@ describe "Cohort imports" do
   end
 
   def then_i_should_see_the_cohorts
-    expect(page).to have_content("Year 8")
+    expect(page).to have_content("Year 8\n2 children")
+    expect(page).to have_content("Year 9\n0 children")
+    expect(page).to have_content("Year 10\n0 children")
+    expect(page).to have_content("Year 11\n0 children")
   end
 
   def when_i_click_on_the_cohort

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -165,7 +165,10 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_cohorts
-    expect(page).to have_content("Year 8")
+    expect(page).to have_content("Year 8\n7 children")
+    expect(page).to have_content("Year 9\n0 children")
+    expect(page).to have_content("Year 10\n0 children")
+    expect(page).to have_content("Year 11\n0 children")
   end
 
   def when_i_click_on_the_cohort


### PR DESCRIPTION
This ensures that when looking at the cohorts tab, we show all cohorts that could possibly exist for a particular programme, not just the ones that do exist.

## Screenshot

<img width="1212" alt="Screenshot 2024-09-18 at 17 11 28" src="https://github.com/user-attachments/assets/f84c0b3f-383c-4d3d-bcb5-7a0d64b182a2">
