### PR TITLE
Remove unused state transition methods

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -107,14 +107,11 @@ class ManageConsentsController < ApplicationController
       end
 
       if @triage.persisted?
-        @patient_session.do_consent!
-        @patient_session.do_triage!
         send_triage_confirmation(@patient_session, @consent)
       else
         # We need to discard the draft triage record so that the patient
         # session can be saved.
         @triage.destroy!
-        @patient_session.do_consent!
       end
 
       if @consent.draft_parent.present?

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -48,7 +48,6 @@ class TriageController < ApplicationController
   def create
     @triage.assign_attributes(triage_params.merge(performed_by: current_user))
     if @triage.save(context: :consent)
-      @patient_session.do_triage!
       @patient.consents.recorded.each do
         send_triage_confirmation(@patient_session, _1)
       end

--- a/app/controllers/vaccinations/edit_controller.rb
+++ b/app/controllers/vaccinations/edit_controller.rb
@@ -39,7 +39,6 @@ class Vaccinations::EditController < ApplicationController
 
     if @draft_vaccination_record.save
       send_vaccination_confirmation(@draft_vaccination_record)
-      @patient_session.do_vaccination!
 
       session.delete(:delivery_site_other)
 

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -47,42 +47,6 @@ module PatientSessionStateConcern
       vaccinated
     ].each { |state| define_method("#{state}?") { self.state == state } }
 
-    def do_consent
-      nil
-    end
-
-    def do_consent!
-      nil
-    end
-
-    def do_triage
-      nil
-    end
-
-    def do_triage!
-      nil
-    end
-
-    def do_vaccination
-      nil
-    end
-
-    def do_vaccination!
-      nil
-    end
-
-    def may_do_consent?
-      true
-    end
-
-    def may_do_triage?
-      true
-    end
-
-    def may_do_vaccination?
-      true
-    end
-
     def consent_given?
       return false if no_consent?
 

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -171,24 +171,19 @@ class Consent < ApplicationRecord
     ActiveRecord::Base.transaction do
       parent = consent_form.find_or_create_parent_with_relationship_to(patient:)
 
-      consent =
-        create!(
-          consent_form:,
-          team: consent_form.session.team,
-          programme: consent_form.programme,
-          patient:,
-          parent:,
-          reason_for_refusal: consent_form.reason,
-          reason_for_refusal_notes: consent_form.reason_notes,
-          recorded_at: Time.zone.now,
-          response: consent_form.response,
-          route: "website",
-          health_answers: consent_form.health_answers
-        )
-
-      patient_session.do_consent! if patient_session.may_do_consent?
-
-      consent
+      create!(
+        consent_form:,
+        team: consent_form.session.team,
+        programme: consent_form.programme,
+        patient:,
+        parent:,
+        reason_for_refusal: consent_form.reason,
+        reason_for_refusal_notes: consent_form.reason_notes,
+        recorded_at: Time.zone.now,
+        response: consent_form.response,
+        route: "website",
+        health_answers: consent_form.health_answers
+      )
     end
   end
 


### PR DESCRIPTION
The state functionality was partially removed in
8200353266453e7728cbdc76cdb2e6a35c7bc05f but the transition methods weren't removed. They're not being used anywhere and don't do anything so we can safely remove them.