### PR TITLE
Rename schools tab

### DIFF
--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -25,7 +25,7 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
       nav.with_item(
         href: sessions_programme_path(programme),
         selected: active == :sessions
-      ) { "Schools" }
+      ) { I18n.t("sessions.index.title") }
 
       nav.with_item(
         href: programme_vaccination_records_path(programme),

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -131,7 +131,9 @@ describe "Parental consent" do
     visit "/dashboard"
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "Schools"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
   end
@@ -145,7 +147,9 @@ describe "Parental consent" do
   def and_the_action_in_the_vaccination_session_is_to_check_refusal
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "Schools"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Record vaccinations"
 

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -42,7 +42,9 @@ describe "Parental consent" do
 
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "Schools"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
   end
@@ -154,9 +156,12 @@ describe "Parental consent" do
   def when_the_nurse_checks_the_consent_responses
     sign_in @team.users.first
     visit "/dashboard"
+
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "Schools"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
   end

--- a/spec/features/response_matching_spec.rb
+++ b/spec/features/response_matching_spec.rb
@@ -38,7 +38,9 @@ describe "Response matching" do
 
   def and_i_click_on_the_check_consent_responses_link
     click_on @programme.name
-    click_on "School sessions"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on @school.name
     click_on "Check consent responses"
   end

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -36,7 +36,9 @@ describe "Self-consent" do
 
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "School sessions"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
 

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -31,7 +31,9 @@ describe "Not Gillick competent" do
 
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "School sessions"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
 

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -46,7 +46,9 @@ describe "User authorisation" do
     visit "/dashboard"
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "Schools"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
   end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -34,7 +34,9 @@ feature "Verbal consent" do
     visit "/dashboard"
     click_on "Programmes", match: :first
     click_on "HPV"
-    click_on "Schools"
+    within ".app-secondary-navigation" do
+      click_on "School sessions"
+    end
     click_on "Pilot School"
     click_on "Check consent responses"
     click_on "Refused"


### PR DESCRIPTION
The prototype used to have a "Schools" tab separate to sessions which has been removed and this tab has been renamed back to "School sessions".