### PR TITLE
Remove triage on programmes

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -31,7 +31,6 @@ class Programme < ApplicationRecord
   has_many :dps_exports, dependent: :destroy
   has_many :immunisation_imports, dependent: :destroy
   has_many :sessions, dependent: :destroy
-  has_many :triage, dependent: :destroy
 
   has_many :batches, through: :vaccines
   has_many :cohort_imports, through: :team

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -27,10 +27,10 @@ class Programme < ApplicationRecord
 
   has_and_belongs_to_many :vaccines
 
-  has_many :consents, dependent: :destroy
-  has_many :dps_exports, dependent: :destroy
-  has_many :immunisation_imports, dependent: :destroy
-  has_many :sessions, dependent: :destroy
+  has_many :consents
+  has_many :dps_exports
+  has_many :immunisation_imports
+  has_many :sessions
 
   has_many :batches, through: :vaccines
   has_many :cohort_imports, through: :team


### PR DESCRIPTION
This relationship doesn't exist, there's no `programme_id` column on the triage model, and the line prevents us from being able to delete programmes.

I've also removed the dependent destroy on the other relationships because I think we should make it hard to delete programmes, without this it's possible to destroy a programme in one go without first destroying it's dependencies.