### PR TITLE
Add catch up personalisation

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -33,6 +33,7 @@ class GovukNotifyPersonalisation
   def call
     {
       batch_name:,
+      catch_up:,
       consent_deadline:,
       consent_link:,
       day_month_year_of_vaccination:,
@@ -41,6 +42,7 @@ class GovukNotifyPersonalisation
       next_session_date:,
       next_session_dates:,
       next_session_dates_or:,
+      not_catch_up:,
       parent_full_name:,
       programme_name:,
       reason_did_not_vaccinate:,
@@ -77,6 +79,16 @@ class GovukNotifyPersonalisation
 
   def batch_name
     vaccination_record&.batch&.name
+  end
+
+  def catch_up
+    return nil if patient.nil? || programme.nil?
+    patient.year_group == programme.year_groups.first ? "no" : "yes"
+  end
+
+  def not_catch_up
+    return nil if patient.nil? || programme.nil?
+    patient.year_group == programme.year_groups.first ? "yes" : "no"
   end
 
   def consent_deadline

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -13,7 +13,7 @@ describe GovukNotifyPersonalisation do
     )
   end
 
-  let(:programme) { create(:programme, :flu) }
+  let(:programme) { create(:programme, :hpv) }
   let(:team) do
     create(
       :team,
@@ -24,7 +24,14 @@ describe GovukNotifyPersonalisation do
     )
   end
 
-  let(:patient) { create(:patient, given_name: "John", family_name: "Smith") }
+  let(:patient) do
+    create(
+      :patient,
+      given_name: "John",
+      family_name: "Smith",
+      date_of_birth: Date.current - 13.years
+    )
+  end
   let(:location) { create(:location, :school, name: "Hogwarts") }
   let(:session) do
     create(:session, location:, team:, programme:, date: Date.new(2026, 1, 1))
@@ -37,6 +44,7 @@ describe GovukNotifyPersonalisation do
   it do
     expect(personalisation).to eq(
       {
+        catch_up: "no",
         consent_deadline: "Wednesday 31 December",
         consent_link:
           "http://localhost:4000/consents/#{session.id}/#{programme.id}/start",
@@ -45,15 +53,29 @@ describe GovukNotifyPersonalisation do
         next_session_date: "Thursday 1 January",
         next_session_dates: "Thursday 1 January",
         next_session_dates_or: "Thursday 1 January",
-        programme_name: "Flu",
+        not_catch_up: "yes",
+        programme_name: "HPV",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",
         team_email: "team@example.com",
         team_name: "Team",
         team_phone: "01234 567890",
-        vaccination: "Flu vaccination"
+        vaccination: "HPV vaccination"
       }
     )
+  end
+
+  context "when patient is in Year 9" do
+    let(:patient) do
+      create(
+        :patient,
+        given_name: "John",
+        family_name: "Smith",
+        date_of_birth: Date.current - 14.years
+      )
+    end
+
+    it { should include(catch_up: "yes", not_catch_up: "no") }
   end
 
   context "with multiple dates" do


### PR DESCRIPTION
This adds some additional personalisation sent to GOV.UK Notify to allow us to customise the templates according to whether the patient is receiving the vaccine at the earliest year group or later.