### PR TITLE
Validate for batch uniqueness

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -46,6 +46,9 @@ class Batch < ApplicationRecord
             comparison: {
               greater_than: -> { Date.new(Date.current.year - 15, 1, 1) },
               less_than: -> { Date.new(Date.current.year + 15, 1, 1) }
+            },
+            uniqueness: {
+              scope: %i[team_id name vaccine_id]
             }
 
   def archived?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,11 +308,12 @@ en:
           attributes:
             expiry:
               blank: Enter an expiry date
+              greater_than: Enter an expiry date after %{count}
+              less_than: Enter an expiry date before %{count}
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year
-              greater_than: Enter an expiry date after %{count}
-              less_than: Enter an expiry date before %{count}
+              taken: This batch already exists
             name:
               blank: Enter a batch
               invalid: Enter a batch with only letters and numbers

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -63,6 +63,14 @@ describe Batch do
       end
     end
 
+    it do
+      expect(subject).to validate_uniqueness_of(:expiry).scoped_to(
+        :team_id,
+        :name,
+        :vaccine_id
+      )
+    end
+
     context "with invalid characters" do
       subject(:batch) { build(:batch, name: "ABC*123") }
 


### PR DESCRIPTION
There is already an index on these attributes so this prevents a crash.

<img width="737" alt="image" src="https://github.com/user-attachments/assets/67a6554b-928b-46fd-8b67-499851c4bead">

<img width="714" alt="image" src="https://github.com/user-attachments/assets/1adf57af-1382-474b-b59a-4e26f69d77dd">
