### PR TITLE
Allow users to be authenticated with MS Auth

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -43,7 +43,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       raise "cis2 authentication: id_assurance_level too low" \
               " (#{raw_cis2_info[:id_assurance_level]} != 3)"
     elsif Integer(raw_cis2_info[:authentication_assurance_level]) <
-          Settings.cis2.authentication_assurance_level
+          Settings.cis2.min_authentication_assurance_level
       raise "cis2 authentication: authentication_assurance_level too low" \
               " (#{raw_cis2_info[:authentication_assurance_level]} < " \
               " #{Settings.cis2.authentication_assurance_level})"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -300,14 +300,6 @@ Devise.setup do |config|
       http_client.ssl.min_version = :TLS1_2
     end
 
-    acr_values =
-      if Settings.cis2.allow_aal2_auth
-        # Enables support for MS Authenticator
-        "AAL2_OR_AAL3_ANY"
-      else
-        "AAL3"
-      end
-
     config.omniauth(
       :openid_connect,
       {
@@ -316,8 +308,11 @@ Devise.setup do |config|
         scope: %i[openid profile email nationalrbacaccess associatedorgs],
         extra_authorize_params: {
           max_age: 300,
-          acr_values:
-        },
+          # https://digital.nhs.uk/services/care-identity-service/applications-and-services/cis2-authentication/guidance-for-developers/detailed-guidance/acr-values
+          # The AAL will be verified in the callback, so there needs to be some
+          # alignment here.
+          acr_values: Settings.cis2.acr_value
+        }.compact,
         response_type: :code,
         # uid_field: "preferred_username",
         issuer: Settings.cis2.issuer,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -300,6 +300,14 @@ Devise.setup do |config|
       http_client.ssl.min_version = :TLS1_2
     end
 
+    acr_values =
+      if Settings.cis2.allow_aal2_auth
+        # Enables support for MS Authenticator
+        "AAL2_OR_AAL3_ANY"
+      else
+        "AAL3"
+      end
+
     config.omniauth(
       :openid_connect,
       {
@@ -307,7 +315,8 @@ Devise.setup do |config|
         name: :cis2,
         scope: %i[openid profile email nationalrbacaccess associatedorgs],
         extra_authorize_params: {
-          max_age: 300
+          max_age: 300,
+          acr_values:
         },
         response_type: :code,
         # uid_field: "preferred_username",

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,5 +5,5 @@ web_concurrency: 2
 fast_reset: false
 
 cis2:
-  authentication_assurance_level: 3
-  allow_aal2_auth: true
+  min_authentication_assurance_level: 2
+  acr_value: AAL2_OR_AAL3_ANY

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,3 +6,4 @@ fast_reset: false
 
 cis2:
   authentication_assurance_level: 3
+  allow_aal2_auth: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -37,5 +37,4 @@ nhs_api:
   base_url: "https://int.api.service.nhs.uk"
 
 cis2:
-  issuer: "https://am.nhsdev.auth-ptl.cis2.spineservices.nhs.uk:443/openam/oauth2/realms/root/realms/oidc"
-  authentication_assurance_level: 1
+  issuer: "https://am.nhsint.auth-ptl.cis2.spineservices.nhs.uk:443/openam/oauth2/realms/root/realms/NHSIdentity/realms/Healthcare"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -186,7 +186,7 @@ create_patients(team)
 create_imports(user, team)
 
 # CIS2 team - the ODS code and user UID need to match the values in the CIS2 env
-user, team = create_user_and_team(ods_code: "Y51", uid: "555057896106")
+user, team = create_user_and_team(ods_code: "A9A5A", uid: "555057896106")
 
 attach_sample_of_schools_to(team)
 attach_specific_school_to_team_if_present(team:, urn: "136126") # potentially needed for automated testing


### PR DESCRIPTION
Enables MS Authentication by default when requesting authentication from CIS2.

Additionally, this changes the ODS code we use in seeds to line up with the testing ODS code NHS recomments, `A9A5A`. UUIDs should be associated with this Org in CIS2.

Deployment plan:
- Deploy to test environment (automatic on PR merge)
- Configure and enable CIS2 in the test environment to test that it works
  - Update ODS code `Y51` -> `A9A5A`
- Deploy to pentest env
- Configure in pentest env
  - Update ODS code `Y51` -> `A9A5A`
- Confirm with pentesters that they've setup their CIS2 UUIDs
- Enable in pentest env