### PR TITLE
Remove the reference to date on consent response confirmation

### DIFF
--- a/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
@@ -1,8 +1,5 @@
 <% title = t("consent_forms.confirmation_agreed.title.#{@consent_form.programme.type}",
-            full_name: @consent_form.full_name,
-            date: @session.dates.map(&:value).min.to_fs(:long)) %>
-
-<% # TODO: Handle multiple dates. %>
+            full_name: @consent_form.full_name) %>
 
 <% content_for :page_title, title %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -535,8 +535,8 @@ en:
         hpv: Yes, I agree
     confirmation_agreed:
       title:
-        flu: " %{full_name} will get their nasal flu vaccination at school on %{date}"
-        hpv: " %{full_name} will get their HPV vaccination at school on %{date}"
+        flu: " %{full_name} will get their nasal flu vaccination at school"
+        hpv: " %{full_name} will get their HPV vaccination at school"
     confirmation_injection:
       title:
         flu: Your child will not get a nasal flu vaccination at school


### PR DESCRIPTION
The SAIS team might make multiple visits to the school and there's no guarantee that the child will be vaccinated on a particular date.

<img width="834" alt="image" src="https://github.com/user-attachments/assets/f76afcc7-eca9-4f85-a7a3-79e0edc77421">
