### PR TITLE
Rename session in progress status

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -25,7 +25,7 @@ module SessionsHelper
     elsif session.completed?
       govuk_tag(text: "All sessions completed", colour: "green")
     else
-      govuk_tag(text: "Session in progress")
+      govuk_tag(text: "Sessions scheduled")
     end
   end
 end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe SessionsHelper do
 
       it do
         expect(session_status_tag).to eq(
-          "<strong class=\"nhsuk-tag\">Session in progress</strong>"
+          "<strong class=\"nhsuk-tag\">Sessions scheduled</strong>"
         )
       end
     end


### PR DESCRIPTION
This is now showing as "Session scheduled" in the prototype.