### PR TITLE
Add missing message for invalid batch name

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -315,6 +315,7 @@ en:
               less_than: Enter an expiry date before %{count}
             name:
               blank: Enter a batch
+              invalid: Enter a batch with only letters and numbers
         class_import:
           attributes:
             csv:


### PR DESCRIPTION
## Before

<img width="420" alt="image" src="https://github.com/user-attachments/assets/be85e17c-783b-40b2-a0e1-b32eb49ed185">


## After

<img width="510" alt="image" src="https://github.com/user-attachments/assets/77157c1a-ab9b-4e52-9f42-28afcfe61899">
