### PR TITLE
Display the `Patient#gender_code` attribute label as Gender

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -37,7 +37,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
         row.with_value { format_date_of_birth }
       end
       summary_list.with_row do |row|
-        row.with_key { "Sex" }
+        row.with_key { "Gender" }
         row.with_value { format_gender_code }
       end
       if @show_address

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -48,7 +48,7 @@ describe AppPatientSummaryComponent do
   it { should have_content("1 January 2000") }
   it { should have_content(/Year [0-9]+/) }
 
-  it { should have_content("Sex") }
+  it { should have_content("Gender") }
   it { should have_content("Male") }
 
   it { should have_content("Postcode") }


### PR DESCRIPTION
What's stored and what's displayed on screen should be consistent.