### PR TITLE
Create a single generic clinic per team

### DIFF
--- a/app/lib/unscheduled_sessions_factory.rb
+++ b/app/lib/unscheduled_sessions_factory.rb
@@ -15,8 +15,12 @@ class UnscheduledSessionsFactory
           next if sessions.any? { _1.location_id == location.id }
 
           programmes =
-            team.programmes.select do
-              _1.year_groups.intersect?(location.year_groups)
+            if location.school?
+              team.programmes.select do
+                _1.year_groups.intersect?(location.year_groups)
+              end
+            else
+              team.programmes
             end
 
           next if programmes.empty?

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -303,8 +303,8 @@ class ImmunisationImportRow
 
     @clinic ||=
       Location
-        .create_with(name: "Generic #{team.name} clinic", team:)
-        .find_or_create_by!(type: :clinic, ods_code:)
+        .create_with(name: "#{team.name} Clinic")
+        .find_or_create_by!(type: :generic_clinic, ods_code:, team:)
         .tap do
           _1.update!(
             year_groups: (_1.year_groups + @programme.year_groups).sort.uniq

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,8 @@ end
 
 def import_schools
   if Settings.fast_reset
-    FactoryBot.create_list(:location, 30, :school)
+    FactoryBot.create_list(:location, 30, :primary)
+    FactoryBot.create_list(:location, 30, :secondary)
   else
     Rake::Task["schools:import"].execute
   end

--- a/lib/tasks/teams.rake
+++ b/lib/tasks/teams.rake
@@ -50,6 +50,13 @@ namespace :teams do
 
       TeamProgramme.create!(team:, programme:)
 
+      Location.create!(
+        name: "#{name} Clinic",
+        ods_code:,
+        type: :generic_clinic,
+        team:
+      )
+
       puts "New #{team.name} team with ID #{team.id} created."
     end
   end

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -7,15 +7,22 @@ describe AppSessionSummaryComponent do
 
   let(:programme) { create(:programme, :hpv) }
   let(:location) { create(:location, :school) }
+  let(:team) { create(:team, programmes: [programme]) }
   let(:session) do
-    create(:session, location:, date: Date.new(2024, 1, 1), programme:)
+    create(:session, location:, date: Date.new(2024, 1, 1), programme:, team:)
   end
 
   it { should have_content("Type") }
   it { should have_content("School session") }
 
-  context "with a clinic" do
-    let(:location) { create(:location, :clinic) }
+  context "with a community clinic" do
+    let(:location) { create(:location, :community_clinic) }
+
+    it { should have_content("Community clinic") }
+  end
+
+  context "with a generic clinic" do
+    let(:location) { create(:location, :generic_clinic, team:) }
 
     it { should have_content("Community clinic") }
   end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -34,8 +34,6 @@ require_relative "../../lib/faker/address"
 
 FactoryBot.define do
   factory :location do
-    name { Faker::Educator.primary_school }
-
     address_line_1 { Faker::Address.street_address }
     address_town { Faker::Address.city }
     address_postcode { Faker::Address.uk_postcode }
@@ -43,15 +41,28 @@ FactoryBot.define do
     url { Faker::Internet.url }
 
     trait :clinic do
-      type { :clinic }
-      sequence(:ods_code, 10_000, &:to_s)
       urn { nil }
+    end
+
+    trait :generic_clinic do
+      clinic
+      type { :generic_clinic }
+      name { "#{team.name} Clinic" }
+      ods_code { team.ods_code }
+    end
+
+    trait :community_clinic do
+      clinic
+      type { :community_clinic }
+      name { "#{Faker::University.name} Clinic" }
+      sequence(:ods_code, 10_000, &:to_s)
     end
 
     trait :school do
       type { :school }
-      ods_code { nil }
+      name { Faker::Educator.primary_school }
       sequence(:urn, 100_000, &:to_s)
+      ods_code { nil }
     end
 
     trait :primary do

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_not_needed,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -42,6 +43,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_needed,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -52,6 +54,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_refused,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -62,6 +65,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_refused_with_notes,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -72,6 +76,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_conflicting,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -143,6 +148,7 @@ FactoryBot.define do
       patient do
         association :patient,
                     :consent_given_triage_not_needed,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -154,6 +160,7 @@ FactoryBot.define do
         association :patient,
                     :consent_given_triage_needed,
                     :triage_ready_to_vaccinate,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -188,6 +195,7 @@ FactoryBot.define do
         association :patient,
                     :consent_given_triage_needed,
                     :triage_ready_to_vaccinate,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location
@@ -212,6 +220,7 @@ FactoryBot.define do
         association :patient,
                     :consent_given_triage_needed,
                     :triage_ready_to_vaccinate,
+                    performed_by: user,
                     programme:,
                     team:,
                     school: session.location

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -23,10 +23,7 @@
 #
 FactoryBot.define do
   factory :team do
-    transient do
-      random { Random.new }
-      sequence(:identifier) { _1 }
-    end
+    transient { sequence(:identifier) { _1 } }
 
     name { "SAIS Team #{identifier}" }
     email { "sais-team-#{identifier}@example.com" }
@@ -50,6 +47,12 @@ FactoryBot.define do
             password: nurse_password
           }.compact
         )
