### PR TITLE
Create sessions from schools

### DIFF
--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -20,7 +20,7 @@
 
             <span>
               <% if session.new_record? %>
-                <%= session.location.name %>
+                <%= govuk_link_to session.location.name, new_session_path(session, location_id: session.location.id) %>
               <% else %>
                 <%= govuk_link_to session.location.name, session_path(session) %>
               <% end %>

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -87,10 +87,6 @@ class Session < ApplicationRecord
 
   validate :programmes_part_of_team
 
-  on_wizard_step :location, exact: true do
-    validates :location_id, presence: true
-  end
-
   on_wizard_step :when, exact: true do
     validates :date, presence: true
   end
@@ -129,7 +125,7 @@ class Session < ApplicationRecord
   end
 
   def wizard_steps
-    %i[location when cohort timeline confirm]
+    %i[when cohort timeline confirm]
   end
 
   def days_between_consent_and_session

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,9 +1,6 @@
 <% content_for :page_title, "#{t(".title")} – Active" %>
 
-<div class="app-heading-group">
-  <%= h1 t(".title"), size: "xl" %>
-  <%= govuk_button_to("Add a new session", sessions_path, secondary: true) %>
-</div>
+<%= h1 t(".title"), size: "xl" %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(href: sessions_path, text: "Today", selected: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :sessions, only: %i[create edit index show] do
+  resources :sessions, only: %i[new edit index show] do
     namespace :parent_interface, path: "/" do
       resources :consent_forms, path: :consents, only: [:create] do
         get "start", on: :collection

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -43,7 +43,7 @@ describe "End-to-end journey" do
   def given_an_hpv_programme_is_underway
     @team = create(:team, :with_one_nurse)
     @programme = create(:programme, :hpv, team: @team)
-    @school = create(:location, :school, name: "Pilot School")
+    @school = create(:location, :secondary, team: @team, name: "Pilot School")
   end
 
   def and_i_am_a_nurse_signed_into_the_service
@@ -98,11 +98,8 @@ describe "End-to-end journey" do
 
   def when_i_start_creating_a_new_session_by_choosing_school_and_time
     click_on "School sessions"
-    click_on "Add a new session"
-
-    expect(page).to have_content("Which school is it at?")
-    select "Pilot School"
-    click_on "Continue"
+    click_on "Unscheduled"
+    click_on "Pilot School"
 
     expect(page).to have_content("When is the session?")
     fill_in "Day", with: "1"

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -11,12 +11,7 @@ describe "Session management" do
 
     when_i_go_to_unscheduled_sessions
     then_i_see_the_school
-
-    when_i_go_to_todays_sessions_as_a_nurse
-    and_i_add_a_new_session
-    then_i_see_the_list_of_schools
-
-    when_i_choose_a_school
+    then_i_click_on_the_school
     then_i_see_the_date_step
 
     when_i_choose_the_date
@@ -86,17 +81,8 @@ describe "Session management" do
     expect(page).to have_content(/There are no (sessions|schools)/)
   end
 
-  def and_i_add_a_new_session
-    click_button "Add a new session"
-  end
-
-  def then_i_see_the_list_of_schools
-    expect(page).to have_content(@location.name)
-  end
-
-  def when_i_choose_a_school
-    select @location.name
-    click_button "Continue"
+  def then_i_click_on_the_school
+    click_link @location.name
   end
 
   def then_i_see_the_date_step

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -55,18 +55,6 @@ describe Session do
     end
   end
 
-  describe "validations" do
-    context "when wizard_step is location" do
-      subject { build(:session, wizard_step:, programme:) }
-
-      let(:wizard_step) { :location }
-      let(:team) { create(:team) }
-      let(:programme) { create(:programme, team:) }
-
-      it { should validate_presence_of(:location_id).on(:update) }
-    end
-  end
-
   it "sets default programmes when creating a new session" do
     team = create(:team)
     location = create(:location, :primary)


### PR DESCRIPTION
This updates the journey for creating sessions by removing the "Add a new session" button and replacing it with the "Unscheduled" tab. When a user clicks on one of these schools, an unscheduled session is automatically created for it and the user is redirected to the session page.