### PR TITLE
Update all patients from PDS when importing

### DIFF
--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PatientUpdateFromPDSJob < ApplicationJob
+  include NHSAPIConcurrencyConcern
+
+  queue_as :patients
+
+  def perform(patient)
+    raise MissingNHSNumber if patient.nhs_number.nil?
+
+    pds_patient = NHS::PDS.get_patient(patient.nhs_number).body
+    patient.update_from_pds!(pds_patient)
+  end
+
+  class MissingNHSNumber < StandardError
+  end
+end

--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -3,7 +3,7 @@
 class PatientUpdateFromPDSJob < ApplicationJob
   include NHSAPIConcurrencyConcern
 
-  queue_as :patients
+  queue_as :imports
 
   def perform(patient)
     raise MissingNHSNumber if patient.nhs_number.nil?

--- a/spec/features/dev_reset_team_spec.rb
+++ b/spec/features/dev_reset_team_spec.rb
@@ -7,7 +7,6 @@ describe "Dev endpoint to reset a team" do
 
   scenario "Resetting a team deletes all associated data" do
     given_an_example_programme_exists
-    and_requests_can_be_made_to_pds
     and_patients_have_been_imported
     and_vaccination_records_have_been_imported
 
@@ -28,13 +27,6 @@ describe "Dev endpoint to reset a team" do
     @user = @team.users.first
   end
 
-  def and_requests_can_be_made_to_pds
-    stub_request(
-      :get,
-      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
-    ).with(query: hash_including({})).to_return_json(body: { total: 0 })
-  end
-
   def and_patients_have_been_imported
     sign_in @user
     visit "/dashboard"
@@ -45,7 +37,6 @@ describe "Dev endpoint to reset a team" do
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
 
-    perform_enqueued_jobs
     expect(@team.cohorts.flat_map(&:patients).size).to eq(3)
     expect(@team.cohorts.flat_map(&:patients).flat_map(&:parents).size).to eq(3)
   end
@@ -62,7 +53,6 @@ describe "Dev endpoint to reset a team" do
     )
     click_on "Continue"
 
-    perform_enqueued_jobs
     expect(VaccinationRecord.count).to eq(11)
   end
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -94,7 +94,6 @@ describe "End-to-end journey" do
     click_on "Import child records"
     attach_file "cohort_import[csv]", csv_file.path
     click_on "Continue"
-    perform_enqueued_jobs
     visit programme_cohort_import_path(@programme, CohortImport.last)
   end
 

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -3,7 +3,6 @@
 describe "Immunisation imports duplicates" do
   scenario "User reviews and selects between duplicate records" do
     given_i_am_signed_in
-    and_requests_can_be_made_to_pds
     and_an_hpv_programme_is_underway
     and_an_existing_patient_record_exists
 
@@ -49,13 +48,6 @@ describe "Immunisation imports duplicates" do
   def given_i_am_signed_in
     @team = create(:team, :with_one_nurse, ods_code: "R1L")
     sign_in @team.users.first
-  end
-
-  def and_requests_can_be_made_to_pds
-    stub_request(
-      :get,
-      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
-    ).with(query: hash_including({})).to_return_json(body: { total: 0 })
   end
 
   def and_an_hpv_programme_is_underway
@@ -153,7 +145,6 @@ describe "Immunisation imports duplicates" do
       "spec/fixtures/immunisation_import/valid_hpv.csv"
     )
     click_on "Continue"
-    perform_enqueued_jobs
     click_link ImmunisationImport.last.created_at.to_fs(:long), match: :first
   end
 

--- a/spec/jobs/patient_update_from_pds_job_spec.rb
+++ b/spec/jobs/patient_update_from_pds_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe PatientUpdateFromPDSJob do
+  subject(:perform_now) { described_class.perform_now(patient) }
+
+  context "without an NHS number" do
+    let(:patient) { create(:patient, nhs_number: nil) }
+
+    it "raises an error" do
+      expect { perform_now }.to raise_error(
+        PatientUpdateFromPDSJob::MissingNHSNumber
+      )
+    end
+  end
+
+  context "with an NHS number" do
+    before do
+      stub_request(
+        :get,
+        "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/0123456789"
+      ).to_return(
+        body: file_fixture("pds/get-patient-response.json"),
+        headers: {
+          "Content-Type" => "application/fhir+json"
+        }
+      )
+    end
+
+    let(:patient) { create(:patient, nhs_number: "0123456789") }
+
+    it "updates the patient details from PDS" do
+      expect(patient).to receive(:update_from_pds!)
+      perform_now
+    end
+  end
+end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -257,6 +257,13 @@ describe ClassImport do
       ).once.on_queue(:imports)
     end
 
+    it "enqueues jobs to update from PDS" do
+      expect { record! }.to have_enqueued_job(PatientUpdateFromPDSJob)
+        .exactly(3)
+        .times
+        .on_queue(:imports)
+    end
+
     context "with an existing patient matching the name" do
       before do
         create(

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -248,6 +248,12 @@ describe CohortImport do
       ).once.on_queue(:imports)
     end
 
+    it "enqueues jobs to update from PDS" do
+      expect { record! }.to have_enqueued_job(
+        PatientUpdateFromPDSJob
+      ).twice.on_queue(:imports)
+    end
+
     context "with an existing patient matching the name" do
       before do
         create(

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -184,6 +184,13 @@ describe ImmunisationImport do
           PatientNHSNumberLookupJob
         ).once.on_queue(:imports)
       end
+
+      it "enqueues jobs to update from PDS" do
+        expect { record! }.to have_enqueued_job(PatientUpdateFromPDSJob)
+          .exactly(6)
+          .times
+          .on_queue(:imports)
+      end
     end
 
     context "with valid HPV rows" do
@@ -258,6 +265,13 @@ describe ImmunisationImport do
         expect { record! }.to have_enqueued_job(
           PatientNHSNumberLookupJob
         ).once.on_queue(:imports)
+      end
+
+      it "enqueues jobs to update from PDS" do
+        expect { record! }.to have_enqueued_job(PatientUpdateFromPDSJob)
+          .exactly(9)
+          .times
+          .on_queue(:imports)
       end
     end
 


### PR DESCRIPTION
When importing patients, if we have an NHS number for the patient already then we can enqueue these jobs to check in PDS that the patient doesn't have any flags set on them such as restricted, or to check that they're not deceased.

To simplify some of the feature tests, I've removed a call to run enqueued jobs, which works because the files we're uploading aren't big enough to trigger the import running in the background.