### PR TITLE
Hide GP information for restricted patients

### DIFF
--- a/app/components/app_consent_patient_summary_component.rb
+++ b/app/components/app_consent_patient_summary_component.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class AppConsentPatientSummaryComponent < ViewComponent::Base
+  def initialize(consent)
+    super
+
+    @consent = consent
+  end
+
+  def call
+    govuk_summary_list(
+      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
+    ) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Full name" }
+        row.with_value { patient.full_name }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Date of birth" }
+        row.with_value { patient.date_of_birth.to_fs(:long) }
+      end
+
+      if (consent_form = consent.consent_form)
+        summary_list.with_row do |row|
+          row.with_key { "Home address" }
+          row.with_value { helpers.format_address_multi_line(consent_form) }
+        end
+
+        summary_list.with_row do |row|
+          row.with_key { "GP surgery" }
+          row.with_value do
+            if consent_form.gp_response_yes?
+              consent_form.gp_name
+            elsif consent_form.gp_response_no?
+              "Not registered"
+            elsif consent_form.gp_response_dont_know?
+              "Not known"
+            end
+          end
+        end
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "School" }
+        row.with_value { helpers.patient_school(patient) }
+      end
+    end
+  end
+
+  private
+
+  attr_reader :consent
+
+  delegate :patient, to: :consent
+end

--- a/app/components/app_consent_patient_summary_component.rb
+++ b/app/components/app_consent_patient_summary_component.rb
@@ -21,7 +21,7 @@ class AppConsentPatientSummaryComponent < ViewComponent::Base
         row.with_value { patient.date_of_birth.to_fs(:long) }
       end
 
-      if (consent_form = consent.consent_form)
+      if !consent.restricted? && (consent_form = consent.consent_form)
         summary_list.with_row do |row|
           row.with_key { "Home address" }
           row.with_value { helpers.format_address_multi_line(consent_form) }

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -137,6 +137,8 @@ class Consent < ApplicationRecord
     ].compact
   end
 
+  delegate :restricted?, to: :patient
+
   def name
     via_self_consent? ? patient.full_name : parent.full_name
   end

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -45,44 +45,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child" } %>
-  <%= govuk_summary_list(
-        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
-      ) do |summary_list|
-        summary_list.with_row do |row|
-          row.with_key { "Full name" }
-          row.with_value { @consent.patient.full_name }
-        end
-      
-        summary_list.with_row do |row|
-          row.with_key { "Date of birth" }
-          row.with_value { @consent.patient.date_of_birth.to_fs(:long) }
-        end
-      
-        if @consent.consent_form.present?
-          summary_list.with_row do |row|
-            row.with_key { "Home address" }
-            row.with_value { format_address_multi_line(@consent.consent_form) }
-          end
-      
-          summary_list.with_row do |row|
-            row.with_key { "GP surgery" }
-            row.with_value {
-              if @consent.consent_form.gp_response_yes?
-                @consent.consent_form.gp_name
-              elsif @consent.consent_form.gp_response_no?
-                "Not registered"
-              elsif @consent.consent_form.gp_response_dont_know?
-                "Not known"
-              end
-            }
-          end
-        end
-      
-        summary_list.with_row do |row|
-          row.with_key { "School" }
-          row.with_value { patient_school(@consent.patient) }
-        end
-      end %>
+  <%= render AppConsentPatientSummaryComponent.new(@consent) %>
 <% end %>
 
 <% if @consent.parent.present? %>

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -51,39 +51,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child" } %>
-  <%= govuk_summary_list(
-        classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0",
-      ) do |summary_list|
-        summary_list.with_row do |row|
-          row.with_key { "Full name" }
-          row.with_value { @consent.patient.full_name }
-        end
-      
-        summary_list.with_row do |row|
-          row.with_key { "Date of birth" }
-          row.with_value { @consent.patient.date_of_birth.to_fs(:long) }
-        end
-      
-        if @consent.consent_form.present?
-          summary_list.with_row do |row|
-            row.with_key { "GP surgery" }
-            row.with_value {
-              if @consent.consent_form.gp_response_yes?
-                @consent.consent_form.gp_name
-              elsif @consent.consent_form.gp_response_no?
-                "Not registered"
-              elsif @consent.consent_form.gp_response_dont_know?
-                "Not known"
-              end
-            }
-          end
-        end
-      
-        summary_list.with_row do |row|
-          row.with_key { "School" }
-          row.with_value { patient_school(@consent.patient) }
-        end
-      end %>
+  <%= render AppConsentPatientSummaryComponent.new(@consent) %>
 <% end %>
 
 <% if @parent.present? %>

--- a/spec/components/app_consent_patient_summary_component_spec.rb
+++ b/spec/components/app_consent_patient_summary_component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe AppConsentPatientSummaryComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(consent) }
+
+  let(:programme) { create(:programme) }
+  let(:team) { create(:team, programmes: [programme]) }
+
+  let(:consent) { create(:consent, patient:, consent_form:, programme:, team:) }
+  let(:school) { create(:location, :school, name: "Waterloo Road", team:) }
+  let(:session) { create(:session, programme:, team:, location: school) }
+  let(:consent_form) do
+    create(
+      :consent_form,
+      address_postcode: "SW1A 1AA",
+      gp_name: "Waterloo GP",
+      session:
+    )
+  end
+  let(:patient) do
+    create(
+      :patient,
+      given_name: "John",
+      family_name: "Doe",
+      date_of_birth: Date.new(2000, 1, 1),
+      school:,
+      team:
+    )
+  end
+
+  it { should have_content("Full name") }
+  it { should have_content("John Doe") }
+
+  it { should have_content("Date of birth") }
+  it { should have_content("1 January 2000") }
+
+  it { should have_content("Home address") }
+  it { should have_content("SW1A 1AA") }
+
+  it { should have_content("GP surgery") }
+  it { should have_content("Waterloo GP") }
+
+  it { should have_content("School") }
+  it { should have_content("Waterloo Road") }
+end

--- a/spec/components/app_consent_patient_summary_component_spec.rb
+++ b/spec/components/app_consent_patient_summary_component_spec.rb
@@ -19,6 +19,8 @@ describe AppConsentPatientSummaryComponent do
       session:
     )
   end
+
+  let(:restricted) { false }
   let(:patient) do
     create(
       :patient,
@@ -26,7 +28,8 @@ describe AppConsentPatientSummaryComponent do
       family_name: "Doe",
       date_of_birth: Date.new(2000, 1, 1),
       school:,
-      team:
+      team:,
+      restricted_at: restricted ? Time.current : nil
     )
   end
 
@@ -44,4 +47,14 @@ describe AppConsentPatientSummaryComponent do
 
   it { should have_content("School") }
   it { should have_content("Waterloo Road") }
+
+  context "with a restricted patient" do
+    let(:restricted) { true }
+
+    it { should_not have_content("GP surgery") }
+    it { should_not have_content("Waterloo GP") }
+
+    it { should_not have_content("Home address") }
+    it { should_not have_content("SW1A 1AA") }
+  end
 end


### PR DESCRIPTION
This follows on from #2068 to hide GP information for any restricted patients as they should not be visible to any users.