### PR TITLE
Add active, planned and completed session tabs

### DIFF
--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -31,7 +31,7 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def gillick_assessment_applicable?
-    patient_session.session.in_progress?
+    patient_session.session.today?
   end
 
   def gillick_assessment_recorded?

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -14,33 +14,39 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
     render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
         href: programme_path(programme),
+        text: "Overview",
         selected: active == :overview
-      ) { "Overview" }
+      )
 
       nav.with_item(
         href: programme_cohorts_path(programme),
+        text: I18n.t("cohorts.index.title"),
         selected: active == :cohorts
-      ) { I18n.t("cohorts.index.title") }
+      )
 
       nav.with_item(
         href: sessions_programme_path(programme),
+        text: I18n.t("sessions.index.title"),
         selected: active == :sessions
-      ) { I18n.t("sessions.index.title") }
+      )
 
       nav.with_item(
         href: programme_vaccination_records_path(programme),
+        text: I18n.t("vaccination_records.index.title"),
         selected: active == :vaccination_records
-      ) { I18n.t("vaccination_records.index.title") }
+      )
 
       nav.with_item(
         href: programme_imports_path(programme),
+        text: I18n.t("imports.index.title"),
         selected: active == :imports
-      ) { I18n.t("imports.index.title") }
+      )
 
       nav.with_item(
         href: programme_import_issues_path(programme),
+        text: import_issues_text,
         selected: active == :import_issues
-      ) { import_issues_text }
+      )
     end
   end
 

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -21,7 +21,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def render?
-    @patient_session.next_step == :vaccinate && session.in_progress?
+    @patient_session.next_step == :vaccinate && session.today?
   end
 
   private

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -13,9 +13,9 @@ class ProgrammesController < ApplicationController
   end
 
   def sessions
-    @in_progress_sessions = @programme.sessions.active.in_progress
-    @future_sessions = @programme.sessions.active.future
-    @past_sessions = @programme.sessions.active.past
+    @today_sessions = @programme.sessions.active.today
+    @planned_sessions = @programme.sessions.active.planned
+    @completed_sessions = @programme.sessions.active.completed
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  before_action :set_session, except: %i[index create]
+  before_action :set_session, except: %i[index planned completed create]
 
   def create
     skip_policy_scope
@@ -21,6 +21,18 @@ class SessionsController < ApplicationController
 
   def index
     @sessions = policy_scope(Session).active.today
+
+    render layout: "full"
+  end
+
+  def planned
+    @sessions = policy_scope(Session).active.planned
+
+    render layout: "full"
+  end
+
+  def completed
+    @sessions = policy_scope(Session).active.completed
 
     render layout: "full"
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
   end
 
   def index
-    @sessions = policy_scope(Session).active.in_progress
+    @sessions = policy_scope(Session).active.today
 
     render layout: "full"
   end

--- a/app/jobs/session_reminders_job.rb
+++ b/app/jobs/session_reminders_job.rb
@@ -26,7 +26,11 @@ class SessionRemindersJob < ApplicationJob
     PatientSession
       .includes(:consents)
       .joins(:session)
-      .merge(Session.active.tomorrow)
+      .merge(
+        Session.active.where(
+          SessionDate.for_session.where(value: Date.tomorrow).arel.exists
+        )
+      )
       .reminder_not_sent
   end
 end

--- a/app/models/session_date.rb
+++ b/app/models/session_date.rb
@@ -22,6 +22,8 @@ class SessionDate < ApplicationRecord
 
   belongs_to :session
 
+  scope :for_session, -> { where("session_id = sessions.id") }
+
   validates :value,
             uniqueness: {
               scope: :session

--- a/app/views/patients/log.html.erb
+++ b/app/views/patients/log.html.erb
@@ -11,12 +11,8 @@
 <% end %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(href: session_patient_path(id: @patient.id)) {
-        "Child record"
-      }
-      nav.with_item(href: session_patient_log_path, selected: true) {
-        "Activity log"
-      }
+      nav.with_item(href: session_patient_path(id: @patient.id), text: "Child record")
+      nav.with_item(href: session_patient_log_path, text: "Activity log", selected: true)
     end %>
 
 <%= render AppActivityLogComponent.new(@patient_session) %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -13,11 +13,13 @@
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
         href: session_patient_path(id: @patient.id),
+        text: "Child record",
         selected: true,
-      ) { "Child record" }
+      )
       nav.with_item(
         href: session_patient_log_path(patient_id: @patient.id),
-      ) { "Activity log" }
+        text: "Activity log",
+      )
     end %>
 
 <%= render AppPatientPageComponent.new(

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -11,9 +11,9 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :sessions) %>
 
