### PR TITLE
Add dev tools endpoint for resetting a team's data

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -55,18 +55,7 @@ class DevController < ApplicationController
       team_session.destroy!
     end
 
-    Patient
-      .joins(:cohort)
-      .where(cohorts: { team: })
-      .distinct
-      .find_each do |patient|
-        parent_ids = patient.parent_ids
-        patient.parents.clear
-        parent_ids.each { |parent_id| Parent.find(parent_id).destroy }
-
-        patient.save!
-        patient.destroy!
-      end
+    Patient.joins(:cohort).where(cohorts: { team: }).distinct.destroy_all
 
     Cohort.where(team:).delete_all
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -104,6 +104,8 @@ class Patient < ApplicationRecord
 
   before_save :remove_spaces_from_nhs_number
 
+  before_destroy :destroy_childless_parents
+
   delegate :year_group, to: :cohort
 
   def self.find_existing(
@@ -147,6 +149,17 @@ class Patient < ApplicationRecord
     location = school
     if location && !location.school?
       errors.add(:school, "must be a school location type")
+    end
+  end
+
+  def destroy_childless_parents
+    parents_to_check = parents.to_a # Store parents before destroying relationships
+
+    # Manually destroy the parent_relationships associated with this Child
+    parent_relationships.each(&:destroy)
+
+    parents_to_check.each do |parent|
+      parent.destroy! if parent.parent_relationships.count.zero?
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,10 @@ Rails.application.routes.draw do
     get "/random_consent_form", to: "dev#random_consent_form"
   end
 
+  constraints -> { Flipper.enabled?(:dev_tools) } do
+    get "/reset/:team_ods_code", to: "dev#reset_team", as: :reset_team
+  end
+
   get "/csrf", to: "csrf#new"
 
   resources :programmes, only: %i[index show] do

--- a/spec/features/dev_reset_team_spec.rb
+++ b/spec/features/dev_reset_team_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+describe "Dev endpoint to reset a team" do
+  before { Flipper.enable(:dev_tools) }
+
+  after { Flipper.disable(:dev_tools) }
+
+  scenario "Resetting a team deletes all associated data" do
+    given_an_example_programme_exists
+    and_patients_have_been_imported
+    and_vaccination_records_have_been_imported
+
+    then_all_associated_data_is_deleted_when_i_reset_the_team
+  end
+
+  def given_an_example_programme_exists
+    programme = create(:programme, :hpv_all_vaccines, batch_count: 4)
+    @team = create(:team, :with_one_nurse, programmes: [programme])
+    @team.update!(ods_code: "R1L") # to match valid_hpv.csv
+    @team.schools << create(:location, :school, urn: "123456") # to match valid_cohort.csv
+    @team.schools << create(:location, :school, urn: "110158") # to match valid_hpv.csv
+    @user = @team.users.first
+  end
+
+  def and_patients_have_been_imported
+    sign_in @user
+    visit "/dashboard"
+    click_on "Programmes", match: :first
+    click_on "HPV"
+    click_on "Cohort"
+    click_on "Import child records"
+    attach_file(
+      "cohort_import[csv]",
+      "spec/fixtures/cohort_import/valid_cohort.csv"
+    )
+    click_on "Continue"
+
+    perform_enqueued_jobs
+    visit current_path
+
+    expect(page).to have_content("Full nameNHS numberDate of birthPostcode")
+
+    click_on "Upload records"
+
+    expect(@team.cohorts.flat_map(&:patients).size).to eq(3)
+    expect(@team.cohorts.flat_map(&:patients).flat_map(&:parents).size).to eq(3)
+  end
+
+  def and_vaccination_records_have_been_imported
+    visit "/dashboard"
+    click_on "Programmes", match: :first
+    click_on "HPV"
+    click_on "Vaccinations"
+    click_on "Import vaccination records"
+    attach_file(
+      "immunisation_import[csv]",
+      "spec/fixtures/immunisation_import/valid_hpv.csv"
+    )
+    click_on "Continue"
+
+    click_on "Upload records"
+    expect(VaccinationRecord.count).to eq(7)
+  end
+
+  def then_all_associated_data_is_deleted_when_i_reset_the_team
+    expect { visit "/reset/#{@team.ods_code}" }.to(
+      change(Patient, :count)
+        .by(-10)
+        .and(change(Cohort, :count).by(-2))
+        .and(change(Parent, :count).by(-3))
+        .and(change(VaccinationRecord, :count).by(-7))
+        .and(change(ImmunisationImport, :count).by(-1))
+        .and(change(CohortImport, :count).by(-1))
+    )
+  end
+end


### PR DESCRIPTION
This will make it easier to run repeatable black box tests of the app.

I'm not convinced this is the best way to implement it – open to suggestions on alternatives.