### PR TITLE
Session page performance improvements

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AppOutcomeBannerComponent < ViewComponent::Base
-  delegate :vaccination_record, :state, to: :@patient_session
+  delegate :state, to: :@patient_session
 
   def initialize(patient_session:, current_user: nil)
     super
@@ -50,9 +50,13 @@ class AppOutcomeBannerComponent < ViewComponent::Base
     end
   end
 
+  def vaccination_record
+    @vaccination_record ||= @patient_session.latest_vaccination_record
+  end
+
   def show_location?
     # location only makes sense if an attempt to vaccinate on site was made
-    @patient_session.vaccination_records.any?(&:recorded?)
+    vaccination_record.present?
   end
 
   def vaccine_summary

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -22,13 +22,7 @@ class ConsentsController < ApplicationController
         )
         .sort_by { |ps| ps.patient.full_name }
 
-    @unmatched_record_counts =
-      SessionStats.new(
-        patient_sessions: all_patient_sessions,
-        session: @session
-      )[
-        :unmatched_responses
-      ]
+    @unmatched_record_counts = @session.unmatched_consent_forms.count
 
     tab_patient_sessions =
       group_patient_sessions_by_conditions(

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -53,7 +53,7 @@ class ConsentsController < ApplicationController
 
   def set_session
     @session =
-      policy_scope(Session).find(
+      policy_scope(Session).includes(:team, :location).find(
         params.fetch(:session_id) { params.fetch(:id) }
       )
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -88,6 +88,12 @@ class SessionsController < ApplicationController
   end
 
   def set_session
-    @session = policy_scope(Session).find(params[:id])
+    @session =
+      policy_scope(Session).includes(
+        :team,
+        :location,
+        :dates,
+        :programmes
+      ).find(params[:id])
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -57,7 +57,8 @@ class SessionsController < ApplicationController
         :gillick_assessment,
         { consents: :parent },
         :triage,
-        :vaccination_records
+        :vaccination_records,
+        :latest_vaccination_record
       )
 
     @counts =

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -24,7 +24,8 @@ class TriageController < ApplicationController
           :gillick_assessment,
           :patient,
           :triage,
-          :vaccination_records
+          :vaccination_records,
+          :latest_vaccination_record
         )
         .preload(:consents)
         .order("patients.first_name", "patients.last_name")

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -66,7 +66,7 @@ class TriageController < ApplicationController
 
   def set_session
     @session =
-      policy_scope(Session).find(
+      policy_scope(Session).includes(:location).find(
         params.fetch(:session_id) { params.fetch(:id) }
       )
   end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -26,7 +26,8 @@ class VaccinationsController < ApplicationController
           :gillick_assessment,
           :patient,
           :triage,
-          :vaccination_records
+          :vaccination_records,
+          :latest_vaccination_record
         )
         .preload(:consents)
         .order("patients.first_name", "patients.last_name")

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -135,7 +135,7 @@ class VaccinationsController < ApplicationController
 
   def set_session
     @session =
-      policy_scope(Session).find(
+      policy_scope(Session).includes(:location).find(
         params.fetch(:session_id) { params.fetch(:id) }
       )
   end

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -95,11 +95,12 @@ module PatientSessionStateConcern
     end
 
     def vaccination_administered?
-      vaccination_record&.administered?
+      # HACK: in future, it will be possible to have multiple vaccination records for a patient session
+      latest_vaccination_record&.administered?
     end
 
     def vaccination_not_administered?
-      vaccination_record&.not_administered?
+      latest_vaccination_record&.not_administered?
     end
 
     def not_gillick_competent?
@@ -110,10 +111,10 @@ module PatientSessionStateConcern
     def vaccination_can_be_delayed?
       vaccination_not_administered? &&
         (
-          vaccination_record.not_well? ||
-            vaccination_record.contraindications? ||
-            vaccination_record.absent_from_session? ||
-            vaccination_record.absent_from_school?
+          latest_vaccination_record.not_well? ||
+            latest_vaccination_record.contraindications? ||
+            latest_vaccination_record.absent_from_session? ||
+            latest_vaccination_record.absent_from_school?
         )
     end
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -48,6 +48,9 @@ class PatientSession < ApplicationRecord
 
   has_many :triage, -> { order(:updated_at) }
   has_many :vaccination_records
+  has_one :latest_vaccination_record,
+          -> { recorded.order(:created_at) },
+          class_name: "VaccinationRecord"
   has_many :consents,
            ->(patient_session) do
              recorded.where(programme: patient_session.programmes).includes(
@@ -74,11 +77,6 @@ class PatientSession < ApplicationRecord
               .exists
           )
         end
-
-  def vaccination_record
-    # HACK: in future, it will be possible to have multiple vaccination records for a patient session
-    vaccination_records.recorded.last
-  end
 
   def draft_vaccination_record
     # HACK: this code will need to be revisited in future as it only really works for HPV, where we only have one

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -47,7 +47,7 @@ describe PatientSession do
         create(:vaccination_record, programme:, patient_session:)
       draft_vaccination_record.update!(recorded_at: nil)
 
-      expect(patient_session.vaccination_record).to eq vaccination_record
+      expect(patient_session.latest_vaccination_record).to eq vaccination_record
     end
   end
 


### PR DESCRIPTION
The session page and its various subpages (check consent, vaccinate, triage) were taking several seconds to load for a session with 300-odd patients.

This PR picks off some low-hanging fruit to reduce the load times to sub-second (review commit-by-commit), mostly by temporarily enabling global strict load and seeing what breaks.

I've not touched the patient page, which will require a bunch more work.

## Multiple vaccination records per `PatientSession`

This work also unearthed a (now erroneous) assumption baked into `PatientSessionStateConcern` that a `PatientSession` only has one record `VaccinationRecord`. That's now not always going to be true, because sessions span multiple dates:

* a patient can't be vaccinated in the session's first visit for whatever reason, and a non-vaccination outcome is recorded for them
* they come back in the second visit and get vaccinated

I think the implication of this assumption is that the patient's session state is likely to be wrong in certain circumstances. I will card up some follow-up work to look at this.