### PR TITLE
Add unscheduled sessions table

### DIFF
--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -19,7 +19,11 @@
             <span class="nhsuk-table-responsive__heading">Location</span>
 
             <span>
-              <%= govuk_link_to session.location.name, session_path(session) %>
+              <% if session.new_record? %>
+                <%= session.location.name %>
+              <% else %>
+                <%= govuk_link_to session.location.name, session_path(session) %>
+              <% end %>
 
               <% if (location = session.location).has_address? %>
                 <br />

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -13,7 +13,20 @@ class ProgrammesController < ApplicationController
   end
 
   def sessions
+    academic_year = Date.current.academic_year
+
     @scheduled_sessions = @programme.sessions.scheduled
+
+    @unscheduled_sessions =
+      @programme.sessions.unscheduled +
+        Location
+          .school
+          .for_programme(@programme)
+          .has_no_session(academic_year)
+          .map do |location|
+            Session.new(team: @programme.team, location:, academic_year:)
+          end
+
     @completed_sessions = @programme.sessions.completed
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -54,6 +54,18 @@ class Location < ApplicationRecord
           )
         end
 
+  scope :has_no_session,
+        ->(academic_year) do
+          where.not(
+            Session
+              .where(academic_year:)
+              .where("location_id = locations.id")
+              .where("team_id = locations.team_id")
+              .arel
+              .exists
+          )
+        end
+
   validates :name, presence: true
   validates :url, url: true, allow_nil: true
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -78,6 +78,8 @@ class Session < ApplicationRecord
   scope :send_consent_reminders_today,
         -> { where(send_consent_reminders_at: Time.zone.today) }
 
+  after_initialize :set_programmes
+
   after_initialize :set_timeline_attributes
   after_validation :set_timeline_timestamps
 
@@ -152,6 +154,14 @@ class Session < ApplicationRecord
     return if programmes.empty?
 
     errors.add(:programmes, :inclusion) if programmes.map(&:team).uniq != [team]
+  end
+
+  def set_programmes
+    return unless new_record?
+    return if location.nil? || team.nil?
+
+    self.programmes =
+      team.programmes.select { _1.year_groups.intersect?(location.year_groups) }
   end
 
   def set_timeline_attributes

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -11,7 +11,8 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :sessions) %>
 
