### PR TITLE
Remove "Register attendance" link to nowhere, readjust layout

### DIFF
--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -27,25 +27,7 @@
           <% end %>
         </li>
       <% else %>
-        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: "#") do |c| %>
-            <% c.with_heading { "Register attendance" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @patient_sessions.size) %> still to register
-            <% end %>
-          <% end %>
-        </li>
-        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
-            <% c.with_heading { "Record vaccinations" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
-              <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
-              <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
-            <% end %>
-          <% end %>
-        </li>
-        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <li class="nhsuk-grid-column-two-thirds nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
             <% c.with_heading { "Check consent responses" } %>
             <% c.with_description do %>
@@ -56,11 +38,21 @@
             <% end %>
           <% end %>
         </li>
-        <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
+        <li class="nhsuk-grid-column-two-thirds nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
             <% c.with_heading { "Triage health questions" } %>
             <% c.with_description do %>
               <%= t("children", count: @counts[:needing_triage]) %> needing triage
+            <% end %>
+          <% end %>
+        </li>
+        <li class="nhsuk-grid-column-two-thirds nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
+            <% c.with_heading { "Record vaccinations" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
+              <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
+              <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
             <% end %>
           <% end %>
         </li>


### PR DESCRIPTION
The prototype design has moved on but this prevents users getting a broken experience.

## Before

<img width="965" alt="image" src="https://github.com/user-attachments/assets/09ffb79d-877e-4eb6-ae20-df7b2e089abc">

## After

<img width="1047" alt="image" src="https://github.com/user-attachments/assets/ed05a303-0c79-483b-bb10-527d1605fc1d">
