### PR TITLE
Only show cohorts in the same team as the programme

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -9,7 +9,7 @@ class CohortsController < ApplicationController
     cohorts =
       policy_scope(Cohort)
         .select("cohorts.*", "COUNT(patients.id) AS patient_count")
-        .for_year_groups(@programme.year_groups)
+        .for_programme(@programme)
         .left_outer_joins(:patients)
         .merge(Patient.recorded)
         .group("cohorts.id")

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -36,6 +36,13 @@ class Cohort < ApplicationRecord
           where(birth_academic_year: birth_academic_years)
         end
 
+  scope :for_programme,
+        ->(programme) do
+          where(team_id: programme.team_id).for_year_groups(
+            programme.year_groups
+          )
+        end
+
   def year_group
     Date.new(birth_academic_year, 9, 1).year_group
   end

--- a/spec/factories/example_campaigns.rb
+++ b/spec/factories/example_campaigns.rb
@@ -6,151 +6,153 @@ FactoryBot.define do
 
     transient do
       user { create(:user) }
+
       # this name and URN matches the data in spec/fixtures/cohort_import/valid_cohort.csv
       location do
-        create(:location, :school, name: "Surrey Primary", urn: "123456")
+        create(:location, :school, name: "Surrey Primary", urn: "123456", team:)
       end
+
       batch_count { 4 }
     end
 
     team { user.team || create(:team, users: [user]) }
-  end
 
-  trait :in_progress do
-    after(:create) do |programme, context|
-      location = context.location
-      user = context.user
+    trait :in_progress do
+      after(:create) do |programme, context|
+        location = context.location
+        user = context.user
 
