### PR TITLE
Don't create sessions for community clinics

### DIFF
--- a/app/lib/unscheduled_sessions_factory.rb
+++ b/app/lib/unscheduled_sessions_factory.rb
@@ -15,12 +15,14 @@ class UnscheduledSessionsFactory
           next if sessions.any? { _1.location_id == location.id }
 
           programmes =
-            if location.school?
+            if location.generic_clinic?
+              team.programmes
+            elsif location.school?
               team.programmes.select do
                 _1.year_groups.intersect?(location.year_groups)
               end
             else
-              team.programmes
+              [] # don't create sessions for unhandled location types
             end
 
           next if programmes.empty?

--- a/lib/tasks/clinics.rake
+++ b/lib/tasks/clinics.rake
@@ -33,7 +33,7 @@ namespace :clinics do
 
     location =
       Location.create!(
-        type: :clinic,
+        type: :community_clinic,
         name:,
         address_line_1:,
         address_town:,

--- a/spec/lib/unscheduled_sessions_factory_spec.rb
+++ b/spec/lib/unscheduled_sessions_factory_spec.rb
@@ -31,6 +31,14 @@ describe UnscheduledSessionsFactory do
       end
     end
 
+    context "with a community clinic" do
+      before { create(:location, :community_clinic, team:) }
+
+      it "doesn't create any unscheduled sessions" do
+        expect { call }.not_to change(team.sessions, :count)
+      end
+    end
+
     context "with a school that's not eligible for the programme" do
       before { create(:location, :primary, team:) }
 


### PR DESCRIPTION
Although these location types exist in the service we don't currently handle them correctly and shouldn't be creating sessions for them.