### PR TITLE
Look up NHS numbers when matching consent forms

### DIFF
--- a/app/jobs/concerns/nhs_api_concurrency_concern.rb
+++ b/app/jobs/concerns/nhs_api_concurrency_concern.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module NHSAPIConcurrencyConcern
+  extend ActiveSupport::Concern
+
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  included do
+    # NHS API imposes a limit of 5 requests per second
+    good_job_control_concurrency_with perform_limit: 5,
+                                      perform_throttle: [5, 1.second],
+                                      key: :nhs_api
+
+    # Because the NHS API imposes a limit of 5 requests per second, we're almost
+    # certain to hit throttling and the default exponential backoff strategy
+    # appears to trigger more race conditions in the job performing code, meaning
+    # there’s more instances where more than 5 requests are attempted.
+    retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
+             attempts: :unlimited,
+             wait: ->(_) { rand(0.5..5) }
+  end
+end

--- a/app/jobs/concerns/nhs_number_lookup_concern.rb
+++ b/app/jobs/concerns/nhs_number_lookup_concern.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module NHSNumberLookupConcern
+  extend ActiveSupport::Concern
+
+  include NHSAPIConcurrencyConcern
+
+  def find_nhs_number(object)
+    query = {
+      "family" => object.family_name,
+      "given" => object.given_name,
+      "birthdate" => "eq#{object.date_of_birth}",
+      "address-postalcode" => object.address_postcode,
+      "_history" => true # look up previous names and addresses,
+    }.compact_blank
+
+    response = NHS::PDS.search_patients(query)
+    results = response.body
+
+    return if results["total"].zero?
+
+    results["entry"].first["resource"]["id"]
+  end
+end

--- a/app/jobs/consent_form_matching_job.rb
+++ b/app/jobs/consent_form_matching_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ConsentFormMatchingJob < ApplicationJob
-  queue_as :default
+  include NHSAPIConcurrencyConcern
 
   def perform(consent_form)
     session = consent_form.scheduled_session

--- a/app/jobs/consent_form_matching_job.rb
+++ b/app/jobs/consent_form_matching_job.rb
@@ -1,14 +1,21 @@
 # frozen_string_literal: true
 
 class ConsentFormMatchingJob < ApplicationJob
-  include NHSAPIConcurrencyConcern
+  include NHSNumberLookupConcern
+
+  queue_as :consents
 
   def perform(consent_form)
     session = consent_form.scheduled_session
 
+    nhs_number = find_nhs_number(consent_form)
+
+    # TODO: What happens if we find an NHS number for a patient,
+    # TODO: but they're not in the session?
+
     patients =
       session.patients.match_existing(
-        nhs_number: nil,
+        nhs_number:,
         given_name: consent_form.given_name,
         family_name: consent_form.family_name,
         date_of_birth: consent_form.date_of_birth,

--- a/app/jobs/patient_nhs_number_lookup_job.rb
+++ b/app/jobs/patient_nhs_number_lookup_job.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-class PDSLookupJob < ApplicationJob
+class PatientNHSNumberLookupJob < ApplicationJob
   include NHSAPIConcurrencyConcern
 
-  queue_as :pds
+  queue_as :imports
 
   def perform(patient)
     return if patient.nhs_number.present?

--- a/app/jobs/pds_lookup_job.rb
+++ b/app/jobs/pds_lookup_job.rb
@@ -1,22 +1,9 @@
 # frozen_string_literal: true
 
 class PDSLookupJob < ApplicationJob
-  include GoodJob::ActiveJobExtensions::Concurrency
+  include NHSAPIConcurrencyConcern
 
   queue_as :pds
-
-  # NHS API imposes a limit of 5 requests per second
-  good_job_control_concurrency_with perform_limit: 5,
-                                    perform_throttle: [5, 1.second],
-                                    key: -> { queue_name }
-
-  # Because the NHS API imposes a limit of 5 requests per second, we're almost
-  # certain to hit throttling and the default exponential backoff strategy
-  # appears to trigger more race conditions in the job performing code, meaning
-  # there’s more instances where more than 5 requests are attempted.
-  retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
-           attempts: :unlimited,
-           wait: ->(_) { rand(0.5..5) }
 
   def perform(patient)
     return if patient.nhs_number.present?

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -109,7 +109,7 @@ module CSVImportable
 
   def look_up_missing_nhs_numbers
     patients.without_nhs_number.find_each do |patient|
-      PDSLookupJob.perform_later(patient)
+      PatientNHSNumberLookupJob.perform_later(patient)
     end
   end
 

--- a/spec/features/dev_reset_team_spec.rb
+++ b/spec/features/dev_reset_team_spec.rb
@@ -7,7 +7,7 @@ describe "Dev endpoint to reset a team" do
 
   scenario "Resetting a team deletes all associated data" do
     given_an_example_programme_exists
-    and_requests_can_be_made_to_dps
+    and_requests_can_be_made_to_pds
     and_patients_have_been_imported
     and_vaccination_records_have_been_imported
 
@@ -28,7 +28,7 @@ describe "Dev endpoint to reset a team" do
     @user = @team.users.first
   end
 
-  def and_requests_can_be_made_to_dps
+  def and_requests_can_be_made_to_pds
     stub_request(
       :get,
       "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -3,7 +3,7 @@
 describe "Immunisation imports duplicates" do
   scenario "User reviews and selects between duplicate records" do
     given_i_am_signed_in
-    and_requests_can_be_made_to_dps
+    and_requests_can_be_made_to_pds
     and_an_hpv_programme_is_underway
     and_an_existing_patient_record_exists
 
@@ -51,7 +51,7 @@ describe "Immunisation imports duplicates" do
     sign_in @team.users.first
   end
 
-  def and_requests_can_be_made_to_dps
+  def and_requests_can_be_made_to_pds
     stub_request(
       :get,
       "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -3,6 +3,7 @@
 describe "Parental consent" do
   scenario "Refused" do
     given_an_hpv_programme_is_underway
+    and_requests_can_be_made_to_pds
     when_i_go_to_the_consent_form
     then_i_see_the_start_page
 
@@ -35,6 +36,13 @@ describe "Parental consent" do
         location:
       )
     @child = create(:patient, session: @session)
+  end
+
+  def and_requests_can_be_made_to_pds
+    stub_request(
+      :get,
+      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
+    ).with(query: hash_including({})).to_return_json(body: { total: 0 })
   end
 
   def when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -3,6 +3,7 @@
 describe "Parental consent" do
   scenario "Consent form exactly matches the cohort" do
     given_an_hpv_programme_is_underway
+    and_requests_can_be_made_to_pds
     when_a_nurse_checks_consent_responses
     then_there_should_be_no_consent_for_my_child
 
@@ -38,6 +39,13 @@ describe "Parental consent" do
         location:
       )
     @child = create(:patient, session: @session)
+  end
+
+  def and_requests_can_be_made_to_pds
+    stub_request(
+      :get,
+      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
+    ).with(query: hash_including({})).to_return_json(body: { total: 0 })
   end
 
   def when_a_nurse_checks_consent_responses

--- a/spec/jobs/consent_form_matching_job_spec.rb
+++ b/spec/jobs/consent_form_matching_job_spec.rb
@@ -10,17 +10,34 @@ describe ConsentFormMatchingJob do
       session:,
       given_name: "John",
       family_name: "Smith",
-      date_of_birth: Date.new(2010, 1, 1)
+      date_of_birth: Date.new(2010, 1, 1),
+      address_postcode: "SW11 1AA"
+    )
+  end
+
+  before do
+    stub_request(
+      :get,
+      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
+    ).with(query: hash_including({})).to_return(
+      body: file_fixture(response_file),
+      headers: {
+        "Content-Type" => "application/fhir+json"
+      }
     )
   end
 
   context "with no matching patients" do
