### PR TITLE
Add summary list to session page

### DIFF
--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class AppSessionSummaryComponent < ViewComponent::Base
+  def initialize(session)
+    super
+
+    @session = session
+  end
+
+  def call
+    govuk_summary_list(
+      classes: %w[app-summary-list--full-width nhsuk-u-margin-bottom-4]
+    ) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Programmes" }
+        row.with_value { programmes }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Session dates" }
+        row.with_value { dates }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Consent period" }
+        row.with_value { consent_period }
+      end
+      summary_list.with_row do |row|
+        row.with_key { "Children" }
+        row.with_value { children }
+      end
+    end
+  end
+
+  private
+
+  def programmes
+    tag.ul(class: "nhsuk-list") do
+      safe_join(@session.programmes.map { tag.li(_1.name) })
+    end
+  end
+
+  def dates
+    if (dates = @session.dates).present?
+      tag.ul(class: "nhsuk-list") do
+        safe_join(dates.map { tag.li(_1.value.to_fs(:long)) })
+      end
+    else
+      "Not provided"
+    end
+  end
+
+  def consent_period
+    helpers.session_consent_period(@session)
+  end
+
+  def children
+    "#{I18n.t("children", count: @session.patients.count)} in this session"
+  end
+end

--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -65,14 +65,7 @@
           <% if show_consent_period %>
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Consent period</span>
-
-              <% if session.close_consent_at.nil? %>
-                n/a
-              <% elsif session.close_consent_at.past? %>
-                <%= "Closed #{session.close_consent_at.to_fs(:short)}" %>
-              <% else %>
-                <%= "Open until #{session.close_consent_at.to_fs(:short)}" %>
-              <% end %>
+              <%= helpers.session_consent_period(session) %>
             <% end %>
           <% end %>
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module SessionsHelper
+  def session_consent_period(session)
+    if session.close_consent_at.nil?
+      "Not provided"
+    elsif session.close_consent_at.past?
+      "Closed #{session.close_consent_at.to_fs(:short)}"
+    else
+      "Open until #{session.close_consent_at.to_fs(:short)}"
+    end
+  end
+
   def session_location(session, part_of_sentence: false)
     if (location = session.location).present?
       location.name

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -13,45 +13,54 @@
   <%= link_to "View session", edit_session_path %>
 </p>
 
-<ul class="nhsuk-grid-row nhsuk-card-group">
-  <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: "#") do |c| %>
-      <% c.with_heading { "Register attendance" } %>
-      <% c.with_description do %>
-        <%= t("children", count: @patient_sessions.size) %> still to register
-      <% end %>
-    <% end %>
-  </li>
-  <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
-      <% c.with_heading { "Record vaccinations" } %>
-      <% c.with_description do %>
-        <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
-        <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
-        <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
-      <% end %>
-    <% end %>
-  </li>
-  <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
-      <% c.with_heading { "Check consent responses" } %>
-      <% c.with_description do %>
-        <%= t("children", count: @counts[:without_a_response]) %> without a response<br>
-        <%= t("children", count: @counts[:with_consent_given]) %> with consent given<br>
-        <%= t("children", count: @counts[:with_consent_refused]) %> with consent refused<br>
-        <%= t("children", count: @counts[:with_conflicting_consent]) %> with conflicting consent
-      <% end %>
-    <% end %>
-  </li>
-  <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
-      <% c.with_heading { "Triage health questions" } %>
-      <% c.with_description do %>
-        <%= t("children", count: @counts[:needing_triage]) %> needing triage
-      <% end %>
-    <% end %>
-  </li>
-</ul>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <ul class="nhsuk-grid-row nhsuk-card-group">
+      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <%= render AppCardComponent.new(link_to: "#") do |c| %>
+          <% c.with_heading { "Register attendance" } %>
+          <% c.with_description do %>
+            <%= t("children", count: @patient_sessions.size) %> still to register
+          <% end %>
+        <% end %>
+      </li>
+      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
+          <% c.with_heading { "Record vaccinations" } %>
+          <% c.with_description do %>
+            <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
+            <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
+            <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
+          <% end %>
+        <% end %>
+      </li>
+      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
+          <% c.with_heading { "Check consent responses" } %>
+          <% c.with_description do %>
+            <%= t("children", count: @counts[:without_a_response]) %> without a response<br>
+            <%= t("children", count: @counts[:with_consent_given]) %> with consent given<br>
+            <%= t("children", count: @counts[:with_consent_refused]) %> with consent refused<br>
+            <%= t("children", count: @counts[:with_conflicting_consent]) %> with conflicting consent
+          <% end %>
+        <% end %>
+      </li>
+      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
+          <% c.with_heading { "Triage health questions" } %>
+          <% c.with_description do %>
+            <%= t("children", count: @counts[:needing_triage]) %> needing triage
+          <% end %>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+
+  <div class="nhsuk-grid-column-one-third">
+    <%= render AppSessionSummaryComponent.new(@session) %>
+  </div>
+</div>
 
 <% content_for :after_main do %>
   <%= render(AppDevToolsComponent.new) do %>

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+describe AppSessionSummaryComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(session) }
+
+  let(:programme) { create(:programme, :hpv) }
+  let(:session) { create(:session, date: Date.new(2024, 1, 1), programme:) }
+
+  it { should have_content("Programmes") }
+  it { should have_content("HPV") }
+
+  it { should have_content("Session dates") }
+  it { should have_content("1 January 2024") }
+
+  it { should have_content("Consent period") }
+  it { should have_content("Closed 1 January") }
+
+  it { should have_content("Children") }
+  it { should have_content("No children") }
+end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -3,7 +3,26 @@
 RSpec.describe SessionsHelper do
   let(:programme) { build(:programme, :flu) }
   let(:location) { build(:location, name: "Waterloo Road") }
-  let(:session) { build(:session, programme:, location:) }
+  let(:close_consent_at) { nil }
+  let(:session) { build(:session, programme:, close_consent_at:, location:) }
+
+  describe "#session_consent_period" do
+    subject(:session_consent_period) { helper.session_consent_period(session) }
+
+    it { should eq("Not provided") }
+
+    context "when in the past" do
+      let(:close_consent_at) { Date.yesterday }
+
+      it { should start_with("Closed ") }
+    end
+
+    context "when in the future" do
+      let(:close_consent_at) { Date.tomorrow }
+
+      it { should start_with("Open until ") }
+    end
+  end
 
   describe "#session_location" do
     subject(:session_location) { helper.session_location(session) }


### PR DESCRIPTION
This adds the summary list sidebar to the session page as per the designs.

## Screenshots

<img width="413" alt="Screenshot 2024-09-26 at 12 07 16" src="https://github.com/user-attachments/assets/76062807-6949-487c-b16b-6f7b3437cb79">
<img width="414" alt="Screenshot 2024-09-26 at 12 07 01" src="https://github.com/user-attachments/assets/12c36bf4-72c2-4954-a146-0711584e230e">
