### PR TITLE
Add ability to remove patients from cohorts

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -3,6 +3,8 @@
 class PatientsController < ApplicationController
   include Pagy::Backend
 
+  before_action :set_patient, except: :index
+
   def index
     @pagy, @patients = pagy(policy_scope(Patient).not_deceased.order_by_name)
 
@@ -10,6 +12,27 @@ class PatientsController < ApplicationController
   end
 
   def show
+  end
+
+  def update
+    cohort = @patient.cohort
+
+    @patient.update!(patient_params)
+
+    redirect_to patient_path(@patient),
+                flash: {
+                  success:
+                    "#{@patient.full_name} removed from #{helpers.format_year_group(cohort.year_group)} cohort"
+                }
+  end
+
+  private
+
+  def set_patient
     @patient = policy_scope(Patient).find(params[:id])
+  end
+
+  def patient_params
+    params.require(:patient).permit(:cohort_id)
   end
 end

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -13,3 +13,38 @@
   <% c.with_heading { "Child record" } %>
   <%= render AppPatientSummaryComponent.new(@patient, show_common_name: true, show_address: true, show_parent_or_guardians: true) %>
 <% end %>
+
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Cohorts" } %>
+
+  <% if (cohort = @patient.cohort) %>
+    <%= govuk_table(html_attributes: {
+                      class: "nhsuk-table-responsive",
+                    }) do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Name") %>
+          <% row.with_cell(text: "Actions") %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Name</span>
+            <%= format_year_group(cohort.year_group) %>
+          <% end %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Actions</span>
+            <%= form_with model: @patient do |f| %>
+              <%= f.hidden_field :cohort_id, value: "" %>
+              <%= f.govuk_submit "Remove from cohort", class: "app-button--secondary-warning app-button--small" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <p class="nhsuk-body">No cohorts</p>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
 
   resources :notices, only: :index
 
-  resources :patients, only: %i[index show]
+  resources :patients, only: %i[index show update]
 
   resources :programmes, only: %i[index show] do
     get "sessions", on: :member

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -1,15 +1,30 @@
 # frozen_string_literal: true
 
 describe "Manage children" do
+  before { given_my_team_exists }
+
   scenario "Viewing children" do
-    given_my_team_exists
-    and_patients_exist
+    given_patients_exist
 
     when_i_click_on_children
     then_i_see_the_children
 
     when_i_click_on_a_child
     then_i_see_the_child
+  end
+
+  scenario "Removing a child from a cohort" do
+    given_patients_exist
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+    then_i_see_the_child
+    and_i_see_the_cohort
+
+    when_i_click_on_remove_from_cohort
+    then_i_see_the_child
+    and_i_see_a_removed_from_cohort_message
+    and_no_longer_see_the_cohort
   end
 
   scenario "Viewing important notices" do
@@ -29,9 +44,16 @@ describe "Manage children" do
     @team = create(:team, :with_one_nurse)
   end
 
-  def and_patients_exist
-    create(:patient, team: @team, given_name: "John", family_name: "Smith")
-    create_list(:patient, 9, team: @team)
+  def given_patients_exist
+    school = create(:location, :school, team: @team)
+    create(
+      :patient,
+      team: @team,
+      given_name: "John",
+      family_name: "Smith",
+      school:
+    )
+    create_list(:patient, 9, team: @team, school:)
   end
 
   def when_a_deceased_patient_exists
@@ -57,9 +79,27 @@ describe "Manage children" do
     click_on "John Smith"
   end
 
+  alias_method :and_i_click_on_a_child, :when_i_click_on_a_child
+
   def then_i_see_the_child
     expect(page).to have_title("JS")
     expect(page).to have_content("John Smith")
+  end
+
+  def and_i_see_the_cohort
+    expect(page).not_to have_content("No cohorts")
+  end
+
+  def when_i_click_on_remove_from_cohort
+    click_on "Remove from cohort"
+  end
+
+  def and_i_see_a_removed_from_cohort_message
+    expect(page).to have_content(/removed from Year ([0-9]+) cohort/)
+  end
+
+  def and_no_longer_see_the_cohort
+    expect(page).to have_content("No cohorts")
   end
 
   def when_i_click_on_notices


### PR DESCRIPTION
This adds the functionality from the prototype that allows nurses to remove patients from cohorts if they don't belong there.

## Screenshots

![Screenshot 2024-10-18 at 14 19 11](https://github.com/user-attachments/assets/ffd0ea26-5345-44db-9d30-776f2f3ace34)
![Screenshot 2024-10-18 at 14 19 17](https://github.com/user-attachments/assets/e980f709-efeb-453d-a80a-1c0e7fcbf299)
![Screenshot 2024-10-18 at 14 19 20](https://github.com/user-attachments/assets/0d0c9af9-6b38-487f-862c-c708f087956a)
