### PR TITLE
Use an imports queue and set concurrency

### DIFF
--- a/app/jobs/consent_reminders_job.rb
+++ b/app/jobs/consent_reminders_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConsentRemindersJob < ApplicationJob
-  queue_as :default
+  queue_as :notifications
 
   def perform
     return unless Flipper.enabled?(:scheduled_emails)

--- a/app/jobs/consent_requests_job.rb
+++ b/app/jobs/consent_requests_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConsentRequestsJob < ApplicationJob
-  queue_as :default
+  queue_as :notifications
 
   def perform
     return unless Flipper.enabled?(:scheduled_emails)

--- a/app/jobs/process_import_job.rb
+++ b/app/jobs/process_import_job.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class ProcessImportJob < ApplicationJob
-  queue_as :default
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :imports
+
+  good_job_control_concurrency_with perform_limit: 1
 
   def perform(import)
     import.parse_rows!

--- a/app/jobs/remove_import_csv_job.rb
+++ b/app/jobs/remove_import_csv_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RemoveImportCSVJob < ApplicationJob
-  queue_as :default
+  queue_as :imports
 
   def perform
     [ClassImport, CohortImport, ImmunisationImport].each do |import_type|

--- a/app/jobs/session_reminders_job.rb
+++ b/app/jobs/session_reminders_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SessionRemindersJob < ApplicationJob
-  queue_as :default
+  queue_as :notifications
 
   def perform
     return unless Flipper.enabled?(:scheduled_emails)


### PR DESCRIPTION
This prevents multiple imports from being processed in parallel which could lead to issues related to race conditions and the same records being added at the same time.

I've also added a `notifications` queue for reminders and requests so they can be managed separately.