### PR TITLE
Add UI to handle proposed sessions 

### DIFF
--- a/app/controllers/session_moves_controller.rb
+++ b/app/controllers/session_moves_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class SessionMovesController < ApplicationController
+  before_action :set_session
+  before_action :set_tab
+
+  layout "full"
+
+  def index
+    @patient_sessions =
+      if @tab == :in
+        @session.patient_sessions_moving_to_this_session
+      elsif @tab == :out
+        @session.patient_sessions_moving_from_this_session
+      else
+        render "errors/not_found", status: :not_found
+      end
+  end
+
+  def update
+    @patient_session = policy_scope(PatientSession).find(params[:id])
+
+    if params[:confirm]
+      @patient_session.confirm_transfer!
+    elsif params[:ignore]
+      @patient_session.ignore_transfer!
+    else
+      render "errors/not_found", status: :not_found
+    end
+
+    name = @patient_session.patient.full_name
+    flash =
+      if params[:confirm]
+        { success: "#{name} moved #{@tab}" }
+      else
+        { notice: "#{name} move ignored" }
+      end
+
+    redirect_to session_moves_path(@session) + "?#{@tab}", flash:
+  end
+
+  private
+
+  def set_session
+    @session = policy_scope(Session).find(params[:session_id])
+  end
+
+  def set_tab
+    @tab = params.key?(:in) ? :in : :out
+  end
+end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -136,7 +136,12 @@ class PatientSession < ApplicationRecord
   def confirm_transfer!
     return unless pending_transfer?
 
-    update!(session: proposed_session, proposed_session: nil)
+    if safe_to_destroy?
+      update!(session: proposed_session, proposed_session: nil)
+    else
+      PatientSession.create!(patient:, session: proposed_session)
+      update!(proposed_session: nil)
+    end
   end
 
   def ignore_transfer!

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -136,11 +136,10 @@ class PatientSession < ApplicationRecord
   def confirm_transfer!
     return unless pending_transfer?
 
-    if safe_to_destroy?
-      update!(session: proposed_session, proposed_session: nil)
-    else
+    PatientSession.transaction do
       PatientSession.create!(patient:, session: proposed_session)
-      update!(proposed_session: nil)
+
+      safe_to_destroy? ? destroy! : update!(proposed_session: nil)
     end
   end
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -230,6 +230,19 @@ class Session < ApplicationRecord
     close_consent_at&.future?
   end
 
+  def patient_sessions_moving_from_this_session
+    patient_sessions.pending_transfer
+  end
+
+  def patient_sessions_moving_to_this_session
+    team.patient_sessions.where(proposed_session: self)
+  end
+
+  def has_movers?
+    patient_sessions_moving_from_this_session.any? ||
+      patient_sessions_moving_to_this_session.any?
+  end
+
   private
 
   def programmes_part_of_team

--- a/app/views/session_moves/index.html.erb
+++ b/app/views/session_moves/index.html.erb
@@ -1,0 +1,82 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(
+        items: [
+          { text: "Home", href: dashboard_path },
+          { text: t("sessions.index.title"), href: sessions_path },
+          { text: @session.location.name, href: session_path(@session) },
+        ],
+      ) %>
+<% end %>
+
+<%= h1 "Review children who have changed schools" %>
+
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(
+        href: session_moves_path(@session) + "?in",
+        text: "Moved in",
+        selected: @tab == :in,
+      )
+    
+      nav.with_item(
+        href: session_moves_path(@session) + "?out",
+        text: "Moved out",
+        selected: @tab == :out,
+      )
+    end %>
+
+<div class="app-patients">
+  <%= govuk_table(html_attributes: {
+                    class: "nhsuk-table-responsive app-patients__table",
+                  }) do |table| %>
+    <%= table.with_caption(
+          text: "#{t("children", count: @patient_sessions.count)} #{@tab == :in ? "joined" : "left"} this school",
+          html_attributes: {
+            class: %w[nhsuk-u-secondary-text-color
+                      nhsuk-u-font-weight-normal
+                      nhsuk-u-font-size-19],
+          },
+        ) %>
+
+    <% if @patient_sessions.any? %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Full name") %>
+          <% row.with_cell(text: "School joined from") %>
+          <% row.with_cell(text: "Actions") %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% @patient_sessions.each do |patient_session| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Full name</span>
+            <%= link_to patient_session.patient.full_name,
+                        patient_path(patient_session.patient) %>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">School joined from</span>
+            <%= patient_session.session.location.name %>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Actions</span>
+            <%= form_with url: session_move_path(@session, patient_session) + "?#{@tab}",
+                          method: :patch do |f| %>
+              <%= f.submit "Confirm move",
+                           class: "nhsuk-button app-button--secondary app-button--small",
+                           name: "confirm",
+                           value: "Confirm move" %>
+              <%= f.submit "Ignore move",
+                           class: "nhsuk-button app-button--secondary-warning app-button--small",
+                           name: "ignore",
+                           value: "Ignore move" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/session_moves/index.html.erb
+++ b/app/views/session_moves/index.html.erb
@@ -10,19 +10,27 @@
 
 <%= h1 "Review children who have changed schools" %>
 
