### PR TITLE
Transfer patients from other sessions

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -51,9 +51,10 @@ class PatientImportRow
     }
 
     if (existing_patient = existing_patients.first)
-      # We need to handle given_name and family_name differently because we store it encrypted and lowercased.
-      # Without this, assign_attributes compares the lowercased version with the new version, and thinks
-      # the model changed when it hasn't really.
+      # We need to handle given_name and family_name differently because we
+      # store it encrypted and lowercased. Without this, assign_attributes
+      # compares the lowercased version with the new version, and thinks the
+      # model changed when it hasn't really.
 
       if existing_patient.given_name != attributes[:given_name]
         existing_patient.given_name = attributes[:given_name]

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -4,16 +4,22 @@
 #
 # Table name: patient_sessions
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  patient_id :bigint           not null
-#  session_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  patient_id          :bigint           not null
+#  proposed_session_id :bigint
+#  session_id          :bigint           not null
 #
 # Indexes
 #
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
+#  index_patient_sessions_on_proposed_session_id        (proposed_session_id)
 #  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (proposed_session_id => sessions.id)
 #
 
 class PatientSession < ApplicationRecord

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -75,9 +75,11 @@ class PatientSession < ApplicationRecord
         end
 
   def draft_vaccination_record
-    # HACK: this code will need to be revisited in future as it only really works for HPV, where we only have one
-    # vaccine. It is likely to fail for the Doubles programme as that has 2 vaccines. It is also likely to fail for
-    # the flu programme for the SAIS teams that offer both nasal and injectable vaccines.
+    # HACK: this code will need to be revisited in future as it only really
+    # works for HPV, where we only have one vaccine. It is likely to fail for
+    # the Doubles programme as that has 2 vaccines. It is also likely to fail
+    # for the flu programme for the SAIS teams that offer both nasal and
+    # injectable vaccines.
 
     programme = programmes.first
     vaccine = programme.vaccines.active.first

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -29,6 +29,7 @@ class PatientSession < ApplicationRecord
 
   belongs_to :patient
   belongs_to :session
+  belongs_to :proposed_session, class_name: "Session", optional: true
 
   has_one :location, through: :session
   has_one :team, through: :session

--- a/db/migrate/20241022064010_add_proposed_session_id_to_patient_sessions.rb
+++ b/db/migrate/20241022064010_add_proposed_session_id_to_patient_sessions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddProposedSessionIdToPatientSessions < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :patient_sessions,
+                  :proposed_session,
+                  foreign_key: {
+                    to_table: :sessions
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -464,7 +464,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_22_110535) do
     t.bigint "patient_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "proposed_session_id"
     t.index ["patient_id", "session_id"], name: "index_patient_sessions_on_patient_id_and_session_id", unique: true
+    t.index ["proposed_session_id"], name: "index_patient_sessions_on_proposed_session_id"
     t.index ["session_id", "patient_id"], name: "index_patient_sessions_on_session_id_and_patient_id", unique: true
   end
 
@@ -705,6 +707,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_22_110535) do
   add_foreign_key "locations", "teams"
   add_foreign_key "parent_relationships", "parents"
   add_foreign_key "parent_relationships", "patients"
+  add_foreign_key "patient_sessions", "sessions", column: "proposed_session_id"
   add_foreign_key "patients", "cohorts"
   add_foreign_key "patients", "locations", column: "school_id"
   add_foreign_key "programmes_sessions", "programmes"

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -4,16 +4,22 @@
 #
 # Table name: patient_sessions
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  patient_id :bigint           not null
-#  session_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  patient_id          :bigint           not null
+#  proposed_session_id :bigint
+#  session_id          :bigint           not null
 #
 # Indexes
 #
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
+#  index_patient_sessions_on_proposed_session_id        (proposed_session_id)
 #  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (proposed_session_id => sessions.id)
 #
 FactoryBot.define do
   factory :patient_session do

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -325,12 +325,17 @@ describe ClassImport do
         create(:patient, nhs_number: "1234567890", session: different_session)
       end
 
-      it "removes the child from the original session and adds them to the new one" do
+      it "proposes moving the child from the original session to the new one" do
         expect(patient.upcoming_sessions).to contain_exactly(different_session)
-        expect { record! }.to change { patient.reload.school }.to(
-          session.location
-        )
-        expect(patient.upcoming_sessions).to contain_exactly(session)
+
+        # stree-ignore
+        expect { record! }
+          .to change { patient.reload.school }.to(session.location)
+          .and change { patient.patient_sessions
+            .find_by(session: different_session)
+            .proposed_session }.from(nil).to(session)
+
+        expect(patient.upcoming_sessions).to contain_exactly(different_session)
       end
 
       it "changes the child's cohort" do

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -4,16 +4,22 @@
 #
 # Table name: patient_sessions
 #
-#  id         :bigint           not null, primary key
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  patient_id :bigint           not null
-#  session_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  patient_id          :bigint           not null
+#  proposed_session_id :bigint
+#  session_id          :bigint           not null
 #
 # Indexes
 #
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
+#  index_patient_sessions_on_proposed_session_id        (proposed_session_id)
 #  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (proposed_session_id => sessions.id)
 #
 
 describe PatientSession do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -315,14 +315,19 @@ describe Session do
       context "in school" do
         let(:location) { school }
 
-        it "adds the unvaccinated patients" do
+        it "adds unvaccinated patients, proposes moving if in other sessions" do
           create_patient_sessions!
 
           expect(session.patients).to contain_exactly(
             unvaccinated_child,
-            unvaccinated_teen,
-            hpv_vaccinated_teen
+            unvaccinated_teen
           )
+
+          # BUG: This patient has an upcoming HPV session, we should not be
+          # proposing the move to this Flu session.
+          expect(
+            PatientSession.where(proposed_session: session).map(&:patient)
+          ).to contain_exactly(hpv_vaccinated_teen)
         end
 
         it "is idempotent" do
@@ -356,13 +361,16 @@ describe Session do
       context "in school" do
         let(:location) { school }
 
-        it "adds the unvaccinated patients" do
+        it "adds unvaccinated patients, proposes moving if in other sessions" do
           create_patient_sessions!
 
-          expect(session.patients).to contain_exactly(
-            unvaccinated_teen,
-            flu_vaccinated_teen
-          )
+          expect(session.patients).to contain_exactly(unvaccinated_teen)
+
+          # BUG: This patient has an upcoming Flu session, we should not be
+          # proposing the move to this HPV session.
+          expect(
+            PatientSession.where(proposed_session: session).map(&:patient)
+          ).to contain_exactly(flu_vaccinated_teen)
         end
 
         it "is idempotent" do
@@ -394,12 +402,17 @@ describe Session do
       context "in school" do
         let(:location) { school }
 
-        it "adds the unvaccinated patients" do
+        it "adds unvaccinated patients, proposes moving if in other sessions" do
           create_patient_sessions!
 
           expect(session.patients).to contain_exactly(
             unvaccinated_child,
-            unvaccinated_teen,
+            unvaccinated_teen
+          )
+
+          expect(
+            PatientSession.where(proposed_session: session).map(&:patient)
+          ).to contain_exactly(
             flu_vaccinated_child,
             hpv_vaccinated_teen,
             flu_vaccinated_teen


### PR DESCRIPTION
This updates the `Session#create_patient_sessions!` method so that instead of destroying the patient sessions for patients in this cohort that are in other sessions, it proposes their transfer to the new session.

A follow-up PR will implement the interface from the prototype on the actual sessions to surface and handle these `proposed_session`s.