-      create(:session, :in_progress, programme:, location:).tap do |session|
-        patients_without_consent =
-          create_list(:patient_session, 4, session:, created_by: user)
-        unmatched_patients = patients_without_consent.sample(2).map(&:patient)
-        unmatched_patients.each do |patient|
-          create(
-            :consent_form,
-            :recorded,
-            first_name: patient.first_name,
-            last_name: patient.last_name,
-            session:
+        create(:session, :in_progress, programme:, location:).tap do |session|
+          patients_without_consent =
+            create_list(:patient_session, 4, session:, created_by: user)
+          unmatched_patients = patients_without_consent.sample(2).map(&:patient)
+          unmatched_patients.each do |patient|
+            create(
+              :consent_form,
+              :recorded,
+              first_name: patient.first_name,
+              last_name: patient.last_name,
+              session:
+            )
+          end
+
+          create_list(
+            :patient_session,
+            4,
+            :consent_given_triage_not_needed,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            4,
+            :consent_given_triage_needed,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            4,
+            :triaged_ready_to_vaccinate,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            4,
+            :consent_refused,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            2,
+            :consent_conflicting,
+            session:,
+            created_by: user
           )
         end
-
-        create_list(
-          :patient_session,
-          4,
-          :consent_given_triage_not_needed,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          4,
-          :consent_given_triage_needed,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          4,
-          :triaged_ready_to_vaccinate,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          4,
-          :consent_refused,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          2,
-          :consent_conflicting,
-          session:,
-          created_by: user
-        )
       end
     end
-  end
 
-  trait :in_past do
-    after(:create) do |programme, context|
-      location = context.location
-      user = context.user
+    trait :in_past do
+      after(:create) do |programme, context|
+        location = context.location
+        user = context.user
 
-      create(:session, :in_past, programme:, location:).tap do |session|
-        create_list(
-          :patient_session,
-          4,
-          :vaccinated,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          4,
-          :delay_vaccination,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          4,
-          :unable_to_vaccinate,
-          session:,
-          created_by: user
-        )
-      end
-    end
-  end
-
-  trait :in_future do
-    after(:create) do |programme, context|
-      location = context.location
-      user = context.user
-
-      create(:session, :in_future, programme:, location:).tap do |session|
-        patients_without_consent =
-          create_list(:patient_session, 16, session:, created_by: user)
-        unmatched_patients = patients_without_consent.sample(8).map(&:patient)
-        unmatched_patients.each do |patient|
-          create(
-            :consent_form,
-            :recorded,
-            first_name: patient.first_name,
-            last_name: patient.last_name,
-            session:
+        create(:session, :in_past, programme:, location:).tap do |session|
+          create_list(
+            :patient_session,
+            4,
+            :vaccinated,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            4,
+            :delay_vaccination,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            4,
+            :unable_to_vaccinate,
+            session:,
+            created_by: user
           )
         end
-        create_list(
-          :patient_session,
-          8,
-          :consent_given_triage_not_needed,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          8,
-          :consent_given_triage_needed,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          8,
-          :consent_refused,
-          session:,
-          created_by: user
-        )
-        create_list(
-          :patient_session,
-          4,
-          :consent_conflicting,
-          session:,
-          created_by: user
-        )
+      end
+    end
+
+    trait :in_future do
+      after(:create) do |programme, context|
+        location = context.location
+        user = context.user
+
+        create(:session, :in_future, programme:, location:).tap do |session|
+          patients_without_consent =
+            create_list(:patient_session, 16, session:, created_by: user)
+          unmatched_patients = patients_without_consent.sample(8).map(&:patient)
+          unmatched_patients.each do |patient|
+            create(
+              :consent_form,
+              :recorded,
+              first_name: patient.first_name,
+              last_name: patient.last_name,
+              session:
+            )
+          end
+          create_list(
+            :patient_session,
+            8,
+            :consent_given_triage_not_needed,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            8,
+            :consent_given_triage_needed,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            8,
+            :consent_refused,
+            session:,
+            created_by: user
+          )
+          create_list(
+            :patient_session,
+            4,
+            :consent_conflicting,
+            session:,
+            created_by: user
+          )
+        end
       end
     end
   end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     transient { programme { association :programme } }
 
     session { association :session, programme: }
-    patient
+    patient { association :patient, school: session.location }
     created_by
 
     active { session.active }
@@ -47,7 +47,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_not_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
     end
 
@@ -55,13 +56,17 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
     end
 
     trait :consent_refused do
       patient do
-        association :patient, :consent_refused, programme: session.programme
+        association :patient,
+                    :consent_refused,
+                    programme: session.programme,
+                    school: session.location
       end
     end
 
@@ -69,13 +74,17 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_refused_with_notes,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
     end
 
     trait :consent_conflicting do
       patient do
-        association :patient, :consent_conflicting, programme: session.programme
+        association :patient,
+                    :consent_conflicting,
+                    programme: session.programme,
+                    school: session.location
       end
     end
 
@@ -83,7 +92,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do
@@ -102,7 +112,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do
@@ -114,7 +125,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do
@@ -126,7 +138,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do
@@ -150,7 +163,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_not_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
     end
 
@@ -158,7 +172,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do
@@ -184,7 +199,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do
@@ -208,7 +224,8 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
-                    programme: session.programme
+                    programme: session.programme,
+                    school: session.location
       end
 
       triage do

--- a/spec/models/cohort_spec.rb
+++ b/spec/models/cohort_spec.rb
@@ -22,14 +22,6 @@
 describe Cohort do
   subject(:cohort) { build(:cohort) }
 
-  describe "validations" do
-    it do
-      expect(cohort).to validate_comparison_of(
-        :birth_academic_year
-      ).is_greater_than_or_equal_to(1990)
-    end
-  end
-
   describe "scopes" do
     describe "#for_year_groups" do
       subject(:scope) { described_class.for_year_groups(year_groups) }
@@ -49,6 +41,14 @@ describe Cohort do
       around { |example| travel_to(today) { example.run } }
 
       it { should contain_exactly(year_one, year_two, year_three) }
+    end
+  end
+
+  describe "validations" do
+    it do
+      expect(cohort).to validate_comparison_of(
+        :birth_academic_year
+      ).is_greater_than_or_equal_to(1990)
     end
   end
 


### PR DESCRIPTION
This uses the `for_year_groups` scope, while also combining a check on the teams, ensuring that we don't expose cohorts for different teams that happen to match the same year groups when looking at a programme.

I've also improves the `example_campaign` trait to associate the cohorts with the team so they're visible.