### PR TITLE
Merge patients when looking up NHS numbers

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -26,14 +26,14 @@
         <%= summary_list.with_row do |row| %>
           <%= row.with_key { "Are they Gillick competent?" } %>
           <%= row.with_value {
-                patient_session.gillick_assessment.gillick_competent ?
+                patient_session.latest_gillick_assessment.gillick_competent ?
                   "Yes, they are Gillick competent" :
                   "No"
               } %>
         <% end %>
         <%= summary_list.with_row do |row| %>
           <%= row.with_key { "Details of your assessment" } %>
-          <%= row.with_value { patient_session.gillick_assessment.notes } %>
+          <%= row.with_value { patient_session.latest_gillick_assessment.notes } %>
         <% end %>
       <% end %>
     <% else %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -35,6 +35,6 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def gillick_assessment_recorded?
-    patient_session.gillick_assessment.present?
+    patient_session.gillick_assessments.present?
   end
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -12,10 +12,10 @@ class ConsentsController < ApplicationController
         .patient_sessions
         .strict_loading
         .includes(
-          :programmes,
-          :gillick_assessment,
           { consents: :parent },
+          :latest_gillick_assessment,
           :patient,
+          :programmes,
           :triages,
           :vaccination_records
         )

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -14,7 +14,7 @@ class GillickAssessmentsController < ApplicationController
   end
 
   def create
-    @patient_session.create_gillick_assessment!(assessor: current_user)
+    @patient_session.gillick_assessments.create!(assessor: current_user)
 
     redirect_to wizard_path(steps.first)
   end
@@ -53,7 +53,7 @@ class GillickAssessmentsController < ApplicationController
   end
 
   def set_assessment
-    @assessment = @patient_session.draft_gillick_assessment
+    @assessment = @patient_session.draft_gillick_assessments.first
   end
 
   def set_steps

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -48,10 +48,10 @@ class SessionsController < ApplicationController
     @patient_sessions =
       @session.patient_sessions.strict_loading.includes(
         :programmes,
-        :gillick_assessment,
         { consents: :parent },
         :latest_triage,
         :vaccination_records,
+        :latest_gillick_assessment,
         :latest_vaccination_record
       )
 

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -20,12 +20,12 @@ class TriagesController < ApplicationController
         .strict_loading
         .includes(
           :programmes,
-          :gillick_assessment,
           :patient,
           :triages,
+          :latest_gillick_assessment,
           :latest_triage,
-          :vaccination_records,
-          :latest_vaccination_record
+          :latest_vaccination_record,
+          :vaccination_records
         )
         .preload(:consents)
         .order("patients.given_name", "patients.family_name")

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -22,12 +22,12 @@ class VaccinationsController < ApplicationController
         .strict_loading
         .includes(
           :programmes,
-          :gillick_assessment,
           :patient,
           :triages,
+          :latest_gillick_assessment,
           :latest_triage,
-          :vaccination_records,
-          :latest_vaccination_record
+          :latest_vaccination_record,
+          :vaccination_records
         )
         .preload(:consents)
         .order("patients.given_name", "patients.family_name")

--- a/app/jobs/pds_lookup_job.rb
+++ b/app/jobs/pds_lookup_job.rb
@@ -37,6 +37,69 @@ class PDSLookupJob < ApplicationJob
     entry = results["entry"].first
     nhs_number = entry["resource"]["id"]
 
