### PR TITLE
Replace dfe-autocomplete with accessible-autocomplete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem "cssbundling-rails"
 gem "csv"
 gem "devise"
 gem "devise-pwned_password"
-gem "dfe-autocomplete",
-    require: "dfe/autocomplete",
-    github: "DFE-Digital/dfe-autocomplete"
 gem "factory_bot_rails"
 gem "faker"
 gem "faraday"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,4 @@
 GIT
-  remote: https://github.com/DFE-Digital/dfe-autocomplete.git
-  revision: 8e7389ff62a38bc8880323f6c58eed9c8d10f080
-  specs:
-    dfe-autocomplete (0.1.0)
-      actionview (>= 7.0.2.3)
-      activemodel (>= 7.0.2.3)
-      govuk-components
-      rails (>= 7.0.2.3)
-      view_component
-
-GIT
   remote: https://github.com/citizensadvice/capybara_accessible_selectors
   revision: 347bbe06cb420416855e80bb4e3a3016b2d5872c
   branch: main
@@ -672,7 +661,6 @@ DEPENDENCIES
   debug
   devise
   devise-pwned_password
-  dfe-autocomplete!
   dockerfile-rails (>= 1.0.0)
   factory_bot_rails
   faker

--- a/app/assets/stylesheets/_autocomplete.scss
+++ b/app/assets/stylesheets/_autocomplete.scss
@@ -1,0 +1,44 @@
+// Ensure the autocomplete uses the correct typeface
+.autocomplete__wrapper {
+  font-family: $govuk-font-family;
+}
+
+.autocomplete__input {
+  font-family: inherit;
+}
+
+// Style the autocomplete if there’s an error
+.nhsuk-form-group--error {
+  .autocomplete__input {
+    border-color: $govuk-error-colour;
+  }
+
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+  }
+}
+
+.autocomplete__dropdown-arrow-down {
+  // Ensure dropdown arrow can be clicked
+  // https://github.com/alphagov/accessible-autocomplete/issues/202
+  pointer-events: none;
+  // Ensure dropdown arrow can be seen
+  z-index: 0;
+}
+
+.autocomplete__input {
+  background-color: $color_nhsuk-white;
+}
+
+.autocomplete__option {
+  margin-bottom: 0;
+}
+
+.autocomplete__option-hint {
+  color: $nhsuk-secondary-text-color;
+
+  .autocomplete__option:hover &,
+  .autocomplete__option:focus & {
+    color: $color_nhsuk-grey-5;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,7 +23,6 @@ $mq-breakpoints: (
 );
 
 @import "nhsuk-frontend/packages/nhsuk";
-@import "dfe-autocomplete/src/dfe-autocomplete";
 
 // App options
 $app-page-width: 1160px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,6 +33,7 @@ $color_app-dark-orange: darken(
 
 // Application components
 @import "action_list";
+@import "autocomplete";
 @import "button";
 @import "button-group";
 @import "card";

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,21 +1,7 @@
 import "@hotwired/turbo-rails";
 // import { initServiceWorker } from "./serviceworker-companion";
 import "./controllers";
-import dfeAutocomplete from "dfe-autocomplete";
 
 Turbo.session.drive = false;
 
 // initServiceWorker();
-function shimAutocomplete() {
-  document
-    .querySelectorAll('[data-module="app-dfe-autocomplete"]')
-    .forEach((element) => {
-      const nhsukFormGroup = element.querySelector("div.nhsuk-form-group");
-      if (nhsukFormGroup) {
-        nhsukFormGroup.classList.add("govuk-form-group");
-      }
-    });
-}
-
-shimAutocomplete();
-dfeAutocomplete({});

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,60 @@
+import { Controller } from "@hotwired/stimulus";
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const enhanceOption = (option) => {
+  return {
+    name: option.label,
+    append: option.getAttribute("data-append"),
+    hint: option.getAttribute("data-hint"),
+  };
+};
+
+const suggestion = (value, options) => {
+  const option = options.find(({ name }) => name === value);
+  if (option) {
+    const html = option.append ? `${value} – ${option.append}` : value;
+    return option.hint
+      ? `${html}<br><span class="autocomplete__option-hint">${option.hint}</span>`
+      : html;
+  } else {
+    return "No results found";
+  }
+};
+
+const autocomplete = ($module) => {
+  if (!$module) {
+    return;
+  }
+
+  const params = $module.dataset;
+
+  const selectOptions = Array.from($module.options);
+  const options = selectOptions.map((option) => enhanceOption(option));
+
+  accessibleAutocomplete.enhanceSelectElement({
+    autoselect: params.autoselect === "true",
+    defaultValue: params.defaultValue || "",
+    displayMenu: params.displayMenu,
+    minLength: params.minLength ? parseInt(params.minLength) : 0,
+    selectElement: $module,
+    showAllValues: params.showAllValues === "true",
+    showNoOptionsFound: params.showNoOptionsFound === "true",
+    templates: {
+      suggestion: (value) => suggestion(value, options),
+    },
+    onConfirm: (value) => {
+      const selectedOption = [].filter.call(
+        selectOptions,
+        (option) => (option.textContent || option.innerText) === value,
+      )[0];
+      if (selectedOption) selectedOption.selected = true;
+    },
+  });
+};
+
+// Connects to data-module="autocomplete"
+export default class extends Controller {
+  connect() {
+    autocomplete(this.element);
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application";
 
+import AutocompleteController from "./autocomplete_controller";
+application.register("autocomplete", AutocompleteController);
+
 import AutosubmitController from "./autosubmit_controller";
 application.register("autosubmit", AutosubmitController);
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
 
     <title><%= page_title(@service_name) %></title>
 
+    <%= stylesheet_link_tag "accessible-autocomplete.min", "data-turbo-track": Rails.env.development? ? "" : "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": Rails.env.development? ? "" : "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": Rails.env.development? ? "" : "reload", defer: true %>
 

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -16,22 +16,16 @@
     If you&apos;ve moved recently, it&apos;s important to mention this.
   </p>
 
-  <%= render DfE::Autocomplete::View.new(
-        f,
-        attribute_name: :location_id,
-        form_field: f.govuk_select(
-          :location_id,
-          options_for_select(
-            dfe_autocomplete_options(
-              @consent_form.eligible_schools.map {
-                OpenStruct.new(name: _1.name, value: _1.id)
-              }
-            ),
-            f.object.id,
-          ),
-          label: { text: "Select a school" },
-        ),
-      ) %>
+  <%= f.govuk_select :location_id,
+                     label: { text: "Select a school" },
+                     data: { module: "autocomplete" } do %>
+        <%= tag.option "", value: "" %>
+        <% @consent_form.eligible_schools.each do |school| %>
+          <%= tag.option(school.name,
+                         value: school.id,
+                         data: { hint: school.address_parts.join(", ") }) %>
+        <% end %>
+  <% end %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,6 +7,9 @@ Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join(
+  "node_modules/accessible-autocomplete/dist"
+)
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -22,7 +22,6 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "NHS"
   inflect.acronym "ODS"
   inflect.acronym "PDS"
-  inflect.acronym "DfE"
 
   inflect.irregular "batch", "batches"
   inflect.irregular "child", "children"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.10",
+    "accessible-autocomplete": "^3.0.1",
     "esbuild": "^0.24.0",
     "govuk-frontend": "^5.6.0",
     "idb": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.10",
-    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete",
     "esbuild": "^0.24.0",
     "govuk-frontend": "^5.6.0",
     "idb": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,13 +1895,6 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
-accessible-autocomplete@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
-  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
-  dependencies:
-    preact "^8.3.1"
-
 acorn-globals@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"
@@ -2623,12 +2616,6 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
-
-"dfe-autocomplete@github:DFE-Digital/dfe-autocomplete":
-  version "0.0.1"
-  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/8e7389ff62a38bc8880323f6c58eed9c8d10f080"
-  dependencies:
-    accessible-autocomplete "^2.0.4"
 
 diff-sequences@^29.6.3:
   version "29.6.3"
@@ -4685,11 +4672,6 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==
-
-preact@^8.3.1:
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
-  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,6 +1895,11 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
+accessible-autocomplete@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz#8ddf4934d0b4ba6acb28de486dd505e062cdc86e"
+  integrity sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==
+
 acorn-globals@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"


### PR DESCRIPTION
The custom CSS seems to not be as accessible as the upstream one when using VoiceOver. It doesn't allow choosing from a list of options by swiping left/right in the focus order.

Add an `autocomplete` stimulus controller that's based on the implementation in the prototype.

See commits.

### Screenshots

![image](https://github.com/user-attachments/assets/90a52110-1e60-4056-ba85-a6a1f06c9485)
