### PR TITLE
Bulk import records link to immunisation imports

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -156,7 +156,7 @@ module CSVImportable
   def join_table_class(import_type, record_type)
     Class.new(ApplicationRecord) do
       @import_type = import_type.to_s.pluralize
-      @record_type = record_type.to_s.singularize
+      @record_type = record_type.to_s
 
       self.table_name = [@import_type, @record_type.pluralize].sort.join("_")
 
@@ -164,7 +164,7 @@ module CSVImportable
         ActiveModel::Name.new(
           self,
           nil,
-          "#{@import_type.camelize}#{@record_type.camelize}"
+          [@import_type.camelize, @record_type.singularize.camelize].sort.join
         )
       end
     end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -160,7 +160,7 @@ describe ImmunisationImport do
       end
 
       it "ignores and counts duplicate records" do
-        build(:immunisation_import, programme:, csv:, uploaded_by:).record!
+        create(:immunisation_import, programme:, csv:, uploaded_by:).record!
         csv.rewind
 
         record!
@@ -222,7 +222,7 @@ describe ImmunisationImport do
       end
 
       it "ignores and counts duplicate records" do
-        build(:immunisation_import, programme:, csv:, uploaded_by:).record!
+        create(:immunisation_import, programme:, csv:, uploaded_by:).record!
         csv.rewind
 
         record!


### PR DESCRIPTION
This uses `link_records_by_type` which uses an `.import` call to speed up the process.