### PR TITLE
Send multiple session dates to GOV.UK Notify

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -94,6 +94,10 @@ class Session < ApplicationRecord
     programmes.flat_map(&:year_groups).uniq.sort
   end
 
+  def today_or_future_dates
+    dates.select(&:today_or_future?).map(&:value)
+  end
+
   def create_patient_sessions!
     return if location.nil?
 

--- a/app/models/session_date.rb
+++ b/app/models/session_date.rb
@@ -33,6 +33,10 @@ class SessionDate < ApplicationRecord
               less_than_or_equal_to: :latest_possible_value
             }
 
+  def today_or_future?
+    value.today? || value.future?
+  end
+
   private
 
   def earliest_possible_value

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -32,8 +32,8 @@ describe GovukNotifyPersonalisation do
       location:,
       team:,
       programme:,
-      close_consent_at: Date.new(2024, 1, 1),
-      date: Date.new(2024, 1, 1)
+      close_consent_at: Date.new(2026, 1, 1),
+      date: Date.new(2026, 1, 1)
     )
   end
   let(:consent) { nil }
@@ -44,15 +44,16 @@ describe GovukNotifyPersonalisation do
   it do
     expect(personalisation).to eq(
       {
-        close_consent_date: "Monday 1 January",
+        close_consent_date: "Thursday 1 January",
         close_consent_short_date: "1 January",
         consent_link:
           "http://localhost:4000/sessions/#{session.id}/consents/start",
         full_and_preferred_patient_name: "John Smith",
         location_name: "Hogwarts",
+        next_session_date: "Thursday 1 January",
+        next_session_dates: "Thursday 1 January",
+        next_session_dates_or: "Thursday 1 January",
         programme_name: "Flu",
-        session_date: "Monday 1 January",
-        session_short_date: "1 January",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",
         team_email: "team@example.com",
@@ -61,6 +62,22 @@ describe GovukNotifyPersonalisation do
         vaccination: "Flu vaccination"
       }
     )
+  end
+
+  context "with multiple dates" do
+    before { create(:session_date, session:, value: Date.new(2026, 1, 2)) }
+
+    it do
+      expect(personalisation).to match(
+        hash_including(
+          next_session_date: "Thursday 1 January",
+          next_session_dates: "Thursday 1 January and Friday 2 January",
+          next_session_dates_or: "Thursday 1 January or Friday 2 January",
+          subsequent_session_dates_offered_message:
+            "If they’re not seen, they’ll be offered the vaccination on Friday 2 January."
+        )
+      )
+    end
   end
 
   context "with a consent" do

--- a/spec/mailers/consent_mailer_spec.rb
+++ b/spec/mailers/consent_mailer_spec.rb
@@ -40,8 +40,7 @@ describe ConsentMailer do
         mail.message.header["personalisation"].unparsed_value
       end
 
-      it { should include(session_date: date.strftime("%A %-d %B")) }
-      it { should include(session_short_date: date.strftime("%-d %B")) }
+      it { should include(next_session_date: date.strftime("%A %-d %B")) }
 
       it do
         expect(personalisation).to include(
@@ -79,7 +78,7 @@ describe ConsentMailer do
         mail.message.header["personalisation"].unparsed_value
       end
 
-      it { should include(session_date: date.strftime("%A %-d %B")) }
+      it { should include(next_session_date: date.strftime("%A %-d %B")) }
 
       it do
         expect(personalisation).to include(

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -22,8 +22,10 @@ describe SessionMailer do
         expect(personalisation.keys).to include(
           :full_and_preferred_patient_name,
           :location_name,
+          :next_session_date,
+          :next_session_dates,
+          :next_session_dates_or,
           :parent_name,
-          :session_date,
           :short_patient_name,
           :short_patient_name_apos,
           :team_email,

--- a/spec/models/session_date_spec.rb
+++ b/spec/models/session_date_spec.rb
@@ -18,9 +18,10 @@
 #  fk_rails_...  (session_id => sessions.id)
 #
 describe SessionDate do
-  subject(:session_date) { build(:session_date, session:) }
+  subject(:session_date) { build(:session_date, session:, value:) }
 
   let(:session) { create(:session, academic_year: 2024) }
+  let(:value) { Date.current }
 
   describe "validations" do
     it "validates that the date is within the academic year" do
@@ -29,6 +30,26 @@ describe SessionDate do
       ).is_greater_than_or_equal_to(
         Date.new(2024, 9, 1)
       ).is_less_than_or_equal_to(Date.new(2025, 8, 31))
+    end
+  end
+
+  describe "#today_or_future?" do
+    subject(:today_or_future?) { session_date.today_or_future? }
+
+    context "with a today's date" do
+      it { should be(true) }
+    end
+
+    context "with a date in the past" do
+      let(:value) { Date.yesterday }
+
+      it { should be(false) }
+    end
+
+    context "with a date in the future" do
+      let(:value) { Date.tomorrow }
+
+      it { should be(true) }
     end
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -140,6 +140,44 @@ describe Session do
     it { should contain_exactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) }
   end
 
+  describe "#today_or_future_dates" do
+    subject(:today_or_future_dates) do
+      travel_to(today) { session.today_or_future_dates }
+    end
+
+    let(:dates) do
+      [Date.new(2024, 1, 1), Date.new(2024, 1, 2), Date.new(2024, 1, 3)]
+    end
+
+    let(:session) { create(:session, academic_year: 2023, date: nil) }
+
+    before { dates.each { |value| create(:session_date, session:, value:) } }
+
+    context "on the first day" do
+      let(:today) { dates.first }
+
+      it { should match_array(dates) }
+    end
+
+    context "on the second day" do
+      let(:today) { dates.second }
+
+      it { should match_array(dates.drop(1)) }
+    end
+
+    context "on the third day" do
+      let(:today) { dates.third }
+
+      it { should match_array(dates.drop(2)) }
+    end
+
+    context "after the session" do
+      let(:today) { dates.third + 1.day }
+
+      it { should be_empty }
+    end
+  end
+
   describe "#create_patient_sessions!" do
     subject(:create_patient_sessions!) { session.create_patient_sessions! }
 


### PR DESCRIPTION
This updates the GOV.UK Notify personalisation to include all the session dates. I've already updated all the templates in GOV.UK Notify to use these new personalisation variables.