### PR TITLE
Skip validation after finishing an import

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -99,7 +99,7 @@ module CSVImportable
 
       record_rows
 
-      update!(recorded_at: Time.zone.now, status: :recorded, **counts)
+      update_columns(recorded_at: Time.zone.now, status: :recorded, **counts)
     end
   end
 


### PR DESCRIPTION
The validation is quite expensive as it checks each row individually, if we've reached the end of the export we can be sure that the rows were already valid as this check is done earlier in the method.