### PR TITLE
Allow adding multiple schools to a team in one go

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The `cis2` feature flag also needs to be enabled in Flipper for CIS2 logins to w
 ## Rake tasks
 
 - `clinics:create[name,address,town,county,postcode,ods_code,team_id]`
-- `schools:add_to_team[team_id,urn]`
+- `schools:add_to_team[team_id,urn,...]`
 - `teams:create_hpv[email,name,phone,ods_code,privacy_policy_url,reply_to_id]`
 - `vaccines:seed[type]`
 

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -18,12 +18,12 @@ This creates a new clinic location and attaches it to a team.
 
 ## Schools
 
-### `schools:add_to_team[team_id,urn]`
+### `schools:add_to_team[team_id,urn,...]`
 
 - `team_id` - The ID of the team.
-- `urn` - The URN of the school to add.
+- `urn` - The URN of the school to add, can be added multiple times.
 
-This adds a school to the list of schools that a particular team manages.
+This adds a school or schools to the list of schools that a particular team manages.
 
 ## Teams
 

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -155,17 +155,25 @@ namespace :schools do
   end
 
   desc "Add a school to a team."
-  task :add_to_team, %i[team_id urn] => :environment do |_task, args|
+  task :add_to_team, %i[team_id] => :environment do |_task, args|
     team = Team.find_by(id: args[:team_id])
-    location = Location.school.find_by(urn: args[:urn])
 
-    raise "Could not find location or team." if location.nil? || team.nil?
+    raise "Could not find team." if team.nil?
 
-    unless location.team.nil?
-      raise "School already belongs to #{location.team.name}."
+    args.extras.each do |urn|
+      location = Location.school.find_by(urn:)
+
+      if location.nil?
+        puts "Could not find location: #{urn}"
+        next
+      end
+
+      if !location.team_id.nil? && location.team_id != team.id
+        puts "#{urn} previously belonged to #{location.team.name}"
+      end
+
+      location.update!(team:)
     end
-
-    location.update!(team:)
 
     UnscheduledSessionsFactory.new.call
   end


### PR DESCRIPTION
This improves the `schools:add_to_team` Rake task to allow adding multiple schools to a team in one go by passing in multiple URNs.