### PR TITLE
Show year groups instead of date of birth

### DIFF
--- a/app/components/app_session_patient_table_component.html.erb
+++ b/app/components/app_session_patient_table_component.html.erb
@@ -14,15 +14,19 @@
                                       "data-autosubmit-target": "field",
                                       "data-action": "autosubmit#submit",
                                       "data-turbo-permanent": "true" %>
-        <%= f.govuk_text_field :dob, label: { text: "By date of birth" },
-                                     hint: {
-                                       text: "e.g. 2005 or 01/03/2014",
-                                       class: "nhsuk-u-font-size-16",
-                                     },
-                                     value: params[:dob],
-                                     "data-autosubmit-target": "field",
-                                     "data-action": "autosubmit#submit",
-                                     "data-turbo-permanent": "true" %>
+
+        <%= f.govuk_check_boxes_fieldset :year_groups, legend: { text: "By year group", size: "s" } do %>
+          <% year_groups.each do |year_group| %>
+            <%= f.govuk_check_box :year_groups,
+                                  year_group,
+                                  label: { text: helpers.format_year_group(year_group) },
+                                  checked: year_group.to_s.in?(params[:year_groups] || []),
+                                  "data-autosubmit-target": "field",
+                                  "data-action": "autosubmit#submit",
+                                  "data-turbo-permanent": "true" %>
+          <% end %>
+        <% end %>
+
         <%= f.hidden_field :sort, value: params[:sort] %>
         <%= f.hidden_field :direction, value: params[:direction] %>
         <%= f.govuk_submit "Reset filters", type: "reset",

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -4,15 +4,17 @@ class AppSessionPatientTableComponent < ViewComponent::Base
   attr_reader :params
 
   def initialize(
+    session:,
     patient_sessions:,
     section:,
     caption: nil,
-    columns: %i[name dob],
+    columns: %i[name year_group],
     consent_form: nil,
     params: {}
   )
     super
 
+    @session = session
     @patient_sessions = patient_sessions
     @columns = columns
     @section = section
@@ -27,7 +29,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     {
       action: "Action needed",
       name: "Full name",
-      dob: "Date of birth",
+      year_group: "Year group",
       reason: "Reason for refusal",
       outcome: "Outcome",
       postcode: "Postcode",
@@ -43,8 +45,8 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       t("patient_session_statuses.#{patient_session.state}.text")
     when :name
       name_cell(patient_session)
-    when :dob
-      patient_session.patient.date_of_birth.to_fs(:long)
+    when :year_group
+      helpers.patient_year_group(patient_session.patient)
     when :reason
       patient_session
         .consents
@@ -123,7 +125,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
                 sort: column,
                 direction:,
                 name: params[:name],
-                dob: params[:dob]
+                year_groups: params[:year_groups]
               ),
               data:
     end
@@ -146,4 +148,6 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       end
     { html_attributes: { aria: { sort: } } }
   end
+
+  delegate :year_groups, to: :@session
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -12,12 +12,12 @@ class ConsentsController < ApplicationController
         .patient_sessions
         .strict_loading
         .includes(
-          { consents: :parent },
           :latest_gillick_assessment,
-          :patient,
           :programmes,
           :triages,
-          :vaccination_records
+          :vaccination_records,
+          consents: :parent,
+          patient: :cohort
         )
         .sort_by { |ps| ps.patient.full_name }
 

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -20,12 +20,12 @@ class TriagesController < ApplicationController
         .strict_loading
         .includes(
           :programmes,
-          :patient,
           :triages,
           :latest_gillick_assessment,
           :latest_triage,
           :latest_vaccination_record,
-          :vaccination_records
+          :vaccination_records,
+          patient: :cohort
         )
         .preload(:consents)
         .order("patients.given_name", "patients.family_name")

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -22,12 +22,12 @@ class VaccinationsController < ApplicationController
         .strict_loading
         .includes(
           :programmes,
-          :patient,
           :triages,
           :latest_gillick_assessment,
           :latest_triage,
           :latest_vaccination_record,
-          :vaccination_records
+          :vaccination_records,
+          patient: :cohort
         )
         .preload(:consents)
         .order("patients.given_name", "patients.family_name")

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -21,8 +21,9 @@
       c.with_heading { "Children in this cohort" }
       if @patient_sessions.count > 0
         render AppSessionPatientTableComponent.new(
+          session: @session,
           patient_sessions: @patient_sessions,
-          columns: %i[name postcode dob select_for_matching],
+          columns: %i[name postcode year_group select_for_matching],
           section: :matching,
           consent_form: @consent_form,
         )

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -34,10 +34,11 @@
 <% end %>
 
 <%= render AppSessionPatientTableComponent.new(
+      session: @session,
       patient_sessions: @patient_sessions,
       caption: t("patients_table.#{@current_tab}.caption",
                  children: t("children", count: @patient_sessions.count)),
-      columns: @current_tab == :consent_refused ? %i[name dob reason] : %i[name dob],
+      columns: @current_tab == :consent_refused ? %i[name year_group reason] : %i[name year_group],
       section: :consents,
       params:,
     ) %>

