### PR TITLE
Take health questions from active vaccines

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -434,7 +434,10 @@ class ConsentForm < ApplicationRecord
 
   def seed_health_questions
     return unless health_answers.empty?
-    vaccine = programme.vaccines.first
+
+    # TODO: handle multiple active vaccines
+    vaccine = programme.vaccines.active.first
+
     self.health_answers = vaccine.health_questions.to_health_answers
   end
 


### PR DESCRIPTION
The HPV programme has two discontinued vaccines (necessary to support importing old vaccination records), however for new consent forms we should make sure to get the health questions from the active vaccine to ensure users are seeing the right information.