### PR TITLE
Show "no children" rather than "0 children"

### DIFF
--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -12,6 +12,6 @@ class AppPatientTableComponent < ViewComponent::Base
   attr_reader :patients
 
   def heading
-    pluralize(patients.count, "child")
+    I18n.t("children", count: patients.count)
   end
 end

--- a/app/components/app_session_details_component.rb
+++ b/app/components/app_session_details_component.rb
@@ -24,8 +24,7 @@ class AppSessionDetailsComponent < ViewComponent::Base
   end
 
   def cohort
-    patients_count = @session.patients.count
-    pluralize(patients_count, "child")
+    I18n.t("children", count: @session.patients.count)
   end
 
   def consent_requests

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module SessionsHelper
-  def pluralize_child(count)
-    count.zero? ? "No children" : pluralize(count, "child")
-  end
-
   def session_location(session, part_of_sentence: false)
     if (location = session.location).present?
       location.name

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -18,7 +18,7 @@
     <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
       <%= render AppCardComponent.new(link_to: cohort.patient_count > 0 ? programme_cohort_path(@programme, cohort) : nil) do |card| %>
         <% card.with_heading { format_year_group(cohort.year_group) } %>
-        <% card.with_description { pluralize(cohort.patient_count, "child") } %>
+        <% card.with_description { t("children", count: cohort.patient_count) } %>
       <% end %>
     </li>
   <% end %>

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -36,7 +36,7 @@
 <%= render AppSessionPatientTableComponent.new(
       patient_sessions: @patient_sessions,
       caption: t("patients_table.#{@current_tab}.caption",
-                 children: pluralize_child(@patient_sessions.count)),
+                 children: t("children", count: @patient_sessions.count)),
       columns: @current_tab == :consent_refused ? %i[name dob reason] : %i[name dob],
       section: :consents,
       params:,

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -12,7 +12,7 @@
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @session.date.to_fs(:long) %> (<%= @session.human_enum_name(:time_of_day) %>) ·
-    <%= pluralize(@patient_sessions.size, "child") %> in cohort
+    <%= t("children", count: @patient_sessions.size) %> in cohort
   </span>
 <% end %>
 
@@ -26,7 +26,7 @@
     <%= render AppCardComponent.new(link_to: "#") do |c| %>
       <% c.with_heading { "Register attendance" } %>
       <% c.with_description do %>
-        <%= pluralize_child(@patient_sessions.size) %> still to register
+        <%= t("children", count: @patient_sessions.size) %> still to register
       <% end %>
     <% end %>
   </li>
@@ -34,9 +34,9 @@
     <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
       <% c.with_heading { "Record vaccinations" } %>
       <% c.with_description do %>
-        <%= pluralize_child(@counts[:vaccinate]) %> to vaccinate<br>
-        <%= pluralize_child(@counts[:vaccinated]) %> vaccinated<br>
-        <%= pluralize_child(@counts[:could_not_vaccinate]) %> could not be vaccinated
+        <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
+        <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
+        <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
       <% end %>
     <% end %>
   </li>
@@ -44,10 +44,10 @@
     <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
       <% c.with_heading { "Check consent responses" } %>
       <% c.with_description do %>
-        <%= pluralize_child(@counts[:without_a_response]) %> without a response<br>
-        <%= pluralize_child(@counts[:with_consent_given]) %> with consent given<br>
-        <%= pluralize_child(@counts[:with_consent_refused]) %> with consent refused<br>
-        <%= pluralize_child(@counts[:with_conflicting_consent]) %> with conflicting consent
+        <%= t("children", count: @counts[:without_a_response]) %> without a response<br>
+        <%= t("children", count: @counts[:with_consent_given]) %> with consent given<br>
+        <%= t("children", count: @counts[:with_consent_refused]) %> with consent refused<br>
+        <%= t("children", count: @counts[:with_conflicting_consent]) %> with conflicting consent
       <% end %>
     <% end %>
   </li>
@@ -55,7 +55,7 @@
     <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
       <% c.with_heading { "Triage health questions" } %>
       <% c.with_description do %>
-        <%= pluralize_child(@counts[:needing_triage]) %> needing triage
+        <%= t("children", count: @counts[:needing_triage]) %> needing triage
       <% end %>
     <% end %>
   </li>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -23,7 +23,7 @@
 <%= render AppSessionPatientTableComponent.new(
       patient_sessions: @patient_sessions,
       caption: t("patients_table.#{@current_tab}.caption",
-                 children: pluralize_child(@patient_sessions.count)),
+                 children: t("children", count: @patient_sessions.count)),
       columns: %i[name dob],
       section: :triage,
       params:,

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -37,7 +37,7 @@
 <%= render AppSessionPatientTableComponent.new(
       patient_sessions: @patient_sessions,
       caption: t("patients_table.#{@current_tab}.caption",
-                 children: pluralize_child(@patient_sessions.count)),
+                 children: t("children", count: @patient_sessions.count)),
       columns: @current_tab == :vaccinate ?
         %i[name dob action] :
         %i[name dob outcome],

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -442,6 +442,10 @@ en:
               inclusion: Choose a reason
             site:
               blank: Choose a site
+  children:
+    zero: No children
+    one: 1 child
+    other: "%{count} children"
   cohorts:
     index:
       title: Cohorts

--- a/spec/features/cohort_imports_upload_spec.rb
+++ b/spec/features/cohort_imports_upload_spec.rb
@@ -99,9 +99,9 @@ describe "Cohort imports" do
 
   def then_i_should_see_the_cohorts
     expect(page).to have_content("Year 8\n2 children")
-    expect(page).to have_content("Year 9\n0 children")
-    expect(page).to have_content("Year 10\n0 children")
-    expect(page).to have_content("Year 11\n0 children")
+    expect(page).to have_content("Year 9\nNo children")
+    expect(page).to have_content("Year 10\nNo children")
+    expect(page).to have_content("Year 11\nNo children")
   end
 
   def when_i_click_on_the_cohort

--- a/spec/features/immunisation_imports_upload_spec.rb
+++ b/spec/features/immunisation_imports_upload_spec.rb
@@ -165,9 +165,9 @@ describe "Immunisation imports" do
 
   def then_i_should_see_the_cohorts
     expect(page).to have_content("Year 8\n7 children")
-    expect(page).to have_content("Year 9\n0 children")
-    expect(page).to have_content("Year 10\n0 children")
-    expect(page).to have_content("Year 11\n0 children")
+    expect(page).to have_content("Year 9\nNo children")
+    expect(page).to have_content("Year 10\nNo children")
+    expect(page).to have_content("Year 11\nNo children")
   end
 
   def when_i_click_on_the_cohort


### PR DESCRIPTION
This replaces everywhere that we show a number of children to use the phrase "No children" instead of "0 children" but introducing a localisation key and using the `count` feature of `I18n.t`.