### PR TITLE
Ensure sessions aren't created with no programmes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,8 @@ class SessionsController < ApplicationController
   skip_after_action :verify_policy_scoped, only: :new
 
   def new
-    location = team.schools.find(params[:location_id])
+    location =
+      team.schools.for_year_groups(team.year_groups).find(params[:location_id])
 
     session =
       ActiveRecord::Base.transaction do
@@ -37,6 +38,7 @@ class SessionsController < ApplicationController
         team
           .schools
           .has_no_session(academic_year)
+          .for_year_groups(team.year_groups)
           .map { |location| Session.new(team:, location:, academic_year:) }
 
     render layout: "full"

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -182,19 +182,19 @@ class Session < ApplicationRecord
 
   private
 
+  def set_programmes
+    return unless new_record?
+    return if location.nil?
+
+    self.programmes =
+      team.programmes.select { _1.year_groups.intersect?(location.year_groups) }
+  end
+
   def programmes_part_of_team
     return if programmes.empty?
 
     unless programmes.all? { team.programmes.include?(_1) }
       errors.add(:programmes, :inclusion)
     end
-  end
-
-  def set_programmes
-    return unless new_record?
-    return if location.nil? || team.nil?
-
-    self.programmes =
-      team.programmes.select { _1.year_groups.intersect?(location.year_groups) }
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -44,6 +44,10 @@ class Team < ApplicationRecord
   validates :ods_code, presence: true, uniqueness: true
   validates :phone, presence: true, phone: true
 
+  def year_groups
+    programmes.flat_map(&:year_groups).uniq.sort
+  end
+
   def weeks_between_first_session_and_consent_requests
     (days_between_first_session_and_consent_requests / 7).to_i
   end


### PR DESCRIPTION
This makes it impossible to create sessions with no programmes, which can lead to bugs down the line as we always expect a session to have at least one programme.

Unfortunately we can't add validation to the session model because of the many-to-many relationship and the way we construct sessions when importing with a find or create.