### PR TITLE
Add session table component

### DIFF
--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -1,0 +1,77 @@
+<div class="nhsuk-table__panel-with-heading-tab">
+  <h3 class="nhsuk-table__heading-tab"><%= heading %></h3>
+
+  <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Location") %>
+        <% row.with_cell(text: "Dates") %>
+        <% row.with_cell(text: "Programmes") if show_programmes %>
+        <% row.with_cell(text: "Consent period") if show_consent_period %>
+        <% row.with_cell(text: "Children", numeric: true) %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% sessions.each do |session| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Location</span>
+
+            <span>
+              <%= govuk_link_to session.location.name, session_path(session) %>
+
+              <% if (location = session.location).has_address? %>
+                <br />
+                <span class="nhsuk-u-secondary-text-color">
+                  <%= helpers.format_address_single_line(location) %>
+                </span>
+              <% end %>
+            </span>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Dates</span>
+
+            <ul class="nhsuk-list">
+              <% session.dates.each do |date| %>
+                <li><%= date.value.to_fs(:long) %></li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if show_programmes %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Programmes</span>
+
+              <ul class="nhsuk-list">
+                <% session.programmes.each do |programme| %>
+                  <li><%= programme.name %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          <% end %>
+
+          <% if show_consent_period %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Consent period</span>
+
+              <% if session.close_consent_at.nil? %>
+                n/a
+              <% elsif session.close_consent_at.past? %>
+                <%= "Closed #{session.close_consent_at.to_fs(:short)}" %>
+              <% else %>
+                <%= "Open until #{session.close_consent_at.to_fs(:short)}" %>
+              <% end %>
+            <% end %>
+          <% end %>
+
+          <% row.with_cell(numeric: true) do %>
+            <span class="nhsuk-table-responsive__heading">Children</span>
+            <%= (count = session.patients.count).zero? ? "None" : count %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/app_session_table_component.rb
+++ b/app/components/app_session_table_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AppSessionTableComponent < ViewComponent::Base
+  def initialize(
+    sessions,
+    description: "sessions",
+    show_programmes: false,
+    show_consent_period: false
+  )
+    super
+
+    @sessions = sessions
+    @description = description
+    @show_programmes = show_programmes
+    @show_consent_period = show_consent_period
+  end
+
+  private
+
+  attr_reader :sessions, :show_programmes, :show_consent_period
+
+  def heading
+    pluralize(sessions.count, @description)
+  end
+end

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -6,13 +6,6 @@ module AddressHelper
   end
 
   def format_address_single_line(addressable)
-    [
-      [
-        addressable.address_line_1,
-        addressable.address_line_2,
-        addressable.address_town
-      ].compact_blank.join(", "),
-      addressable.address_postcode
-    ].compact_blank.join(". ")
+    addressable.address_parts.join(", ")
   end
 end

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -11,55 +11,10 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :sessions) %>
 
-<% [[@in_progress_sessions, "In progress sessions"],
-    [@future_sessions, "Planned sessions"],
-    [@past_sessions, "Past sessions"]]
-     .select { |sessions, _| sessions.any? }.each do |sessions, title| %>
-  <div class="nhsuk-table__panel-with-heading-tab">
-    <h3 class="nhsuk-table__heading-tab"><%= title %></h3>
-    <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: "Dates") %>
-          <% row.with_cell(text: "Location") %>
-          <% row.with_cell(text: "Consent period") %>
-          <% row.with_cell(text: "Cohort") %>
-        <% end %>
-      <% end %>
+<% [[@in_progress_sessions, "active session"],
+    [@future_sessions, "planned session"],
+    [@past_sessions, "past session"]]
+     .select { |sessions, _| sessions.any? }.each do |sessions, description| %>
 
