### PR TITLE
Remove references to programme teams

### DIFF
--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class AppProgrammeNavigationComponent < ViewComponent::Base
-  attr_reader :programme, :active
+  attr_reader :programme, :team, :active
 
-  def initialize(programme, active:)
+  def initialize(programme, team:, active:)
     super
 
     @programme = programme
+    @team = team
     @active = active
   end
 
@@ -53,7 +54,14 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
   private
 
   def import_issues_text
-    count = programme.import_issues.count
+    count =
+      team
+        .vaccination_records
+        .where(programme:)
+        .with_pending_changes
+        .distinct
+        .count
+
     base_text = I18n.t("import_issues.index.title")
 
     safe_join([base_text, " ", render(AppCountComponent.new(count:))])

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -13,7 +13,7 @@ class CohortImportsController < ApplicationController
     @cohort_import =
       CohortImport.new(
         programme: @programme,
-        team: @programme.team,
+        team: current_user.team,
         uploaded_by: current_user,
         **cohort_import_params
       )
@@ -56,7 +56,7 @@ class CohortImportsController < ApplicationController
   end
 
   def set_cohort_import
-    @cohort_import = @programme.team.cohort_imports.find(params[:id])
+    @cohort_import = policy_scope(CohortImport).find(params[:id])
   end
 
   def set_patients

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -6,16 +6,18 @@ class CohortsController < ApplicationController
   layout "full"
 
   def index
+    year_groups = @programme.year_groups
+
     cohorts =
       policy_scope(Cohort)
         .select("cohorts.*", "COUNT(patients.id) AS patient_count")
-        .for_programme(@programme)
+        .for_year_groups(year_groups)
         .left_outer_joins(:patients)
         .merge(Patient.recorded)
         .group("cohorts.id")
         .index_by(&:year_group)
 
-    @programme.year_groups.each do |year_group|
+    year_groups.each do |year_group|
       cohorts[year_group] ||= OpenStruct.new(year_group:, patient_count: 0)
     end
 

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -19,12 +19,12 @@ class ProgrammesController < ApplicationController
 
     @unscheduled_sessions =
       @programme.sessions.unscheduled +
-        Location
+        policy_scope(Location)
           .school
-          .for_programme(@programme)
+          .for_year_groups(@programme.year_groups)
           .has_no_session(academic_year)
           .map do |location|
-            Session.new(team: @programme.team, location:, academic_year:)
+            Session.new(team: current_user.team, location:, academic_year:)
           end
 
     @completed_sessions = @programme.sessions.completed

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -51,7 +51,7 @@ class ApplicationMailer < Mail::Notify::Mailer
   def reply_to_id
     team =
       programme&.team || session&.team || patient_session&.team ||
-        consent_form&.team || consent&.team || vaccination_record&.team
+        consent_form&.team || vaccination_record&.team
 
     team.reply_to_id
   end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -28,6 +28,8 @@ class Batch < ApplicationRecord
 
   has_and_belongs_to_many :immunisation_imports
 
+  has_many :programmes, through: :vaccine
+
   validates :name, presence: true
   validates :expiry, presence: true
 end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -36,13 +36,6 @@ class Cohort < ApplicationRecord
           where(birth_academic_year: birth_academic_years)
         end
 
-  scope :for_programme,
-        ->(programme) do
-          where(team_id: programme.team_id).for_year_groups(
-            programme.year_groups
-          )
-        end
-
   def year_group
     Date.new(birth_academic_year, 9, 1).year_group
   end

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -72,7 +72,7 @@ class CohortImport < ApplicationRecord
   end
 
   def parse_row(row_data)
-    CohortImportRow.new(data: row_data, programme:)
+    CohortImportRow.new(data: row_data, team:, programme:)
   end
 
   def process_row(row)

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -36,8 +36,9 @@ class CohortImportRow
 
   validate :zero_or_one_existing_patient
 
-  def initialize(data:, programme:)
+  def initialize(data:, team:, programme:)
     @data = data
+    @team = team
     @programme = programme
   end
 
@@ -195,7 +196,7 @@ class CohortImportRow
     @cohort ||=
       Cohort.find_or_create_by!(
         birth_academic_year: date_of_birth.academic_year,
-        team: @programme.team
+        team: @team
       )
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -71,7 +71,7 @@ class ConsentForm < ApplicationRecord
   belongs_to :consent, optional: true
   belongs_to :session
 
