### PR TITLE
Don't show secondary navigation in consent journey

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
   before_action :set_header_path
   before_action :set_service_name
+  before_action :set_secondary_navigation
   before_action :authenticate_basic
 
   after_action :verify_policy_scoped,
@@ -35,6 +36,10 @@ class ApplicationController < ActionController::Base
 
   def set_service_name
     @service_name = "Manage vaccinations in schools"
+  end
+
+  def set_secondary_navigation
+    @show_secondary_navigation = current_user.present?
   end
 
   def set_disable_cache_headers

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -34,6 +34,10 @@ module ParentInterface
       @service_name = "Give or refuse consent for vaccinations"
     end
 
+    def set_secondary_navigation
+      @show_secondary_navigation = false
+    end
+
     def set_privacy_policy_url
       @privacy_policy_url = @session.programme.team.privacy_policy_url
     end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -36,9 +36,9 @@
     <% end %>
   </div>
 
-  <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
-    <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
-      <% if current_user.present? %>
+  <% if current_user.present? %>
+    <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
+      <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
         <li class="nhsuk-header__navigation-item">
           <%= link_to t("programmes.index.title"), programmes_path,
                       class: "nhsuk-header__navigation-link",
@@ -57,16 +57,16 @@
                       aria: { current: request.path.start_with?(vaccines_path) ?
                         "true" : nil } %>
         </li>
-      <% end %>
-      <li class="nhsuk-mobile-menu-container">
-        <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
-          <span class="nhsuk-u-visually-hidden">Browse</span>
-          More
-          <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-          </svg>
-        </button>
-      </li>
-    </ul>
-  </nav>
+        <li class="nhsuk-mobile-menu-container">
+          <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
+            <span class="nhsuk-u-visually-hidden">Browse</span>
+            More
+            <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+            </svg>
+          </button>
+        </li>
+      </ul>
+    </nav>
+  <% end %>
 </header>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -36,7 +36,7 @@
     <% end %>
   </div>
 
-  <% if current_user.present? %>
+  <% if @show_secondary_navigation %>
     <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
       <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
         <li class="nhsuk-header__navigation-item">


### PR DESCRIPTION
This ensures that if a nurse is signed in and they visit the consent journey, they don't see the secondary navigation that's part of the main Mavis app.

Review without whitespace.