### PR TITLE
Don't match patients if NHS numbers are different

### DIFF
--- a/app/jobs/consent_form_matching_job.rb
+++ b/app/jobs/consent_form_matching_job.rb
@@ -7,7 +7,8 @@ class ConsentFormMatchingJob < ApplicationJob
     session = consent_form.scheduled_session
 
     patients =
-      session.patients.matching_three_of(
+      session.patients.match_existing(
+        nhs_number: nil,
         first_name: consent_form.first_name,
         last_name: consent_form.last_name,
         date_of_birth: consent_form.date_of_birth,

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -378,7 +378,7 @@ class ImmunisationImportRow
   end
 
   def find_existing_patients
-    Patient.find_existing(
+    Patient.match_existing(
       nhs_number: patient_nhs_number,
       first_name: patient_first_name,
       last_name: patient_last_name,

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -217,7 +217,7 @@ class PatientImportRow
     return if first_name.blank? || last_name.blank? || date_of_birth.nil?
 
     @existing_patients ||=
-      Patient.find_existing(
+      Patient.match_existing(
         nhs_number:,
         first_name:,
         last_name:,

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -55,11 +55,12 @@ describe Patient do
     end
   end
 
+  it { should normalize(:nhs_number).from(" 0123456789 ").to("0123456789") }
   it { should normalize(:address_postcode).from(" SW111AA ").to("SW11 1AA") }
 
-  describe "#find_existing" do
-    subject(:find_existing) do
-      described_class.find_existing(
+  describe "#match_existing" do
+    subject(:match_existing) do
+      described_class.match_existing(
         nhs_number:,
         first_name:,
         last_name:,
@@ -87,7 +88,13 @@ describe Patient do
 
       context "when other patients match too" do
         let(:other_patient) do
-          create(:patient, first_name:, last_name:, date_of_birth:)
+          create(
+            :patient,
+            nhs_number: nil,
+            first_name:,
+            last_name:,
+            date_of_birth:
+          )
         end
 
         it { should_not include(other_patient) }
@@ -95,6 +102,7 @@ describe Patient do
     end
 
     context "with matching first name, last name and date of birth" do
+      let(:nhs_number) { nil }
       let(:patient) do
         create(:patient, first_name:, last_name:, date_of_birth:)
       end
@@ -103,6 +111,7 @@ describe Patient do
     end
 
     context "with matching first name, last name and postcode" do
+      let(:nhs_number) { nil }
       let(:patient) do
         create(:patient, first_name:, last_name:, address_postcode:)
       end
@@ -111,6 +120,7 @@ describe Patient do
     end
 
     context "with matching first name, date of birth and postcode" do
+      let(:nhs_number) { nil }
       let(:patient) do
         create(:patient, first_name:, date_of_birth:, address_postcode:)
       end
@@ -119,11 +129,27 @@ describe Patient do
     end
 
     context "with matching last name, date of birth and postcode" do
+      let(:nhs_number) { nil }
       let(:patient) do
         create(:patient, last_name:, date_of_birth:, address_postcode:)
       end
 
       it { should include(patient) }
+    end
+
+    context "when matching everything except the NHS number" do
+      let(:other_patient) do
+        create(
+          :patient,
+          nhs_number: "9876543210",
+          first_name:,
+          last_name:,
+          date_of_birth:,
+          address_postcode:
+        )
+      end
+
+      it { should_not include(other_patient) }
     end
   end
 


### PR DESCRIPTION
At the moment when we find existing patients, if we haven't found one based on the NHS number we look at three other personally identifiable fields. However, this can lead to a false positive situation where we match on a patient that has a different NHS number but happens to match in other respects. If the NHS numbers don't match we can be sure that they're not the same patient.

https://good-machine.sentry.io/issues/5976469496/