### PR TITLE
Fix vaccination record factory creating locations

### DIFF
--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
     delivery_site { "left_arm_upper_position" }
     delivery_method { "intramuscular" }
     vaccine { programme.vaccines.active.first }
-    batch { association :batch, team: session.team, vaccine: }
+    batch { association :batch, team: patient_session.team, vaccine: }
 
     performed_by
 


### PR DESCRIPTION
This fixes an issue where creating vaccination records would end up creating new sessions to access the team, rather than using the patient session already available to us.

https://good-machine.sentry.io/issues/5995332908/