+      end
+    end
+
+    trait :with_generic_clinic do
+      after(:create) do |team, _evaluator|
+        create(:location, :generic_clinic, team:)
       end
     end
   end

--- a/spec/lib/unscheduled_sessions_factory_spec.rb
+++ b/spec/lib/unscheduled_sessions_factory_spec.rb
@@ -19,6 +19,18 @@ describe UnscheduledSessionsFactory do
       end
     end
 
+    context "with a generic clinic" do
+      let!(:location) { create(:location, :generic_clinic, team:) }
+
+      it "creates missing unscheduled sessions" do
+        expect { call }.to change(team.sessions, :count).by(1)
+
+        session = team.sessions.first
+        expect(session.location).to eq(location)
+        expect(session.programmes).to eq([programme])
+      end
+    end
+
     context "with a school that's not eligible for the programme" do
       before { create(:location, :primary, team:) }
 

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -248,7 +248,9 @@ describe DPSExportRow do
       end
 
       context "when the session has a location with an ODS code" do
-        let(:location) { create(:location, :clinic, ods_code: "12345") }
+        let(:location) do
+          create(:location, :community_clinic, ods_code: "12345")
+        end
 
         it { should eq("12345") }
       end
@@ -273,7 +275,7 @@ describe DPSExportRow do
       end
 
       context "when the session has a location without a URN" do
-        let(:location) { create(:location, :clinic) }
+        let(:location) { create(:location, :community_clinic) }
 
         it { should eq("https://fhir.nhs.uk/Id/ods-organization-code") }
       end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -48,11 +48,26 @@ describe Location do
   describe "validations" do
     it { should validate_presence_of(:name) }
 
-    context "with a clinic" do
-      subject(:location) { build(:location, :clinic, ods_code: "abc") }
+    context "with a community clinic" do
+      subject(:location) do
+        build(:location, :community_clinic, ods_code: "abc")
+      end
 
       it { should validate_presence_of(:ods_code) }
       it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
+
+      it { should_not validate_presence_of(:urn) }
+      it { should validate_uniqueness_of(:urn) }
+    end
+
+    context "with a generic clinic" do
+      subject(:location) { build(:location, :generic_clinic, team:) }
+
+      let(:team) { create(:team) }
+
+      it { should validate_presence_of(:ods_code) }
+      it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
+      it { should validate_comparison_of(:ods_code).is_equal_to(team.ods_code) }
 
       it { should_not validate_presence_of(:urn) }
       it { should validate_uniqueness_of(:urn) }
@@ -70,6 +85,28 @@ describe Location do
   end
 
   it { should normalize(:address_postcode).from(" SW111AA ").to("SW11 1AA") }
-
   it { should normalize(:ods_code).from(" r1a ").to("R1A") }
+  it { should normalize(:urn).from(" 123 ").to("123") }
+
+  describe "#clinic?" do
+    subject(:clinic?) { location.clinic? }
+
+    context "with a community clinic" do
+      let(:location) { build(:location, :community_clinic) }
+
+      it { should be(true) }
+    end
+
+    context "with a generic clinic" do
+      let(:location) { build(:location, :generic_clinic, team: create(:team)) }
+
+      it { should be(true) }
+    end
+
+    context "with a school" do
+      let(:location) { build(:location, :school) }
+
+      it { should be(false) }
+    end
+  end
 end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -50,7 +50,9 @@ describe Patient do
     end
 
     context "with an invalid school" do
-      subject(:patient) { build(:patient, school: create(:location, :clinic)) }
+      subject(:patient) do
+        build(:patient, school: create(:location, :community_clinic))
+      end
 
       it "is invalid" do
         expect(patient.valid?).to be(false)


### PR DESCRIPTION
This makes a number of changes to the clinic locations to split them up in to two types (generic clinics as we had before and community clinics), this distinction doesn't necessarily change the behaviour but it makes it easier for us to track the two types of clinics in the future. I've also ensured that when creating a team we get one generic clinic, and that a unscheduled session is created for it each academic year.

This replaces #2085.

## Screenshot

### Single unscheduled session for clinic location

<img width="1187" alt="Screenshot 2024-10-22 at 07 59 43" src="https://github.com/user-attachments/assets/f46bee13-3713-470a-ad44-f0d6c3a8d8fb">