-<% [[@in_progress_sessions, "active session"],
-    [@future_sessions, "planned session"],
-    [@past_sessions, "past session"]]
+<% [[@today_sessions, "active session"],
+    [@planned_sessions, "planned session"],
+    [@completed_sessions, "completed session"]]
      .select { |sessions, _| sessions.any? }.each do |sessions, description| %>
 
   <%= render AppSessionTableComponent.new(sessions, description:, show_consent_period: true) %>

--- a/app/views/sessions/completed.html.erb
+++ b/app/views/sessions/completed.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{t("sessions.index.title")} – Completed" %>
+
+<%= h1 t("sessions.index.title"), size: "xl" %>
+
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(href: sessions_path, text: "Active")
+      nav.with_item(href: planned_sessions_path, text: "Planned")
+      nav.with_item(href: completed_sessions_path, text: "Completed", selected: true)
+    end %>
+
+<% if @sessions.empty? %>
+  <p>There are no sessions completed.</p>
+<% else %>
+  <%= render AppSessionTableComponent.new(@sessions, description: "completed session", show_programmes: true) %>
+<% end %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,7 +1,15 @@
+<% content_for :page_title, "#{t(".title")} – Active" %>
+
 <div class="app-heading-group">
   <%= h1 t(".title"), size: "xl" %>
   <%= govuk_button_to("Add a new session", sessions_path, secondary: true) %>
 </div>
+
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(href: sessions_path, text: "Active", selected: true)
+      nav.with_item(href: planned_sessions_path, text: "Planned")
+      nav.with_item(href: completed_sessions_path, text: "Completed")
+    end %>
 
 <% if @sessions.empty? %>
   <p>There are no sessions scheduled for today.</p>

--- a/app/views/sessions/planned.html.erb
+++ b/app/views/sessions/planned.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{t("sessions.index.title")} – Planned" %>
+
+<%= h1 t("sessions.index.title"), size: "xl" %>
+
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(href: sessions_path, text: "Active")
+      nav.with_item(href: planned_sessions_path, text: "Planned", selected: true)
+      nav.with_item(href: completed_sessions_path, text: "Completed")
+    end %>
+
+<% if @sessions.empty? %>
+  <p>There are no sessions planned.</p>
+<% else %>
+  <%= render AppSessionTableComponent.new(@sessions, description: "planned session", show_programmes: true) %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,6 +105,11 @@ Rails.application.routes.draw do
       end
     end
 
+    collection do
+      get "planned"
+      get "completed"
+    end
+
     resources :edit, controller: "sessions/edit", only: %i[show update]
 
     constraints -> { Flipper.enabled?(:dev_tools) } do

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -22,7 +22,7 @@ describe AppConsentComponent, type: :component do
 
   context "consent is not present and session is not in progress" do
     let(:patient_session) do
-      create(:patient_session, session: create(:session, :in_future))
+      create(:patient_session, session: create(:session, :planned))
     end
 
     it { should_not have_css("button", text: "Assess Gillick competence") }

--- a/spec/components/app_secondary_navigation_component_spec.rb
+++ b/spec/components/app_secondary_navigation_component_spec.rb
@@ -2,7 +2,7 @@
 
 require "govuk_helper"
 
-describe AppSecondaryNavigationComponent, type: :component do
+describe AppSecondaryNavigationComponent do
   subject { rendered_content }
 
   before { render_inline(component) }

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -6,7 +6,7 @@ describe AppVaccinateFormComponent do
   let(:heading) { "A Heading" }
   let(:body) { "A Body" }
   let(:programme) { create(:programme, :hpv) }
