### PR TITLE
Add test case with duplicate surnames

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -55,7 +55,7 @@ module CSVImportable
   end
 
   def slow?
-    rows_count > 10
+    rows_count > 15
   end
 
   def load_data!

--- a/spec/features/dev_reset_team_spec.rb
+++ b/spec/features/dev_reset_team_spec.rb
@@ -50,16 +50,16 @@ describe "Dev endpoint to reset a team" do
     click_on "Continue"
 
     perform_enqueued_jobs
-    expect(VaccinationRecord.count).to eq(8)
+    expect(VaccinationRecord.count).to eq(11)
   end
 
   def then_all_associated_data_is_deleted_when_i_reset_the_team
     expect { visit "/reset/r1l" }.to(
       change(Patient, :count)
-        .by(-10)
+        .by(-13)
         .and(change(Cohort, :count).by(-2))
         .and(change(Parent, :count).by(-3))
-        .and(change(VaccinationRecord, :count).by(-8))
+        .and(change(VaccinationRecord, :count).by(-11))
         .and(change(ImmunisationImport, :count).by(-1))
         .and(change(CohortImport, :count).by(-1))
     )

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -168,7 +168,7 @@ describe "Immunisation imports" do
   end
 
   def then_i_should_see_the_cohorts
-    expect(page).to have_content("Year 8\n7 children")
+    expect(page).to have_content("Year 8\n10 children")
     expect(page).to have_content("Year 9\nNo children")
     expect(page).to have_content("Year 10\nNo children")
     expect(page).to have_content("Year 11\nNo children")

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -7,3 +7,6 @@ R1L,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,G
 R1L,110158,Eton College,8160442742,Oliver,Bowers,20100917,Male,LE5 2RP,20240514,Gardasil9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,Cervarix,123013326,20220730,Right Thigh,2,LocalPatient7,www.LocalPatient7,1
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20230410,Cervarix,123013325,20250730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1
+R1L,110158,,9999148581,Harold,Andrew,20101002,Not known,SW11 1AA,20230113,Gardasil,OU1731,20241015,left upper arm,1,LocalPatient7,www.LocalPatient7,1
+R1L,110158,,9999525156,Martial,Dare,20101002,Not known,SW11 1AA,20230126,Gardasil,OZ2022,20241010,left upper arm,1,LocalPatient7,www.LocalPatient7,1
+R1L,110158,,9999525157,Harold,Dare,20101002,Not known,SW11 1AA,20220126,Gardasil,SA6880,20241012,left upper arm,1,LocalPatient7,www.LocalPatient7,1

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -192,12 +192,12 @@ describe ImmunisationImport do
         # stree-ignore
         expect { record! }
           .to change(immunisation_import, :recorded_at).from(nil)
-          .and change(immunisation_import.vaccination_records, :count).by(8)
+          .and change(immunisation_import.vaccination_records, :count).by(11)
           .and change(immunisation_import.locations, :count).by(1)
-          .and change(immunisation_import.patients, :count).by(7)
-          .and change(immunisation_import.sessions, :count).by(3)
-          .and change(immunisation_import.patient_sessions, :count).by(8)
-          .and change(immunisation_import.batches, :count).by(6)
+          .and change(immunisation_import.patients, :count).by(10)
+          .and change(immunisation_import.sessions, :count).by(5)
+          .and change(immunisation_import.patient_sessions, :count).by(11)
+          .and change(immunisation_import.batches, :count).by(9)
 
         # Second import should not duplicate the vaccination records if they're
         # identical.
@@ -217,7 +217,7 @@ describe ImmunisationImport do
         # stree-ignore
         expect { record! }
           .to change(immunisation_import, :exact_duplicate_record_count).to(0)
-          .and change(immunisation_import, :new_record_count).to(8)
+          .and change(immunisation_import, :new_record_count).to(11)
           .and change(immunisation_import, :not_administered_record_count).to(0)
       end
 
@@ -226,13 +226,13 @@ describe ImmunisationImport do
         csv.rewind
 
         record!
-        expect(immunisation_import.exact_duplicate_record_count).to eq(8)
+        expect(immunisation_import.exact_duplicate_record_count).to eq(11)
       end
 
       it "creates a new session for each date" do
         record!
 
-        expect(immunisation_import.sessions.count).to eq(3)
+        expect(immunisation_import.sessions.count).to eq(5)
 
         session = immunisation_import.sessions.first
         expect(session.dates.map(&:value)).to contain_exactly(
@@ -241,18 +241,18 @@ describe ImmunisationImport do
       end
 
       it "records the patients" do
-        expect { record! }.to change(Patient.recorded, :count).from(0).to(7)
+        expect { record! }.to change(Patient.recorded, :count).from(0).to(10)
       end
 
       it "records the vaccination records" do
         expect { record! }.to change(VaccinationRecord.recorded, :count).from(
           0
-        ).to(8)
+        ).to(11)
       end
 
       it "activates the patient sessions" do
         expect { record! }.to change(PatientSession.active, :count).from(0).to(
-          8
+          11
         )
       end
     end


### PR DESCRIPTION
This file was causing an error before fb77b2da1c4aae4d1ad2383a363c1026a7513671 was applied, so adding this test case should help to catch any regressions.