### PR TITLE
Fix pagination styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@ $govuk-assets-path: "/";
 @import "govuk-frontend/dist/govuk/components/checkboxes";
 @import "govuk-frontend/dist/govuk/components/file-upload/index";
 @import "govuk-frontend/dist/govuk/components/notification-banner/index";
+@import "govuk-frontend/dist/govuk/components/pagination/index";
 @import "govuk-frontend/dist/govuk/components/panel/index";
 
 // Configure and import NHS.UK Frontend

--- a/config/initializers/govuk_components.rb
+++ b/config/initializers/govuk_components.rb
@@ -4,6 +4,7 @@ Govuk::Components.configure do |config|
   config.brand = "nhsuk"
   config.brand_overrides = {
     "GovukComponent::NotificationBannerComponent" => "govuk",
+    "GovukComponent::PaginationComponent" => "govuk",
     "GovukComponent::PanelComponent" => "govuk"
   }
 end


### PR DESCRIPTION
We need to use the GOV.UK pagination styles to ensure the component renders correctly, the NHS Design System has a different style of pagination, but the GOV.UK component matches our prototype designs.

## Screenshot

![Screenshot 2024-10-09 at 13 52 37](https://github.com/user-attachments/assets/92a74f77-66a1-4dab-b43a-a41cb416b656)
