### PR TITLE
Fix styling issue on session edit screen

### DIFF
--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -45,7 +45,10 @@
           summary_list.with_row do |row|
             row.with_key { "Consent reminders" }
             row.with_value do
-              "Send #{pluralize(@session.weeks_before_consent_reminders, "week")} before each session" + tag.br + tag.span("First: #{send_consent_reminders_at.to_fs(:long_day_of_week)}", class: "nhsuk-u-secondary-text-color")
+              safe_join([
+                "Send #{pluralize(@session.weeks_before_consent_reminders, "week")} before each session",
+                tag.span("First: #{send_consent_reminders_at.to_fs(:long_day_of_week)}", class: "nhsuk-u-secondary-text-color"),
+              ], tag.br)
             end
           end
         end


### PR DESCRIPTION
## Before

![image](https://github.com/user-attachments/assets/ca0429a1-12fd-4519-89e1-13d3cc282694)

## After

<img width="767" alt="image" src="https://github.com/user-attachments/assets/b749803f-f82b-4434-a2e5-8a55495fc806">
