### PR TITLE
Vaccinate using active vaccines

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -82,10 +82,11 @@ class PatientSession < ApplicationRecord
     # the flu programme for the SAIS teams that offer both nasal and injectable vaccines.
 
     programme = programmes.first
+    vaccine = programme.vaccines.active.first
 
     draft_vaccination_records.create_with(
       programme:,
-      vaccine: programme.vaccines.first
+      vaccine:
     ).find_or_initialize_by(recorded_at: nil)
   end
 

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -48,6 +48,7 @@ class Vaccine < ApplicationRecord
   enum :method, %i[injection nasal], validate: true
 
   scope :active, -> { where(discontinued: false) }
+  scope :discontinued, -> { where(discontinued: true) }
 
   delegate :first_health_question, to: :health_questions
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -21,10 +21,17 @@ describe "HPV Vaccination" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
+    programme = create(:programme, :hpv_all_vaccines)
     team = create(:team, :with_one_nurse, programmes: [programme])
     location = create(:location, :school)
-    @batch = create(:batch, team:, vaccine: programme.vaccines.first)
+
+    programme.vaccines.discontinued.each do |vaccine|
+      create(:batch, team:, vaccine:)
+    end
+
+    active_vaccine = programme.vaccines.active.first
+    @active_batch = create(:batch, team:, vaccine: active_vaccine)
+
     @session = create(:session, team:, programme:, location:)
     @patient =
       create(:patient, :consent_given_triage_not_needed, session: @session)
@@ -45,14 +52,14 @@ describe "HPV Vaccination" do
   end
 
   def and_i_select_the_batch
-    choose @batch.name
+    choose @active_batch.name
     click_button "Continue"
   end
 
   def then_i_see_the_confirmation_page
     expect(page).to have_content("Check and confirm")
     expect(page).to have_content("Child#{@patient.full_name}")
-    expect(page).to have_content("Batch#{@batch.name}")
+    expect(page).to have_content("Batch#{@active_batch.name}")
     expect(page).to have_content("MethodIntramuscular")
     expect(page).to have_content("SiteLeft arm")
     expect(page).to have_content("OutcomeVaccinated")


### PR DESCRIPTION
When recording a vaccination we should only pick from the active vaccines as nurses wouldn't be recording vaccinations using vaccines which have discontinued.