### PR TITLE
Only send reminders to unvaccinated patients

### DIFF
--- a/app/jobs/session_reminders_job.rb
+++ b/app/jobs/session_reminders_job.rb
@@ -10,12 +10,14 @@ class SessionRemindersJob < ApplicationJob
 
     patient_sessions =
       PatientSession
-        .includes(:consents, :patient)
+        .includes(:consents, :patient, :vaccination_records)
         .joins(:session)
         .merge(Session.has_date(date))
         .reminder_not_sent(date)
 
     patient_sessions.each do |patient_session|
+      next if patient_session.vaccination_administered?
+
       # We create a record in the database first to avoid sending duplicate emails/texts.
       # If a problem occurs while the emails/texts are sent, they will be in the job
       # queue and restarted at a later date.

--- a/spec/jobs/session_reminders_job_spec.rb
+++ b/spec/jobs/session_reminders_job_spec.rb
@@ -66,6 +66,25 @@ describe SessionRemindersJob do
         expect { perform_now }.not_to change(SessionNotification, :count)
       end
     end
+
+    context "when already vaccinated" do
+      before { create(:vaccination_record, patient_session:, programme:) }
+
+      it "doesn't send a reminder email" do
+        expect { perform_now }.not_to have_enqueued_mail(
+          SessionMailer,
+          :reminder
+        )
+      end
+
+      it "doesn't sent a reminder text" do
+        expect { perform_now }.not_to have_enqueued_text(:session_reminder)
+      end
+
+      it "doesn't record a notification" do
+        expect { perform_now }.not_to change(SessionNotification, :count)
+      end
+    end
   end
 
   context "for a session today" do


### PR DESCRIPTION
If the patient was already vaccinated in the session we should not send out a reminder email for any subsequent dates.