### PR TITLE
Use sets to avoid updating rows multiple times

### DIFF
--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -85,42 +85,47 @@ class ImmunisationImport < ApplicationRecord
     return count_column_to_increment unless vaccination_record
 
     # Instead of saving individually, we'll collect the records
-    @vaccination_records ||= []
-    @batches ||= []
-    @locations ||= []
-    @patients ||= []
-    @patient_sessions ||= []
-    @sessions ||= []
+    @vaccination_records_batch ||= Set.new
+    @batches_batch ||= Set.new
+    @locations_batch ||= Set.new
+    @patients_batch ||= Set.new
+    @patient_sessions_batch ||= Set.new
+    @sessions_batch ||= Set.new
 
-    @vaccination_records << vaccination_record
-    @batches << vaccination_record.batch
-    @locations << vaccination_record.location
-    @patients << vaccination_record.patient
-    @patient_sessions << vaccination_record.patient_session
-    @sessions << vaccination_record.session
+    @vaccination_records_batch.add(vaccination_record)
+    @batches_batch.add(vaccination_record.batch)
+    if vaccination_record.location
+      @locations_batch.add(vaccination_record.location)
+    end
+    @patients_batch.add(vaccination_record.patient)
+    @patient_sessions_batch.add(vaccination_record.patient_session)
+    @sessions_batch.add(vaccination_record.session)
 
     count_column_to_increment
   end
 
   def bulk_import(rows: 100)
-    return if rows != :all && @vaccination_records.size < rows
+    return if rows != :all && @vaccination_records_batch.size < rows
 
-    VaccinationRecord.import(
-      @vaccination_records,
-      on_duplicate_key_update: :all
-    )
+    # We need to convert the batch to an array as `import` modifies the
+    # objects to add IDs to any new records.
+    vaccination_records = @vaccination_records_batch.to_a
+
+    VaccinationRecord.import(vaccination_records, on_duplicate_key_update: :all)
 
     [
-      [:vaccination_records, @vaccination_records],
-      [:batches, @batches],
-      [:locations, @locations],
-      [:patients, @patients],
-      [:patient_sessions, @patient_sessions],
-      [:sessions, @sessions]
+      [:vaccination_records, vaccination_records],
+      [:batches, @batches_batch],
+      [:locations, @locations_batch],
+      [:patients, @patients_batch],
+      [:patient_sessions, @patient_sessions_batch],
+      [:sessions, @sessions_batch]
     ].each do |association, collection|
-      link_records_by_type(association, collection.compact)
+      link_records_by_type(association, collection)
       collection.clear
     end
+
+    @vaccination_records_batch.clear
   end
 
   def record_rows

--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -40,13 +40,13 @@ class PatientImport < ApplicationRecord
       count_column(patient, parents, parent_relationships)
 
     # Instead of saving individually, we'll collect the records
-    @parents ||= []
-    @patients ||= []
-    @relationships ||= []
+    @parents_batch ||= Set.new
+    @patients_batch ||= Set.new
+    @relationships_batch ||= Set.new
 
-    @parents.concat(parents)
-    @patients << patient
-    @relationships.concat(parent_relationships)
+    @parents_batch.merge(parents)
+    @patients_batch.add(patient)
+    @relationships_batch.merge(parent_relationships)
 
     count_column_to_increment
   end
@@ -71,22 +71,29 @@ class PatientImport < ApplicationRecord
   end
 
   def bulk_import(rows: 100)
-    return if rows != :all && @patients.size < rows
+    return if rows != :all && @patients_batch.size < rows
 
-    Parent.import(@parents, on_duplicate_key_update: :all)
+    # We need to convert the batches to arrays as `import` modifies the
+    # objects to add IDs to any new records.
 
-    @patients.each { |patient| patient.run_callbacks(:save) { false } }
-    Patient.import(@patients, on_duplicate_key_update: :all)
+    parents = @parents_batch.to_a
+    patients = @patients_batch.to_a
+    relationships = @relationships_batch.to_a
 
-    ParentRelationship.import(@relationships, on_duplicate_key_update: :all)
+    Parent.import(parents, on_duplicate_key_update: :all)
 
-    link_records_by_type(:patients, @patients)
-    link_records_by_type(:parents, @parents)
-    link_records_by_type(:parent_relationships, @relationships)
+    patients.each { |patient| patient.run_callbacks(:save) { false } }
+    Patient.import(patients, on_duplicate_key_update: :all)
 
-    # Clear the arrays for the next batch
-    @parents.clear
-    @patients.clear
-    @relationships.clear
+    ParentRelationship.import(relationships, on_duplicate_key_update: :all)
+
+    link_records_by_type(:patients, patients)
+    link_records_by_type(:parents, parents)
+    link_records_by_type(:parent_relationships, relationships)
+
+    # Clear the sets for the next batch
+    @parents_batch.clear
+    @patients_batch.clear
+    @relationships_batch.clear
   end
 end


### PR DESCRIPTION
This fixes an issue where using `import` expects there to only be unique records to update, and can't handle the case where we ask it to update the same record multiple times. By using a `Set` we can avoid this problem, although now we'll only pick the most recent version of a record and ignore any others.

https://good-machine.sentry.io/issues/5977551439/