### PR TITLE
Allow admin role to authenticate

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -34,7 +34,7 @@ module AuthenticationConcern
     end
 
     def valid_cis2_roles
-      ["S8000:G8000:R8001"]
+      %w[S8000:G8000:R8001 S8000:G8001:R8006]
     end
 
     def selected_cis2_role_is_valid?

--- a/app/views/users/errors/role_not_found.html.erb
+++ b/app/views/users/errors/role_not_found.html.erb
@@ -23,6 +23,4 @@
 <%= govuk_list([
       "Nurse Access Role (R8001)",
       "Medical Secretary Access Role (R8006)",
-      "Admin/Clinical Support Access Role (R8008)",
-      "Receptionist Access Role (R8009)",
     ], type: "bullet") %>


### PR DESCRIPTION
Add R8006 to the list of allowed roles to use the system. Also removes R8008 and R8009 from the role-not-found error page.