### PR TITLE
Only import unique relationships

### DIFF
--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -53,7 +53,8 @@ class PatientImport < ApplicationRecord
 
     parents = @parents_batch.to_a
     patients = @patients_batch.to_a
-    relationships = @relationships_batch.to_a
+
+    relationships = @relationships_batch.to_a.uniq { [_1.parent, _1.patient] }
 
     Parent.import(parents, on_duplicate_key_update: :all)
     Patient.import(patients, on_duplicate_key_update: :all)


### PR DESCRIPTION
This should fix https://good-machine.sentry.io/issues/6012276805/ where if we import a file that contains the same parent relationship multiple times we end up raising an error. This was unlikely to happen before, but we no longer require parent names and relationships to be in the import so it's more likely to occur now.

This effectively re-implements the same behaviour from before we switched to `activerecord-import`, where only the latest row is saved to the database. We don't have this problem with patients and parents as we use a `Set` which prevents the same objects from being imported, however for the `ParentRelationship` model we have a unique constraint on the parent and patient IDs, which isn't de-duplicated by using a `Set` so we have to do it manually.