### PR TITLE
Add session status tag

### DIFF
--- a/app/assets/stylesheets/_action_list.scss
+++ b/app/assets/stylesheets/_action_list.scss
@@ -1,0 +1,33 @@
+.app-action-list {
+  @include nhsuk-typography-responsive(19);
+  @include nhsuk-responsive-margin(7, "bottom");
+
+  display: flex;
+  padding: 0;
+
+  .nhsuk-table__cell & {
+    margin-bottom: 0;
+  }
+
+  .nhsuk-link {
+    @include nhsuk-link-style-no-visited-state;
+  }
+}
+
+.app-action-list__item {
+  align-self: center;
+  display: inline-flex;
+  margin: 0;
+  margin-right: nhsuk-spacing(3);
+  padding-right: nhsuk-spacing(3);
+}
+
+.app-action-list__item:not(:last-child) {
+  border-right: 1px solid $nhsuk-border-color;
+}
+
+.app-action-list__item:last-child {
+  border: 0;
+  margin-right: 0;
+  padding-right: 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ $color_app-dark-orange: darken(
 );
 
 // Application components
+@import "action_list";
 @import "button";
 @import "button-group";
 @import "card";

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -18,4 +18,14 @@ module SessionsHelper
       part_of_sentence ? "unknown location" : "Unknown location"
     end
   end
+
+  def session_status_tag(session)
+    if session.unscheduled?
+      govuk_tag(text: "No sessions scheduled", colour: "purple")
+    elsif session.completed?
+      govuk_tag(text: "All sessions completed", colour: "green")
+    else
+      govuk_tag(text: "Session in progress")
+    end
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -129,6 +129,11 @@ class Session < ApplicationRecord
     dates.empty?
   end
 
+  def completed?
+    return false if unscheduled?
+    Date.current > dates.map(&:value).max
+  end
+
   def wizard_steps
     %i[when cohort timeline confirm]
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -125,6 +125,10 @@ class Session < ApplicationRecord
     dates.map(&:value).include?(Date.current)
   end
 
+  def unscheduled?
+    dates.empty?
+  end
+
   def wizard_steps
     %i[when cohort timeline confirm]
   end

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -8,10 +8,11 @@
 
 <%= h1 session_location(@session) %>
 
-<p class="nhsuk-body nhsuk-u-margin-bottom-7">
-  <%= govuk_tag(text: "In progress", colour: "blue", classes: "nhsuk-u-margin-right-3") %>
-  <%= link_to "View session", edit_session_path %>
-</p>
+<ul class="app-action-list">
+  <li class="app-action-list__item">
+    <%= session_status_tag(@session) %>
+  </li>
+</ul>
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -43,4 +43,38 @@ RSpec.describe SessionsHelper do
       end
     end
   end
+
+  describe "#session_status_tag" do
+    subject(:session_status_tag) { helper.session_status_tag(session) }
+
+    context "when unscheduled" do
+      let(:session) { create(:session, :unscheduled) }
+
+      it do
+        expect(session_status_tag).to eq(
+          "<strong class=\"nhsuk-tag nhsuk-tag--purple\">No sessions scheduled</strong>"
+        )
+      end
+    end
+
+    context "when completed" do
+      let(:session) { create(:session, :completed) }
+
+      it do
+        expect(session_status_tag).to eq(
+          "<strong class=\"nhsuk-tag nhsuk-tag--green\">All sessions completed</strong>"
+        )
+      end
+    end
+
+    context "when scheduled" do
+      let(:session) { create(:session, :scheduled) }
+
+      it do
+        expect(session_status_tag).to eq(
+          "<strong class=\"nhsuk-tag\">Session in progress</strong>"
+        )
+      end
+    end
+  end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -69,7 +69,7 @@ describe Session do
   end
 
   describe "#today?" do
-    subject { session.today? }
+    subject(:today?) { session.today? }
 
     context "when the session is scheduled for today" do
       let(:session) { create(:session, :today) }
@@ -87,6 +87,20 @@ describe Session do
       let(:session) { create(:session, :scheduled) }
 
       it { should be_falsey }
+    end
+  end
+
+  describe "#unscheduled?" do
+    subject(:unscheduled?) { session.unscheduled? }
+
+    let(:session) { create(:session, date: nil) }
+
+    it { should be(true) }
+
+    context "with a date" do
+      before { create(:session_date, session:) }
+
+      it { should be(false) }
     end
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -103,4 +103,24 @@ describe Session do
       it { should be(false) }
     end
   end
+
+  describe "#completed?" do
+    subject(:scheduled?) { session.completed? }
+
+    let(:session) { create(:session, date: nil) }
+
+    it { should be(false) }
+
+    context "with a date before today" do
+      before { create(:session_date, session:, value: Date.yesterday) }
+
+      it { should be(true) }
+    end
+
+    context "with a date after today" do
+      before { create(:session_date, session:, value: Date.tomorrow) }
+
+      it { should be(false) }
+    end
+  end
 end


### PR DESCRIPTION
This adds a new tag shown on the status page which displays the status of the session, either one of completed, in progress or unscheduled.

## Screenshots

<img width="721" alt="Screenshot 2024-09-26 at 14 12 42" src="https://github.com/user-attachments/assets/39031eca-546a-435b-bdc6-8b8e5ed46fa0">
<img width="527" alt="Screenshot 2024-09-26 at 14 12 32" src="https://github.com/user-attachments/assets/fc68d358-ca51-473b-b82b-a174d49624ec">
<img width="383" alt="Screenshot 2024-09-26 at 14 12 27" src="https://github.com/user-attachments/assets/1f314743-4a51-4fe2-8679-ab3c750139e4">
