### PR TITLE
Update wording when parent name is unknown

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -145,10 +145,10 @@ class AppPatientSummaryComponent < ViewComponent::Base
           tag.li do
             [
               parent.label_to(patient: @patient),
-              if parent.full_name.present? && (email = parent.email).present?
+              if (email = parent.email).present?
                 tag.span(email, class: "nhsuk-u-secondary-text-color")
               end,
-              if parent.full_name.present? && (phone = parent.phone).present?
+              if (phone = parent.phone).present?
                 tag.span(phone, class: "nhsuk-u-secondary-text-color")
               end
             ].compact.join(tag.br).html_safe

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -65,7 +65,7 @@ class Parent < ApplicationRecord
             if: :contact_method_other?
 
   def label
-    full_name.presence || contact_label
+    full_name.presence || "Parent or guardian (name unknown)"
   end
 
   def contact_label

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -21,7 +21,7 @@
     <% @parent_options.each.with_index do |parent, i| %>
       <%= f.govuk_radio_button :new_or_existing_parent, parent.id,
                                label: { text: parent.label_to(patient: @patient) },
-                               hint: { text: parent.full_name.present? ? parent.contact_label : nil },
+                               hint: { text: parent.contact_label },
                                link_errors: i == 0 %>
     <% end %>
     <%= f.govuk_radio_divider %>

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -49,16 +49,9 @@ describe Parent do
     end
 
     context "without a full name" do
-      let(:parent) do
-        create(
-          :parent,
-          full_name: nil,
-          email: "test@example.com",
-          phone: "07700900123"
-        )
-      end
+      let(:parent) { create(:parent, full_name: nil) }
 
-      it { should eq("test@example.com / 07700900123") }
+      it { should eq("Parent or guardian (name unknown)") }
     end
   end
 


### PR DESCRIPTION
This updates the wording to match the latest designs in the prototype.