### PR TITLE
Update batches only if team exists

### DIFF
--- a/db/migrate/20240924112619_add_programme_to_consent_forms.rb
+++ b/db/migrate/20240924112619_add_programme_to_consent_forms.rb
@@ -4,7 +4,7 @@ class AddProgrammeToConsentForms < ActiveRecord::Migration[7.2]
   def up
     add_reference :consent_forms, :programme, foreign_key: true
 
-    ConsentForm.all.find_each do |consent_form|
+    ConsentForm.find_each do |consent_form|
       consent_form.update!(
         programme_id: (consent_form.session.programme || Programme.first).id
       )

--- a/db/migrate/20241002125816_add_team_to_consent_forms.rb
+++ b/db/migrate/20241002125816_add_team_to_consent_forms.rb
@@ -4,7 +4,7 @@ class AddTeamToConsentForms < ActiveRecord::Migration[7.2]
   def up
     add_reference :consent_forms, :team, foreign_key: true
 
-    ConsentForm.all.find_each do |consent_form|
+    ConsentForm.find_each do |consent_form|
       consent_form.update!(team_id: consent_form.session.team_id)
     end
 

--- a/db/migrate/20241002130716_add_school_to_consent_forms.rb
+++ b/db/migrate/20241002130716_add_school_to_consent_forms.rb
@@ -4,7 +4,7 @@ class AddSchoolToConsentForms < ActiveRecord::Migration[7.2]
   def up
     add_reference :consent_forms, :school, foreign_key: { to_table: :locations }
 
-    ConsentForm.all.find_each do |consent_form|
+    ConsentForm.find_each do |consent_form|
       consent_form.update!(location_id: consent_form.session.team_id)
     end
 

--- a/db/migrate/20241015090951_add_team_to_batches.rb
+++ b/db/migrate/20241015090951_add_team_to_batches.rb
@@ -3,7 +3,7 @@
 class AddTeamToBatches < ActiveRecord::Migration[7.2]
   def up
     add_reference :batches, :team, foreign_key: true
-    Batch.update_all(team_id: Team.first.id)
+    Batch.update_all(team_id: Team.first.id) if Team.any?
     change_column_null :batches, :team_id, false
     add_index :batches, %i[team_id name expiry vaccine_id], unique: true
   end


### PR DESCRIPTION
The reference to `Team.first.id` breaks on an empty database because there are no teams.