### PR TITLE
Add home educated and unknown patients to the generic clinic

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -52,8 +52,10 @@ class ClassImport < PatientImport
 
     return if session.closed?
 
+    # Add newly imported patients to the session
     session.create_patient_sessions!
 
+    # Remove unknown patients from the session and school
     unknown_patients = session.patients - patients
 
     Patient.where(id: unknown_patients.map(&:id)).update_all(school_id: nil)
@@ -62,5 +64,14 @@ class ClassImport < PatientImport
       .patient_sessions
       .where(patient: unknown_patients)
       .find_each(&:destroy_if_safe!)
+
+    # Add the unknown patients to the generic clinic
+    generic_clinic_session_id = team.generic_clinic_session.id
+
+    PatientSession.import!(
+      %i[patient_id session_id],
+      unknown_patients.map { [_1.id, generic_clinic_session_id] },
+      on_duplicate_key_ignore: true
+    )
   end
 end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -290,7 +290,7 @@ class ImmunisationImportRow
       if school && (care_setting.nil? || care_setting == CARE_SETTING_SCHOOL)
         school
       else
-        clinic
+        generic_clinic
       end
   end
 
@@ -304,18 +304,15 @@ class ImmunisationImportRow
       end
   end
 
-  def clinic
+  def generic_clinic
     return unless valid?
 
-    @clinic ||=
-      Location
-        .create_with(name: "#{team.name} Clinic")
-        .find_or_create_by!(type: :generic_clinic, ods_code:, team:)
-        .tap do
-          _1.update!(
-            year_groups: (_1.year_groups + @programme.year_groups).sort.uniq
-          )
-        end
+    @generic_clinic ||=
+      team.generic_clinic.tap do
+        _1.update!(
+          year_groups: (_1.year_groups + @programme.year_groups).sort.uniq
+        )
+      end
   end
 
   def vaccine

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -290,7 +290,7 @@ class ImmunisationImportRow
       if school && (care_setting.nil? || care_setting == CARE_SETTING_SCHOOL)
         school
       else
-        generic_clinic
+        team.generic_clinic
       end
   end
 
@@ -301,17 +301,6 @@ class ImmunisationImportRow
       if school_urn != SCHOOL_URN_HOME_EDUCATED &&
            school_urn != SCHOOL_URN_UNKNOWN
         Location.find_by!(urn: school_urn)
-      end
-  end
-
-  def generic_clinic
-    return unless valid?
-
-    @generic_clinic ||=
-      team.generic_clinic.tap do
-        _1.update!(
-          year_groups: (_1.year_groups + @programme.year_groups).sort.uniq
-        )
       end
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -45,6 +45,8 @@ class Location < ApplicationRecord
 
   enum :type, %w[school generic_clinic community_clinic]
 
+  scope :clinic, -> { generic_clinic.or(community_clinic) }
+
   scope :for_year_groups,
         ->(year_groups) do
           where("year_groups && ARRAY[?]::integer[]", year_groups)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -25,14 +25,15 @@ class Team < ApplicationRecord
   include ODSCodeConcern
 
   has_many :batches
+  has_many :clinics, -> { clinic }, class_name: "Location"
   has_many :cohort_imports
   has_many :cohorts
   has_many :consent_forms
   has_many :consents
   has_many :locations
-  has_many :team_programmes
   has_many :schools, -> { school }, class_name: "Location"
   has_many :sessions
+  has_many :team_programmes
 
   has_many :patient_sessions, through: :sessions
   has_many :programmes, through: :team_programmes
@@ -47,6 +48,13 @@ class Team < ApplicationRecord
 
   def year_groups
     programmes.flat_map(&:year_groups).uniq.sort
+  end
+
+  def generic_clinic
+    locations.create_with(name: "#{name} Clinic").find_or_create_by!(
+      ods_code:,
+      type: :generic_clinic
+    )
   end
 
   def weeks_before_consent_reminders

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -57,6 +57,16 @@ class Team < ApplicationRecord
     )
   end
 
+  def generic_clinic_session
+    academic_year = Date.current.academic_year
+    location = generic_clinic
+
+    sessions.create_with(programmes:).find_or_create_by!(
+      academic_year:,
+      location:
+    )
+  end
+
   def weeks_before_consent_reminders
     (days_before_consent_reminders / 7).to_i
   end

--- a/lib/tasks/teams.rake
+++ b/lib/tasks/teams.rake
@@ -50,12 +50,7 @@ namespace :teams do
 
       TeamProgramme.create!(team:, programme:)
 
-      Location.create!(
-        name: "#{name} Clinic",
-        ods_code:,
-        type: :generic_clinic,
-        team:
-      )
+      team.generic_clinic # ensure it exists
 
       puts "New #{team.name} team with ID #{team.id} created."
     end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -373,12 +373,21 @@ describe ClassImport do
     end
 
     context "with an existing patient not in the class list" do
-      let(:existing_patient) { create(:patient, session:) }
+      let!(:existing_patient) { create(:patient, session:) }
 
       it "moves the existing patient to an unknown school" do
         expect(session.patients).to include(existing_patient)
         expect { record! }.to change { existing_patient.reload.school }.to(nil)
         expect(session.reload.patients).not_to include(existing_patient)
+      end
+
+      it "moves the existing patient to the generic clinic" do
+        location = create(:location, :generic_clinic, team:)
+        generic_clinic_session = create(:session, location:, team:, programme:)
+
+        expect(generic_clinic_session.patients).to be_empty
+        record!
+        expect(generic_clinic_session.patients).to include(existing_patient)
       end
 
       context "when the existing patient has been vaccinated" do


### PR DESCRIPTION
This adds the functionality to add home educated and unknown patients to the generic clinic under the following circumstances:

- When importing the cohort
- When importing a class list and moving unknown patients out of the school
- When closing a session