### PR TITLE
Show cohort when displaying patient summary

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -84,8 +84,8 @@ class AppPatientSummaryComponent < ViewComponent::Base
 
   def format_date_of_birth
     highlight_if(
-      "#{@patient.date_of_birth.to_fs(:long)} (aged #{@patient.age})",
-      @patient.date_of_birth_changed?
+      "#{@patient.date_of_birth.to_fs(:long)} (#{helpers.format_year_group(@patient.cohort.year_group)})",
+      @patient.date_of_birth_changed? || @patient.cohort_id_changed?
     )
   end
 

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -42,7 +42,7 @@ class VaccinationRecordsController < ApplicationController
           :performed_by_user,
           :programme,
           :vaccine,
-          patient: [:school, { parent_relationships: :parent }],
+          patient: [:cohort, :school, { parent_relationships: :parent }],
           session: :location
         )
         .where(programme:)

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -50,7 +50,7 @@ class Programme < ApplicationRecord
                  :batch,
                  :patient_session,
                  session: :location,
-                 patient: :school
+                 patient: %i[cohort school]
                )
                .strict_loading
            end,

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -46,6 +46,7 @@ describe AppPatientSummaryComponent do
 
   it { should have_content("Date of birth") }
   it { should have_content("1 January 2000") }
+  it { should have_content(/Year [0-9]+/) }
 
   it { should have_content("Sex") }
   it { should have_content("Male") }


### PR DESCRIPTION
This is useful to be able to highlight when the cohort has changed (likely due to the date of birth changing) after importing a patient record.

Depends on #1818.