### PR TITLE
Handle importing "mum" and "dad" relationships

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -201,12 +201,12 @@ class PatientImportRow
   end
 
   def parent_relationship_attributes(relationship)
-    case relationship
-    when "Mother"
+    case relationship.downcase
+    when "mother", "mum"
       { type: "mother" }
-    when "Father"
+    when "father", "dad"
       { type: "father" }
-    when "Guardian"
+    when "guardian"
       { type: "guardian" }
     else
       { type: "other", other_name: relationship }

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -230,5 +230,23 @@ describe CohortImportRow do
         expect(parent_relationships.first.other_name).to eq("Stepdad")
       end
     end
+
+    context "when using shorted versions" do
+      let(:data) do
+        valid_data
+          .merge(parent_1_data)
+          .merge(parent_2_data)
+          .merge(
+            "PARENT_1_RELATIONSHIP" => "Dad",
+            "PARENT_2_RELATIONSHIP" => "Mum"
+          )
+      end
+
+      it "returns two parent relationships" do
+        expect(parent_relationships.count).to eq(2)
+        expect(parent_relationships.first).to be_father
+        expect(parent_relationships.second).to be_mother
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently we only accept "Mother" and "Father" as valid relationship types, but we might see values such as "Mum" and "Dad" (these are given as examples in the prototype) and since it's clear what these means we should import them correctly.