-<%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(
-        href: session_moves_path(@session) + "?in",
-        text: "Moved in",
-        selected: @tab == :in,
-      )
-    
-      nav.with_item(
-        href: session_moves_path(@session) + "?out",
-        text: "Moved out",
-        selected: @tab == :out,
-      )
-    end %>
+<%= render AppSecondaryNavigationComponent.new do |nav| %>
+  <% nav.with_item(
+       href: session_moves_path(@session) + "?in",
+       selected: @tab == :in,
+     ) do %>
+    Moved in
+    <%= render AppCountComponent.new(
+          count: @session.patient_sessions_moving_to_this_session.count,
+        ) %>
+  <% end %>
+
+  <% nav.with_item(
+       href: session_moves_path(@session) + "?out",
+       selected: @tab == :out,
+     ) do %>
+    Moved out
+    <%= render AppCountComponent.new(
+          count: @session.patient_sessions_moving_from_this_session.count,
+        ) %>
+  <% end %>
+<% end %>
 
 <div class="app-patients">
   <%= govuk_table(html_attributes: {

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -28,6 +28,21 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
     <ul class="nhsuk-grid-row nhsuk-card-group">
+      <% if @session.has_movers? %>
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+          <%= render AppCardComponent.new(
+                link_to: session_moves_path(@session) + "?in",
+              ) do |c| %>
+            <% c.with_heading { "Review children who have changed schools" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @session.patient_sessions_moving_to_this_session.count) %>
+              joined this school<br />
+              <%= t("children", count: @session.patient_sessions_moving_from_this_session.count) %>
+              left this school
+            <% end %>
+          <% end %>
+        </li>
+      <% end %>
       <% if @session.unscheduled? %>
         <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: edit_session_path) do |c| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,8 @@ Rails.application.routes.draw do
     resources :class_imports, path: "class-imports", except: %i[index destroy]
 
     resource :dates, controller: "session_dates", only: %i[show update]
+
+    resources :moves, controller: "session_moves", only: %i[index update]
   end
 
   scope "/sessions/:session_id/:section", as: "session" do

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+describe "Import class lists - Moving patients" do
+  around { |example| travel_to(Date.new(2023, 5, 20)) { example.run } }
+
+  scenario "User uploads a file and moves patients to a new session" do
+    given_an_hpv_programme_is_underway
+
+    when_i_visit_a_session_page_for_the_hpv_programme
+    and_i_start_adding_children_to_the_session
+    then_i_should_see_the_import_page
+
+    when_i_upload_a_valid_file
+    then_i_should_see_the_imports_page_with_the_completed_flash
+
+    when_i_visit_a_different_session_page_for_the_hpv_programme
+    and_i_start_adding_children_to_the_session
+    and_i_upload_a_valid_file
+    then_i_should_see_the_imports_page_with_the_completed_flash
+
+    when_i_visit_a_session_page_for_the_hpv_programme
+    then_i_should_see_pending_moves_out
+
+    when_i_click_on_the_pending_moves_card
+    then_i_should_see_the_patients_moving_out_tab
+
+    when_i_click_on_the_moved_out_tab
+    then_i_should_see_the_patients_moving_out_table
+
+    when_i_confirm_a_move
+    then_i_should_see_a_success_flash
+
+    when_i_ignore_a_move
+    then_i_should_see_a_notice_flash
+  end
+
+  def given_an_hpv_programme_is_underway
+    @team = create(:team, :with_one_nurse)
+    location = create(:location, :secondary, name: "Waterloo Road", team: @team)
+    other_location =
+      create(:location, :secondary, name: "Different Road", team: @team)
+    @user = @team.users.first
+    programme = create(:programme, :hpv, teams: [@team])
+    create(:session, :unscheduled, team: @team, location:, programme:)
+    create(
+      :session,
+      :unscheduled,
+      team: @team,
+      location: other_location,
+      programme:
+    )
+  end
+
+  def when_i_visit_a_session_page_for_the_hpv_programme
+    sign_in @user
+    visit "/dashboard"
+    click_on "Sessions", match: :first
+    click_on "Unscheduled"
+    click_on "Waterloo Road"
+  end
+
+  def when_i_visit_a_different_session_page_for_the_hpv_programme
+    visit "/dashboard"
+    click_on "Sessions", match: :first
+    click_on "Unscheduled"
+    click_on "Different Road"
+  end
+
+  def and_i_start_adding_children_to_the_session
+    click_on "Import class list"
+  end
+
+  def then_i_should_see_the_import_page
+    expect(page).to have_content("Import class list")
+  end
+
+  def when_i_upload_a_valid_file
+    attach_file("class_import[csv]", "spec/fixtures/class_import/valid.csv")
+    click_on "Continue"
+  end
+  alias_method :and_i_upload_a_valid_file, :when_i_upload_a_valid_file
+
+  def when_i_go_to_the_upload_page
+    click_on "Import class list"
+  end
+
+  def then_i_should_see_the_imports_page_with_the_completed_flash
+    expect(page).to have_content("Import completed")
+  end
+
+  def then_i_should_see_pending_moves_out
+    expect(page).to have_content("4 children left this school")
+  end
+
+  def when_i_click_on_the_pending_moves_card
+    click_link "Review children who have changed schools"
+  end
+
+  def then_i_should_see_the_patients_moving_out_tab
+    expect(page).to have_content("Moved out ( 4 )")
+  end
+
+  def when_i_click_on_the_moved_out_tab
+    click_link "Moved out"
+  end
+
+  def then_i_should_see_the_patients_moving_out_table
+    expect(page).to have_content("4 children left this school")
+  end
+
+  def when_i_confirm_a_move
+    click_button "Confirm move", match: :first
+  end
+
+  def then_i_should_see_a_success_flash
+    expect(page).to have_alert("Success")
+  end
+
+  def when_i_ignore_a_move
+    click_button "Ignore move", match: :first
+  end
+
+  def then_i_should_see_a_notice_flash
+    expect(page).to have_region("Information")
+  end
+end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -163,11 +163,12 @@ describe PatientSession do
       )
     end
 
-    it "updates the session and clears the proposed session" do
+    it "destroys the patient session, creates one with the proposed session" do
       # stree-ignore
       expect { confirm_transfer! }
-        .to change(patient_session, :session).to(proposed_session)
-        .and change(patient_session, :proposed_session).to(nil)
+        .to change { described_class.exists?(patient_session.id) }
+        .from(true).to(false)
+        .and not_change(patient_session.patient.patient_sessions, :count)
     end
 
     context "when there is no proposed session" do


### PR DESCRIPTION
This allows nurses to transfer patients from one session to another after they upload a class list.

TODO:

- [x] Handle scenario where session they're coming from has vaccination records (create new patient_session)
- [x] Count of moving out/in
- [x] End to end test

### Screenshots

![Screenshot 2024-10-23 at 10 46 25](https://github.com/user-attachments/assets/81121d77-e0b7-4f7a-bf57-4232f83ed77c)
![Screenshot 2024-10-23 at 10 46 38](https://github.com/user-attachments/assets/9e82e8a1-ec4a-4f83-833c-40f8539c1bce)

![Screenshot 2024-10-23 at 10 46 41](https://github.com/user-attachments/assets/fb90399b-dbac-41a3-a3f2-f5ed61898fb7)