--- a/app/views/triages/index.html.erb
+++ b/app/views/triages/index.html.erb
@@ -21,10 +21,11 @@
 <% end %>
 
 <%= render AppSessionPatientTableComponent.new(
+      session: @session,
       patient_sessions: @patient_sessions,
       caption: t("patients_table.#{@current_tab}.caption",
                  children: t("children", count: @patient_sessions.count)),
-      columns: %i[name dob],
+      columns: %i[name year_group],
       section: :triage,
       params:,
     ) %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -35,12 +35,13 @@
 <% end %>
 
 <%= render AppSessionPatientTableComponent.new(
+      session: @session,
       patient_sessions: @patient_sessions,
       caption: t("patients_table.#{@current_tab}.caption",
                  children: t("children", count: @patient_sessions.count)),
       columns: @current_tab == :vaccinate ?
-        %i[name dob action] :
-        %i[name dob outcome],
+        %i[name year_group action] :
+        %i[name year_group outcome],
       section: :vaccinations,
       params:,
     ) %>

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe AppSessionPatientTableComponent, type: :component do
+describe AppSessionPatientTableComponent do
   subject(:rendered) { render_inline(component) }
 
   before do
@@ -11,14 +11,21 @@ describe AppSessionPatientTableComponent, type: :component do
 
   let(:section) { :consent }
   let(:programme) { create(:programme) }
-  let(:patient_sessions) { create_list(:patient_session, 2, programme:) }
-  let(:columns) { %i[name dob] }
+  let(:session) { create(:session, programme:) }
+  let(:patient_sessions) { create_list(:patient_session, 2, session:) }
+  let(:columns) { %i[name year_group] }
   let(:params) { { session_id: 1, section:, tab: :needed } }
-  let(:args) do
-    { patient_sessions:, caption: "Foo", section:, columns:, params: }
-  end
 
-  let(:component) { described_class.new(**args) }
+  let(:component) do
+    described_class.new(
+      session:,
+      patient_sessions:,
+      caption: "Foo",
+      section:,
+      columns:,
+      params:
+    )
+  end
 
   def have_column(text)
     have_css(".nhsuk-table__head th", text:)
@@ -27,7 +34,7 @@ describe AppSessionPatientTableComponent, type: :component do
   it { should have_css(".nhsuk-table") }
   it { should have_css(".nhsuk-table__head") }
   it { should have_column("Full name") }
-  it { should have_column("Date of birth") }
+  it { should have_column("Year group") }
   it { should have_css(".nhsuk-table__head .nhsuk-table__row", count: 1) }
 
   it "includes the patient's full name" do
@@ -57,6 +64,7 @@ describe AppSessionPatientTableComponent, type: :component do
   describe "when the section is :matching" do
     let(:component) do
       described_class.new(
+        session:,
         patient_sessions:,
         section: :matching,
         consent_form:
@@ -65,7 +73,7 @@ describe AppSessionPatientTableComponent, type: :component do
             programme:,
             session: patient_sessions.first.session
           ),
-        columns: %i[name postcode dob select_for_matching]
+        columns: %i[name postcode year_group select_for_matching]
       )
     end
 
@@ -88,20 +96,22 @@ describe AppSessionPatientTableComponent, type: :component do
 
   describe "columns parameter" do
     context "is not set" do
-      let(:component) { described_class.new(**args.except(:columns)) }
+      let(:component) do
+        described_class.new(session:, patient_sessions:, section:, params:)
+      end
 
       it { should have_column("Full name") }
-      it { should have_column("Date of birth") }
+      it { should have_column("Year group") }
     end
 
     context "includes action" do
-      let(:columns) { %i[name dob action] }
+      let(:columns) { %i[name year_group action] }
 
       it { should have_column("Action needed") }
     end
 
     context "includes outcome" do
-      let(:columns) { %i[name dob outcome] }
+      let(:columns) { %i[name year_group outcome] }
 
       it { should have_column("Outcome") }
     end

--- a/spec/components/previews/app_session_patient_table_component_preview.rb
+++ b/spec/components/previews/app_session_patient_table_component_preview.rb
@@ -11,9 +11,10 @@ class AppSessionPatientTableComponentPreview < ViewComponent::Preview
     patient_sessions.first.patient.update!(common_name: "Bobby")
 
     render AppSessionPatientTableComponent.new(
+             session: patient_sessions.first.session,
              patient_sessions:,
              caption: I18n.t("states.consent_given.title"),
-             columns: %i[name dob],
+             columns: %i[name year_group],
              route: :consent
            )
   end
