### PR TITLE
Use session CIS2 roles to authorize user

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -88,9 +88,11 @@
   <% end %>
 <% end %>
 
-<%= render AppVaccinateFormComponent.new(
-      patient_session:,
-      vaccination_record: @vaccination_record,
-      section: @section,
-      tab: @tab,
-    ) %>
+<% if helpers.policy(VaccinationRecord).create? %>
+  <%= render AppVaccinateFormComponent.new(
+        patient_session:,
+        vaccination_record: @vaccination_record,
+        section: @section,
+        tab: @tab,
+      ) %>
+<% end %>

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -71,7 +71,7 @@
   <% end %>
 <% end %>
 
-<% if @patient_session.next_step == :triage %>
+<% if helpers.policy(Triage).create? && @patient_session.next_step == :triage %>
   <%= render AppCardComponent.new do %>
     <%= render AppTriageFormComponent.new(
           patient_session:,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_user_location!
   before_action :authenticate_user!
+  before_action :set_user_sso_session
   before_action :set_disable_cache_headers
   before_action :set_header_path
   before_action :set_service_name
@@ -50,5 +51,11 @@ class ApplicationController < ActionController::Base
 
   def handle_unprocessable_entity
     render "errors/unprocessable_entity", status: :unprocessable_entity
+  end
+
+  def set_user_sso_session
+    return unless Flipper.enabled?(:sso_session) && current_user
+
+    current_user.sso_session = session["cis2_info"]
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,6 +29,8 @@ class ApplicationController < ActionController::Base
 
   layout "two_thirds"
 
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
   private
 
   def set_header_path
@@ -57,5 +59,10 @@ class ApplicationController < ActionController::Base
     return unless Flipper.enabled?(:sso_session) && current_user
 
     current_user.sso_session = session["cis2_info"]
+  end
+
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to(request.referer || root_path, status: :forbidden)
   end
 end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -11,7 +11,7 @@ class TriagesController < ApplicationController
   before_action :set_triage, only: %i[create new]
   before_action :set_section_and_tab, only: %i[create new]
 
-  after_action :verify_policy_scoped, only: %i[index create new]
+  after_action :verify_authorized
 
   def index
     all_patient_sessions =
@@ -40,14 +40,18 @@ class TriagesController < ApplicationController
 
     session[:current_section] = "triage"
 
+    authorize Triage
+
     render layout: "full"
   end
 
   def new
+    authorize @triage
   end
 
   def create
     @triage.assign_attributes(triage_params.merge(performed_by: current_user))
+    authorize @triage
     if @triage.save(context: :consent)
       @patient.consents.recorded.each do
         send_triage_confirmation(@patient_session, _1)

--- a/app/controllers/vaccinations/edit_controller.rb
+++ b/app/controllers/vaccinations/edit_controller.rb
@@ -13,11 +13,16 @@ class Vaccinations::EditController < ApplicationController
   before_action :set_steps
   before_action :setup_wizard_translated
 
+  after_action :verify_authorized
+
   def show
+    authorize @draft_vaccination_record, :edit?
     render_wizard
   end
 
   def update
+    authorize @draft_vaccination_record
+
     if current_step == :confirm
       handle_confirm
     elsif current_step == :batch

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,8 @@
 class User < ApplicationRecord
   include FullNameConcern
 
+  attr_accessor :sso_session
+
   devise :database_authenticatable,
          :trackable,
          :timeoutable,
@@ -83,5 +85,20 @@ class User < ApplicationRecord
     user.email = userinfo[:info][:email]
 
     user.tap(&:save!)
+  end
+
+  def is_medical_secretary?
+    return false unless Flipper.enabled?(:cis2)
+
+    role_codes = sso_session.dig("selected_role", "code")
+    role_codes.include?("R8006")
+  end
+
+  def is_nurse?
+    # All users are nurses if cis2 is disabled
+    return true unless Flipper.enabled?(:cis2)
+
+    role_codes = sso_session.dig("selected_role", "code")
+    role_codes.include?("R8001")
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,15 +9,15 @@ class ApplicationPolicy
   end
 
   def index?
-    false
+    @user.is_nurse? || @user.is_medical_secretary?
   end
 
   def show?
-    false
+    @user.is_nurse? || @user.is_medical_secretary?
   end
 
   def create?
-    false
+    @user.is_nurse? || @user.is_medical_secretary?
   end
 
   def new?
@@ -25,7 +25,7 @@ class ApplicationPolicy
   end
 
   def update?
-    false
+    @user.is_nurse? || @user.is_medical_secretary?
   end
 
   def edit?
@@ -33,7 +33,7 @@ class ApplicationPolicy
   end
 
   def destroy?
-    false
+    @user.is_nurse? || @user.is_medical_secretary?
   end
 
   class Scope

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BatchPolicy
+class BatchPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/class_import_policy.rb
+++ b/app/policies/class_import_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ClassImportPolicy
+class ClassImportPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/cohort_import_policy.rb
+++ b/app/policies/cohort_import_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CohortImportPolicy
+class CohortImportPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/cohort_policy.rb
+++ b/app/policies/cohort_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CohortPolicy
+class CohortPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/consent_form_policy.rb
+++ b/app/policies/consent_form_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ConsentFormPolicy
+class ConsentFormPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/consent_policy.rb
+++ b/app/policies/consent_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ConsentPolicy
+class ConsentPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/immunisation_import_policy.rb
+++ b/app/policies/immunisation_import_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ImmunisationImportPolicy
+class ImmunisationImportPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LocationPolicy
+class LocationPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PatientPolicy
+class PatientPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/patient_session_policy.rb
+++ b/app/policies/patient_session_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PatientSessionPolicy
+class PatientSessionPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/programme_policy.rb
+++ b/app/policies/programme_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ProgrammePolicy
+class ProgrammePolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SessionPolicy
+class SessionPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/triage_policy.rb
+++ b/app/policies/triage_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TriagePolicy < ApplicationPolicy
+  def create?
+    @user.is_nurse?
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserPolicy
+class UserPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VaccinationRecordPolicy
+class VaccinationRecordPolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
 class VaccinationRecordPolicy < ApplicationPolicy
+  def create?
+    @user.is_nurse?
+  end
+
+  def new?
+    create?
+  end
+
+  def edit?
+    @user.is_nurse?
+  end
+
+  def update?
+    edit?
+  end
+
   class Scope
     def initialize(user, scope)
       @user = user

--- a/app/policies/vaccine_policy.rb
+++ b/app/policies/vaccine_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VaccinePolicy
+class VaccinePolicy < ApplicationPolicy
   class Scope
     def initialize(user, scope)
       @user = user


### PR DESCRIPTION
Users receive a role from the CIS2 callback that gives them certain privileges in Mavis. This sets up the controller to assign the `session` hash to an `attr_accessor` on the user that we can then parse to figure out a user's role.

Then the `is_nurse?` and `is_medical_secretary?` methods can be used in the policies to decide if a user is allowed to perform certain actions.

Parts that are missing in this initial implementation:

- Restricting Mavis so that users with *only* the R8001 or R8006 role have access (currently access control is only enforced for Triage and Vaccination routes)
- Restricting access by `org_code` from `session["cis2_info"]`