### PR TITLE
Seed clinics

### DIFF
--- a/app/lib/unscheduled_sessions_factory.rb
+++ b/app/lib/unscheduled_sessions_factory.rb
@@ -15,8 +15,12 @@ class UnscheduledSessionsFactory
           next if sessions.any? { _1.location_id == location.id }
 
           programmes =
-            team.programmes.select do
-              _1.year_groups.intersect?(location.year_groups)
+            if location.school?
+              team.programmes.select do
+                _1.year_groups.intersect?(location.year_groups)
+              end
+            else
+              team.programmes
             end
 
           next if programmes.empty?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -65,7 +65,11 @@ def create_user_and_team(ods_code:, uid: nil)
   [user, team]
 end
 
-def attach_locations_to(team)
+def create_clinics_and_attach_to(team)
+  FactoryBot.create_list(:location, 10, :clinic, team:)
+end
+
+def attach_sample_of_random_locations_to(team)
   Location.order("RANDOM()").limit(50).update_all(team_id: team.id)
 end
 
@@ -132,8 +136,6 @@ def create_session(user, team)
       user:
     )
   end
-
-  UnscheduledSessionsFactory.new.call
 end
 
 def create_patients(team)
@@ -178,7 +180,8 @@ import_schools
 # Nurse Joy's team
 user, team = create_user_and_team(ods_code: "R1L")
 
-attach_locations_to(team)
+create_clinics_and_attach_to(team)
+attach_sample_of_random_locations_to(team)
 attach_specific_school_to_team_if_present(team:, urn: "136126") # potentially needed for automated testing
 
 Audited.audit_class.as_user(user) { create_session(user, team) }
@@ -188,8 +191,12 @@ create_imports(user, team)
 # CIS2 team - the ODS code and user UID need to match the values in the CIS2 env
 user, team = create_user_and_team(ods_code: "Y51", uid: "555057896106")
 
-attach_locations_to(team)
+create_clinics_and_attach_to(team)
+attach_sample_of_random_locations_to(team)
 attach_specific_school_to_team_if_present(team:, urn: "136126") # potentially needed for automated testing
+
 Audited.audit_class.as_user(user) { create_session(user, team) }
 create_patients(team)
 create_imports(user, team)
+
+UnscheduledSessionsFactory.new.call

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,8 @@ end
 
 def import_schools
   if Settings.fast_reset
-    FactoryBot.create_list(:location, 30, :school)
+    FactoryBot.create_list(:location, 30, :primary)
+    FactoryBot.create_list(:location, 30, :secondary)
   else
     Rake::Task["schools:import"].execute
   end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -34,8 +34,6 @@ require_relative "../../lib/faker/address"
 
 FactoryBot.define do
   factory :location do
-    name { Faker::Educator.primary_school }
-
     address_line_1 { Faker::Address.street_address }
     address_town { Faker::Address.city }
     address_postcode { Faker::Address.uk_postcode }
@@ -44,14 +42,16 @@ FactoryBot.define do
 
     trait :clinic do
       type { :clinic }
+      name { "#{Faker::University.name} Clinic" }
       sequence(:ods_code, 10_000, &:to_s)
       urn { nil }
     end
 
     trait :school do
       type { :school }
-      ods_code { nil }
+      name { Faker::Educator.primary_school }
       sequence(:urn, 100_000, &:to_s)
+      ods_code { nil }
     end
 
     trait :primary do

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_not_needed,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -42,6 +43,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -52,6 +54,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_refused,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -62,6 +65,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_refused_with_notes,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -72,6 +76,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_conflicting,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -143,6 +148,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_not_needed,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -154,6 +160,7 @@ FactoryBot.define do
         association :patient,
                     :consent_given_triage_needed,
                     :triage_ready_to_vaccinate,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -188,6 +195,7 @@ FactoryBot.define do
         association :patient,
                     :consent_given_triage_needed,
                     :triage_ready_to_vaccinate,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -212,6 +220,7 @@ FactoryBot.define do
         association :patient,
                     :consent_given_triage_needed,
                     :triage_ready_to_vaccinate,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location

--- a/spec/lib/unscheduled_sessions_factory_spec.rb
+++ b/spec/lib/unscheduled_sessions_factory_spec.rb
@@ -19,6 +19,18 @@ describe UnscheduledSessionsFactory do
       end
     end
 
+    context "with a clinic" do
+      let!(:location) { create(:location, :clinic, team:) }
+
+      it "creates missing unscheduled sessions" do
+        expect { call }.to change(team.sessions, :count).by(1)
+
+        session = team.sessions.first
+        expect(session.location).to eq(location)
+        expect(session.programmes).to eq([programme])
+      end
+    end
+
     context "with a school that's not eligible for the programme" do
       before { create(:location, :primary, team:) }
 


### PR DESCRIPTION
When running the database seeds this creates a number of clinics as well as schools so we can demonstrate that unscheduled sessions are also created for clinics.