-  let(:session) { create(:session, :in_progress, programme:) }
+  let(:session) { create(:session, :today, programme:) }
   let(:vaccine) { programme.vaccines.first }
   let(:patient_session) do
     create(
@@ -65,13 +65,13 @@ describe AppVaccinateFormComponent do
       end
 
       context "session is in progress" do
-        let(:session) { create(:session, :in_progress, programme:) }
+        let(:session) { create(:session, :today, programme:) }
 
         it { should be_falsey }
       end
 
       context "session is in the future" do
-        let(:session) { create(:session, :in_future, programme:) }
+        let(:session) { create(:session, :planned, programme:) }
 
         it { should be_falsey }
       end
@@ -83,13 +83,13 @@ describe AppVaccinateFormComponent do
       end
 
       context "session is progress" do
-        let(:session) { create(:session, :in_progress, programme:) }
+        let(:session) { create(:session, :today, programme:) }
 
         it { should be_truthy }
       end
 
       context "session is in the future" do
-        let(:session) { create(:session, :in_future, programme:) }
+        let(:session) { create(:session, :planned, programme:) }
 
         it { should be_falsey }
       end

--- a/spec/factories/example_campaigns.rb
+++ b/spec/factories/example_campaigns.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
 
         create(
           :session,
-          :in_progress,
+          :today,
           team: programme.team,
           programme:,
           location:
@@ -100,7 +100,7 @@ FactoryBot.define do
 
         create(
           :session,
-          :in_past,
+          :completed,
           team: programme.team,
           programme:,
           location:
@@ -140,7 +140,7 @@ FactoryBot.define do
 
         create(
           :session,
-          :in_future,
+          :planned,
           team: programme.team,
           programme:,
           location:

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -291,7 +291,7 @@ FactoryBot.define do
     end
 
     trait :session_in_progress do
-      session { association :session, :in_progress, programme: }
+      session { association :session, :today, programme: }
     end
 
     trait :not_gillick_competent do

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -50,15 +50,15 @@ FactoryBot.define do
       active { false }
     end
 
-    trait :in_progress do
+    trait :today do
       date { Date.current }
     end
 
-    trait :in_future do
+    trait :planned do
       date { Date.current + 1.week }
     end
 
-    trait :in_past do
+    trait :completed do
       date { Date.current - 1.week }
     end
 

--- a/spec/features/manage_vaccines_batches_spec.rb
+++ b/spec/features/manage_vaccines_batches_spec.rb
@@ -24,7 +24,7 @@ describe "Batches" do
 
   def and_there_is_a_vaccination_session_today_with_one_patient_ready_to_vaccinate
     location = create(:location, :school)
-    session = create(:session, :in_progress, programme: @programme, location:)
+    session = create(:session, :today, programme: @programme, location:)
 
     create(:patient_session, :consent_given_triage_not_needed, session:)
 

--- a/spec/features/parental_consent_authentication_spec.rb
+++ b/spec/features/parental_consent_authentication_spec.rb
@@ -23,7 +23,7 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, programme:, location:)
+    @session = create(:session, :planned, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/parental_consent_backfilled_session_spec.rb
+++ b/spec/features/parental_consent_backfilled_session_spec.rb
@@ -11,7 +11,7 @@ describe "Parental consent for a backfilled session" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_past, :minimal, programme:, location:)
+    @session = create(:session, :completed, :minimal, programme:, location:)
   end
 
   def when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -75,7 +75,7 @@ RSpec.feature "Parental consent change answers" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :flu, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, team: @team, programme:, location:)
+    @session = create(:session, :planned, team: @team, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -23,7 +23,7 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :flu, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, programme:, location:)
+    @session = create(:session, :planned, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -27,7 +27,7 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, team: @team, programme:, location:)
+    @session = create(:session, :planned, team: @team, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -32,7 +32,7 @@ describe "Parental consent" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, team: @team, programme:, location:)
+    @session = create(:session, :planned, team: @team, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -21,7 +21,7 @@ describe "Self-consent" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, team: @team, programme:, location:)
+    @session = create(:session, :planned, team: @team, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -16,7 +16,7 @@ describe "Not Gillick competent" do
     @team = create(:team, :with_one_nurse)
     programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
-    @session = create(:session, :in_future, team: @team, programme:, location:)
+    @session = create(:session, :planned, team: @team, programme:, location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -30,6 +30,9 @@ describe "Session management" do
     when_i_go_to_todays_sessions_as_a_nurse
     then_i_see_no_sessions
 
+    when_i_go_to_planned_sessions_as_a_nurse
+    then_i_see_the_new_session
+
     when_the_parent_visits_the_consent_form
     then_they_can_give_consent
 
@@ -38,6 +41,9 @@ describe "Session management" do
 
     when_i_go_to_todays_sessions_as_a_nurse
     then_i_see_the_new_session
+
+    when_i_go_to_planned_sessions_as_a_nurse
+    then_i_see_no_sessions
   end
 
   def given_my_team_is_running_an_hpv_vaccination_programme
@@ -51,6 +57,13 @@ describe "Session management" do
     sign_in @team.users.first
     visit "/dashboard"
     click_link "School sessions", match: :first
+  end
+
+  def when_i_go_to_planned_sessions_as_a_nurse
+    sign_in @team.users.first
+    visit "/dashboard"
+    click_link "School sessions", match: :first
+    click_link "Planned"
   end
 
   def then_i_see_no_sessions

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -26,11 +26,11 @@ describe "User authorisation" do
       create(:programme, :hpv, team: @other_team, vaccines: [vaccine])
     location = create(:location, :school, name: "Pilot School")
     other_location = create(:location, :school, name: "Other School")
-    @session = create(:session, :in_future, team: @team, programme:, location:)
+    @session = create(:session, :planned, team: @team, programme:, location:)
     @other_session =
       create(
         :session,
-        :in_future,
+        :planned,
         team: @other_team,
         programme: other_programme,
         location: other_location

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -17,13 +17,7 @@ feature "Verbal consent" do
     @programme = create(:programme, :hpv, team: @team)
     location = create(:location, :school, name: "Pilot School")
     @session =
-      create(
-        :session,
-        :in_future,
-        team: @team,
-        programme: @programme,
-        location:
-      )
+      create(:session, :planned, team: @team, programme: @programme, location:)
   end
 
   def and_a_parent_has_refused_consent_for_their_child

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -49,23 +49,23 @@ describe Session, type: :model do
     end
   end
 
-  describe "#in_progress?" do
-    subject { session.in_progress? }
+  describe "#today?" do
+    subject { session.today? }
 
     context "when the session is scheduled for today" do
-      let(:session) { create(:session, :in_progress) }
+      let(:session) { create(:session, :today) }
 
       it { should be_truthy }
     end
 
     context "when the session is scheduled in the past" do
-      let(:session) { create(:session, :in_past) }
+      let(:session) { create(:session, :completed) }
 
       it { should be_falsey }
     end
 
     context "when the session is scheduled in the future" do
-      let(:session) { create(:session, :in_future) }
+      let(:session) { create(:session, :planned) }
 
       it { should be_falsey }
     end


### PR DESCRIPTION
This adds new tabs to the "School sessions" page allowing the user to see the sessions that are active, planned in the future, and already completed in the past.

I've also refactored the date scopes for sessions to matching the naming convention we'll be using the UI, and to fix the queries to work with the new multiple session dates.

Ideally the `today` scope would be named `active`, but this clashes with the `active` column. Eventually I think we'll be able to rename this when we create sessions automatically from locations.

## Screenshots

![Screenshot 2024-09-25 at 16 18 01](https://github.com/user-attachments/assets/ec30dace-46c7-450c-8b68-57d62182293e)
![Screenshot 2024-09-25 at 16 18 05](https://github.com/user-attachments/assets/eb3487ff-5a67-4195-87b7-c9b62a69a099)
![Screenshot 2024-09-25 at 16 18 08](https://github.com/user-attachments/assets/516fceca-93ad-4d1f-b645-62d7d4f0fd61)
