### PR TITLE
Remove feedback email

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -17,7 +17,5 @@ module ConsentFormMailerConcern
       mailer.confirmation.deliver_later
       TextDeliveryJob.perform_later(:consent_given, consent_form:)
     end
-
-    mailer.give_feedback.deliver_later(wait: 1.hour)
   end
 end

--- a/app/mailers/consent_mailer.rb
+++ b/app/mailers/consent_mailer.rb
@@ -17,10 +17,6 @@ class ConsentMailer < ApplicationMailer
     app_template_mail(:parental_consent_confirmation_refused)
   end
 
-  def give_feedback
-    app_template_mail(:parental_consent_give_feedback)
-  end
-
   def request
     app_template_mail(:hpv_session_consent_request)
   end

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -14,7 +14,6 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   parental_consent_confirmation_needs_triage:
     "604ee667-c996-471e-b986-79ab98d0767c",
   parental_consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",
-  parental_consent_give_feedback: "1250c83b-2a5a-4456-8922-657946eba1fd",
   triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
   triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f"
 }.freeze

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -17,23 +17,10 @@ describe ConsentFormMailerConcern do
       ).with(params: { consent_form: }, args: [])
     end
 
-    it "sends a conset given text" do
+    it "sends a consent given text" do
       expect { send_consent_form_confirmation }.to have_enqueued_text(
         :consent_given
       ).with(consent_form:)
-    end
-
-    it "sends a feedback email" do
-      today = Time.zone.local(2024, 1, 1)
-
-      expect {
-        travel_to(today) { send_consent_form_confirmation }
-      }.to have_enqueued_mail(ConsentMailer, :give_feedback).with(
-        params: {
-          consent_form:
-        },
-        args: []
-      ).at(today + 1.hour)
     end
 
     context "when user agrees to be contacted about injections" do

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -16,7 +16,6 @@ describe "Parental consent" do
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirming_that_my_child_wont_be_vaccinated
     and_i_receive_a_text_confirming_that_my_child_wont_be_vaccinated
-    and_i_receive_an_email_prompting_me_to_give_feedback
 
     when_the_nurse_checks_the_consent_responses
     then_they_see_that_the_child_has_consent_refused
@@ -108,21 +107,11 @@ describe "Parental consent" do
   end
 
   def and_i_receive_an_email_confirming_that_my_child_wont_be_vaccinated
-    expect(enqueued_jobs.first["scheduled_at"]).to be_nil
-    expect(
-      Time.zone.parse(enqueued_jobs.third["scheduled_at"]).to_i
-    ).to be_within(1.second).of(1.hour.from_now.to_i)
-
     expect_email_to "jane@example.com", :parental_consent_confirmation_refused
   end
 
   def and_i_receive_a_text_confirming_that_my_child_wont_be_vaccinated
     expect_text_to "07123456789", :consent_refused
-  end
-
-  def and_i_receive_an_email_prompting_me_to_give_feedback
-    expect_email_to "jane@example.com", :parental_consent_give_feedback, :second
-    expect(ActionMailer::Base.deliveries.count).to eq(2)
   end
 
   def when_the_nurse_checks_the_consent_responses

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -142,11 +142,6 @@ describe "Parental consent" do
     )
 
     expect_email_to("jane@example.com", :parental_consent_confirmation)
-    expect_email_to(
-      "jane@example.com",
-      :parental_consent_give_feedback,
-      :second
-    )
   end
 
   def and_i_get_a_confirmation_text

--- a/spec/mailers/consent_mailer_spec.rb
+++ b/spec/mailers/consent_mailer_spec.rb
@@ -25,43 +25,6 @@ describe ConsentMailer do
     end
   end
 
-  describe "#give_feedback" do
-    context "with a consent form" do
-      subject(:mail) { described_class.with(consent_form:).give_feedback }
-
-      let(:consent_form) do
-        create(:consent_form, :recorded, recorded_at: Date.new(2021, 1, 1))
-      end
-
-      it "calls template_mail with correct survey_deadline_date" do
-        expect(
-          mail.message.header["personalisation"].unparsed_value
-        ).to include(survey_deadline_date: "8 January 2021")
-      end
-    end
-
-    context "with a consent record" do
-      subject(:mail) { described_class.with(consent:, session:).give_feedback }
-
-      let(:programme) { create(:programme) }
-      let(:session) { create(:session, programme:) }
-      let(:consent) do
-        create(
-          :consent,
-          :recorded,
-          recorded_at: Date.new(2021, 1, 1),
-          programme:
-        )
-      end
-
-      it "calls template_mail with correct survey_deadline_date" do
-        expect(
-          mail.message.header["personalisation"].unparsed_value
-        ).to include(survey_deadline_date: "8 January 2021")
-      end
-    end
-  end
-
   describe "#request" do
     subject(:mail) { described_class.with(session:, patient:, parent:).request }
 


### PR DESCRIPTION
This content is related to the pilot so we want to remove this until we have a better idea of what survey we might send out for the private beta.