-  has_one :team, through: :programme
+  has_one :team, through: :session
   has_many :eligible_schools, through: :team, source: :schools
 
   enum :response, %w[given refused not_provided], prefix: "consent"

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -46,12 +46,9 @@ class Location < ApplicationRecord
 
   enum :type, %w[school generic_clinic]
 
-  scope :for_programme,
-        ->(programme) do
-          where(team: programme.team).where(
-            "year_groups && ARRAY[?]::integer[]",
-            programme.year_groups
-          )
+  scope :for_year_groups,
+        ->(year_groups) do
+          where("year_groups && ARRAY[?]::integer[]", year_groups)
         end
 
   scope :has_no_session,

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -36,7 +36,6 @@ class Programme < ApplicationRecord
   has_many :vaccination_records
 
   has_many :batches, through: :vaccines
-  has_many :cohort_imports, through: :team
   has_many :patient_sessions, through: :sessions
   has_many :patients, through: :patient_sessions
 

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -34,6 +34,7 @@ class Programme < ApplicationRecord
   has_many :immunisation_imports
   has_many :triages
   has_many :vaccination_records
+  has_many :teams
 
   has_many :batches, through: :vaccines
   has_many :patient_sessions, through: :sessions

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -39,25 +39,6 @@ class Programme < ApplicationRecord
   has_many :patient_sessions, through: :sessions
   has_many :patients, through: :patient_sessions
 
-  has_many :import_issues,
-           -> do
-             joins(:patient)
-               .where(
-                 "patients.pending_changes != '{}' OR vaccination_records.pending_changes != '{}'"
-               )
-               .distinct
-               .includes(
-                 :vaccine,
-                 :batch,
-                 :patient_session,
-                 session: :location,
-                 patient: %i[cohort school]
-               )
-               .strict_loading
-           end,
-           through: :immunisation_imports,
-           source: :vaccination_records
-
   enum :type, { flu: "flu", hpv: "hpv" }, validate: true
 
   validate :vaccines_match_type

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -33,6 +33,9 @@ class Team < ApplicationRecord
   has_many :schools, -> { school }, class_name: "Location"
   has_many :sessions
 
+  has_many :patient_sessions, through: :sessions
+  has_many :vaccination_records, through: :patient_sessions
+
   has_and_belongs_to_many :users
 
   validates :email, presence: true, notify_safe_email: true

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -37,7 +37,7 @@ class Triage < ApplicationRecord
 
   has_one :patient, through: :patient_session
   has_one :session, through: :patient_session
