### PR TITLE
Control cis2 with a setting vs feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,16 +276,16 @@ $ curl -s https://am.nhsdev.auth-ptl.cis2.spineservices.nhs.uk/openam/oauth2/rea
 New client ids and secrets can be obtained from the NHS CIS2 Authentication team
 (<nhscareidentityauthentication@nhs.net>).
 
-Put the `issuer`, `client_id` and `secret` into the Settings for your env:
+Put the `issuer`, `client_id` and `secret` into the Settings for your env, and
+ensure cis2 is enabled:
 
 ```yml
 cis2:
+  enabled: true
   issuer: "https://am.nhsdev.auth-ptl.cis2.spineservices.nhs.uk:443/openam/oauth2/realms/root/realms/oidc"
   client_id: CLIENT_ID
   secret: SECRET
 ```
-
-The `cis2` feature flag also needs to be enabled in Flipper for CIS2 logins to work.
 
 ## Rake tasks
 

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -12,7 +12,7 @@ module AuthenticationConcern
           store_location_for(:user, request.fullpath)
         end
 
-        unless request.path == new_user_session_path
+        if Settings.cis2.enabled || request.path != new_user_session_path
           flash[:info] = "You must be logged in to access this page."
           redirect_to start_path
         end
@@ -71,6 +71,10 @@ module AuthenticationConcern
 
     def after_sign_in_path_for(scope)
       stored_location_for(scope) || dashboard_path
+    end
+
+    def user_signed_in?
+      super && (Settings.cis2.enabled ? cis2_session? : true)
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -35,6 +35,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def logout
+    signed_out =
+      (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+    flash[:notice] = "You have been logged out" if signed_out
+    redirect_to after_sign_out_path_for(resource_name)
+  end
+
   private
 
   def verify_cis2_response

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,11 +30,11 @@ class User < ApplicationRecord
 
   attr_accessor :sso_session
 
-  devise :database_authenticatable,
-         :trackable,
-         :timeoutable,
-         :omniauthable,
-         omniauth_providers: %i[cis2]
+  if Settings.cis2.enabled
+    devise :omniauthable, :trackable, :timeoutable, omniauth_providers: %i[cis2]
+  else
+    devise :database_authenticatable, :trackable, :timeoutable
+  end
 
   has_and_belongs_to_many :teams
 
@@ -82,7 +82,7 @@ class User < ApplicationRecord
   end
 
   def is_medical_secretary?
-    return email.include?("admin") unless Flipper.enabled?(:cis2)
+    return email.include?("admin") unless Settings.cis2.enabled
 
     role_codes = sso_session.dig("selected_role", "code")
     role_codes.include?("R8006")
@@ -90,7 +90,7 @@ class User < ApplicationRecord
 
   def is_nurse?
     # All users are nurses if cis2 is disabled
-    return email.include?("nurse") unless Flipper.enabled?(:cis2)
+    return email.include?("nurse") unless Settings.cis2.enabled
 
     role_codes = sso_session.dig("selected_role", "code")
     role_codes.include?("R8001")

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -22,13 +22,13 @@
             </svg>
             <%= current_user.full_name %>
           </span>
-          <% if Flipper.enabled? :cis2 %>
+          <% if Settings.cis2.enabled %>
             <span class="app-header__account-item">
               <%= button_to "Change role", user_cis2_omniauth_authorize_path, class: "app-header__account-button", params: { change_role: true } %>
             </span>
           <% end %>
           <span class="app-header__account-item">
-            <%= button_to "Log out", destroy_user_session_path,
+            <%= button_to "Log out", logout_path,
                           class: "app-header__account-button", method: :delete %>
           </span>
         </div>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -10,7 +10,7 @@
   <li>view and download performance reports</li>
 </ul>
 
-<% if Flipper.enabled?(:cis2) %>
+<% if Settings.cis2.enabled %>
   <%= govuk_button_to(user_cis2_omniauth_authorize_path, class: "app-button--cis2 nhsuk-u-margin-bottom-4") do %>
     <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 32" height="27" aria-hidden="true" focusable="false">
       <path fill="currentColor" d="M80 0v32H0V0h80ZM69 2.2c-5.8 0-11.6 2-11.6 8.8 0 7.4 10.2 5.8 10.2 10 0 2.6-3.4 3-5.6 3-2.2 0-5-.6-6.4-1.4L54 28c2.2.8 5.4 1.4 8 1.4 6.2 0 12.8-1.8 12.8-9 0-7.8-10.2-6.6-10.2-10.2 0-2.2 2.2-2.6 5-2.6 2.6 0 4.4.6 5.8 1.2L77 3.4c-1.8-.8-4.8-1.2-8-1.2ZM16.6 3H7.8L2.2 29h6.6l3.6-18h.2L18 29h8.6l5.6-26h-6.6L22 21h-.2L16.6 3Zm25.2 0h-7.2l-5.2 26h6.8l2.4-11.2h8.2L44.6 29h7L57 3h-7l-2.2 9.8h-8l2-9.8Z"></path>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  if Settings.cis2.present?
+  if Settings.cis2.enabled
     redirect_uri =
       begin
         host =

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,18 +11,27 @@ Rails.application.routes.draw do
           }
   end
 
