### PR TITLE
Move unknown patients to unknown school

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -59,5 +59,9 @@ class ClassImport < PatientImport
     super
 
     session.create_patient_sessions! unless session.completed?
+
+    (session.patients - patients).each do |unknown_patient|
+      unknown_patient.update!(school: nil)
+    end
   end
 end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -320,5 +320,15 @@ describe ClassImport do
         expect { record! }.not_to change(PatientSession, :count)
       end
     end
+
+    context "with an existing patient not in the class list" do
+      let(:existing_patient) { create(:patient, session:) }
+
+      it "moves the existing patient to an unknown school" do
+        expect(session.patients).to include(existing_patient)
+        expect { record! }.to change { existing_patient.reload.school }.to(nil)
+        expect(session.reload.patients).not_to include(existing_patient)
+      end
+    end
   end
 end


### PR DESCRIPTION
When importing a class list, any patients that didn't appear in the class list should be moved to an unknown school so they can be picked up in a clinic later.