### PR TITLE
Fix NHS API expiration check

### DIFF
--- a/app/lib/nhs/api.rb
+++ b/app/lib/nhs/api.rb
@@ -21,7 +21,7 @@ module NHS::API
 
       epoch_msec = Time.zone.now.strftime("%Q").to_i
       safety_msec = 1000 # safety to accommodate connection time
-      epoch_msec - safety_msec < @auth_info[:expires_at]
+      epoch_msec + safety_msec < @auth_info[:expires_at]
     end
 
     private


### PR DESCRIPTION
Currently the safety buffer is being taken away from the current date/time meaning we have more time available before the expiration than we think, instead we should be applying the safety buffer to the future so we're more likely to have expired.