### PR TITLE
Reference .ruby-version in Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.4
 
-# Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
+# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
 ARG RUBY_VERSION=3.3.4
 FROM ruby:$RUBY_VERSION-slim AS base
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.3.4"
+ruby file: ".ruby-version"
 gem "rails", "~> 7.2.1"
 
 gem "activerecord-import"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,4 +727,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.3.24
+   2.5.21


### PR DESCRIPTION
Instead of locking Ruby in both .ruby-version and the Gemfile, you can read .ruby-version directly in the Gemfile.

Might have to run `bin/bundle update --bundler` for this to work.