### PR TITLE
Additional OIDC security measures for CIS2

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -301,14 +301,7 @@ Devise.setup do |config|
       {
         setup:,
         name: :cis2,
-        scope: %i[
-          openid
-          profile
-          email
-          nationalrbacaccess
-          associatedorgs
-          professionalmemberships
-        ],
+        scope: %i[openid profile email nationalrbacaccess associatedorgs],
         response_type: :code,
         # uid_field: "preferred_username",
         issuer: Settings.cis2.issuer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -302,6 +302,9 @@ Devise.setup do |config|
         setup:,
         name: :cis2,
         scope: %i[openid profile email nationalrbacaccess associatedorgs],
+        extra_authorize_params: {
+          max_age: 300
+        },
         response_type: :code,
         # uid_field: "preferred_username",
         issuer: Settings.cis2.issuer,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,6 @@ allow_dev_phone_numbers: false
 support_username: manage
 support_password: vaccinations
 web_concurrency: 2
+
+cis2:
+  authentication_assurance_level: 3

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -4,6 +4,7 @@ web_concurrency: 0
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via Devise.
 cis2:
   issuer: "https://am.nhsdev.auth-ptl.cis2.spineservices.nhs.uk:443/openam/oauth2/realms/root/realms/oidc"
+  authentication_assurance_level: 1
 
 mesh:
   base_url: https://localhost:8700

--- a/spec/fixtures/cis2_auth_info.rb
+++ b/spec/fixtures/cis2_auth_info.rb
@@ -19,6 +19,9 @@ CIS2_AUTH_INFO = {
   },
   "extra" => {
     "raw_info" => {
+      "id_assurance_level" => "3",
+      "authentication_assurance_level" => "3",
+      "auth_time" => Time.zone.now.to_i,
       "nhsid_useruid" => "123456789012",
       "name" => "Flo Nurse",
       "nhsid_nrbac_roles" => [


### PR DESCRIPTION
As part of onboarding for CIS2 there are some additional measures we need to implement when performing authorisation with OIDC. The measures in this PR are:

- Check user has level 3 CIS2 identity
- Remove `professionalmemberships` scope from CIS2 auth
- Check `auth_time` in CIS2 callback
- Set the prompt when authenticating user with CIS2
- Check user has authenticated securely to CIS2

There are still some other measures that need to be implemented but they are a bit chunkier and will be spun out into separate PRs.
