### PR TITLE
Skip further PDS checks for invalidated patients, until invalidation cleared

### DIFF
--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -9,6 +9,8 @@ class PatientUpdateFromPDSJob < ApplicationJob
   def perform(patient)
     raise MissingNHSNumber if patient.nhs_number.nil?
 
+    return if patient.invalidated?
+
     pds_patient = PDS::Patient.find(patient.nhs_number)
 
     if pds_patient.nhs_number != patient.nhs_number

--- a/spec/jobs/patient_update_from_pds_job_spec.rb
+++ b/spec/jobs/patient_update_from_pds_job_spec.rb
@@ -13,6 +13,15 @@ describe PatientUpdateFromPDSJob do
     end
   end
 
+  context "invalidated patient" do
+    let!(:patient) { create(:patient, :invalidated) }
+
+    it "doesn't update the patient" do
+      expect(patient).not_to receive(:update_from_pds!)
+      perform_now
+    end
+  end
+
   context "with an NHS number" do
     context "when the patient is valid" do
       before do


### PR DESCRIPTION
See https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir/pds-fhir-technical-conformance---application-restricted-access-mode#invalidated-patient-records