### PR TITLE
Ensure .ruby-version included in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -sL --ssl https://github.com/nodenv/node-build/archive/master.tar.gz | 
     rm -rf /tmp/node-build-master
 
 # Install application gems
-COPY --link Gemfile Gemfile.lock ./
+COPY --link Gemfile Gemfile.lock .ruby-version ./
 RUN bundle install && \
     bundle exec bootsnap precompile --gemfile && \
     rm -rf ~/.bundle/ "$BUNDLE_PATH/ruby/*/cache" "$BUNDLE_PATH/ruby/*/bundler/gems/*/.git"


### PR DESCRIPTION
This follows on from f1c4bcd127894428b3df3fb604024edc3f432109, now that we're referencing this file in the `Gemfile` we need to ensure it's available when building the Docker image.