+    let(:response_file) { "pds/search-patients-no-results-response.json" }
+
     it "doesn't create a consent" do
       expect { perform }.not_to change(Consent, :count)
     end
   end
 
   context "with one matching patient" do
+    let(:response_file) { "pds/search-patients-no-results-response.json" }
+
     let!(:patient) do
       create(
         :patient,
@@ -64,9 +81,22 @@ describe ConsentFormMatchingJob do
         expect { perform }.to change(Consent, :count).by(1)
       end
     end
+
+    context "with a successful NHS number lookup" do
+      let(:response_file) { "pds/search-patients-response.json" }
+
+      let!(:patient) { create(:patient, nhs_number: "9449306168", session:) }
+
+      it "creates a consent" do
+        expect { perform }.to change(Consent, :count).by(1)
+        expect(Consent.first.patient).to eq(patient)
+      end
+    end
   end
 
   context "with multiple matching patients" do
+    let(:response_file) { "pds/search-patients-no-results-response.json" }
+
     before do
       create_list(
         :patient,

--- a/spec/jobs/patient_nhs_number_lookup_job_spec.rb
+++ b/spec/jobs/patient_nhs_number_lookup_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe PDSLookupJob do
+describe PatientNHSNumberLookupJob do
   subject(:perform_now) { described_class.perform_now(patient) }
 
   context "with an NHS number already" do

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -252,7 +252,9 @@ describe ClassImport do
     end
 
     it "enqueues jobs to look up missing NHS numbers" do
-      expect { record! }.to have_enqueued_job(PDSLookupJob).once.on_queue(:pds)
+      expect { record! }.to have_enqueued_job(
+        PatientNHSNumberLookupJob
+      ).once.on_queue(:imports)
     end
 
     context "with an existing patient matching the name" do

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -243,7 +243,9 @@ describe CohortImport do
     end
 
     it "enqueues jobs to look up missing NHS numbers" do
-      expect { record! }.to have_enqueued_job(PDSLookupJob).once.on_queue(:pds)
+      expect { record! }.to have_enqueued_job(
+        PatientNHSNumberLookupJob
+      ).once.on_queue(:imports)
     end
 
     context "with an existing patient matching the name" do

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -184,9 +184,9 @@ describe ImmunisationImport do
       end
 
       it "enqueues jobs to look up missing NHS numbers" do
-        expect { record! }.to have_enqueued_job(PDSLookupJob).once.on_queue(
-          :pds
-        )
+        expect { record! }.to have_enqueued_job(
+          PatientNHSNumberLookupJob
+        ).once.on_queue(:imports)
       end
     end
 
@@ -263,9 +263,9 @@ describe ImmunisationImport do
       end
 
       it "enqueues jobs to look up missing NHS numbers" do
-        expect { record! }.to have_enqueued_job(PDSLookupJob).once.on_queue(
-          :pds
-        )
+        expect { record! }.to have_enqueued_job(
+          PatientNHSNumberLookupJob
+        ).once.on_queue(:imports)
       end
     end
 


### PR DESCRIPTION
When matching a consent form with a patient, we can look up an NHS number using the patient details provided in the consent form, which makes it more likely that we'll successfully match a consent form with a patient and with increased accuracy.