-      <% table.with_body do |body| %>
-        <% sessions.each do |session| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Dates</span>
-              <%= safe_join(session.dates.map { _1.value.to_fs(:long) }, tag.br) %>
-            <% end %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Location</span>
-              <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
-                <%= link_to session_location(session), session_path(session) %>
-                <% if (location = session.location)&.has_address? %>
-                  <br /><%= format_address_single_line(location) %>
-                <% end %>
-              </p>
-            <% end %>
-              <% row.with_cell do %>
-                <span class="nhsuk-table-responsive__heading">Consent period</span>
-                <% if session.close_consent_at.nil? %>
-                  n/a
-                <% elsif session.close_consent_at.past? %>
-                  <%= "Closed #{session.close_consent_at.to_fs(:short)}" %>
-                <% else %>
-                  <%= "Open until #{session.close_consent_at.to_fs(:short)}" %>
-                <% end %>
-              <% end %>
-            <% row.with_cell(numeric: true) do %>
-              <span class="nhsuk-table-responsive__heading">Cohort</span>
-              <%= session.patients.count %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render AppSessionTableComponent.new(sessions, description:, show_consent_period: true) %>
 <% end %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -6,36 +6,5 @@
 <% if @sessions.empty? %>
   <p>There are no sessions scheduled for today.</p>
 <% else %>
-  <div class="nhsuk-table__panel-with-heading-tab">
-    <h3 class="nhsuk-table__heading-tab"><%= pluralize(@sessions.count, "sessions") %></h3>
-
-    <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: "Location") %>
-          <% row.with_cell(text: "Cohort") %>
-        <% end %>
-      <% end %>
-
-      <% table.with_body do |body| %>
-        <% @sessions.each do |session| %>
-          <% body.with_row do |row| %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Location</span>
-              <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
-                <%= link_to session_location(session), session_path(session) %>
-                <% if (location = session.location)&.has_address? %>
-                  <br /><%= format_address_single_line(location) %>
-                <% end %>
-              </p>
-            <% end %>
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Cohort</span>
-              <%= session.patients.count %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render AppSessionTableComponent.new(@sessions, description: "active session", show_programmes: true) %>
 <% end %>

--- a/spec/components/app_session_table_component_spec.rb
+++ b/spec/components/app_session_table_component_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe AppSessionTableComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(sessions) }
+
+  let(:sessions) do
+    [
+      create(
+        :session,
+        academic_year: 2024,
+        date: Date.new(2024, 10, 1),
+        location: create(:location, :school, name: "Waterloo Road"),
+        programme: create(:programme, :hpv)
+      )
+    ] + create_list(:session, 9)
+  end
+
+  before { create_list(:patient, 5, session: sessions.first) }
+
+  it { should have_css(".nhsuk-table__heading-tab", text: "10 sessions") }
+
+  context "with a custom description" do
+    let(:component) do
+      described_class.new(sessions, description: "active sessions")
+    end
+
+    it { should have_content("10 active sessions") }
+  end
+
+  it "renders the headers" do
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Location")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Dates")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Children")
+  end
+
+  it "renders the rows" do
+    expect(rendered).to have_css(
+      ".nhsuk-table__body .nhsuk-table__row",
+      count: 10
+    )
+
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "Waterloo Road")
+
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "1 October 2024")
+
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "5")
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "None")
+  end
+
+  context "when showing programmes" do
+    let(:component) { described_class.new(sessions, show_programmes: true) }
+
+    it { should have_css(".nhsuk-table__header", text: "Programmes") }
+    it { should have_css(".nhsuk-table__cell", text: "HPV") }
+  end
+
+  context "when showing consent period" do
+    let(:component) { described_class.new(sessions, show_consent_period: true) }
+
+    it { should have_css(".nhsuk-table__header", text: "Consent period") }
+    it { should have_css(".nhsuk-table__cell", text: "Open until 1 October") }
+  end
+end

--- a/spec/helpers/address_helper_spec.rb
+++ b/spec/helpers/address_helper_spec.rb
@@ -20,6 +20,6 @@ RSpec.describe AddressHelper do
   describe "#format_address_single_line" do
     subject(:formatted_string) { helper.format_address_single_line(location) }
 
-    it { should eq("10 Downing Street, London. SW1A 1AA") }
+    it { should eq("10 Downing Street, London, SW1A 1AA") }
   end
 end


### PR DESCRIPTION
This adds a new component for rendering a table of sessions, which will be used when looking at the overview of school sessions and when looking at the sessions per programme.

## Screenshot

![Screenshot 2024-09-25 at 15 21 24](https://github.com/user-attachments/assets/3cd72604-f20f-4288-90a1-975c984621d2)
