### PR TITLE
Remove hpv_no_batches trait

### DIFF
--- a/spec/factories/programmes.rb
+++ b/spec/factories/programmes.rb
@@ -15,8 +15,6 @@
 #
 FactoryBot.define do
   factory :programme do
-    transient { batch_count { 1 } }
-
     type { %w[flu hpv].sample }
     vaccines { [association(:vaccine, programme: instance)] }
 
@@ -34,11 +32,6 @@ FactoryBot.define do
           association(:vaccine, :gardasil_9, programme: instance)
         ]
       end
-    end
-
-    trait :hpv_no_batches do
-      batch_count { 0 }
-      hpv
     end
 
     trait :flu do

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -20,7 +20,7 @@ describe "HPV Vaccination" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv, batch_count: 4)
+    programme = create(:programme, :hpv)
     team = create(:team, :with_one_nurse, programmes: [programme])
 
     batches =

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -22,7 +22,7 @@ describe "Manage batches" do
   end
 
   def given_my_team_is_running_an_hpv_vaccination_programme
-    @programme = create(:programme, :hpv_all_vaccines, batch_count: 0)
+    @programme = create(:programme, :hpv_all_vaccines)
     @team = create(:team, :with_one_nurse, programmes: [@programme])
   end
 

--- a/spec/features/manage_vaccines_spec.rb
+++ b/spec/features/manage_vaccines_spec.rb
@@ -14,7 +14,7 @@ describe "Manage vaccines" do
   end
 
   def given_my_team_is_running_an_hpv_vaccination_programme
-    programme = create(:programme, :hpv_no_batches)
+    programme = create(:programme, :hpv)
     @team = create(:team, :with_one_nurse, programmes: [programme])
   end
 


### PR DESCRIPTION
This trait no longer does anything different to hpv as we've removed the `batch_count` attribute on programmes and vaccines as batches are now linked to teams, so they need to be created outside of the vaccine and programmes.