### PR TITLE
Remove parent_contact_method feature flag

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -232,7 +232,7 @@ class ConsentForm < ApplicationRecord
       :date_of_birth,
       :school,
       :parent,
-      (:contact_method if ask_for_contact_method?),
+      (:contact_method if parent_phone.present?),
       :consent,
       (:reason if consent_refused?),
       (:reason_notes if consent_refused? && reason_notes_must_be_provided?),
@@ -385,10 +385,6 @@ class ConsentForm < ApplicationRecord
       end
     end
     true
-  end
-
-  def ask_for_contact_method?
-    Flipper.enabled?(:parent_contact_method) && parent_phone.present?
   end
 
   # Because there are branching paths in the consent form journey, fields

--- a/spec/features/parental_consent_authentication_spec.rb
+++ b/spec/features/parental_consent_authentication_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
-  before { Flipper.enable(:parent_contact_method) }
-
   scenario "Authentication" do
     given_an_hpv_programme_is_underway
     when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -119,6 +119,10 @@ RSpec.feature "Parental consent change answers" do
     choose "Yes" # Parental responsibility
     click_button "Continue"
 
+    expect(page).to have_content("Phone contact method")
+    choose "I do not have specific needs"
+    click_on "Continue"
+
     # BUG: The page should be the consent confirm page, but because we
     # encountered a validation error, the skip_to_confirm flag gets lost and we
     # end up on the next page in the wizard.

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
-  before { Flipper.enable(:parent_contact_method) }
-
   scenario "Refused" do
     given_an_hpv_programme_is_underway
     when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
-  before { Flipper.enable(:parent_contact_method) }
-
   scenario "Consent form exactly matches the cohort" do
     given_an_hpv_programme_is_underway
     when_a_nurse_checks_consent_responses

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -738,9 +738,33 @@ describe ConsentForm do
     expect(consent_form.health_answers).not_to be_empty
   end
 
-  it "removes the health questions when the parent refuses consent" do
+  it "removes the health questions when the parent refuses consent for flu" do
     consent_form =
-      create(:consent_form, :with_health_answers_no_branching, response: nil)
+      create(
+        :consent_form,
+        :with_health_answers_no_branching,
+        programme: create(:programme, :flu),
+        response: nil
+      )
+
+    consent_form.update!(
+      response: "refused",
+      reason: "personal_choice",
+      contact_injection: false
+    )
+    consent_form.reload
+
+    expect(consent_form.health_answers).to be_empty
+  end
+
+  it "removes the health questions when the parent refuses consent for HPV" do
+    consent_form =
+      create(
+        :consent_form,
+        :with_health_answers_no_branching,
+        programme: create(:programme, :hpv),
+        response: nil
+      )
 
     consent_form.update!(response: "refused", reason: "personal_choice")
     consent_form.reload


### PR DESCRIPTION
The parental consent form now supports texts, so we can enable this step of the journey for all users.