### PR TITLE
Don't always remove patients from sessions

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -56,10 +56,11 @@ class ClassImport < PatientImport
 
     unknown_patients = session.patients - patients
 
-    unknown_patients.each do |unknown_patient|
-      unknown_patient.update!(school: nil)
-    end
+    Patient.where(id: unknown_patients.map(&:id)).update_all(school_id: nil)
 
-    session.patients.delete(unknown_patients)
+    session
+      .patient_sessions
+      .where(patient: unknown_patients)
+      .find_each(&:destroy_if_safe!)
   end
 end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -356,7 +356,10 @@ class ConsentForm < ApplicationRecord
       if school && school != patient.school
         patient.update!(school:)
 
-        patient.patient_sessions.find_by(session: scheduled_session)&.destroy!
+        patient
+          .patient_sessions
+          .where(session: scheduled_session)
+          .find_each(&:destroy_if_safe!)
 
         upcoming_session =
           Session

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -151,6 +151,6 @@ class ImmunisationImport < ApplicationRecord
     PatientSession.where(
       session: team.sessions.upcoming,
       patient: already_vaccinated_patients
-    ).delete_all
+    ).find_each(&:destroy_if_safe!)
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -188,7 +188,7 @@ class Patient < ApplicationRecord
       self.date_of_death = pds_patient.date_of_death
 
       if date_of_death_changed?
-        upcoming_sessions.clear unless date_of_death.nil?
+        clear_upcoming_sessions unless date_of_death.nil?
         self.date_of_death_recorded_at = Time.current
       end
 
@@ -210,7 +210,7 @@ class Patient < ApplicationRecord
     return if invalidated?
 
     ActiveRecord::Base.transaction do
-      upcoming_sessions.clear
+      clear_upcoming_sessions
       update!(invalidated_at: Time.current)
     end
   end
@@ -236,5 +236,11 @@ class Patient < ApplicationRecord
     parents_to_check.each do |parent|
       parent.destroy! if parent.parent_relationships.count.zero?
     end
+  end
+
+  def clear_upcoming_sessions
+    patient_sessions.where(session: upcoming_sessions).find_each(
+      &:destroy_if_safe!
+    )
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -95,6 +95,14 @@ class PatientSession < ApplicationRecord
     !unable_to_vaccinate? && !unable_to_vaccinate_not_gillick_competent?
   end
 
+  def safe_to_destroy?
+    vaccination_records.empty? && gillick_assessments.empty?
+  end
+
+  def destroy_if_safe!
+    destroy! if safe_to_destroy?
+  end
+
   def latest_consents
     consents
       .group_by(&:name)

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -360,6 +360,25 @@ describe ClassImport do
         expect { record! }.to change { existing_patient.reload.school }.to(nil)
         expect(session.reload.patients).not_to include(existing_patient)
       end
+
+      context "when the existing patient has been vaccinated" do
+        before do
+          create(
+            :vaccination_record,
+            patient_session:
+              session.patient_sessions.find_by(patient: existing_patient),
+            programme:
+          )
+        end
+
+        it "doesn't remove the patient from the session" do
+          expect(session.patients).to include(existing_patient)
+          expect { record! }.to change { existing_patient.reload.school }.to(
+            nil
+          )
+          expect(session.reload.patients).to include(existing_patient)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If the patient session has been interacted with in some way (either consent received, or triaged, or even vaccinated) we can't safely remove the patient from the session as it's unclear what state they're in.

https://good-machine.sentry.io/issues/5990842901