### PR TITLE
Set minimum TLS version for CIS2 to 1.2

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -296,6 +296,10 @@ Devise.setup do |config|
         end
       end
 
+    OpenIDConnect.http_config do |http_client|
+      http_client.ssl_config.min_version = :TLS1_2
+    end
+
     config.omniauth(
       :openid_connect,
       {


### PR DESCRIPTION
This is a requirement of CIS2:
- NHS CIA Sec Req 003

This has been tested by creating a simple Ruby script that configures Faraday similarly (see below) and connecting against `openssl` configured to accept connections but only offering TLS v1.1 (see cmdline below). Running the script results in an error indicating that a version error has occured:

```
.../installs/ruby/3.3.4/lib/ruby/3.3.0/net/protocol.rb:46:in `connect_nonblock': SSL_connect returned=1 errno=0 peeraddr=127.0.0.1:8443 state=error: tlsv1 alert protocol version (SSL alert number 70) (Faraday::SSLError)
```

OpenSSL command:
```
openssl s_server -accept 8443 -cert server.crt -key server.key -tls1_1 -www
```

Test ruby script:
```ruby
#!/usr/bin/env ruby

require 'faraday'

http = Faraday.new('https://localhost:8443') do |faraday|
  faraday.ssl.min_version = :TLS1_2
  faraday.ssl.verify = false
end

puts http.get("/").body
```