### PR TITLE
Add cohorts to sessions

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -18,7 +18,7 @@ class ProgrammesController < ApplicationController
     @scheduled_sessions = @programme.sessions.scheduled
 
     @unscheduled_sessions =
-      @programme.sessions.unscheduled +
+      @programme.sessions.unscheduled.where(academic_year:) +
         policy_scope(Location)
           .school
           .for_year_groups(@programme.year_groups)
@@ -27,7 +27,7 @@ class ProgrammesController < ApplicationController
             Session.new(team: current_user.team, location:, academic_year:)
           end
 
-    @completed_sessions = @programme.sessions.completed
+    @completed_sessions = @programme.sessions.completed.where(academic_year:)
   end
 
   private

--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -16,10 +16,6 @@ class Sessions::EditController < ApplicationController
     case current_step
     when :confirm
       @session.patient_sessions.update_all(active: true)
-
-      if @session.send_consent_requests_at.today?
-        ConsentRequestsSessionBatchJob.perform_later(@session)
-      end
     else
       @session.assign_attributes update_params
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -33,7 +33,7 @@ class SessionsController < ApplicationController
 
   def unscheduled
     @sessions =
-      policy_scope(Session).unscheduled +
+      policy_scope(Session).unscheduled.where(academic_year:) +
         team
           .schools
           .has_no_session(academic_year)
@@ -43,7 +43,7 @@ class SessionsController < ApplicationController
   end
 
   def completed
-    @sessions = policy_scope(Session).completed
+    @sessions = policy_scope(Session).completed.where(academic_year:)
 
     render layout: "full"
   end

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -27,8 +27,8 @@ class Cohort < ApplicationRecord
   validates :birth_academic_year, comparison: { greater_than_or_equal_to: 1990 }
 
   scope :for_year_groups,
-        ->(year_groups) do
-          academic_year = Time.zone.today.academic_year
+        ->(year_groups, academic_year: nil) do
+          academic_year ||= Date.current.academic_year
 
           birth_academic_years =
             year_groups.map { |year_group| academic_year - year_group - 5 }

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -113,5 +113,12 @@ class CohortImport < ApplicationRecord
       patients.draft.update_all(recorded_at:)
       parents.draft.update_all(recorded_at:)
     end
+
+    sessions =
+      team.sessions.scheduled.or(
+        Session.unscheduled.where(academic_year: Date.current.academic_year)
+      )
+
+    sessions.each(&:create_patient_sessions!)
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -63,13 +63,14 @@ class Patient < ApplicationRecord
   # https://www.datadictionary.nhs.uk/attributes/person_gender_code.html
   enum :gender_code, { not_known: 0, male: 1, female: 2, not_specified: 9 }
 
+  scope :consent_request_sent, -> { where.not(consent_request_sent_at: nil) }
   scope :consent_request_not_sent, -> { where(consent_request_sent_at: nil) }
   scope :consent_reminder_not_sent, -> { where(consent_reminder_sent_at: nil) }
 
   scope :without_consent,
         -> { includes(:consents).where(consents: { id: nil }) }
   scope :needing_consent_reminder,
-        -> { without_consent.consent_reminder_not_sent }
+        -> { consent_request_sent.without_consent.consent_reminder_not_sent }
 
   scope :matching_three_of,
         ->(first_name:, last_name:, date_of_birth:, address_postcode:) do

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -70,9 +70,9 @@ class Session < ApplicationRecord
         end
 
   scope :send_consent_requests_today,
-        -> { where(send_consent_requests_at: Time.zone.today) }
+        -> { scheduled.where("send_consent_requests_at <= ?", Date.current) }
   scope :send_consent_reminders_today,
-        -> { where(send_consent_reminders_at: Time.zone.today) }
+        -> { scheduled.where("send_consent_reminders_at <= ?", Date.current) }
 
   after_initialize :set_programmes
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -104,7 +104,7 @@ class Session < ApplicationRecord
   def create_patient_sessions!
     return if location.nil?
 
-    cohorts = team.cohorts.for_year_groups(year_groups)
+    cohorts = team.cohorts.for_year_groups(year_groups, academic_year:)
 
     patients_in_cohorts =
       Patient.where(cohort: cohorts, school: location).includes(

--- a/app/views/sessions/edit/confirm.html.erb
+++ b/app/views/sessions/edit/confirm.html.erb
@@ -9,16 +9,6 @@
 
 <%= render AppSessionSummaryCardComponent.new(@session) %>
 
-<% if @session.send_consent_requests_at.today? %>
-  <%= govuk_inset_text do %>
-    <span class="nhsuk-visually-hidden">Information: </span>
-
-    <p>
-      After clicking confirm, consent request emails will be sent immediately.
-    </p>
-  <% end %>
-<% end %>
-
 <%= govuk_button_to "Confirm",
                     wizard_path,
                     method: :put,

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -89,6 +89,10 @@ FactoryBot.define do
       home_educated { true }
     end
 
+    trait :consent_request_sent do
+      consent_request_sent_at { 1.week.ago }
+    end
+
     trait :consent_given_triage_not_needed do
       consents do
         [

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -23,7 +23,6 @@ describe "Manage sessions" do
 
     when_i_confirm
     then_i_should_see_the_session_details
-    and_the_parents_should_receive_a_consent_request
 
     when_i_go_to_todays_sessions_as_a_nurse
     then_i_see_no_sessions
@@ -112,7 +111,6 @@ describe "Manage sessions" do
 
   def then_i_see_the_confirmation_page
     expect(page).to have_content("Check and confirm details")
-    expect(page).to have_content("After clicking confirm")
   end
 
   def when_i_confirm
@@ -121,13 +119,6 @@ describe "Manage sessions" do
 
   def then_i_should_see_the_session_details
     expect(page).to have_content(@location.name.to_s)
-  end
-
-  def and_the_parents_should_receive_a_consent_request
-    @patient.parents.each do |parent|
-      expect_email_to(parent.email, :hpv_session_consent_request, :any)
-      expect_text_to(parent.phone, :consent_request, :any)
-    end
   end
 
   def when_the_parent_visits_the_consent_form

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -258,5 +258,33 @@ describe CohortImport do
     it "records the parents" do
       expect { record! }.to change(Parent.recorded, :count).from(0).to(3)
     end
+
+    context "with an unscheduled session" do
+      let(:session) do
+        create(:session, :unscheduled, team:, programme:, location:)
+      end
+
+      it "adds the patients to the session" do
+        expect { record! }.to change(session.patients, :count).from(0).to(3)
+      end
+    end
+
+    context "with a scheduled session" do
+      let(:session) do
+        create(:session, :scheduled, team:, programme:, location:)
+      end
+
+      it "adds the patients to the session" do
+        expect { record! }.to change(session.patients, :count).from(0).to(3)
+      end
+    end
+
+    context "with a completed session" do
+      before { create(:session, :completed, team:, programme:, location:) }
+
+      it "doesn't add the patients to the session" do
+        expect { record! }.not_to change(PatientSession, :count)
+      end
+    end
   end
 end


### PR DESCRIPTION
When importing cohorts this ensures that patients are added to any unscheduled or scheduled sessions for the current academic year and school. It also updates the consent request process to ensure that new consent forms are sent out to those new patients.