### PR TITLE
Ensure unknown school vaccination records can be imported

### DIFF
--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -114,11 +114,13 @@ class ImmunisationImport < ApplicationRecord
   end
 
   def link_records(*records)
-    records.each do |record|
-      unless record.immunisation_imports.exists?(id)
-        record.immunisation_imports << self
+    records
+      .reject(&:nil?)
+      .each do |record|
+        unless record.immunisation_imports.exists?(id)
+          record.immunisation_imports << self
+        end
       end
-    end
   end
 
   def record_rows

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -5,4 +5,4 @@ R1L,110158,Eton College,4146825652,Caden,Attwater,20100914,Male,LE1 2DA,20240514
 R1L,110158,Eton College,2675725722,Berry,Hamilton,20100915,Female,LE8 2DA,20240514,Cervarix,123013325,20220730,Nasal,1,LocalPatient4,www.LocalPatient4,1
 R1L,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,Gardasil,123013325,20220730,Left Upper Arm,1,LocalPatient5,www.LocalPatient5,1
 R1L,110158,Eton College,8160442742,Oliver,Bowers,20100917,Male,LE5 2RP,20240514,Gardasil9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
-R1L,110158,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,Cervarix,123013326,20220730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1
+R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,Cervarix,123013326,20220730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -177,7 +177,7 @@ describe ImmunisationImport do
           .and change(immunisation_import.vaccination_records, :count).by(7)
           .and change(immunisation_import.locations, :count).by(1)
           .and change(immunisation_import.patients, :count).by(7)
-          .and change(immunisation_import.sessions, :count).by(1)
+          .and change(immunisation_import.sessions, :count).by(2)
           .and change(immunisation_import.patient_sessions, :count).by(7)
           .and change(immunisation_import.batches, :count).by(5)
 
@@ -214,7 +214,7 @@ describe ImmunisationImport do
       it "creates a new session for each date" do
         process!
 
-        expect(immunisation_import.sessions.count).to eq(1)
+        expect(immunisation_import.sessions.count).to eq(2)
 
         session = immunisation_import.sessions.first
         expect(session.dates.map(&:value)).to contain_exactly(


### PR DESCRIPTION
Currently this fails as we try and link a location to the immunisation import, but the location will be `nil`. I've updated the fixture to include an example of this case.