### PR TITLE
Ensure patient sessions are active

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -175,7 +175,9 @@ class Patient < ApplicationRecord
             .or(Session.unscheduled)
 
         new_sessions.find_each do |session|
-          patient_sessions.find_or_create_by!(session:)
+          patient_sessions
+            .find_or_initialize_by(session:)
+            .tap { |patient_session| patient_session.update!(active: true) }
         end
       end
     end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -274,6 +274,7 @@ describe ClassImport do
           session.location
         )
         expect(patient.upcoming_sessions).to contain_exactly(session)
+        expect(patient.patient_sessions.find_by(session:)).to be_active
       end
     end
   end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -251,6 +251,9 @@ describe Patient do
           it "adds the patient to the session" do
             match_consent_form!
             expect(new_session.reload.patients).to include(patient)
+            expect(
+              patient.patient_sessions.find_by(session: new_session)
+            ).to be_active
           end
         end
       end


### PR DESCRIPTION
When moving a patient between schools we need to ensure the patient session is active so that the patient appears in the list for any scheduled sessions.

I think we might be able to remove the concept of active/inactive patient sessions as nurses aren't creating these manually anymore, but we can fix that separately.