### PR TITLE
Remove registration from users:create task docs

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -5,7 +5,7 @@ require_relative "../task_helpers"
 namespace :users do
   desc "Create a new user and add them to a team."
   task :create,
-       %i[email password given_name family_name team_ods_code registration] =>
+       %i[email password given_name family_name team_ods_code] =>
          :environment do |_task, args|
     include TaskHelpers
 


### PR DESCRIPTION
This used to be:

```
bin/rails users:create[email,password,given_name,family_name,team_ods_code,registration]  # Create a new user and add them to a team
```

We don't have `registration` anymore and it's not accepted as an arg, so this is now:

```
bin/rails users:create[email,password,given_name,family_name,team_ods_code]           # Create a new user and add them to a team
```
