### PR TITLE
Prevent parallel resets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "turbo-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "uk_postcode"
 gem "wicked"
+gem "with_advisory_lock"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -630,6 +630,9 @@ GEM
     websocket-extensions (0.1.5)
     wicked (2.0.0)
       railties (>= 3.0.7)
+    with_advisory_lock (5.1.0)
+      activerecord (>= 6.1)
+      zeitwerk (>= 2.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.36)
@@ -717,6 +720,7 @@ DEPENDENCIES
   web-console
   webmock
   wicked
+  with_advisory_lock
 
 RUBY VERSION
    ruby 3.3.4p94


### PR DESCRIPTION
These developer endpoints change a lot about the database in one go, and running them in parallel is not safe (for example, when we create unscheduled sessions). For a developer endpoint, a simple solution would be to introduce a lock on these actions so they can only happen one at a time.

https://good-machine.sentry.io/issues/5990891241