### PR TITLE
Update session timeouts

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -188,7 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 2.hours
+  config.timeout_in = 15.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 Rails.application.config.session_store :cookie_store,
                                        secure: Rails.env.production?,
-                                       expire_after: 2.hours
+                                       expire_after: 12.hours


### PR DESCRIPTION
Sets session timeouts according to CIS2 requirements:
- 15 mins of inactivity: NHS CIA Ses Req 005
- session maximum age to 12 hours: NHS CIA Ses Req 007
