### PR TITLE
Split completed sessions in to completed and closed

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -19,9 +19,10 @@ class ProgrammesController < ApplicationController
         .includes(:dates, :location)
         .strict_loading
 
+    @closed_sessions = sessions_for_programme.closed.sort
+    @completed_sessions = sessions_for_programme.completed.sort
     @scheduled_sessions = sessions_for_programme.scheduled.sort
     @unscheduled_sessions = sessions_for_programme.unscheduled.sort
-    @completed_sessions = sessions_for_programme.completed.sort
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -27,6 +27,12 @@ class SessionsController < ApplicationController
     render layout: "full"
   end
 
+  def closed
+    @sessions = sessions_scope.closed.sort
+
+    render layout: "full"
+  end
+
   def show
     @patient_sessions =
       @session.patient_sessions.strict_loading.includes(

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -12,9 +12,11 @@ module SessionsHelper
   end
 
   def session_status_tag(session)
-    if session.unscheduled?
+    if session.closed?
+      govuk_tag(text: "Closed", colour: "red")
+    elsif session.unscheduled?
       govuk_tag(text: "No sessions scheduled", colour: "purple")
-    elsif session.closed?
+    elsif session.completed?
       govuk_tag(text: "All sessions completed", colour: "green")
     else
       govuk_tag(text: "Sessions scheduled")

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -13,7 +13,8 @@
 
 <% [[@scheduled_sessions, "Sessions scheduled"],
     [@completed_sessions, "All sessions completed"],
-    [@unscheduled_sessions, "No sessions scheduled"]]
+    [@unscheduled_sessions, "No sessions scheduled"],
+    [@closed_sessions, "Sessions closed"]]
      .select { |sessions, _| sessions.any? }.each do |sessions, heading| %>
 
   <%= render AppSessionTableComponent.new(sessions, heading:, show_dates: true, show_consent_period: true) %>

--- a/app/views/sessions/closed.html.erb
+++ b/app/views/sessions/closed.html.erb
@@ -1,17 +1,17 @@
-<% content_for :page_title, "#{t("sessions.index.title")} – Unscheduled" %>
+<% content_for :page_title, "#{t("sessions.index.title")} – Closed" %>
 
 <%= h1 t("sessions.index.title"), size: "xl" %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(href: sessions_path, text: "Today")
-      nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled", selected: true)
+      nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled")
       nav.with_item(href: completed_sessions_path, text: "Completed")
-      nav.with_item(href: closed_sessions_path, text: "Closed")
+      nav.with_item(href: closed_sessions_path, text: "Closed", selected: true)
     end %>
 
 <% if @sessions.empty? %>
   <p class="nhsuk-body"><%= t(".table_heading.zero") %></p>
 <% else %>
-  <%= render AppSessionTableComponent.new(@sessions, heading: t(".table_heading", count: @sessions.count), show_programmes: true) %>
+  <%= render AppSessionTableComponent.new(@sessions, heading: t(".table_heading", count: @sessions.count), show_dates: true, show_programmes: true) %>
 <% end %>

--- a/app/views/sessions/completed.html.erb
+++ b/app/views/sessions/completed.html.erb
@@ -7,6 +7,7 @@
       nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled")
       nav.with_item(href: completed_sessions_path, text: "Completed", selected: true)
+      nav.with_item(href: closed_sessions_path, text: "Closed")
     end %>
 
 <% if @sessions.empty? %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -7,6 +7,7 @@
       nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled")
       nav.with_item(href: completed_sessions_path, text: "Completed")
+      nav.with_item(href: closed_sessions_path, text: "Closed")
     end %>
 
 <% if @sessions.empty? %>

--- a/app/views/sessions/scheduled.html.erb
+++ b/app/views/sessions/scheduled.html.erb
@@ -7,6 +7,7 @@
       nav.with_item(href: unscheduled_sessions_path, text: "Unscheduled")
       nav.with_item(href: scheduled_sessions_path, text: "Scheduled", selected: true)
       nav.with_item(href: completed_sessions_path, text: "Completed")
+      nav.with_item(href: closed_sessions_path, text: "Closed")
     end %>
 
 <% if @sessions.empty? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,6 +694,11 @@ en:
         zero: There are no sessions scheduled for today.
         one: 1 session today
         other: "%{count} sessions today"
+    closed:
+      table_heading:
+        zero: There are no locations with closed sessions.
+        one: 1 location with sessions closed
+        other: "%{count} locations with sessions closed"
     completed:
       table_heading:
         zero: There are no locations with all sessions completed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,6 +121,7 @@ Rails.application.routes.draw do
 
   resources :sessions, only: %i[edit index show] do
     collection do
