### PR TITLE
Set session timeout to 2 weeks in local dev

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -188,7 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 15.minutes
+  config.timeout_in = Rails.env.development? ? 2.weeks : 15.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.


### PR DESCRIPTION
With 15 minutes we get logged out constantly while developing and it's distracting.