### PR TITLE
OIDC wants to be free! (unauthenticated)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,7 +3,8 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped, only: %i[start jwks]
-  skip_before_action :store_user_location!, only: :start
+  skip_before_action :store_user_location!, only: %i[start jwks]
+  skip_before_action :authenticate_basic, only: :jwks
 
   def start
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,6 +7,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped
   skip_before_action :verify_authenticity_token, only: [:cis2_logout]
+  skip_before_action :authenticate_basic, only: [:cis2_logout]
 
   before_action :verify_cis2_response, only: %i[cis2]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,8 @@ Rails.application.routes.draw do
                omniauth_callbacks: "users/omniauth_callbacks"
              }
   devise_scope :user do
-    post "auth/cis2_logout", to: "users/omniauth_callbacks#cis2_logout"
+    post "/users/auth/cis2/backchannel_logout",
+         to: "users/omniauth_callbacks#cis2_logout"
   end
 
   root to: redirect("/start")

--- a/spec/features/cis2_backchannel_logout_spec.rb
+++ b/spec/features/cis2_backchannel_logout_spec.rb
@@ -84,7 +84,7 @@ describe "CIS2 backchannel logout" do
   end
 
   def when_a_backchannel_signout_request_is_received
-    page.driver.post "/auth/cis2_logout", logout_token: @token
+    page.driver.post "/users/auth/cis2/backchannel_logout", logout_token: @token
   end
   alias_method :and_the_backchannel_signout_request_is_replayed,
                :when_a_backchannel_signout_request_is_received


### PR DESCRIPTION
The logout and jwks endpoints will be called by CIS2 and should not be behind basic auth.

Also tidies up the routes a little:

```
                           user_cis2_omniauth_authorize GET|POST /users/auth/cis2(.:format)                                                                        users/omniauth_callbacks#passthru
                            user_cis2_omniauth_callback GET|POST /users/auth/cis2/callback(.:format)                                                               users/omniauth_callbacks#cis2
                     users_auth_cis2_backchannel_logout POST     /users/auth/cis2/backchannel_logout(.:format)                                                     users/omniauth_callbacks#cis2_logout
```