### PR TITLE
Move patient's cohort when changing schools

### DIFF
--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -266,6 +266,12 @@ describe ClassImport do
         )
         expect(patient.upcoming_sessions).to contain_exactly(session)
       end
+
+      it "changes the child's cohort" do
+        expect(patient.cohort.team).to eq(different_session.team)
+        expect { record! }.to(change { patient.reload.cohort })
+        expect(patient.cohort.team).to eq(session.team)
+      end
     end
 
     it "records the patients" do


### PR DESCRIPTION
If the schools belongs to a different team to the current cohort we should move the patient to a new cohort for the new team so they appear correctly in the service.