### PR TITLE
Remove ClassImport CSVs

### DIFF
--- a/app/jobs/remove_import_csv_job.rb
+++ b/app/jobs/remove_import_csv_job.rb
@@ -4,14 +4,11 @@ class RemoveImportCSVJob < ApplicationJob
   queue_as :default
 
   def perform
-    ImmunisationImport
-      .csv_not_removed
-      .where("created_at < ?", Time.zone.now - 30.days)
-      .find_each(&:remove!)
-
-    CohortImport
-      .csv_not_removed
-      .where("created_at < ?", Time.zone.now - 30.days)
-      .find_each(&:remove!)
+    [ClassImport, CohortImport, ImmunisationImport].each do |import_type|
+      import_type
+        .csv_not_removed
+        .where("created_at < ?", Time.zone.now - 30.days)
+        .find_each(&:remove!)
+    end
   end
 end

--- a/spec/factories/class_imports.rb
+++ b/spec/factories/class_imports.rb
@@ -35,7 +35,8 @@
 #
 FactoryBot.define do
   factory :class_import do
-    team
+    session
+    team { session.team }
     uploaded_by
 
     csv_data { "my,csv\n" }

--- a/spec/jobs/remove_import_csv_job_spec.rb
+++ b/spec/jobs/remove_import_csv_job_spec.rb
@@ -4,7 +4,7 @@ describe RemoveImportCSVJob, type: :job do
   describe "#perform" do
     subject(:perform) { described_class.new.perform }
 
-    %w[cohort_import immunisation_import].each do |factory_name|
+    %w[class_import cohort_import immunisation_import].each do |factory_name|
       context "for #{factory_name.camelize}" do
         let(:to_remove) do
           create(factory_name, created_at: Time.zone.now - 90.days)


### PR DESCRIPTION
After 30 days, like we do for other imports, to avoid keeping personal information longer than we need to.