### PR TITLE
Pass team ODS code to Rake tasks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ The `cis2` feature flag also needs to be enabled in Flipper for CIS2 logins to w
 
 ## Rake tasks
 
-- `clinics:create[name,address,town,county,postcode,ods_code,team_id]`
-- `schools:add_to_team[team_id,urn,...]`
+- `clinics:create[name,address,town,county,postcode,ods_code,team_ods_code]`
+- `schools:add_to_team[ods_code,urn,...]`
 - `teams:create_hpv[email,name,phone,ods_code,privacy_policy_url,reply_to_id]`
 - `vaccines:seed[type]`
 

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -17,7 +17,7 @@ class DevController < ApplicationController
   end
 
   def reset_team
-    team = Team.find_by!("LOWER(ods_code) = ?", params[:team_ods_code].downcase)
+    team = Team.find_by!(ods_code: params[:team_ods_code])
 
     cohort_imports = CohortImport.where(team:)
     cohort_imports.find_each do |cohort_import|

--- a/app/models/concerns/ods_code_concern.rb
+++ b/app/models/concerns/ods_code_concern.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ODSCodeConcern
+  extend ActiveSupport::Concern
+
+  included do
+    validates :ods_code, uniqueness: true, allow_nil: true
+
+    normalizes :ods_code, with: -> { _1.blank? ? nil : _1.upcase.strip }
+  end
+end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -204,7 +204,7 @@ class ImmunisationImportRow
   end
 
   def organisation_code
-    @data["ORGANISATION_CODE"]&.strip
+    @data["ORGANISATION_CODE"]&.strip&.upcase
   end
 
   def vaccine_given

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -31,6 +31,7 @@
 #
 class Location < ApplicationRecord
   include AddressConcern
+  include ODSCodeConcern
 
   self.inheritance_column = :nil
 
@@ -55,7 +56,6 @@ class Location < ApplicationRecord
   validates :url, url: true, allow_nil: true
 
   validates :ods_code, presence: true, if: :clinic?
-  validates :ods_code, uniqueness: true, allow_nil: true
 
   validates :urn, presence: true, if: :school?
   validates :urn, uniqueness: true, allow_nil: true

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -25,6 +25,8 @@
 #  index_teams_on_ods_code  (ods_code) UNIQUE
 #
 class Team < ApplicationRecord
+  include ODSCodeConcern
+
   has_many :cohort_imports
   has_many :cohorts
   has_many :consent_forms
@@ -42,7 +44,7 @@ class Team < ApplicationRecord
 
   validates :email, presence: true, notify_safe_email: true
   validates :name, presence: true, uniqueness: true
-  validates :ods_code, presence: true, uniqueness: true
+  validates :ods_code, presence: true
   validates :phone, presence: true, phone: true
 
   def year_groups

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -2,7 +2,7 @@
 
 ## Clinics
 
-### `clinics:create[name,address,town,county,postcode,ods_code,team_id]`
+### `clinics:create[name,address,town,county,postcode,ods_code,team_ods_code]`
 
 - `name` - The name of the clinic.
 - `address` - The first line of the address.
@@ -10,7 +10,7 @@
 - `country` - The county of the clinic.
 - `postcode` - The postcode of the clinic.
 - `ods_code` - The ODS code of the clinic.
-- `team_id` - The ID of the team.
+- `team_ods_code` - The ODS code of the team.
 
 If none of the arguments are provided (`rake clinics:create`), the user will be prompted for responses.
 
@@ -18,9 +18,9 @@ This creates a new clinic location and attaches it to a team.
 
 ## Schools
 
-### `schools:add_to_team[team_id,urn,...]`
+### `schools:add_to_team[ods_code,urn,...]`
 
-- `team_id` - The ID of the team.
+- `ods_code` - The ODS code of the team.
 - `urn` - The URN of the school to add, can be added multiple times.
 
 This adds a school or schools to the list of schools that a particular team manages.

--- a/lib/tasks/clinics.rake
+++ b/lib/tasks/clinics.rake
@@ -5,7 +5,7 @@ require_relative "../task_helpers"
 namespace :clinics do
   desc "Create a new clinic location and add it to a team."
   task :create,
-       %i[name address town county postcode ods_code team_id] =>
+       %i[name address town county postcode ods_code team_ods_code] =>
          :environment do |_task, args|
     include TaskHelpers
 
@@ -16,7 +16,7 @@ namespace :clinics do
       address_county = prompt_user_for "Enter county:"
       address_postcode = prompt_user_for "Enter postcode:", required: true
       ods_code = prompt_user_for "Enter ODS code:"
-      team_id = prompt_user_for "Enter team ID:", required: true
+      team_ods_code = prompt_user_for "Enter team ODS code:", required: true
     elsif args.to_a.size == 7
       name = args[:name]
       address_line_1 = args[:address]
@@ -24,12 +24,12 @@ namespace :clinics do
       address_county = args[:county]
       address_postcode = args[:postcode]
       ods_code = args[:urn]
-      team_id = args[:team_id]
+      team_ods_code = args[:team_ods_code]
     elsif args.to_a.size != 7
       raise "Expected 7 arguments got #{args.to_a.size}"
     end
 
-    team = Team.find(team_id)
+    team = Team.find_by!(ods_code: team_ods_code)
 
     location =
       Location.create!(

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -155,8 +155,8 @@ namespace :schools do
   end
 
   desc "Add a school to a team."
-  task :add_to_team, %i[team_id] => :environment do |_task, args|
-    team = Team.find_by(id: args[:team_id])
+  task :add_to_team, %i[ods_code] => :environment do |_task, args|
+    team = Team.find_by(ods_code: args[:ods_code])
 
     raise "Could not find team." if team.nil?
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -769,7 +769,7 @@ describe ImmunisationImportRow, type: :model do
     context "with a value" do
       let(:data) { { "ORGANISATION_CODE" => "abc" } }
 
-      it { should eq("abc") }
+      it { should eq("ABC") }
     end
   end
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -52,7 +52,7 @@ describe Location do
       subject(:location) { build(:location, :clinic, ods_code: "abc") }
 
       it { should validate_presence_of(:ods_code) }
-      it { should validate_uniqueness_of(:ods_code) }
+      it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
 
       it { should_not validate_presence_of(:urn) }
       it { should validate_uniqueness_of(:urn) }
@@ -62,7 +62,7 @@ describe Location do
       subject(:location) { build(:location, :school, urn: "abc") }
 
       it { should_not validate_presence_of(:ods_code) }
-      it { should validate_uniqueness_of(:ods_code) }
+      it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
 
       it { should validate_presence_of(:urn) }
       it { should validate_uniqueness_of(:urn) }
@@ -70,4 +70,6 @@ describe Location do
   end
 
   it { should normalize(:address_postcode).from(" SW111AA ").to("SW11 1AA") }
+
+  it { should normalize(:ods_code).from(" r1a ").to("R1A") }
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -35,6 +35,8 @@ describe Team do
     it { should validate_presence_of(:phone) }
 
     it { should validate_uniqueness_of(:name) }
-    it { should validate_uniqueness_of(:ods_code) }
+    it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
   end
+
+  it { should normalize(:ods_code).from(" r1a ").to("R1A") }
 end


### PR DESCRIPTION
These are known when running these tasks whereas getting the ID of the team requires us to look in the database first. I've also normalised the values to ensure they're always uppercase regardless of how the user provides them.