@@ -31,12 +32,14 @@ class AppSessionPatientTableComponentPreview < ViewComponent::Preview
       ps.patient.update!(address_postcode: Faker::Address.postcode)
     end
 
-    consent_form =
-      create(:consent_form, programme:, session: patient_sessions.first.session)
+    session = patient_sessions.first.session
+
+    consent_form = create(:consent_form, programme:, session:)
 
     render AppSessionPatientTableComponent.new(
+             session:,
              patient_sessions:,
-             columns: %i[name postcode dob select_for_matching],
+             columns: %i[name postcode year_group select_for_matching],
              route: :matching,
              consent_form:
            )

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -14,15 +14,9 @@ describe PatientSortingConcern do
     end
   end
 
-  let(:alex) do
-    create(:patient, given_name: "Alex", date_of_birth: Date.new(2010, 1, 1))
-  end
-  let(:blair) do
-    create(:patient, given_name: "Blair", date_of_birth: Date.new(2010, 1, 2))
-  end
-  let(:casey) do
-    create(:patient, given_name: "Casey", date_of_birth: Date.new(2010, 1, 3))
-  end
+  let(:alex) { create(:patient, given_name: "Alex", year_group: 8) }
+  let(:blair) { create(:patient, given_name: "Blair", year_group: 9) }
+  let(:casey) { create(:patient, given_name: "Casey", year_group: 10) }
 
   let(:programme) { create(:programme) }
   let(:session) { create(:session, programme:) }
@@ -110,8 +104,8 @@ describe PatientSortingConcern do
       end
     end
 
-    context "when filtering by date of birth" do
-      let(:params) { { dob: "02/01/2010" } }
+    context "when filtering by year group" do
+      let(:params) { { year_groups: %w[9] } }
 
       it "filters patient sessions by date of birth" do
         subject.filter_patients!(patient_sessions)
@@ -121,7 +115,7 @@ describe PatientSortingConcern do
     end
 
     context "when filtering by name and date of birth" do
-      let(:params) { { name: "Alex", dob: "01/01/2010" } }
+      let(:params) { { name: "Alex", year_groups: %w[8] } }
 
       it "filters patient sessions by both name and date of birth" do
         subject.filter_patients!(patient_sessions)

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -45,13 +45,13 @@ FactoryBot.define do
 
   factory :patient do
     transient do
-      session { nil }
+      parents { [create(:parent, :recorded, family_name:)] }
       programme { session&.programmes&.first }
+      session { nil }
       team do
         session&.team || association(:team, programmes: [programme].compact)
       end
-
-      parents { [create(:parent, :recorded, family_name:)] }
+      year_group { nil }
     end
 
     cohort do
@@ -77,7 +77,13 @@ FactoryBot.define do
 
     given_name { Faker::Name.first_name }
     family_name { Faker::Name.last_name }
-    date_of_birth { Faker::Date.birthday(min_age: 7, max_age: 16) }
+    date_of_birth do
+      if year_group
+        Faker::Date.birthday(min_age: year_group + 5, max_age: year_group + 5)
+      else
+        Faker::Date.birthday(min_age: 7, max_age: 16)
+      end
+    end
     school { session&.location }
     registration do
       "#{date_of_birth.year_group}#{Faker::Alphanumeric.alpha(number: 2)}"

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -15,27 +15,23 @@ describe "Patient sorting and filtering" do
     when_i_click_on_the_name_header
     then_i_see_patients_ordered_by_name_asc
 
-    when_i_click_on_the_dob_header
-    then_i_see_patients_ordered_by_dob_asc
+    when_i_click_on_the_year_group_header
+    then_i_see_patients_ordered_by_year_group_asc
 
-    when_i_click_on_the_dob_header
-    then_i_see_patients_ordered_by_dob_desc
+    when_i_click_on_the_year_group_header
+    then_i_see_patients_ordered_by_year_group_desc
 
     when_i_filter_by_names_starting_with_cas
     and_i_click_filter
-    then_i_see_patients_with_names_starting_with_cas_by_dob_desc
+    then_i_see_patients_with_names_starting_with_cas_by_year_group_desc
     and_by_name_contains_cas
 
     when_i_click_on_the_name_header
     then_i_see_patients_with_names_starting_with_cas_by_name_asc
 
-    when_i_filter_by_dob_01_2002
+    when_i_filter_by_year_group_10
     and_i_click_filter
-    then_i_see_patients_with_dob_01_2002
-
-    when_i_filter_by_dob_01_01_2002
-    and_i_click_filter
-    then_i_see_patients_with_dob_01_01_2002
+    then_i_see_patients_with_year_group_10
   end
 
   scenario "Users can sort and filter patients with JS", type: :system do