-  has_one :team, through: :programme
+  has_one :team, through: :session
 
   enum :status,
        %i[

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,8 @@ class User < ApplicationRecord
 
   has_and_belongs_to_many :teams
 
+  has_many :programmes, through: :teams
+
   encrypts :email, deterministic: true
   encrypts :family_name, :given_name
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -88,6 +88,13 @@ class VaccinationRecord < ApplicationRecord
   scope :administered, -> { where.not(administered_at: nil) }
   scope :unexported, -> { where.missing(:dps_exports) }
 
+  scope :with_pending_changes,
+        -> do
+          joins(:patient).where(
+            "patients.pending_changes != '{}' OR vaccination_records.pending_changes != '{}'"
+          )
+        end
+
   enum :delivery_method,
        %w[intramuscular subcutaneous nasal_spray],
        prefix: true

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -8,9 +8,9 @@ class BatchPolicy
     end
 
     def resolve
-      @scope.joins(vaccine: { programmes: :team }).where(
-        teams: {
-          id: @user.teams.ids
+      @scope.joins(vaccine: :programmes).where(
+        programmes: {
+          team: @user.teams
         }
       )
     end

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -8,11 +8,7 @@ class BatchPolicy
     end
 
     def resolve
-      @scope.joins(vaccine: :programmes).where(
-        programmes: {
-          team: @user.teams
-        }
-      )
+      @scope.joins(:programmes).where(programmes: @user.programmes)
     end
   end
 end

--- a/app/policies/cohort_import_policy.rb
+++ b/app/policies/cohort_import_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ImmunisationImportPolicy
+class CohortImportPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/cohort_policy.rb
+++ b/app/policies/cohort_policy.rb
@@ -8,7 +8,7 @@ class CohortPolicy
     end
 
     def resolve
-      @scope.where(team: @user.team)
+      @scope.where(team: @user.teams)
     end
   end
 end

--- a/app/policies/consent_form_policy.rb
+++ b/app/policies/consent_form_policy.rb
@@ -8,7 +8,7 @@ class ConsentFormPolicy
     end
 
     def resolve
-      @scope.joins(:programme).where(programme: { team_id: @user.teams.ids })
+      @scope.joins(:session).where(session: { team: @user.teams })
     end
   end
 end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -8,7 +8,7 @@ class LocationPolicy
     end
 
     def resolve
-      @scope
+      @scope.where(team: @user.teams)
     end
   end
 end

--- a/app/policies/patient_session_policy.rb
+++ b/app/policies/patient_session_policy.rb
@@ -8,7 +8,7 @@ class PatientSessionPolicy
     end
 
     def resolve
-      @scope.joins(:session).where(session: { team_id: @user.teams.ids })
+      @scope.joins(:session).where(session: { team: @user.teams })
     end
   end
 end

--- a/app/policies/programme_policy.rb
+++ b/app/policies/programme_policy.rb
@@ -8,7 +8,7 @@ class ProgrammePolicy
     end
 
     def resolve
-      @scope.where(team: @user.team)
+      @scope.where(team: @user.teams)
     end
   end
 end

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -8,7 +8,7 @@ class SessionPolicy
     end
 
     def resolve
-      @scope.where(team_id: @user.teams.ids)
+      @scope.where(team: @user.teams)
     end
   end
 end

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -8,7 +8,7 @@ class VaccinationRecordPolicy
     end
 
     def resolve
-      @scope.joins(:programme).where(programme: { team_id: @user.teams.ids })
+      @scope.joins(:session).where(session: { team: @user.teams })
     end
   end
 end

--- a/app/policies/vaccine_policy.rb
+++ b/app/policies/vaccine_policy.rb
@@ -8,7 +8,7 @@ class VaccinePolicy
     end
 
     def resolve
-      @scope.joins(:programmes).where(programmes: { team_id: @user.teams.ids })
+      @scope.joins(:programmes).where(programmes: { team: @user.teams })
     end
   end
 end

--- a/app/policies/vaccine_policy.rb
+++ b/app/policies/vaccine_policy.rb
@@ -8,7 +8,7 @@ class VaccinePolicy
     end
 
     def resolve
-      @scope.joins(:programmes).where(programmes: { team: @user.teams })
+      @scope.joins(:programmes).where(programmes: @user.programmes)
     end
   end
 end

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :cohorts) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :cohorts) %>
 
 <%= govuk_button_link_to "Import child records", new_programme_cohort_import_path(@programme), class: "app-button--secondary" %>
 

--- a/app/views/import_issues/index.html.erb
+++ b/app/views/import_issues/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :import_issues) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :import_issues) %>
 
 <% if @import_issues.any? %>
   <div class="nhsuk-table__panel-with-heading-tab">

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :imports) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :imports) %>
 
 <%= govuk_button_link_to "Import records", new_programme_import_path, class: "app-button--secondary" %>
 

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :sessions) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :sessions) %>
 
 <% [[@unscheduled_sessions, "No sessions scheduled"],
     [@scheduled_sessions, "Sessions scheduled"],

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -8,4 +8,4 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :overview) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :overview) %>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :vaccination_records) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :vaccination_records) %>
 
 <%= govuk_button_link_to "Import vaccination records", new_programme_immunisation_import_path, class: "app-button--secondary" %>
 

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -11,8 +11,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    team = create(:team, :with_one_nurse)
-    programme = create(:programme, :hpv, team:)
+    programme = create(:programme, :hpv)
+    team = create(:team, :with_one_nurse, programmes: [programme])
+
     @session = create(:session, team:, programme:)
     @patient = create(:patient, session: @session)
 

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -13,21 +13,24 @@ describe GovukNotifyPersonalisation do
     )
   end
 
+  let(:programme) { create(:programme, :flu) }
   let(:team) do
     create(
       :team,
       name: "Team",
       email: "team@example.com",
-      phone: "01234 567890"
+      phone: "01234 567890",
+      programmes: [programme]
     )
   end
