### PR TITLE
Remove patients from sessions if already vaccinated

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -48,6 +48,8 @@ class ClassImport < PatientImport
   end
 
   def postprocess_rows!
+    # Remove patients already in the session but not in the class list.
+
     return if session.completed?
 
     session.create_patient_sessions!

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -52,6 +52,8 @@ class CohortImport < PatientImport
   end
 
   def postprocess_rows!
+    # Add imported patients to upcoming sessions.
+
     team
       .sessions
       .has_programme(programme)

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -107,9 +107,6 @@ module CSVImportable
     look_up_missing_nhs_numbers
   end
 
-  def postprocess_rows!
-  end
-
   def look_up_missing_nhs_numbers
     patients.without_nhs_number.find_each do |patient|
       PDSLookupJob.perform_later(patient)

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -139,4 +139,18 @@ class ImmunisationImport < ApplicationRecord
       :exact_duplicate_record_count
     end
   end
+
+  def postprocess_rows!
+    # Remove patients from upcoming sessions who have already been vaccinated.
+
+    already_vaccinated_patients =
+      patients
+        .includes(:vaccination_records)
+        .select { _1.vaccinated?(programme) }
+
+    PatientSession.where(
+      session: team.sessions.upcoming,
+      patient: already_vaccinated_patients
+    ).delete_all
+  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -143,6 +143,14 @@ class Patient < ApplicationRecord
     super.merge("full_name" => full_name, "age" => age)
   end
 
+  def vaccinated?(programme)
+    # TODO: This logic doesn't work for vaccinations that require multiple doses.
+
+    vaccination_records.any? do
+      _1.recorded? && _1.administered? && _1.programme_id == programme.id
+    end
+  end
+
   private
 
   def school_is_correct_type

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -128,17 +128,7 @@ class Session < ApplicationRecord
 
     unvaccinated_patients =
       patients_in_cohorts.reject do |patient|
-        # TODO: This logic doesn't work for vaccinations that require multiple doses.
-
-        vaccinated_programmes =
-          Set.new(
-            patient
-              .vaccination_records
-              .select { _1.recorded? && _1.administered? }
-              .map(&:programme)
-          )
-
-        required_programmes.subset?(vaccinated_programmes)
+        required_programmes.all? { |programme| patient.vaccinated?(programme) }
       end
 
     unvaccinated_patients.each do |patient|

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -317,5 +317,23 @@ describe ImmunisationImport do
         )
       end
     end
+
+    context "with an existing patient in an upcoming session" do
+      let(:programme) { create(:programme, :flu_all_vaccines) }
+      let(:file) { "valid_flu.csv" }
+
+      let(:session) { create(:session, :scheduled, team:, programme:) }
+      let(:patient) { create(:patient, nhs_number: "7420180008", session:) }
+
+      it "removes the patient from the upcoming session" do
+        expect(patient.vaccinated?(programme)).to be(false)
+        expect(patient.upcoming_sessions).to contain_exactly(session)
+
+        record!
+
+        expect(patient.reload.upcoming_sessions).to be_empty
+        expect(patient.vaccinated?(programme)).to be(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
When importing vaccination records for patients, we should remove those patients from any upcoming sessions so they don't get vaccinated twice.