### PR TITLE
Add AppWarningCalloutComponent

### DIFF
--- a/app/components/app_warning_callout_component.rb
+++ b/app/components/app_warning_callout_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AppWarningCalloutComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <div class="nhsuk-warning-callout">
+      <h3 class="nhsuk-warning-callout__label">
+        <span role="text">
+          <span class="nhsuk-u-visually-hidden">Important: </span>
+          <%= @heading %>
+        </span>
+      </h3>
+
+      <% if @description.present? %>
+        <p><%= @description %></p>
+      <% end %>
+
+      <%= content %>
+    </div>
+  ERB
+
+  def initialize(heading:, description: nil)
+    super
+
+    @heading = heading
+    @description = description
+  end
+end

--- a/app/views/cohort_imports/edit.html.erb
+++ b/app/views/cohort_imports/edit.html.erb
@@ -12,12 +12,7 @@
 
 <% if @cohort_import.exact_duplicate_record_count > 1 ||
       @cohort_import.changed_record_count > 1 %>
-  <div class="nhsuk-warning-callout">
-    <h3 class="nhsuk-warning-callout__label">
-      <span class="nhsuk-u-visually-hidden">Important: </span>
-      Uploaded records will differ from the file
-    </h3>
-
+  <%= render AppWarningCalloutComponent.new(heading: "Uploaded records will differ from file") do %>
     <ul class="nhsuk-list nhsuk-list--bullet">
       <% if @cohort_import.exact_duplicate_record_count > 1 %>
         <li>
@@ -32,7 +27,7 @@
         </li>
       <% end %>
     </ul>
-  </div>
+  <% end %>
 <% end %>
 
 <%= govuk_button_to "Upload records", programme_cohort_import_path(

--- a/app/views/immunisation_imports/duplicates/show.html.erb
+++ b/app/views/immunisation_imports/duplicates/show.html.erb
@@ -11,17 +11,7 @@
 <span class="nhsuk-caption-l"><%= @patient.full_name %></span>
 <%= h1 title, page_title: "#{@patient.full_name} – #{title}" %>
 
-<div class="nhsuk-warning-callout">
-  <h3 class="nhsuk-warning-callout__label">
-    <span class="nhsuk-u-visually-hidden">Important: </span>
-    This record needs reviewing
-  </h3>
-
-  <p>
-    A field in a duplicate record does not match that in a previously uploaded
-    record
-  </p>
-</div>
+<%= render AppWarningCalloutComponent.new(heading: "This record needs reviewing", description: "A field in a duplicate record does not match that in a previously uploaded record.") %>
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-half">

--- a/app/views/immunisation_imports/edit.html.erb
+++ b/app/views/immunisation_imports/edit.html.erb
@@ -10,7 +10,7 @@
 <span class="nhsuk-caption-l"><%= @programme.name %></span>
 <%= h1 title, page_title: "#{@programme.name} – #{title}" %>
 
-<% if @immunisation_import.exact_duplicate_record_count > 1 ||
+<% if @immunisation_import.exact_duplicate_record_count > 1 || @immunisation_import.changed_record_count > 1 ||
       @immunisation_import.not_administered_record_count > 1 %>
   <%= render AppWarningCalloutComponent.new(heading: "Uploaded records will differ from file") do %>
     <ul class="nhsuk-list nhsuk-list--bullet">
@@ -18,6 +18,12 @@
         <li>
           <%= @immunisation_import.exact_duplicate_record_count %> previously
           uploaded records were omitted
+        </li>
+      <% end %>
+
+      <% if @immunisation_import.changed_record_count > 1 %>
+        <li>
+          <%= @immunisation_import.changed_record_count %> previously uploaded records were updated
         </li>
       <% end %>
 

--- a/app/views/immunisation_imports/edit.html.erb
+++ b/app/views/immunisation_imports/edit.html.erb
@@ -12,12 +12,7 @@
 
 <% if @immunisation_import.exact_duplicate_record_count > 1 ||
       @immunisation_import.not_administered_record_count > 1 %>
-  <div class="nhsuk-warning-callout">
-    <h3 class="nhsuk-warning-callout__label">
-      <span class="nhsuk-u-visually-hidden">Important: </span>
-      Uploaded records will differ from the file
-    </h3>
-
+  <%= render AppWarningCalloutComponent.new(heading: "Uploaded records will differ from file") do %>
     <ul class="nhsuk-list nhsuk-list--bullet">
       <% if @immunisation_import.exact_duplicate_record_count > 1 %>
         <li>
@@ -33,7 +28,7 @@
         </li>
       <% end %>
     </ul>
-  </div>
+  <% end %>
 <% end %>
 
 <%= govuk_button_to "Upload records", programme_immunisation_import_path(

--- a/app/views/import_issues/show.html.erb
+++ b/app/views/import_issues/show.html.erb
@@ -10,17 +10,7 @@
 <span class="nhsuk-caption-l"><%= @vaccination_record.patient.full_name %></span>
 <%= h1 title, page_title: "#{@vaccination_record.patient.full_name} – #{title}" %>
 
-<div class="nhsuk-warning-callout">
-  <h3 class="nhsuk-warning-callout__label">
-    <span class="nhsuk-u-visually-hidden">Important: </span>
-    This record needs reviewing
-  </h3>
-
-  <p>
-    A field in a duplicate record does not match that in a previously uploaded
-    record
-  </p>
-</div>
+<%= render AppWarningCalloutComponent.new(heading: "This record needs reviewing", description: "A field in a duplicate record does not match that in a previously uploaded record.") %>
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-half">

--- a/spec/components/app_warning_callout_component_spec.rb
+++ b/spec/components/app_warning_callout_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe AppWarningCalloutComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(heading:, description:) }
+
+  let(:heading) { "Heading" }
+  let(:description) { "Description" }
+
+  it { should have_css(".nhsuk-warning-callout") }
+  it { should have_css(".nhsuk-u-visually-hidden", text: "Important:") }
+  it { should have_css("h3.nhsuk-warning-callout__label", text: "Heading") }
+  it { should have_css("p", text: "Description") }
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -184,6 +184,11 @@ RSpec.configure do |config|
   #
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
+
+  config.define_derived_metadata(
+    file_path: Regexp.new("/spec/components/")
+  ) { |metadata| metadata[:type] = :component }
+
   config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.


### PR DESCRIPTION
This adds a component which we can use to render a warning callout in the NHS style, simplifying where we render these. I've updated the places where we render callouts to use this component, and updated RSpec to automatically set the `type` to `:component` for files in the `spec/components` directory.