+      get "closed"
       get "completed"
       get "scheduled"
       get "unscheduled"

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -58,7 +58,6 @@ FactoryBot.define do
     end
 
     trait :completed do
-      closed
       date { Date.current - 1.week }
     end
 

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -37,6 +37,16 @@ describe SessionsHelper do
       end
     end
 
+    context "when scheduled" do
+      let(:session) { create(:session, :scheduled) }
+
+      it do
+        expect(session_status_tag).to eq(
+          "<strong class=\"nhsuk-tag\">Sessions scheduled</strong>"
+        )
+      end
+    end
+
     context "when completed" do
       let(:session) { create(:session, :completed) }
 
@@ -47,12 +57,12 @@ describe SessionsHelper do
       end
     end
 
-    context "when scheduled" do
-      let(:session) { create(:session, :scheduled) }
+    context "when closed" do
+      let(:session) { create(:session, :closed) }
 
       it do
         expect(session_status_tag).to eq(
-          "<strong class=\"nhsuk-tag\">Sessions scheduled</strong>"
+          "<strong class=\"nhsuk-tag nhsuk-tag--red\">Closed</strong>"
         )
       end
     end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -364,10 +364,8 @@ describe ClassImport do
       end
     end
 
-    context "with a completed session" do
-      let(:session) do
-        create(:session, :completed, team:, programme:, location:)
-      end
+    context "with a closed session" do
+      let(:session) { create(:session, :closed, team:, programme:, location:) }
 
       it "doesn't add the patients to the session" do
         expect { record! }.not_to change(PatientSession, :count)

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -310,8 +310,8 @@ describe CohortImport do
       end
     end
 
-    context "with a completed session" do
-      before { create(:session, :completed, team:, programme:, location:) }
+    context "with a closed session" do
+      before { create(:session, :closed, team:, programme:, location:) }
 
       it "doesn't add the patients to the session" do
         expect { record! }.not_to change(PatientSession, :count)

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -28,33 +28,28 @@ describe Session do
   describe "scopes" do
     let(:programme) { create(:programme) }
 
-    let(:today_session) { create(:session, :today, programme:) }
-    let(:unscheduled_session) { create(:session, :unscheduled, programme:) }
+    let(:closed_session) { create(:session, :closed, programme:) }
     let(:completed_session) { create(:session, :completed, programme:) }
     let(:scheduled_session) { create(:session, :scheduled, programme:) }
-
-    describe "#open" do
-      subject(:scope) { described_class.open }
-
-      it do
-        expect(scope).to contain_exactly(
-          today_session,
-          unscheduled_session,
-          scheduled_session
-        )
-      end
-    end
-
-    describe "#closed" do
-      subject(:scope) { described_class.closed }
-
-      it { should contain_exactly(completed_session) }
-    end
+    let(:today_session) { create(:session, :today, programme:) }
+    let(:unscheduled_session) { create(:session, :unscheduled, programme:) }
 
     describe "#today" do
       subject(:scope) { described_class.today }
 
       it { should contain_exactly(today_session) }
+    end
+
+    describe "#upcoming" do
+      subject(:scope) { described_class.upcoming }
+
+      it do
+        expect(scope).to contain_exactly(
+          unscheduled_session,
+          today_session,
+          scheduled_session
+        )
+      end
     end
 
     describe "#unscheduled" do
@@ -77,18 +72,6 @@ describe Session do
       it { should contain_exactly(today_session, scheduled_session) }
     end
 
-    describe "#upcoming" do
-      subject(:scope) { described_class.upcoming }
-
-      it do
-        expect(scope).to contain_exactly(
-          unscheduled_session,
-          today_session,
-          scheduled_session
-        )
-      end
-    end
-
     describe "#completed" do
       subject(:scope) { described_class.completed }
 
@@ -101,6 +84,12 @@ describe Session do
 
         it { should_not include(completed_session) }
       end
+    end
+
+    describe "#closed" do
+      subject(:scope) { described_class.closed }
+
+      it { should contain_exactly(closed_session) }
     end
   end
 


### PR DESCRIPTION
This partially reverts eabbb6c6c95eeecbe5fbe790d24d09a90caafdc4 by splitting the "Completed" state in to two separate "Completed" and "Closed" states. Completed means that there are no more upcoming dates, but only once someone has pressed the "Close session" button does it move to the closed state.

## Screenshots

<img width="634" alt="Screenshot 2024-10-22 at 16 48 46" src="https://github.com/user-attachments/assets/8a6edba2-fbe3-487f-b752-06f1f67b934f">
