### PR TITLE
Add link to parental consent form

### DIFF
--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -27,6 +27,18 @@ class AppSessionSummaryComponent < ViewComponent::Base
         row.with_key { "Consent period" }
         row.with_value { consent_period }
       end
+      if consent_link
+        summary_list.with_row do |row|
+          row.with_key { "Consent link" }
+          row.with_value do
+            govuk_link_to(
+              "View parental consent form (opens in a new tab)",
+              consent_link,
+              new_tab: true
+            )
+          end
+        end
+      end
       summary_list.with_row do |row|
         row.with_key { "Children" }
         row.with_value { children }
@@ -58,6 +70,16 @@ class AppSessionSummaryComponent < ViewComponent::Base
 
   def consent_period
     helpers.session_consent_period(@session)
+  end
+
+  def consent_link
+    if @session.open_for_consent?
+      # TODO: handle multiple programmes
+      start_parent_interface_consent_forms_path(
+        @session,
+        @session.programmes.first
+      )
+    end
   end
 
   def children

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -29,6 +29,17 @@ describe AppSessionSummaryComponent do
   it { should have_content("Consent period") }
   it { should have_content("Closed 31 December") }
 
+  it { should_not have_content("Consent link") }
+
   it { should have_content("Children") }
   it { should have_content("No children") }
+
+  context "when consent is open" do
+    let(:session) do
+      create(:session, location:, date: 1.week.from_now.to_date, programme:)
+    end
+
+    it { should have_content("Consent link") }
+    it { should have_link("View parental consent form (opens in a new tab)") }
+  end
 end


### PR DESCRIPTION
This adds a link to allow users to see the parental consent form for a particular session.