-  let(:programme) { create(:programme, :flu, team:) }
+
   let(:patient) { create(:patient, first_name: "John", last_name: "Smith") }
   let(:location) { create(:location, :school, name: "Hogwarts") }
   let(:session) do
     create(
       :session,
       location:,
+      team:,
       programme:,
       close_consent_at: Date.new(2024, 1, 1),
       date: Date.new(2024, 1, 1)

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe CohortImportRow do
-  subject(:cohort_import_row) { described_class.new(data:, programme:) }
+  subject(:cohort_import_row) { described_class.new(data:, team:, programme:) }
 
+  let(:team) { create(:team) }
   let(:programme) { create(:programme) }
 
   let(:school_urn) { "123456" }
@@ -140,10 +141,7 @@ describe CohortImportRow do
         let(:date_of_birth) { "2000-08-31" }
 
         it do
-          expect(cohort).to have_attributes(
-            team: programme.team,
-            birth_academic_year: 1999
-          )
+          expect(cohort).to have_attributes(team:, birth_academic_year: 1999)
         end
       end
 
@@ -151,10 +149,7 @@ describe CohortImportRow do
         let(:date_of_birth) { "2000-09-01" }
 
         it do
-          expect(cohort).to have_attributes(
-            team: programme.team,
-            birth_academic_year: 2000
-          )
+          expect(cohort).to have_attributes(team:, birth_academic_year: 2000)
         end
       end
     end

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -3,8 +3,8 @@
 describe CohortImportRow do
   subject(:cohort_import_row) { described_class.new(data:, team:, programme:) }
 
-  let(:team) { create(:team) }
   let(:programme) { create(:programme) }
+  let(:team) { create(:team, programmes: [programme]) }
 
   let(:school_urn) { "123456" }
 
@@ -140,17 +140,13 @@ describe CohortImportRow do
       context "with a date of birth before September" do
         let(:date_of_birth) { "2000-08-31" }
 
-        it do
-          expect(cohort).to have_attributes(team:, birth_academic_year: 1999)
-        end
+        it { should have_attributes(team:, birth_academic_year: 1999) }
       end
 
       context "with a date of birth after September" do
         let(:date_of_birth) { "2000-09-01" }
 
-        it do
-          expect(cohort).to have_attributes(team:, birth_academic_year: 2000)
-        end
+        it { should have_attributes(team:, birth_academic_year: 2000) }
       end
     end
 

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -31,11 +31,12 @@
 describe CohortImport do
   subject(:cohort_import) { create(:cohort_import, csv:, programme:, team:) }
 
-  let(:team) { create(:team) }
-  let(:programme) { create(:programme, team:) }
+  let(:programme) { create(:programme) }
+  let(:team) { create(:team, programmes: [programme]) }
 
   let(:file) { "valid_cohort.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/cohort_import/#{file}") }
+
   # Ensure location URN matches the URN in our fixture files
   let!(:location) do
     Location.find_by(urn: "123456") || create(:location, :school, urn: "123456")

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -31,8 +31,9 @@
 describe CohortImport do
   subject(:cohort_import) { create(:cohort_import, csv:, programme:, team:) }
 
-  let(:programme) { create(:programme) }
-  let(:team) { programme.team }
+  let(:team) { create(:team) }
+  let(:programme) { create(:programme, team:) }
+
   let(:file) { "valid_cohort.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/cohort_import/#{file}") }
   # Ensure location URN matches the URN in our fixture files

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -3,11 +3,11 @@
 describe DPSExportRow do
   subject(:row) { described_class.new(vaccination_record) }
 
-  let(:team) { create(:team) }
-  let(:vaccine) { create(:vaccine, :gardasil_9, dose: 0.5) }
   let(:programme) do
-    create(:programme, type: vaccine.type, team:, vaccines: [vaccine])
+    create(:programme, type: vaccine.type, vaccines: [vaccine])
   end
+  let(:team) { create(:team, programmes: [programme]) }
+  let(:vaccine) { create(:vaccine, :gardasil_9, dose: 0.5) }
   let(:location) { create(:location, :school) }
   let(:school) { create(:location, :school) }
   let(:patient) do
@@ -256,7 +256,7 @@ describe DPSExportRow do
 
       context "when the session doesn't have a location" do
         let(:location) { nil }
-        let(:team) { create(:team, ods_code: "ABC") }
+        let(:team) { create(:team, ods_code: "ABC", programmes: [programme]) }
 
         it { should eq("ABC") }
       end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -5,8 +5,8 @@ describe ImmunisationImportRow, type: :model do
     described_class.new(data:, programme:, user: uploaded_by)
   end
 
