### PR TITLE
Add AppImportErrorsComponent

### DIFF
--- a/app/components/app_import_errors_component.rb
+++ b/app/components/app_import_errors_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AppImportErrorsComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <% @errors.each do |error| %>
+      <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
+        <% if error.attribute == :csv %>
+          CSV
+        <% else %>
+          <%= error.attribute.to_s.humanize %>
+        <% end %>
+      </h2>
+    
+      <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-font-size-16">
+        <% if error.type.is_a?(Array) %>
+          <% error.type.each do |type| %>
+            <li><%= sanitize type %></li>
+          <% end %>
+        <% else %>
+          <li><%= sanitize error.type %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  ERB
+
+  def initialize(errors)
+    super
+
+    @errors = errors
+  end
+
+  def render?
+    @errors.present?
+  end
+end

--- a/app/views/cohort_imports/errors.html.erb
+++ b/app/views/cohort_imports/errors.html.erb
@@ -14,22 +14,4 @@
   When fixing these errors, note that the header does not count as a row.
 </p>
 
-<% @cohort_import.errors.each do |error| %>
-  <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
-    <% if error.attribute == :csv %>
-      CSV
-    <% else %>
-      <%= error.attribute.to_s.humanize %>
-    <% end %>
-  </h2>
-
-  <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-font-size-16">
-    <% if error.type.is_a?(Array) %>
-      <% error.type.each do |type| %>
-        <li><%= sanitize type %></li>
-      <% end %>
-    <% else %>
-      <li><%= sanitize error.type %></li>
-    <% end %>
-  </ul>
-<% end %>
+<%= render AppImportErrorsComponent.new(@cohort_import.errors) %>

--- a/app/views/immunisation_imports/errors.html.erb
+++ b/app/views/immunisation_imports/errors.html.erb
@@ -14,22 +14,4 @@
   When fixing these errors, note that the header does not count as a row.
 </p>
 
-<% @immunisation_import.errors.each do |error| %>
-  <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
-    <% if error.attribute == :csv %>
-      CSV
-    <% else %>
-      <%= error.attribute.to_s.humanize %>
-    <% end %>
-  </h2>
-
-  <ul class="nhsuk-list nhsuk-list--bullet nhsuk-u-font-size-16">
-    <% if error.type.is_a?(Array) %>
-      <% error.type.each do |type| %>
-        <li><%= sanitize type %></li>
-      <% end %>
-    <% else %>
-      <li><%= sanitize error.type %></li>
-    <% end %>
-  </ul>
-<% end %>
+<%= render AppImportErrorsComponent.new(@immunisation_import.errors) %>

--- a/spec/components/app_import_errors_component_spec.rb
+++ b/spec/components/app_import_errors_component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe AppImportErrorsComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(errors) }
+
+  let(:errors) do
+    [
+      OpenStruct.new(attribute: :csv, type: :invalid),
+      OpenStruct.new(attribute: :first_name, type: :blank),
+      OpenStruct.new(attribute: :first_name, type: %i[invalid blank])
+    ]
+  end
+
+  it { should have_text("CSV") }
+  it { should have_text("First name") }
+
+  it { should have_css("li", count: 4) }
+
+  it { should have_text("blank") }
+  it { should have_text("invalid") }
+end


### PR DESCRIPTION
This adds a component which can be used to render the validation errors for cohort imports, class imports and immunisation imports in a standard and consistent way.