### PR TITLE
Add "Close session" functionality

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class SessionsController < ApplicationController
-  before_action :set_session, only: %i[show edit make_in_progress]
+  before_action :set_session,
+                except: %i[index scheduled unscheduled completed closed]
 
   def index
     @sessions = sessions_scope.today.sort
@@ -56,34 +57,20 @@ class SessionsController < ApplicationController
   def make_in_progress
     @session.dates.find_or_create_by!(value: Date.current)
 
-    redirect_to session_path,
-                flash: {
-                  success: {
-                    heading: "Session is now in progress"
-                  }
-                }
+    redirect_to session_path, flash: { success: "Session is now in progress" }
   end
 
   private
 
   delegate :team, to: :current_user
 
-  def academic_year
-    Date.current.academic_year
-  end
-
   def set_session
-    @session =
-      policy_scope(Session).includes(
-        :team,
-        :location,
-        :dates,
-        :programmes
-      ).find(params[:id])
+    @session = sessions_scope.find(params[:id])
   end
 
   def sessions_scope
     policy_scope(Session).includes(
+      :team,
       :dates,
       :location,
       :programmes

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -54,6 +54,18 @@ class SessionsController < ApplicationController
   def edit
   end
 
+  def edit_close
+    @unvaccinated_patients_count = @session.unvaccinated_patients.length
+
+    render :close
+  end
+
+  def update_close
+    @session.close!
+
+    redirect_to session_path(@session), flash: { success: "Session closed." }
+  end
+
   def make_in_progress
     @session.dates.find_or_create_by!(value: Date.current)
 
@@ -70,10 +82,10 @@ class SessionsController < ApplicationController
 
   def sessions_scope
     policy_scope(Session).includes(
-      :team,
       :dates,
       :location,
-      :programmes
+      :programmes,
+      team: :programmes
     ).strict_loading
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -88,6 +88,13 @@ class Patient < ApplicationRecord
   scope :not_restricted, -> { where(restricted_at: nil) }
   scope :restricted, -> { where.not(restricted_at: nil) }
 
+  scope :unvaccinated_for,
+        ->(programmes:) do
+          reject do |patient|
+            programmes.all? { |programme| patient.vaccinated?(programme) }
+          end
+        end
+
   validates :given_name, :family_name, :date_of_birth, presence: true
 
   validates :nhs_number,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -170,6 +170,7 @@ class Session < ApplicationRecord
 
   def close!
     return if closed?
+    return unless completed?
 
     ActiveRecord::Base.transaction do
       unvaccinated_patients =

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -108,6 +108,10 @@ class Session < ApplicationRecord
     closed_at != nil
   end
 
+  def closable?
+    open? && completed?
+  end
+
   def year_groups
     programmes.flat_map(&:year_groups).uniq.sort
   end

--- a/app/views/sessions/close.html.erb
+++ b/app/views/sessions/close.html.erb
@@ -1,0 +1,25 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: session_path(@session),
+        name: @session.location.name,
+      ) %>
+<% end %>
+
+<%= h1 "Close session" do %>
+  <span class="nhsuk-caption-l"><%= @session.location.name %></span>
+  Close session
+<% end %>
+
+<p class="nhsuk-body">All sessions for this school have been completed.</p>
+
+<% if @unvaccinated_patients_count > 0 %>
+  <p class="nhsuk-body">When you close this session, the following children will be invited to community clinics:</p>
+
+  <ul class="nhsuk-list nhsuk-list--bullet">
+    <li>
+      <%= t("children", count: @unvaccinated_patients_count) %> who could not be vaccinated
+    </li>
+  </ul>
+<% end %>
+
+<%= govuk_button_to "Close session", close_session_path(@session) %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -75,6 +75,10 @@
     <% unless @session.unscheduled? %>
       <%= govuk_button_link_to "Edit session", edit_session_path(@session), class: "app-button--secondary" %>
     <% end %>
+
+    <% if @session.closable? %>
+      <%= govuk_button_link_to "Close session", close_session_path(@session), class: "app-button--secondary" %>
+    <% end %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,9 @@ Rails.application.routes.draw do
     end
 
     member do
+      get "close", action: "edit_close"
+      post "close", action: "update_close"
+
       constraints -> { Flipper.enabled?(:dev_tools) } do
         put "make-in-progress", to: "sessions#make_in_progress"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,18 +128,20 @@ Rails.application.routes.draw do
       get "unscheduled"
     end
 
+    member do
+      constraints -> { Flipper.enabled?(:dev_tools) } do
+        put "make-in-progress", to: "sessions#make_in_progress"
+      end
+
+      constraints -> { Flipper.enabled?(:offline_working) } do
+        get "setup-offline", to: "offline_passwords#new"
+        post "setup-offline", to: "offline_passwords#create"
+      end
+    end
+
     resources :class_imports, path: "class-imports", except: %i[index destroy]
 
     resource :dates, controller: "session_dates", only: %i[show update]
-
-    constraints -> { Flipper.enabled?(:dev_tools) } do
-      put "make-in-progress", to: "sessions#make_in_progress", on: :member
-    end
-
-    constraints -> { Flipper.enabled? :offline_working } do
-      get "setup-offline", to: "offline_passwords#new", on: :member
-      post "setup-offline", to: "offline_passwords#create", on: :member
-    end
   end
 
   scope "/sessions/:session_id/:section", as: "session" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -450,7 +450,7 @@ describe Session do
 
     let(:programme) { create(:programme) }
     let(:team) { create(:team, programmes: [programme]) }
-    let(:session) { create(:session, programme:, team:) }
+    let(:session) { create(:session, :completed, programme:, team:) }
 
     it "sets the closed at time" do
       freeze_time do


### PR DESCRIPTION
This adds a button which is shown when a session is complete that allows the user to close the session, and if necessary, move any outstanding patients to the generic clinic for that team.

## Screenshots

![Screenshot 2024-10-23 at 10 16 42](https://github.com/user-attachments/assets/3a7d7c19-0895-4dae-8732-5e39acd5947f)
![Screenshot 2024-10-23 at 10 16 46](https://github.com/user-attachments/assets/3451e13b-ab8d-49ab-9875-730b258bea9d)
![Screenshot 2024-10-23 at 10 16 49](https://github.com/user-attachments/assets/dd0ced04-a040-4c9d-af85-39584bcc1e29)
![Screenshot 2024-10-23 at 10 16 52](https://github.com/user-attachments/assets/c47225e2-8f35-49fb-add8-f89cf1ac6872)
![Screenshot 2024-10-23 at 10 17 00](https://github.com/user-attachments/assets/630d180d-261c-4a1a-9c59-86d006c49b26)