-    patient.update!(nhs_number:)
+    if (
+         existing_patient =
+           Patient.includes(
+             :class_imports,
+             :cohort_imports,
+             :immunisation_imports,
+             :patient_sessions
+           ).find_by(nhs_number:)
+       )
+      merge_patients!(existing_patient, patient)
+    else
+      patient.update!(nhs_number:)
+    end
+  end
+
+  def merge_patients!(patient_to_keep, patient_to_remove)
+    ActiveRecord::Base.transaction do
+      patient_to_remove.patient_sessions.each do |patient_session|
+        if (
+             existing_patient_session =
+               patient_to_keep.patient_sessions.find_by(
+                 session_id: patient_session.session_id
+               )
+           )
+          patient_session.gillick_assessments.update_all(
+            patient_session: existing_patient_session
+          )
+          patient_session.triages.update_all(
+            patient_session: existing_patient_session
+          )
+          patient_session.vaccination_records.update_all(
+            patient_session: existing_patient_session
+          )
+        else
+          patient_session.update!(patient: patient_to_keep)
+        end
+      end
+
+      PatientSession.where(patient: patient_to_remove).destroy_all
+
+      patient_to_remove.class_imports.each do |import|
+        unless patient_to_keep.class_imports.include?(import)
+          patient_to_keep.class_imports << import
+        end
+      end
+
+      patient_to_remove.cohort_imports.each do |import|
+        unless patient_to_keep.cohort_imports.include?(import)
+          patient_to_keep.cohort_imports << import
+        end
+      end
+
+      patient_to_remove.immunisation_imports.each do |import|
+        unless patient_to_keep.immunisation_imports.include?(import)
+          patient_to_keep.immunisation_imports << import
+        end
+      end
+
+      patient_to_remove.class_imports.clear
+      patient_to_remove.cohort_imports.clear
+      patient_to_remove.immunisation_imports.clear
+
+      patient_to_remove.destroy!
+    end
   end
 end

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -103,7 +103,7 @@ module PatientSessionStateConcern
     end
 
     def not_gillick_competent?
-      gillick_assessment&.gillick_competent == false
+      latest_gillick_assessment&.gillick_competent == false
     end
 
     def vaccination_can_be_delayed?

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -32,6 +32,8 @@ class GillickAssessment < ApplicationRecord
   belongs_to :patient_session
   belongs_to :assessor, class_name: "User", foreign_key: :assessor_user_id
 
+  has_one :patient, through: :patient_session
+
   encrypts :notes
 
   on_wizard_step :gillick do

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -28,9 +28,12 @@ class PatientSession < ApplicationRecord
   has_one :team, through: :session
   has_many :programmes, through: :session
 
-  has_one :gillick_assessment, -> { recorded }
-  has_one :draft_gillick_assessment,
-          -> { draft },
+  has_many :gillick_assessments, -> { recorded }
+  has_many :draft_gillick_assessments,
+           -> { draft },
+           class_name: "GillickAssessment"
+  has_one :latest_gillick_assessment,
+          -> { recorded.order(created_at: :desc) },
           class_name: "GillickAssessment"
 
   has_many :triages, -> { order(:updated_at) }
@@ -87,7 +90,7 @@ class PatientSession < ApplicationRecord
   end
 
   def gillick_competent?
-    gillick_assessment&.gillick_competent?
+    latest_gillick_assessment&.gillick_competent?
   end
 
   def able_to_vaccinate?

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -226,10 +226,14 @@ FactoryBot.define do
     end
 
     trait :unable_to_vaccinate_not_gillick_competent do
-      gillick_assessment do
-        association :gillick_assessment,
-                    :not_competent,
-                    patient_session: instance
+      gillick_assessments do
+        [
+          association(
+            :gillick_assessment,
+            :not_competent,
+            patient_session: instance
+          )
+        ]
       end
 
       patient do
@@ -304,10 +308,14 @@ FactoryBot.define do
     end
 
     trait :not_gillick_competent do
-      gillick_assessment do
-        association :gillick_assessment,
-                    :not_competent,
-                    patient_session: instance
+      gillick_assessments do
+        [
+          association(
+            :gillick_assessment,
+            :not_competent,
+            patient_session: instance
+          )
+        ]
       end
     end
   end


### PR DESCRIPTION
If we look up the NHS number for a patient without an NHS number, and we end up finding an NHS number for which we already have a patient for, we need to merge the two patient records otherwise we'll end up with a unique constraint failure when trying to change the NHS number on the original patient.