### PR TITLE
Refactor vaccination record relationship on patient sessions 

### DIFF
--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -95,27 +95,20 @@ module PatientSessionStateConcern
     end
 
     def vaccination_administered?
-      # HACK: in future, it will be possible to have multiple vaccination records for a patient session
-      latest_vaccination_record&.administered?
+      vaccination_records.any?(&:administered?)
     end
 
     def vaccination_not_administered?
-      latest_vaccination_record&.not_administered?
+      vaccination_records.any?(&:not_administered?)
     end
 
     def not_gillick_competent?
-      gillick_assessment.present? &&
-        gillick_assessment.gillick_competent == false
+      gillick_assessment&.gillick_competent == false
     end
 
     def vaccination_can_be_delayed?
-      vaccination_not_administered? &&
-        (
-          latest_vaccination_record.not_well? ||
-            latest_vaccination_record.contraindications? ||
-            latest_vaccination_record.absent_from_session? ||
-            latest_vaccination_record.absent_from_school?
-        )
+      latest_vaccination_record&.not_administered? &&
+        latest_vaccination_record&.retryable_reason?
     end
 
     def next_step

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -187,6 +187,11 @@ class VaccinationRecord < ApplicationRecord
       ActiveModel::Type::Boolean.new.cast(value) ? Time.zone.now : nil
   end
 
+  def retryable_reason?
+    not_well? || contraindications? || absent_from_session? ||
+      absent_from_school?
+  end
+
   def wizard_steps
     [
       ("delivery-site" if administered? && delivery_site_other),

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -37,18 +37,27 @@ describe PatientSession do
     end
   end
 
-  describe "#vaccine_record" do
-    it "returns the last non-draft vaccination record" do
-      patient_session = create(:patient_session, programme:)
-      vaccination_record =
-        create(:vaccination_record, programme:, patient_session:)
-      vaccination_record.update!(recorded_at: 1.day.ago)
-      draft_vaccination_record =
-        create(:vaccination_record, programme:, patient_session:)
-      draft_vaccination_record.update!(recorded_at: nil)
-
-      expect(patient_session.latest_vaccination_record).to eq vaccination_record
+  describe "#latest_vaccination_record" do
+    subject(:latest_vaccination_record) do
+      patient_session.latest_vaccination_record
     end
+
+    let(:patient_session) { create(:patient_session, programme:) }
+    let(:later_vaccination_record) do
+      create(:vaccination_record, programme:, patient_session:)
+    end
+
+    before do
+      create(
+        :vaccination_record,
+        programme:,
+        patient_session:,
+        recorded_at: 1.day.ago
+      )
+      create(:vaccination_record, :not_recorded, programme:, patient_session:)
+    end
+
+    it { should eq(later_vaccination_record) }
   end
 
   describe "#latest_consents" do


### PR DESCRIPTION
This updates the relationships defined on patient sessions to ensure that vaccination records are always recorded, introduces a new separate relationship to draft vaccination records, and fixes a bug with the latest vaccination record where it was actually returning the oldest record.

One question renames over the use of "Delay vaccinations", currently if a triage is marked as this then the parents will get an email saying their child won't be vaccinated in this session, which in this case means all the dates in the session. We're likely to need to change the logic around delayed vaccinations to talk about sending a child to a clinic.