### PR TITLE
Delete ClassImports in reset team endpoint

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -42,6 +42,8 @@ class DevController < ApplicationController
 
     team_sessions = Session.where(team:)
 
+    ClassImport.where(session: team_sessions).destroy_all
+
     patient_sessions = PatientSession.where(session: team_sessions)
     patient_sessions.each do |patient_session|
       patient_session.vaccination_records.destroy_all


### PR DESCRIPTION
This is currently failing on staging because the ClassImports records are orphaned when the sessions are destroyed.