### PR TITLE
Fix microcopy duplication on the session page

### DIFF
--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -32,7 +32,7 @@ class AppSessionSummaryComponent < ViewComponent::Base
           row.with_key { "Consent link" }
           row.with_value do
             govuk_link_to(
-              "View parental consent form (opens in a new tab)",
+              "View parental consent form",
               consent_link,
               new_tab: true
             )

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -40,6 +40,6 @@ describe AppSessionSummaryComponent do
     end
 
     it { should have_content("Consent link") }
-    it { should have_link("View parental consent form (opens in a new tab)") }
+    it { should have_link("View parental consent form (opens in new tab)") }
   end
 end


### PR DESCRIPTION
## Before

<img width="493" alt="image" src="https://github.com/user-attachments/assets/84fbf573-34d5-4434-80b2-62176458740a">

## After

<img width="439" alt="image" src="https://github.com/user-attachments/assets/08e004d0-f001-482f-b33a-2b73dc1536a3">


Calling `govuk_link_to` with `new_tab: true` already adds "(opens in new tab)" to the link text, so adding it explicitly creates duplicate copy