### PR TITLE
Patient page title: use patient initials instead of full name

### DIFF
--- a/app/controllers/concerns/full_name_concern.rb
+++ b/app/controllers/concerns/full_name_concern.rb
@@ -8,4 +8,8 @@ module FullNameConcern
   def full_name
     "#{given_name} #{family_name}"
   end
+
+  def initials
+    [given_name[0], family_name[0]].join
+  end
 end

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -5,7 +5,7 @@
       ) %>
 <% end %>
 
-<%= h1 page_title: @patient.full_name do %>
+<%= h1 page_title: @patient.initials do %>
   <span class="nhsuk-caption-l"><%= patient_school(@patient) %></span>
   <%= @patient.full_name %>
 <% end %>

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -174,6 +174,14 @@ describe Patient do
     end
   end
 
+  describe "#initials" do
+    subject(:initials) { patient.initials }
+
+    let(:patient) { create(:patient, given_name: "John", family_name: "Doe") }
+
+    it { should eq("JD") }
+  end
+
   describe "#stage_changes" do
     let(:patient) { create(:patient, given_name: "John", family_name: "Doe") }
 


### PR DESCRIPTION
This is to avoid the patient name appearing in browser histories