### PR TITLE
Refactor NotifySafeEmailValidator

### DIFF
--- a/app/forms/parent_details_form.rb
+++ b/app/forms/parent_details_form.rb
@@ -14,7 +14,7 @@ class ParentDetailsForm
   attribute :relationship_other_name, :string
   attribute :relationship_type, :string
 
-  validates :email, presence: true, notify_safe_email: true
+  validates :email, notify_safe_email: true
   validates :phone,
             presence: {
               if: :phone_receive_updates

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -53,7 +53,7 @@ class Parent < ApplicationRecord
             phone: {
               allow_blank: true
             }
-  validates :email, presence: true, notify_safe_email: true
+  validates :email, notify_safe_email: true
   validates :contact_method_other_details,
             :email,
             :full_name,

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -18,14 +18,14 @@ class PatientImportRow
   with_options if: :parent_1_exists? do
     validates :parent_1_name, presence: true
     validates :parent_1_relationship, presence: true
-    validates :parent_1_email, presence: true, notify_safe_email: true
+    validates :parent_1_email, notify_safe_email: true
     validates :parent_1_phone, phone: { allow_blank: true }
   end
 
   with_options if: :parent_2_exists? do
     validates :parent_2_name, presence: true
     validates :parent_2_relationship, presence: true
-    validates :parent_2_email, presence: true, notify_safe_email: true
+    validates :parent_2_email, notify_safe_email: true
     validates :parent_2_phone, phone: { allow_blank: true }
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -40,7 +40,7 @@ class Team < ApplicationRecord
 
   has_and_belongs_to_many :users
 
-  validates :email, presence: true, notify_safe_email: true
+  validates :email, notify_safe_email: true
   validates :name, presence: true, uniqueness: true
   validates :ods_code, presence: true
   validates :phone, presence: true, phone: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,13 +45,7 @@ class User < ApplicationRecord
 
   validates :family_name, :given_name, presence: true, length: { maximum: 255 }
 
-  validates :email,
-            presence: true,
-            length: {
-              maximum: 255
-            },
-            uniqueness: true,
-            notify_safe_email: true
+  validates :email, uniqueness: true, notify_safe_email: true
 
   validates :password,
             presence: true,

--- a/app/validators/notify_safe_email_validator.rb
+++ b/app/validators/notify_safe_email_validator.rb
@@ -7,30 +7,29 @@ class NotifySafeEmailValidator < ActiveModel::EachValidator
   TLD_PART = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/i
 
   def validate_each(record, attribute, value)
-    match = EMAIL_REGEX_PATTERN.match(value)
+    if value.nil?
+      record.errors.add(attribute, :blank) unless options[:allow_nil]
+    elsif value.blank?
+      record.errors.add(attribute, :blank) unless options[:allow_blank]
+    else
+      match = EMAIL_REGEX_PATTERN.match(value)
 
-    if !match || value.length > 320 || value.include?("..")
-      record.errors.add(attribute, :invalid)
-      return
-    end
+      if !match || value.length > 320 || value.include?("..")
+        record.errors.add(attribute, :invalid)
+        return
+      end
 
-    hostname = match[1]
+      hostname = match[1]
 
-    parts = hostname.split(".")
+      parts = hostname.split(".")
 
-    if hostname.length > 253 || parts.length < 2
-      record.errors.add(attribute, :invalid)
-      return
-    end
-
-    unless parts.all? { |part| HOSTNAME_PART.match?(part) }
-      record.errors.add(attribute, :invalid)
-      return
-    end
-
-    unless TLD_PART.match?(parts.last)
-      record.errors.add(attribute, :invalid)
-      return # rubocop:disable Style/RedundantReturn
+      if hostname.length > 253 || parts.length < 2
+        record.errors.add(attribute, :invalid)
+      elsif !parts.all? { |part| HOSTNAME_PART.match?(part) }
+        record.errors.add(attribute, :invalid)
+      elsif !TLD_PART.match?(parts.last)
+        record.errors.add(attribute, :invalid)
+      end
     end
   end
 end

--- a/spec/validators/notify_safe_email_validator_spec.rb
+++ b/spec/validators/notify_safe_email_validator_spec.rb
@@ -1,84 +1,108 @@
 # frozen_string_literal: true
 
 describe NotifySafeEmailValidator do
-  subject(:model) do
-    cls =
-      Class.new do
-        include ActiveModel::Validations
-        attr_accessor :email
-        validates :email, notify_safe_email: true
-      end
-    cls.new
-  end
+  subject(:model) { Validatable.new(email:) }
 
-  let(:valid_email_addresses) do
-    [
-      "email@domain.com",
-      "email@domain.COM",
-      "firstname.lastname@domain.com",
-      "firstname.o'lastname@domain.com",
-      "email@subdomain.domain.com",
-      "firstname+lastname@domain.com",
-      "1234567890@domain.com",
-      "email@domain-one.com",
-      "_______@domain.com",
-      "email@domain.name",
-      "email@domain.superlongtld",
-      "email@domain.co.jp",
-      "firstname-lastname@domain.com",
-      # "info@german-financial-services.vermögensberatung",
-      "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
-      # "japanese-info@例え.テスト",
-      "email@double--hyphen.com"
-    ]
-  end
+  before do
+    stub_const("Validatable", Class.new).class_eval do
+      include ActiveModel::Model
+      attr_accessor :email
+      validates :email, notify_safe_email: true
+    end
 
-  let(:invalid_email_addresses) do
-    [
-      "email@123.123.123.123",
-      "email@[123.123.123.123]",
-      "plainaddress",
-      "@no-local-part.com",
-      "Outlook Contact <outlook-contact@domain.com>",
-      "no-at.domain.com",
-      "no-tld@domain",
-      ";beginning-semicolon@domain.co.uk",
-      "middle-semicolon@domain.co;uk",
-      "trailing-semicolon@domain.com;",
-      '"email+leading-quotes@domain.com',
-      'email+middle"-quotes@domain.com',
-      '"quoted-local-part"@domain.com',
-      '"quoted@domain.com"',
-      "lots-of-dots@domain..gov..uk",
-      "two-dots..in-local@domain.com",
-      "multiple@domains@domain.com",
-      "spaces in local@domain.com",
-      "spaces-in-domain@dom ain.com",
-      "underscores-in-domain@dom_ain.com",
-      "pipe-in-domain@example.com|gov.uk",
-      "comma,in-local@gov.uk",
-      "comma-in-domain@domain,gov.uk",
-      "pound-sign-in-local£@domain.com",
-      "local-with-’-apostrophe@domain.com",
-      "local-with-”-quotes@domain.com",
-      "domain-starts-with-a-dot@.domain.com",
-      "brackets(in)local@domain.com",
-      "email-too-long-#{"a" * 320}@example.com",
-      "incorrect-punycode@xn---something.com"
-    ]
-  end
+    stub_const("ValidatableAllowNil", Class.new).class_eval do
+      include ActiveModel::Model
+      attr_accessor :email
+      validates :email, notify_safe_email: { allow_nil: true }
+    end
 
-  it "validates valid email addresses" do
-    valid_email_addresses.each do |email|
-      model.email = email
-      expect(model).to be_valid
+    stub_const("ValidatableAllowBlank", Class.new).class_eval do
+      include ActiveModel::Model
+      attr_accessor :email
+      validates :email, notify_safe_email: { allow_blank: true }
     end
   end
 
-  it "does not validate invalid email addresses" do
-    invalid_email_addresses.each do |email|
-      model.email = email
-      expect(model).not_to be_valid
+  [
+    "email@domain.com",
+    "email@domain.COM",
+    "firstname.lastname@domain.com",
+    "firstname.o'lastname@domain.com",
+    "email@subdomain.domain.com",
+    "firstname+lastname@domain.com",
+    "1234567890@domain.com",
+    "email@domain-one.com",
+    "_______@domain.com",
+    "email@domain.name",
+    "email@domain.superlongtld",
+    "email@domain.co.jp",
+    "firstname-lastname@domain.com",
+    # "info@german-financial-services.vermögensberatung",
+    "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
+    # "japanese-info@例え.テスト",
+    "email@double--hyphen.com"
+  ].each do |value|
+    context "with #{value}" do
+      let(:email) { value }
+
+      it { should be_valid }
     end
+  end
+
+  [
+    nil,
+    "",
+    "email@123.123.123.123",
+    "email@[123.123.123.123]",
+    "plainaddress",
+    "@no-local-part.com",
+    "Outlook Contact <outlook-contact@domain.com>",
+    "no-at.domain.com",
+    "no-tld@domain",
+    ";beginning-semicolon@domain.co.uk",
+    "middle-semicolon@domain.co;uk",
+    "trailing-semicolon@domain.com;",
+    '"email+leading-quotes@domain.com',
+    'email+middle"-quotes@domain.com',
+    '"quoted-local-part"@domain.com',
+    '"quoted@domain.com"',
+    "lots-of-dots@domain..gov..uk",
+    "two-dots..in-local@domain.com",
+    "multiple@domains@domain.com",
+    "spaces in local@domain.com",
+    "spaces-in-domain@dom ain.com",
+    "underscores-in-domain@dom_ain.com",
+    "pipe-in-domain@example.com|gov.uk",
+    "comma,in-local@gov.uk",
+    "comma-in-domain@domain,gov.uk",
+    "pound-sign-in-local£@domain.com",
+    "local-with-’-apostrophe@domain.com",
+    "local-with-”-quotes@domain.com",
+    "domain-starts-with-a-dot@.domain.com",
+    "brackets(in)local@domain.com",
+    "email-too-long-#{"a" * 320}@example.com",
+    "incorrect-punycode@xn---something.com"
+  ].each do |value|
+    context "with #{value}" do
+      let(:email) { value }
+
+      it { should be_invalid }
+    end
+  end
+
+  context "when allowing nil values" do
+    subject(:model) { ValidatableAllowNil.new(email:) }
+
+    let(:email) { nil }
+
+    it { should be_valid }
+  end
+
+  context "when allowing blank values" do
+    subject(:model) { ValidatableAllowBlank.new(email:) }
+
+    let(:email) { "" }
+
+    it { should be_valid }
   end
 end


### PR DESCRIPTION
This refactors the validator to add an `allow_nil` and `allow_blank` parameter to the validator which we can use when allowing optional email addresses, using a similar pattern to other validators.