### PR TITLE
Delete consents when resetting teams

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -58,6 +58,8 @@ class DevController < ApplicationController
 
     ConsentForm.where(team:).delete_all
 
+    Consent.where(team:).delete_all
+
     Patient.joins(:cohort).where(cohorts: { team: }).distinct.destroy_all
 
     Cohort.where(team:).delete_all


### PR DESCRIPTION
This is currently failing on test because it leaves orphaned consent records when patients and parents are deleted.