-<% [[@scheduled_sessions, "Sessions scheduled"],
+<% [[@unscheduled_sessions, "No sessions scheduled"],
+    [@scheduled_sessions, "Sessions scheduled"],
     [@completed_sessions, "All sessions completed"]]
      .select { |sessions, _| sessions.any? }.each do |sessions, heading| %>
 

--- a/app/views/sessions/completed.html.erb
+++ b/app/views/sessions/completed.html.erb
@@ -4,6 +4,7 @@
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(href: sessions_path, text: "Today")
+      nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled")
       nav.with_item(href: completed_sessions_path, text: "Completed", selected: true)
     end %>

--- a/app/views/sessions/scheduled.html.erb
+++ b/app/views/sessions/scheduled.html.erb
@@ -1,9 +1,10 @@
-<% content_for :page_title, "#{t("sessions.index.title")} – Planned" %>
+<% content_for :page_title, "#{t("sessions.index.title")} – Scheduled" %>
 
 <%= h1 t("sessions.index.title"), size: "xl" %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(href: sessions_path, text: "Today")
+      nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled", selected: true)
       nav.with_item(href: completed_sessions_path, text: "Completed")
     end %>

--- a/app/views/sessions/unscheduled.html.erb
+++ b/app/views/sessions/unscheduled.html.erb
@@ -1,13 +1,10 @@
-<% content_for :page_title, "#{t(".title")} – Active" %>
+<% content_for :page_title, "#{t("sessions.index.title")} – Unscheduled" %>
 
-<div class="app-heading-group">
-  <%= h1 t(".title"), size: "xl" %>
-  <%= govuk_button_to("Add a new session", sessions_path, secondary: true) %>
-</div>
+<%= h1 t("sessions.index.title"), size: "xl" %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(href: sessions_path, text: "Today", selected: true)
-      nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
+      nav.with_item(href: sessions_path, text: "Today")
+      nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled", selected: true)
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled")
       nav.with_item(href: completed_sessions_path, text: "Completed")
     end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,8 +106,9 @@ Rails.application.routes.draw do
     end
 
     collection do
-      get "scheduled"
       get "completed"
+      get "scheduled"
+      get "unscheduled"
     end
 
     resources :edit, controller: "sessions/edit", only: %i[show update]

--- a/spec/factories/example_programmes.rb
+++ b/spec/factories/example_programmes.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
 
     team { user.team || create(:team, users: [user]) }
 
+    after(:create) do |_programme, context|
+      create_list(:location, 20, :school, team: context.team)
+    end
+
     trait :in_progress do
       after(:create) do |programme, context|
         location = context.location

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -53,11 +53,13 @@ FactoryBot.define do
 
     trait :primary do
       school
+      name { Faker::Educator.primary_school }
       year_groups { (0..6).to_a }
     end
 
     trait :secondary do
       school
+      name { Faker::Educator.secondary_school }
       year_groups { (7..11).to_a }
     end
   end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
     academic_year { (date || Date.current).academic_year }
     programmes { [programme] }
     team { programmes.first&.team || association(:team) }
-    location { association :location, :school }
+    location { association :location, :school, team: }
 
     send_consent_requests_at { date - 14.days if date }
     send_consent_reminders_at do

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -5,10 +5,15 @@ describe "Session management" do
 
   scenario "Adding a new session, closing consent" do
     given_my_team_is_running_an_hpv_vaccination_programme
+
     when_i_go_to_todays_sessions_as_a_nurse
     then_i_see_no_sessions
 
-    when_i_add_a_new_session
+    when_i_go_to_unscheduled_sessions
+    then_i_see_the_school
+
+    when_i_go_to_todays_sessions_as_a_nurse
+    and_i_add_a_new_session
     then_i_see_the_list_of_schools
 
     when_i_choose_a_school
@@ -31,7 +36,7 @@ describe "Session management" do
     then_i_see_no_sessions
 
     when_i_go_to_scheduled_sessions
-    then_i_see_the_new_session
+    then_i_see_the_school
 
     when_the_parent_visits_the_consent_form
     then_they_can_give_consent
@@ -40,10 +45,13 @@ describe "Session management" do
     then_they_can_no_longer_give_consent
 
     when_i_go_to_todays_sessions_as_a_nurse
-    then_i_see_the_new_session
+    then_i_see_the_school
+
+    when_i_go_to_unscheduled_sessions
+    then_i_see_no_sessions
 
     when_i_go_to_scheduled_sessions
-    then_i_see_the_new_session
+    then_i_see_the_school
 
     when_i_go_to_completed_sessions
     then_i_see_no_sessions
@@ -52,7 +60,7 @@ describe "Session management" do
   def given_my_team_is_running_an_hpv_vaccination_programme
     @team = create(:team, :with_one_nurse)
     create(:programme, :hpv, team: @team)
-    @location = create(:location, :school)
+    @location = create(:location, :secondary, team: @team)
     @patient = create(:patient, school: @location)
   end
 
@@ -60,6 +68,10 @@ describe "Session management" do
     sign_in @team.users.first
     visit "/dashboard"
     click_link "School sessions", match: :first
+  end
+
+  def when_i_go_to_unscheduled_sessions
+    click_link "Unscheduled"
   end
 
   def when_i_go_to_scheduled_sessions
@@ -74,7 +86,7 @@ describe "Session management" do
     expect(page).to have_content(/There are no (sessions|schools)/)
   end
 
-  def when_i_add_a_new_session
+  def and_i_add_a_new_session
     click_button "Add a new session"
   end
 
@@ -161,7 +173,7 @@ describe "Session management" do
     expect(page).to have_content("The deadline for responding has passed")
   end
 
-  def then_i_see_the_new_session
+  def then_i_see_the_school
     expect(page).to have_content(@location.name)
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -33,7 +33,7 @@
 describe Location do
   describe "scopes" do
     describe "#for_programme" do
-      subject(:for_programme) { described_class.for_programme(programme) }
+      subject(:scope) { described_class.for_programme(programme) }
 
       let(:team) { create(:team) }
       let(:programme) { create(:programme, :hpv, team:) } # 8-11
@@ -44,6 +44,26 @@ describe Location do
       it { should include(matching) }
       it { should_not include(mismatch_year_group) }
       it { should_not include(mismatch_team) }
+    end
+
+    describe "#has_no_session" do
+      subject(:scope) { described_class.has_no_session(academic_year) }
+
+      let(:academic_year) { 2024 }
+
+      let(:location_with_session) { create(:session).location }
+      let(:location_without_session) { create(:location, :school) }
+      let(:location_with_session_in_different_year) do
+        create(
+          :session,
+          academic_year: 2023,
+          date: Date.new(2023, 9, 1)
+        ).location
+      end
+
+      it { should include(location_without_session) }
+      it { should_not include(location_with_session) }
+      it { should include(location_with_session_in_different_year) }
     end
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -67,6 +67,18 @@ describe Session do
     end
   end
 
+  it "sets default programmes when creating a new session" do
+    team = create(:team)
+    location = create(:location, :primary)
+    hpv_programme = create(:programme, :hpv, team:)
+    flu_programme = create(:programme, :flu, team:)
+
+    session = described_class.new(team:, location:)
+
+    expect(session.programmes).to include(flu_programme)
+    expect(session.programmes).not_to include(hpv_programme)
+  end
+
   describe "#today?" do
     subject { session.today? }
 


### PR DESCRIPTION
This adds a table showing unscheduled sessions for the team and for an individual programme, based on the table in the designs.

When looking at a team level we see all the locations associated with the team that have no sessions, and when looking at it from a programme level we see only locations with appropriate year groups.

## Screenshots

<img width="1222" alt="Screenshot 2024-09-26 at 10 53 21" src="https://github.com/user-attachments/assets/9d84f25e-a567-4055-a08a-41af8fb2f72f">
<img width="1211" alt="Screenshot 2024-09-26 at 10 53 08" src="https://github.com/user-attachments/assets/9c0037f4-ccc4-4208-98e5-fb36ae440958">