-  let(:team) { create(:team, ods_code: "abc") }
-  let(:programme) { create(:programme, :flu, team:) }
+  let(:programme) { create(:programme, :flu) }
+  let(:team) { create(:team, ods_code: "abc", programmes: [programme]) }
   let(:uploaded_by) { create(:user, teams: [team]) }
 
   let(:nhs_number) { "1234567890" }
@@ -191,7 +191,7 @@ describe ImmunisationImportRow, type: :model do
     end
 
     context "with an invalid dose sequence" do
-      let(:programme) { create(:programme, :hpv, team:) }
+      let(:programme) { create(:programme, :hpv) }
 
       let(:data) { { "VACCINE_GIVEN" => "Gardasil9", "DOSE_SEQUENCE" => "4" } }
 
@@ -204,7 +204,7 @@ describe ImmunisationImportRow, type: :model do
     end
 
     context "with valid fields for Flu" do
-      let(:programme) { create(:programme, :flu, team:) }
+      let(:programme) { create(:programme, :flu) }
 
       let(:data) do
         {
@@ -231,7 +231,7 @@ describe ImmunisationImportRow, type: :model do
     end
 
     context "with valid fields for HPV" do
-      let(:programme) { create(:programme, :hpv, team:) }
+      let(:programme) { create(:programme, :hpv) }
 
       let(:data) do
         {
@@ -734,7 +734,7 @@ describe ImmunisationImportRow, type: :model do
   describe "#dose_sequence" do
     subject(:dose_sequence) { immunisation_import_row.dose_sequence }
 
-    let(:programme) { create(:programme, :hpv, team:) }
+    let(:programme) { create(:programme, :hpv) }
 
     context "without a value" do
       let(:data) { { "VACCINE_GIVEN" => "Gardasil9" } }

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -33,9 +33,9 @@
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 
-describe ImmunisationImport, type: :model do
+describe ImmunisationImport do
   subject(:immunisation_import) do
-    create(:immunisation_import, programme:, csv:, uploaded_by:)
+    create(:immunisation_import, team:, programme:, csv:, uploaded_by:)
   end
 
   before do
@@ -44,10 +44,11 @@ describe ImmunisationImport, type: :model do
     create(:location, :school, urn: "144012")
   end
 
+  let(:team) { create(:team, ods_code: "R1L") }
   let(:programme) { create(:programme, :flu_all_vaccines, team:) }
+
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
-  let(:team) { create(:team, ods_code: "R1L") }
   let(:uploaded_by) { create(:user, teams: [team]) }
 
   it_behaves_like "a CSVImportable model"
@@ -265,7 +266,7 @@ describe ImmunisationImport, type: :model do
 
         expect(existing_patient.reload.pending_changes).to eq(
           "address_postcode" => "LE3 2DB",
-          "cohort_id" => programme.team.cohorts.first.id,
+          "cohort_id" => team.cohorts.first.id,
           "date_of_birth" => "2011-09-13",
           "gender_code" => "female",
           "school_id" => Location.find_by(urn: "110158").id

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -44,8 +44,8 @@ describe ImmunisationImport do
     create(:location, :school, urn: "144012")
   end
 
-  let(:team) { create(:team, ods_code: "R1L") }
-  let(:programme) { create(:programme, :flu_all_vaccines, team:) }
+  let(:programme) { create(:programme, :flu_all_vaccines) }
+  let(:team) { create(:team, ods_code: "R1L", programmes: [programme]) }
 
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
@@ -88,7 +88,7 @@ describe ImmunisationImport do
     before { immunisation_import.parse_rows! }
 
     context "with valid Flu rows" do
-      let(:programme) { create(:programme, :flu_all_vaccines, team:) }
+      let(:programme) { create(:programme, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       it "populates the rows" do
@@ -98,7 +98,7 @@ describe ImmunisationImport do
     end
 
     context "with valid HPV rows" do
-      let(:programme) { create(:programme, :hpv_all_vaccines, team:) }
+      let(:programme) { create(:programme, :hpv_all_vaccines) }
       let(:file) { "valid_hpv.csv" }
 
       it "populates the rows" do
@@ -121,7 +121,7 @@ describe ImmunisationImport do
     subject(:process!) { immunisation_import.process! }
 
     context "with valid Flu rows" do
-      let(:programme) { create(:programme, :flu_all_vaccines, team:) }
+      let(:programme) { create(:programme, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -167,7 +167,7 @@ describe ImmunisationImport do
     end
 
     context "with valid HPV rows" do
-      let(:programme) { create(:programme, :hpv_all_vaccines, team:) }
+      let(:programme) { create(:programme, :hpv_all_vaccines) }
       let(:file) { "valid_hpv.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -224,7 +224,7 @@ describe ImmunisationImport do
     end
 
     context "with an existing patient matching the name" do
-      let(:programme) { create(:programme, :flu_all_vaccines, team:) }
+      let(:programme) { create(:programme, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       let!(:patient) do
@@ -247,7 +247,7 @@ describe ImmunisationImport do
     end
 
     context "with a patient record that has different attributes" do
-      let(:programme) { create(:programme, :hpv_all_vaccines, team:) }
+      let(:programme) { create(:programme, :hpv_all_vaccines) }
       let(:file) { "valid_hpv_with_changes.csv" }
       let!(:existing_patient) do
         create(
@@ -279,7 +279,7 @@ describe ImmunisationImport do
     subject(:record!) { immunisation_import.record! }
 
     context "with valid Flu rows" do
-      let(:programme) { create(:programme, :flu_all_vaccines, team:) }
+      let(:programme) { create(:programme, :flu_all_vaccines) }
       let(:file) { "valid_flu.csv" }
 
       it "records the patients" do
@@ -300,7 +300,7 @@ describe ImmunisationImport do
     end
 
     context "with valid HPV rows" do
-      let(:programme) { create(:programme, :hpv_all_vaccines, team:) }
+      let(:programme) { create(:programme, :hpv_all_vaccines) }
       let(:file) { "valid_hpv.csv" }
 
       it "records the patients" do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -32,18 +32,16 @@
 
 describe Location do
   describe "scopes" do
-    describe "#for_programme" do
-      subject(:scope) { described_class.for_programme(programme) }
+    describe "#for_year_groups" do
+      subject(:scope) { described_class.for_year_groups(year_groups) }
 
-      let(:team) { create(:team) }
-      let(:programme) { create(:programme, :hpv, team:) } # 8-11
-      let(:matching) { create(:location, :secondary, team:) } # 7-11
-      let(:mismatch_year_group) { create(:location, :primary, team:) } # 0-6
-      let(:mismatch_team) { create(:location, :secondary) }
+      let(:year_groups) { [8, 9, 10, 11] }
+
+      let(:matching) { create(:location, :secondary) } # 7-11
+      let(:mismatch) { create(:location, :primary) } # 0-6
 
       it { should include(matching) }
-      it { should_not include(mismatch_year_group) }
-      it { should_not include(mismatch_team) }
+      it { should_not include(mismatch) }
     end
 
     describe "#has_no_session" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -57,10 +57,11 @@ describe Session do
   end
 
   it "sets default programmes when creating a new session" do
-    team = create(:team)
+    hpv_programme = create(:programme, :hpv)
+    flu_programme = create(:programme, :flu)
+
+    team = create(:team, programmes: [hpv_programme, flu_programme])
     location = create(:location, :primary)
-    hpv_programme = create(:programme, :hpv, team:)
-    flu_programme = create(:programme, :flu, team:)
 
     session = described_class.new(team:, location:)
 

--- a/spec/policies/patient_session_policy_spec.rb
+++ b/spec/policies/patient_session_policy_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 describe PatientSessionPolicy do
-  let(:team) { create(:team) }
+  let(:programme) { create(:programme) }
+
+  let(:team) { create(:team, programmes: [programme]) }
   let(:user) { create(:user, teams: [team]) }
 
-  let(:programme) { create(:programme, team:) }
   let(:patient_session) do
     create(
       :patient_session,

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -4,12 +4,11 @@ describe SessionPolicy do
   describe "Scope#resolve" do
     subject { SessionPolicy::Scope.new(user, Session).resolve }
 
-    let(:team) { create(:team) }
+    let(:programme) { create(:programme) }
+    let(:team) { create(:team, programmes: [programme]) }
     let(:user) { create(:user, teams: [team]) }
 
-    let(:users_teams_session) do
-      create(:session, programme: create(:programme, team:))
-    end
+    let(:users_teams_session) { create(:session, team:, programme:) }
     let(:another_teams_session) { create(:session) }
 
     it { should include(users_teams_session) }


### PR DESCRIPTION
This updates various parts of the code to stop using the `team` attribute of `Programme` as this will be being removed shortly to support global programmes. See individual commits for more details.