### PR TITLE
Handle importing multiple doses in same file

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -380,14 +380,13 @@ class ImmunisationImportRow
   end
 
   def find_existing_patients
-    @find_existing_patients ||=
-      Patient.find_existing(
-        nhs_number: patient_nhs_number,
-        first_name: patient_first_name,
-        last_name: patient_last_name,
-        date_of_birth: patient_date_of_birth,
-        address_postcode: patient_postcode
-      )
+    Patient.find_existing(
+      nhs_number: patient_nhs_number,
+      first_name: patient_first_name,
+      last_name: patient_last_name,
+      date_of_birth: patient_date_of_birth,
+      address_postcode: patient_postcode
+    )
   end
 
   def zero_or_one_existing_patient

--- a/spec/features/dev_reset_team_spec.rb
+++ b/spec/features/dev_reset_team_spec.rb
@@ -62,7 +62,7 @@ describe "Dev endpoint to reset a team" do
           )
 
     click_on "Upload records"
-    expect(VaccinationRecord.count).to eq(7)
+    expect(VaccinationRecord.count).to eq(8)
   end
 
   def then_all_associated_data_is_deleted_when_i_reset_the_team
@@ -71,7 +71,7 @@ describe "Dev endpoint to reset a team" do
         .by(-10)
         .and(change(Cohort, :count).by(-2))
         .and(change(Parent, :count).by(-3))
-        .and(change(VaccinationRecord, :count).by(-7))
+        .and(change(VaccinationRecord, :count).by(-8))
         .and(change(ImmunisationImport, :count).by(-1))
         .and(change(CohortImport, :count).by(-1))
     )

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -136,7 +136,7 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_success_heading
-    expect(page).to have_content("7 new vaccination records")
+    expect(page).to have_content("8 new vaccination records")
   end
 
   def then_i_should_see_the_vaccination_records

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -5,4 +5,5 @@ R1L,110158,Eton College,4146825652,Caden,Attwater,20100914,Male,LE1 2DA,20240514
 R1L,110158,Eton College,2675725722,Berry,Hamilton,20100915,Female,LE8 2DA,20240514,Cervarix,123013325,20220730,Nasal,1,LocalPatient4,www.LocalPatient4,1
 R1L,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,Gardasil,123013325,20220730,Left Upper Arm,1,LocalPatient5,www.LocalPatient5,1
 R1L,110158,Eton College,8160442742,Oliver,Bowers,20100917,Male,LE5 2RP,20240514,Gardasil9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
-R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,Cervarix,123013326,20220730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1
+R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,Cervarix,123013326,20220730,Right Thigh,2,LocalPatient7,www.LocalPatient7,1
+R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20230410,Cervarix,123013325,20250730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -177,7 +177,7 @@ describe ImmunisationImport do
         # stree-ignore
         expect { process! }
           .to change(immunisation_import, :processed_at).from(nil)
-          .and change(immunisation_import.vaccination_records, :count).by(7)
+          .and change(immunisation_import.vaccination_records, :count).by(8)
           .and change(immunisation_import.locations, :count).by(1)
           .and change(immunisation_import.patients, :count).by(7)
           .and change(immunisation_import.sessions, :count).by(2)
@@ -313,7 +313,7 @@ describe ImmunisationImport do
       it "records the vaccination records" do
         expect { record! }.to change(VaccinationRecord.recorded, :count).from(
           0
-        ).to(7)
+        ).to(8)
       end
 
       it "activates the patient sessions" do

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -180,9 +180,9 @@ describe ImmunisationImport do
           .and change(immunisation_import.vaccination_records, :count).by(8)
           .and change(immunisation_import.locations, :count).by(1)
           .and change(immunisation_import.patients, :count).by(7)
-          .and change(immunisation_import.sessions, :count).by(2)
-          .and change(immunisation_import.patient_sessions, :count).by(7)
-          .and change(immunisation_import.batches, :count).by(5)
+          .and change(immunisation_import.sessions, :count).by(3)
+          .and change(immunisation_import.patient_sessions, :count).by(8)
+          .and change(immunisation_import.batches, :count).by(6)
 
         # Second import should not duplicate the vaccination records if they're
         # identical.
@@ -202,7 +202,7 @@ describe ImmunisationImport do
         # stree-ignore
         expect { process! }
           .to change(immunisation_import, :exact_duplicate_record_count).to(0)
-          .and change(immunisation_import, :new_record_count).to(7)
+          .and change(immunisation_import, :new_record_count).to(8)
           .and change(immunisation_import, :not_administered_record_count).to(0)
       end
 
@@ -211,13 +211,13 @@ describe ImmunisationImport do
         csv.rewind
 
         process!
-        expect(immunisation_import.exact_duplicate_record_count).to eq(7)
+        expect(immunisation_import.exact_duplicate_record_count).to eq(8)
       end
 
       it "creates a new session for each date" do
         process!
 
-        expect(immunisation_import.sessions.count).to eq(2)
+        expect(immunisation_import.sessions.count).to eq(3)
 
         session = immunisation_import.sessions.first
         expect(session.dates.map(&:value)).to contain_exactly(
@@ -318,7 +318,7 @@ describe ImmunisationImport do
 
       it "activates the patient sessions" do
         expect { record! }.to change(PatientSession.active, :count).from(0).to(
-          7
+          8
         )
       end
     end


### PR DESCRIPTION
If the same patient appears multiple times in a single file we currently get an error because we try and create multiple patients for the same NHS number, and other personal details.

To fix this we can looking for duplicate patients each time we process a row, ensuring that if a patient was created in a previous row, we would now match with it and avoid creating a second patient.