### PR TITLE
Make parent duplication matching more robust

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -169,7 +169,8 @@ class Consent < ApplicationRecord
 
   def self.from_consent_form!(consent_form, patient:)
     ActiveRecord::Base.transaction do
-      parent = consent_form.find_or_create_parent_with_relationship_to(patient:)
+      parent =
+        consent_form.find_or_create_parent_with_relationship_to!(patient:)
 
       create!(
         consent_form:,

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -64,6 +64,24 @@ class Parent < ApplicationRecord
             presence: true,
             if: :contact_method_other?
 
+  def self.match_existing(patient:, email:, phone:, full_name:)
+    if email.present? && (parent = Parent.find_by(email:))
+      return parent
+    end
+
+    return unless patient
+
+    # We don't match on phone numbers or names globally as they can be re-used.
+
+    if phone.present? && (parent = patient.parents.find_by(phone:))
+      return parent
+    end
+
+    if full_name.present? && (parent = patient.parents.find_by(full_name:))
+      parent
+    end
+  end
+
   def label
     full_name.presence || "Parent or guardian (name unknown)"
   end

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -99,25 +99,19 @@ class PatientImportRow
       full_name = attributes[:full_name]
 
       parent =
-        if email.present?
-          Parent.find_by(email:)
-        elsif (existing_patient = existing_patients.first)
-          # We don't match on phone numbers or names globally as they can be re-used.
-          if phone.present?
-            existing_patient.parents.find_by(phone:)
-          elsif full_name.present?
-            existing_patient.parents.find_by(full_name:)
-          end
-        end
+        Parent.match_existing(
+          patient: existing_patients.first,
+          email:,
+          phone:,
+          full_name:
+        ) || Parent.new
 
-      parent ||= Parent.new
+      parent.recorded_at = Time.current unless parent.recorded?
 
       parent.email = attributes[:email]
       parent.full_name = attributes[:full_name]
       parent.phone = attributes[:phone]
       parent.phone_receive_updates = false if parent.phone.blank?
-
-      parent.recorded_at = Time.current unless parent.recorded?
 
       parent
     end

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -92,6 +92,7 @@ describe Consent do
       end
 
       it "creates a parent" do
+        expect(consent.parent).to be_recorded
         expect(consent.parent).to have_attributes(
           full_name: consent_form.parent_full_name,
           email: consent_form.parent_email,
@@ -104,6 +105,25 @@ describe Consent do
         expect(consent.health_answers.to_json).to eq(
           consent_form.health_answers.to_json
         )
+      end
+
+      context "with an existing parent" do
+        let(:parent) do
+          create(:parent, full_name: consent_form.parent_full_name)
+        end
+
+        before { create(:parent_relationship, patient:, parent:) }
+
+        it "re-uses the same parent" do
+          expect(consent.parent).to eq(parent)
+          expect(consent.parent).to be_recorded
+          expect(consent.parent).to have_attributes(
+            full_name: consent_form.parent_full_name,
+            email: consent_form.parent_email,
+            phone: consent_form.parent_phone,
+            phone_receive_updates: consent_form.parent_phone_receive_updates
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
This updates how we match on existing parents to make the process more robust by looking for matching email addresses, names and phone numbers both when importing new records and when matching consent forms with patients.