### PR TITLE
Handle INVALID_RESOURCE_ID error

### DIFF
--- a/spec/fixtures/files/pds/invalid-nhs-number-response.json
+++ b/spec/fixtures/files/pds/invalid-nhs-number-response.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "structure",
+      "details": {
+        "coding": [
+          {
+            "system": "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+            "version": "1",
+            "code": "INVALID_RESOURCE_ID",
+            "display": "Resource ID is invalid"
+          }
+        ]
+      },
+      "diagnostics": "Resource ID is invalid"
+    }
+  ]
+}

--- a/spec/lib/nhs/pds_spec.rb
+++ b/spec/lib/nhs/pds_spec.rb
@@ -23,6 +23,25 @@ describe NHS::PDS do
       end
     end
 
+    context "with an invalid NHS number" do
+      before do
+        stub_request(
+          :get,
+          "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9000000009"
+        ).to_return(
+          body: file_fixture("pds/invalid-nhs-number-response.json"),
+          status: 400,
+          headers: {
+            "Content-Type" => "application/fhir+json"
+          }
+        )
+      end
+
+      it "raises an error" do
+        expect { get_patient }.to raise_error(NHS::PDS::InvalidNHSNumber)
+      end
+    end
+
     context "with an invalidated resource response" do
       before do
         stub_request(


### PR DESCRIPTION
If we get this error from the PDS API, this raises a more approriate exception that we can then choose to handle ourselves or ignore.

https://good-machine.sentry.io/issues/6001980138/