@@ -60,14 +56,19 @@ describe "Patient sorting and filtering" do
     location = create(:location, :school)
     @user = @team.users.first
     @session = create(:session, team: @team, programme: @programme, location:)
-    create_list(:patient, 4, session: @session)
-      .zip(
-        %w[Alex Blair Casey Cassidy],
-        %w[2000-01-01 2001-01-01 2002-01-01 2002-01-02]
-      )
-      .each do |(patient, name, dob)|
-        patient.update!(given_name: name, date_of_birth: dob)
+
+    %w[Alex Blair Casey Cassidy]
+      .zip([8, 9, 10, 10], %w[A B C D])
+      .each do |(given_name, year_group, registration)|
+        create(
+          :patient,
+          session: @session,
+          given_name:,
+          year_group:,
+          registration:
+        )
       end
+
     sign_in @user
   end
 
@@ -80,8 +81,8 @@ describe "Patient sorting and filtering" do
     sleep 0.1
   end
 
-  def when_i_click_on_the_dob_header
-    click_link "Date of birth"
+  def when_i_click_on_the_year_group_header
+    click_link "Year group"
   end
 
   def then_i_see_patients_ordered_by_name_asc
@@ -90,7 +91,7 @@ describe "Patient sorting and filtering" do
     expect(page).to have_selector("tr:nth-child(3)", text: "Casey")
     expect(page).to have_selector("tr:nth-child(4)", text: "Cassidy")
   end
-  alias_method :then_i_see_patients_ordered_by_dob_asc,
+  alias_method :then_i_see_patients_ordered_by_year_group_asc,
                :then_i_see_patients_ordered_by_name_asc
 
   def then_i_see_patients_ordered_by_name_desc
@@ -99,7 +100,7 @@ describe "Patient sorting and filtering" do
     expect(page).to have_selector("tr:nth-child(3)", text: "Blair")
     expect(page).to have_selector("tr:nth-child(4)", text: "Alex")
   end
-  alias_method :then_i_see_patients_ordered_by_dob_desc,
+  alias_method :then_i_see_patients_ordered_by_year_group_desc,
                :then_i_see_patients_ordered_by_name_desc
 
   def when_i_filter_by_names_starting_with_cas
@@ -119,7 +120,7 @@ describe "Patient sorting and filtering" do
     expect(page).to have_selector("tr:nth-child(1)", text: "Cassidy")
     expect(page).to have_selector("tr:nth-child(2)", text: "Casey")
   end
-  alias_method :then_i_see_patients_with_names_starting_with_cas_by_dob_desc,
+  alias_method :then_i_see_patients_with_names_starting_with_cas_by_year_group_desc,
                :then_i_see_patients_with_names_starting_with_cas_by_name_desc
 
   def then_i_see_patients_with_names_starting_with_cas_by_name_asc
@@ -127,30 +128,21 @@ describe "Patient sorting and filtering" do
     expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
     expect(page).to have_selector("tr:nth-child(2)", text: "Cassidy")
   end
-  alias_method :then_i_see_patients_with_names_starting_with_cas_by_dob_asc,
+  alias_method :then_i_see_patients_with_names_starting_with_cas_by_year_group_asc,
                :then_i_see_patients_with_names_starting_with_cas_by_name_asc
 
   def and_by_name_contains_cas
     expect(page).to have_field("By name", with: "cas")
   end
 
-  def when_i_filter_by_dob_01_2002
-    fill_in "By date of birth", with: "01/2002"
+  def when_i_filter_by_year_group_10
+    check "Year 10"
   end
 
-  def then_i_see_patients_with_dob_01_2002
+  def then_i_see_patients_with_year_group_10
     expect(page).not_to have_selector("tr:nth-child(3)")
     expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
     expect(page).to have_selector("tr:nth-child(2)", text: "Cassidy")
-  end
-
-  def when_i_filter_by_dob_01_01_2002
-    fill_in "By date of birth", with: "01/01/2002"
-  end
-
-  def then_i_see_patients_with_dob_01_01_2002
-    expect(page).not_to have_selector("tr:nth-child(2)")
-    expect(page).to have_selector("tr:nth-child(1)", text: "Casey")
   end
 
   def when_i_reset_filters


### PR DESCRIPTION
On tables where we show a list of patients, we want to show the year group and cohort rather than the date of birth as this is more useful for the nursing team, and matches our latest designs.

## Screenshots

<img width="264" alt="Screenshot 2024-10-17 at 10 53 30" src="https://github.com/user-attachments/assets/7fb0745b-e90a-41d5-b617-122e487a5b6c">
<img width="761" alt="Screenshot 2024-10-17 at 10 54 20" src="https://github.com/user-attachments/assets/f8b5b234-9f0c-4763-8bdd-ec49547c564e">
