### PR TITLE
Process cohort imports using background job

### DIFF
--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -28,11 +28,9 @@ class CohortImportsController < ApplicationController
       render :errors, status: :unprocessable_entity and return
     end
 
-    @cohort_import.process!
+    @cohort_import.save!
 
-    if @cohort_import.processed_only_exact_duplicates?
-      render :duplicates and return
-    end
+    ProcessCohortImportJob.perform_later(@programme, @cohort_import)
 
     redirect_to edit_programme_cohort_import_path(@programme, @cohort_import)
   end

--- a/app/jobs/process_cohort_import_job.rb
+++ b/app/jobs/process_cohort_import_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ProcessCohortImportJob < ApplicationJob
+  queue_as :default
+
+  def perform(programme, cohort_import)
+    cohort_import.programme = programme
+    cohort_import.process!
+  end
+end

--- a/app/views/cohort_imports/edit.html.erb
+++ b/app/views/cohort_imports/edit.html.erb
@@ -10,29 +10,35 @@
 <span class="nhsuk-caption-l"><%= @programme.name %></span>
 <%= h1 title, page_title: "#{@programme.name} – #{title}" %>
 
-<% if @cohort_import.exact_duplicate_record_count > 1 ||
-      @cohort_import.changed_record_count > 1 %>
-  <%= render AppWarningCalloutComponent.new(heading: "Uploaded records will differ from file") do %>
-    <ul class="nhsuk-list nhsuk-list--bullet">
-      <% if @cohort_import.exact_duplicate_record_count > 1 %>
-        <li>
-          <%= @cohort_import.exact_duplicate_record_count %> previously
-          uploaded records were omitted
-        </li>
-      <% end %>
+<% unless @cohort_import.processed? %>
+  <p>
+    This import is still processing. Please check back later.
+  </p>
+<% else %>
+  <% if @cohort_import.exact_duplicate_record_count > 1 ||
+        @cohort_import.changed_record_count > 1 %>
+    <%= render AppWarningCalloutComponent.new(heading: "Uploaded records will differ from file") do %>
+      <ul class="nhsuk-list nhsuk-list--bullet">
+        <% if @cohort_import.exact_duplicate_record_count > 1 %>
+          <li>
+            <%= @cohort_import.exact_duplicate_record_count %> previously
+            uploaded records were omitted
+          </li>
+        <% end %>
 
-      <% if @cohort_import.changed_record_count > 1 %>
-        <li>
-          <%= @cohort_import.changed_record_count %> previously uploaded records were updated
-        </li>
-      <% end %>
-    </ul>
+        <% if @cohort_import.changed_record_count > 1 %>
+          <li>
+            <%= @cohort_import.changed_record_count %> previously uploaded records were updated
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   <% end %>
+
+  <%= govuk_button_to "Upload records", programme_cohort_import_path(
+        @programme,
+        @cohort_import
+      ), method: :put %>
+
+  <%= render AppPatientTableComponent.new(@patients) %>
 <% end %>
-
-<%= govuk_button_to "Upload records", programme_cohort_import_path(
-      @programme,
-      @cohort_import
-    ), method: :put %>
-
-<%= render AppPatientTableComponent.new(@patients) %>

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -87,6 +87,8 @@ describe "End-to-end journey" do
     click_on "Import child records"
     attach_file "cohort_import[csv]", csv_file.path
     click_on "Continue"
+    perform_enqueued_jobs
+    visit current_path
     click_on "Upload records"
   end
 

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -25,7 +25,11 @@ describe "Import child records" do
     and_i_go_back_to_the_upload_page
 
     when_i_upload_a_valid_file
-    and_i_should_see_the_patients
+    then_i_should_see_the_holding_page
+
+    when_i_wait_for_the_background_job_to_complete
+    and_i_refresh_the_page
+    then_i_should_see_the_patients
 
     when_i_click_on_upload_records
     then_i_should_see_the_upload
@@ -43,9 +47,6 @@ describe "Import child records" do
     when_i_click_on_the_imports_tab
     and_i_choose_to_import_child_records
     then_i_should_see_the_import_page
-
-    when_i_upload_a_valid_file
-    then_i_should_see_the_duplicates_page
   end
 
   def given_the_app_is_setup
@@ -88,13 +89,14 @@ describe "Import child records" do
     click_on "Continue"
   end
 
-  def and_i_should_see_the_patients
+  def then_i_should_see_the_patients
     expect(page).to have_content("Full nameNHS numberDate of birthPostcode")
     expect(page).to have_content("Jimmy Smith")
     expect(page).to have_content(/NHS number.*123.*456.*7890/)
     expect(page).to have_content("Date of birth 1 January 2010")
     expect(page).to have_content("Postcode SW1A 1AA")
   end
+  alias_method :and_i_should_see_the_patients, :then_i_should_see_the_patients
 
   def when_i_click_on_upload_records
     click_on "Upload records"
@@ -180,9 +182,15 @@ describe "Import child records" do
     click_on "Back"
   end
 
-  def then_i_should_see_the_duplicates_page
-    expect(page).to have_content(
-      "All records in this CSV file have been uploaded."
-    )
+  def then_i_should_see_the_holding_page
+    expect(page).to have_content("This import is still processing")
+  end
+
+  def when_i_wait_for_the_background_job_to_complete
+    perform_enqueued_jobs
+  end
+
+  def and_i_refresh_the_page
+    visit current_path
   end
 end

--- a/spec/jobs/process_cohort_import_job_spec.rb
+++ b/spec/jobs/process_cohort_import_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe ProcessCohortImportJob do
+  let(:programme) { create(:programme) }
+  let(:cohort_import) { create(:cohort_import) }
+
+  describe "#perform" do
+    it "assigns the programme to the cohort import and processes it" do
+      allow(CohortImport).to receive(:find).and_return(cohort_import)
+      allow(Programme).to receive(:find).and_return(programme)
+      expect(cohort_import).to receive(:programme=).with(programme)
+      expect(cohort_import).to receive(:process!)
+
+      described_class.new.perform(programme, cohort_import)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new `ProcessCohortImportJob` that's called from the `CohortImportsController#create` action. The `edit` page is updated to display a holding message while processing is ongoing.

Review without whitespace changes.

TODO:

- [ ] Update the content/layout based on suggestions from designers
- [ ] Try to get it to stream and update automatically
- [x] Fix job spec
- [x] Fix other specs broken by this change

### Holding page

<img width="1007" alt="Screenshot 2024-09-24 at 17 20 39" src="https://github.com/user-attachments/assets/57444d0d-8996-4f0d-8ed5-edab09099ff0">

### After processing

<img width="1006" alt="Screenshot 2024-09-24 at 17 29 19" src="https://github.com/user-attachments/assets/1d03cd3c-3c84-479e-9a4d-72c5c689edd5">

