### PR TITLE
Add button to schedule sessions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
 
     session = Session.find_or_create_by!(team:, academic_year:, location:)
 
-    redirect_to session_edit_path(session, Wicked::FIRST_STEP)
+    redirect_to session_path(session)
   end
 
   def index

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
-                                          { text: session_location(@session), active: true },
+                                          { text: session_location(@session), href: session_path(@session) },
                                         ]) %>
 <% end %>
 

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -2,7 +2,6 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: "Home", href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
-                                          { text: session_location(@session), href: session_path(@session) },
                                         ]) %>
 <% end %>
 
@@ -16,50 +15,62 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-
     <ul class="nhsuk-grid-row nhsuk-card-group">
-      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <%= render AppCardComponent.new(link_to: "#") do |c| %>
-          <% c.with_heading { "Register attendance" } %>
-          <% c.with_description do %>
-            <%= t("children", count: @patient_sessions.size) %> still to register
+      <% if @session.unscheduled? %>
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_edit_path(@session, Wicked::FIRST_STEP)) do |c| %>
+            <% c.with_heading { "Schedule sessions" } %>
+            <% c.with_description { "Add dates for this school." } %>
           <% end %>
-        <% end %>
-      </li>
-      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
-          <% c.with_heading { "Record vaccinations" } %>
-          <% c.with_description do %>
-            <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
-            <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
-            <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
+        </li>
+      <% else %>
+        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: "#") do |c| %>
+            <% c.with_heading { "Register attendance" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @patient_sessions.size) %> still to register
+            <% end %>
           <% end %>
-        <% end %>
-      </li>
-      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
-          <% c.with_heading { "Check consent responses" } %>
-          <% c.with_description do %>
-            <%= t("children", count: @counts[:without_a_response]) %> without a response<br>
-            <%= t("children", count: @counts[:with_consent_given]) %> with consent given<br>
-            <%= t("children", count: @counts[:with_consent_refused]) %> with consent refused<br>
-            <%= t("children", count: @counts[:with_conflicting_consent]) %> with conflicting consent
+        </li>
+        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
+            <% c.with_heading { "Record vaccinations" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
+              <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
+              <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
+            <% end %>
           <% end %>
-        <% end %>
-      </li>
-      <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
-          <% c.with_heading { "Triage health questions" } %>
-          <% c.with_description do %>
-            <%= t("children", count: @counts[:needing_triage]) %> needing triage
+        </li>
+        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
+            <% c.with_heading { "Check consent responses" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @counts[:without_a_response]) %> without a response<br>
+              <%= t("children", count: @counts[:with_consent_given]) %> with consent given<br>
+              <%= t("children", count: @counts[:with_consent_refused]) %> with consent refused<br>
+              <%= t("children", count: @counts[:with_conflicting_consent]) %> with conflicting consent
+            <% end %>
           <% end %>
-        <% end %>
-      </li>
+        </li>
+        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
+            <% c.with_heading { "Triage health questions" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @counts[:needing_triage]) %> needing triage
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
     </ul>
   </div>
 
   <div class="nhsuk-grid-column-one-third">
     <%= render AppSessionSummaryComponent.new(@session) %>
+
+    <% unless @session.unscheduled? %>
+      <%= govuk_button_link_to "Edit session", edit_session_path(session), secondary: true %>
+    <% end %>
   </div>
 </div>
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -100,6 +100,7 @@ describe "End-to-end journey" do
     click_on "School sessions"
     click_on "Unscheduled"
     click_on "Pilot School"
+    click_on "Schedule sessions"
 
     expect(page).to have_content("When is the session?")
     fill_in "Day", with: "1"

--- a/spec/features/session_management_spec.rb
+++ b/spec/features/session_management_spec.rb
@@ -11,7 +11,11 @@ describe "Session management" do
 
     when_i_go_to_unscheduled_sessions
     then_i_see_the_school
-    then_i_click_on_the_school
+
+    when_i_click_on_the_school
+    then_i_see_the_school_session
+
+    when_i_click_on_schedule_sessions
     then_i_see_the_date_step
 
     when_i_choose_the_date
@@ -81,8 +85,18 @@ describe "Session management" do
     expect(page).to have_content(/There are no (sessions|schools)/)
   end
 
-  def then_i_click_on_the_school
+  def when_i_click_on_the_school
     click_link @location.name
+  end
+
+  def then_i_see_the_school_session
+    expect(page).to have_content(@location.name)
+    expect(page).to have_content("No sessions scheduled")
+    expect(page).to have_content("Schedule sessions")
+  end
+
+  def when_i_click_on_schedule_sessions
+    click_link "Schedule sessions"
   end
 
   def then_i_see_the_date_step


### PR DESCRIPTION
This adds a button which allows users to start scheduling dates for a session. The button is only shown if the session is unscheduled, if a user wants to add dates to an existing session they will need to use the "Edit session" button.

## Screenshot

<img width="820" alt="Screenshot 2024-09-26 at 14 20 40" src="https://github.com/user-attachments/assets/e4f1b205-8cb0-4d1b-a43f-8eecb899848a">