-  devise_for :users,
-             module: :users,
-             path_names: {
-               sign_in: "sign-in",
-               sign_out: "sign-out"
-             },
-             controllers: {
-               omniauth_callbacks: "users/omniauth_callbacks"
-             }
-  devise_scope :user do
-    post "/users/auth/cis2/backchannel-logout",
-         to: "users/omniauth_callbacks#cis2_logout"
+  if Settings.cis2.enabled
+    devise_for :users,
+               module: :users,
+               controllers: {
+                 omniauth_callbacks: "users/omniauth_callbacks"
+               }
+    devise_scope :user do
+      post "/users/auth/cis2/backchannel-logout",
+           to: "users/omniauth_callbacks#cis2_logout"
+      delete "/logout", to: "users/omniauth_callbacks#logout"
+    end
+  else
+    devise_for :users,
+               module: :users,
+               path_names: {
+                 sign_in: "sign-in",
+                 sign_out: "sign-out"
+               }
+    devise_scope :user do
+      delete "/logout", to: "users/sessions#destroy"
+    end
   end
 
   root to: redirect("/start")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,5 +5,6 @@ web_concurrency: 2
 fast_reset: false
 
 cis2:
+  enabled: false
   min_authentication_assurance_level: 2
   acr_value: AAL2_OR_AAL3_ANY

--- a/spec/features/cis2_backchannel_logout_spec.rb
+++ b/spec/features/cis2_backchannel_logout_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "CIS2 backchannel logout" do
+describe "CIS2 backchannel logout", :cis2 do
   scenario "CIS2 sends a logout request" do
     given_the_app_is_setup
     and_that_i_am_signed_in

--- a/spec/features/user_cis2_authentication_from_start_page_spec.rb
+++ b/spec/features/user_cis2_authentication_from_start_page_spec.rb
@@ -2,7 +2,7 @@
 
 require "fixtures/cis2_auth_info"
 
-describe "User CIS2 authentication" do
+describe "User CIS2 authentication", :cis2 do
   let(:test_team_ods_code) { "AB12" }
 
   let(:cis2_auth_mock) do

--- a/spec/features/user_cis2_authentication_with_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_with_redirect_spec.rb
@@ -2,7 +2,7 @@
 
 require "fixtures/cis2_auth_info"
 
-describe "User CIS2 authentication" do
+describe "User CIS2 authentication", :cis2 do
   let(:test_team_ods_code) { "AB12" }
 
   let(:cis2_auth_mock) do

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -2,7 +2,7 @@
 
 require "fixtures/cis2_auth_info"
 
-describe "User CIS2 authentication" do
+describe "User CIS2 authentication", :cis2 do
   let(:test_team_ods_code) { "AB12" }
 
   let(:cis2_auth_info) { CIS2_AUTH_INFO.deep_dup }

--- a/spec/features/user_cis2_authentication_with_wrong_team_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_team_spec.rb
@@ -2,7 +2,7 @@
 
 require "fixtures/cis2_auth_info"
 
-describe "User CIS2 authentication" do
+describe "User CIS2 authentication", :cis2 do
   let(:test_team_ods_code) { "AB12" }
 
   let(:cis2_auth_mock) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -185,6 +185,8 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
 
+  config.filter_run_excluding cis2: true
+
   config.define_derived_metadata(
     file_path: Regexp.new("/spec/components/")
   ) { |metadata| metadata[:type] = :component }


### PR DESCRIPTION
This has wider reaching changesa as it means only one of database_authenticatable or omniauth_authenticatable is in effect at any one time, depending on whether CIS2 is on or off. The benefit is when in CIS2 mode Mavis should be more secure.