### PR TITLE
Stretch sessions show cards to full width

### DIFF
--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -36,7 +36,7 @@
           <% end %>
         </li>
       <% else %>
-        <li class="nhsuk-grid-column-two-thirds nhsuk-card-group__item">
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
             <% c.with_heading { "Check consent responses" } %>
             <% c.with_description do %>
@@ -47,7 +47,7 @@
             <% end %>
           <% end %>
         </li>
-        <li class="nhsuk-grid-column-two-thirds nhsuk-card-group__item">
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
             <% c.with_heading { "Triage health questions" } %>
             <% c.with_description do %>
@@ -55,7 +55,7 @@
             <% end %>
           <% end %>
         </li>
-        <li class="nhsuk-grid-column-two-thirds nhsuk-card-group__item">
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
             <% c.with_heading { "Record vaccinations" } %>
             <% c.with_description do %>


### PR DESCRIPTION
This aligns the design of the cards to the prototype.

<img width="1230" alt="Screenshot 2024-10-20 at 23 29 30" src="https://github.com/user-attachments/assets/b11dbe30-343c-4445-9c0e-b995a97a4496">