### PR TITLE
Speed up imports

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -89,17 +89,18 @@ module CSVImportable
     counts = count_columns.index_with(0)
 
     ActiveRecord::Base.transaction do
-      save!
-
       rows.each do |row|
         count_column_to_increment = process_row(row)
         counts[count_column_to_increment] += 1
+        bulk_import(rows: 100)
       end
 
-      record_rows
-    end
+      bulk_import(rows: :all)
 
-    update!(recorded_at: Time.zone.now, status: :recorded, **counts)
+      record_rows
+
+      update!(recorded_at: Time.zone.now, status: :recorded, **counts)
+    end
   end
 
   def remove!

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -88,6 +88,9 @@ class ImmunisationImportRow
         delivery_site:
       )
     else
+      # Postgres UUID generation is skipped in bulk import
+      vaccination_record.uuid = SecureRandom.uuid
+
       vaccination_record.batch = batch
       vaccination_record.delivery_method = delivery_method
       vaccination_record.delivery_site = delivery_site


### PR DESCRIPTION
Use .import to import records in bulk, while skipping Rails validations.