### PR TITLE
Handle sessions with locations in table

### DIFF
--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -25,7 +25,7 @@
                 <%= govuk_link_to helpers.session_location(session), session_path(session) %>
               <% end %>
 
-              <% if (location = session.location).has_address? %>
+              <% if (location = session.location)&.has_address? %>
                 <br />
                 <span class="nhsuk-u-secondary-text-color">
                   <%= helpers.format_address_single_line(location) %>

--- a/spec/components/app_session_table_component_spec.rb
+++ b/spec/components/app_session_table_component_spec.rb
@@ -13,8 +13,9 @@ describe AppSessionTableComponent do
         date: Date.new(2024, 10, 1),
         location: create(:location, :school, name: "Waterloo Road"),
         programme: create(:programme, :hpv)
-      )
-    ] + create_list(:session, 9)
+      ),
+      create(:session, location: nil)
+    ] + create_list(:session, 8)
   end
 
   before { create_list(:patient, 5, session: sessions.first) }


### PR DESCRIPTION
This updates the session table component to ensure it can render session rows without a location, which is possible when importing vaccination records.