### PR TITLE
Remove separate record_rows step

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -48,9 +48,7 @@ class ClassImport < PatientImport
     ClassImportRow.new(data:, session:)
   end
 
-  def record_rows
-    super
-
+  def postprocess_rows!
     session.create_patient_sessions! unless session.completed?
 
     (session.patients - patients).each do |unknown_patient|

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -52,9 +52,7 @@ class CohortImport < PatientImport
     CohortImportRow.new(data:, team:, programme:)
   end
 
-  def record_rows
-    super
-
+  def postprocess_rows!
     team
       .sessions
       .has_programme(programme)

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -97,10 +97,13 @@ module CSVImportable
 
       bulk_import(rows: :all)
 
-      record_rows
+      postprocess_rows!
 
       update_columns(recorded_at: Time.zone.now, status: :recorded, **counts)
     end
+  end
+
+  def postprocess_rows!
   end
 
   def remove!

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -123,14 +123,6 @@ class ImmunisationImport < ApplicationRecord
     end
   end
 
-  def record_rows
-    Time.zone.now.tap do |recorded_at|
-      patient_sessions.draft.update_all(active: true)
-      patients.draft.update_all(recorded_at:)
-      vaccination_records.draft.update_all(recorded_at:)
-    end
-  end
-
   def count_column(vaccination_record)
     if !vaccination_record
       :not_administered_record_count

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -70,7 +70,7 @@ class ImmunisationImportRow
     vaccination_record =
       VaccinationRecord.create_with(
         notes:,
-        recorded_at: nil
+        recorded_at: Time.zone.now
       ).find_or_initialize_by(
         programme: @programme,
         administered_at:,
@@ -88,7 +88,7 @@ class ImmunisationImportRow
         delivery_site:
       )
     else
-      # Postgres UUID generation is skipped in bulk import
+      # Postgres UUID generation is skipped in bulk import
       vaccination_record.uuid = SecureRandom.uuid
 
       vaccination_record.batch = batch
@@ -107,7 +107,7 @@ class ImmunisationImportRow
         existing_patient.stage_changes(staged_patient_attributes)
         existing_patient
       else
-        Patient.create!(patient_attributes)
+        Patient.create!(recorded_at: Time.zone.now, **patient_attributes)
       end
   end
 
@@ -135,10 +135,10 @@ class ImmunisationImportRow
     return unless valid?
 
     @patient_session ||=
-      PatientSession.create_with(created_by: @user).find_or_create_by!(
-        patient:,
-        session:
-      )
+      PatientSession.create_with(
+        created_by: @user,
+        active: true
+      ).find_or_create_by!(patient:, session:)
   end
 
   def notes

--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -51,13 +51,6 @@ class PatientImport < ApplicationRecord
     count_column_to_increment
   end
 
-  def record_rows
-    Time.zone.now.tap do |recorded_at|
-      patients.draft.update_all(recorded_at:)
-      parents.draft.update_all(recorded_at:)
-    end
-  end
-
   def count_column(patient, parents, parent_relationships)
     if patient.new_record? || parents.any?(&:new_record?) ||
          parent_relationships.any?(&:new_record?)

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -44,6 +44,7 @@ class PatientImportRow
 
     parents.map do |attributes|
       Parent
+        .create_with(recorded_at: Time.zone.now)
         .find_or_initialize_by(attributes.slice(:email, :name))
         .tap do |parent|
           parent.assign_attributes(
@@ -83,7 +84,7 @@ class PatientImportRow
       existing_patient.assign_attributes(attributes)
       existing_patient
     else
-      Patient.new(attributes)
+      Patient.new(recorded_at: Time.zone.now, **attributes)
     end
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -492,7 +492,7 @@ describe ImmunisationImportRow, type: :model do
       let(:data) { valid_data }
 
       it { should_not be_nil }
-      it { should be_draft }
+      it { should be_active }
     end
   end
 
@@ -937,9 +937,7 @@ describe ImmunisationImportRow, type: :model do
 
     let(:data) { valid_data }
 
-    it "is not recorded" do
-      expect(vaccination_record).not_to be_recorded
-    end
+    it { should be_recorded }
 
     it "has a vaccinator" do
       expect(vaccination_record.performed_by).to have_attributes(


### PR DESCRIPTION
The import process is no longer split up in to two separate steps so we can combine the two and save a little bit of processing time. The whole import is done in a transaction anyway so no records will appear until the whole thing is complete.