### PR TITLE
Handle patient moving schools

### DIFF
--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -30,17 +30,16 @@ class ConsentFormsController < ApplicationController
       policy_scope(PatientSession).find(params[:patient_session_id])
 
     patient = @patient_session.patient
+    session = @patient_session.session
 
-    session =
-      patient.match_consent_form!(@consent_form) ||
-        @consent_form.scheduled_session
+    patient.match_consent_form!(@consent_form)
 
     flash[:success] = {
       heading: "Consent matched for",
       heading_link_text: patient.full_name,
       heading_link_href:
         session_patient_path(
-          session,
+          patient.upcoming_sessions.first || @consent_form.scheduled_session,
           id: patient.id,
           section: "triage",
           tab: "given"

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -260,6 +260,22 @@ describe ClassImport do
         expect { process! }.to change(Patient, :count).by(3)
       end
     end
+
+    context "with an existing patient in a different session" do
+      let(:different_session) { create(:session, programme:) }
+
+      let(:patient) do
+        create(:patient, nhs_number: "1234567890", session: different_session)
+      end
+
+      it "removes the child from the original session and adds them to the new one" do
+        expect(patient.upcoming_sessions).to contain_exactly(different_session)
+        expect { process! }.to change { patient.reload.school }.to(
+          session.location
+        )
+        expect(patient.upcoming_sessions).to contain_exactly(session)
+      end
+    end
   end
 
   describe "#record!" do

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -193,7 +193,8 @@ describe Patient do
   describe "#match_consent_form!" do
     subject(:match_consent_form!) { patient.match_consent_form!(consent_form) }
 
-    let(:patient) { create(:patient) }
+    let(:old_school) { create(:location, :school) }
+    let(:patient) { create(:patient, school: old_school) }
 
     context "when consent form confirms the school" do
       let(:consent_form) { create(:consent_form, school_confirmed: true) }
@@ -222,12 +223,15 @@ describe Patient do
       end
 
       context "when the patient is already in a session" do
-        let(:session) { create(:session, patients: [patient]) }
+        let(:session) do
+          create(:session, location: old_school, patients: [patient])
+        end
         let(:consent_form) do
           create(:consent_form, school_confirmed: false, school:, session:)
         end
 
         it "removes the patient from the session" do
+          expect(patient.upcoming_sessions).to include(session)
           match_consent_form!
           expect(session.reload.patients).not_to include(patient)
         end


### PR DESCRIPTION
This updates the process for handling when a consent form indicates the patient belongs to a different school to apply the same logic as when importing class lists and cohorts, allowing existing patients to be added to any upcoming sessions automatically.