### PR TITLE
Allow users to specify location when recording vaccinations

### DIFF
--- a/app/controllers/vaccinations/edit_controller.rb
+++ b/app/controllers/vaccinations/edit_controller.rb
@@ -12,11 +12,13 @@ class Vaccinations::EditController < ApplicationController
   before_action :set_batches
   before_action :set_steps
   before_action :setup_wizard_translated
+  before_action :set_locations, only: %i[show update]
 
   after_action :verify_authorized
 
   def show
     authorize @draft_vaccination_record, :edit?
+
     render_wizard
   end
 
@@ -69,8 +71,9 @@ class Vaccinations::EditController < ApplicationController
   def update_params
     permitted_attributes = {
       "delivery-site": %i[delivery_site delivery_method],
-      confirm: %i[notes],
       batch: %i[batch_id],
+      confirm: %i[notes],
+      location: %i[location_name],
       reason: %i[reason]
     }.fetch(current_step)
 
@@ -105,6 +108,10 @@ class Vaccinations::EditController < ApplicationController
       policy_scope(Batch).where(
         vaccine: @draft_vaccination_record.vaccine
       ).order_by_name_and_expiration
+  end
+
+  def set_locations
+    @locations = policy_scope(Location).community_clinic if step == "location"
   end
 
   def set_patient_session

--- a/app/models/concerns/location_name_concern.rb
+++ b/app/models/concerns/location_name_concern.rb
@@ -4,13 +4,10 @@ module LocationNameConcern
   extend ActiveSupport::Concern
 
   included do
+    validates :location_name, absence: true, unless: :requires_location_name?
     validates :location_name,
-              absence: {
-                unless: :requires_location_name?
-              },
-              presence: {
-                if: :requires_location_name?
-              }
+              presence: true,
+              if: -> { recorded? && requires_location_name? }
   end
 
   def requires_location_name?

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -44,15 +44,15 @@ class GillickAssessment < ApplicationRecord
     validates :gillick_competent, inclusion: { in: [true, false] }
   end
 
+  on_wizard_step :location, exact: true do
+    validates :location_name, presence: true
+  end
+
   on_wizard_step :notes do
     validates :notes, length: { maximum: 1000 }, presence: true
   end
 
-  def self.wizard_steps
-    %i[gillick notes confirm]
-  end
-
   def wizard_steps
-    self.class.wizard_steps
+    [:gillick, (:location if requires_location_name?), :notes, :confirm].compact
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -99,6 +99,10 @@ class PatientSession < ApplicationRecord
     ).find_or_initialize_by(recorded_at: nil)
   end
 
+  def draft_gillick_assessment
+    draft_gillick_assessments.find_or_initialize_by(recorded_at: nil)
+  end
+
   def gillick_competent?
     latest_gillick_assessment&.gillick_competent?
   end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -176,6 +176,10 @@ class VaccinationRecord < ApplicationRecord
     validates :batch_id, presence: true
   end
 
+  on_wizard_step :location, exact: true do
+    validates :location_name, presence: true
+  end
+
   def administered?
     administered_at != nil
   end
@@ -196,8 +200,9 @@ class VaccinationRecord < ApplicationRecord
 
   def wizard_steps
     [
-      ("delivery-site" if administered? && delivery_site_other),
+      (:"delivery-site" if administered? && delivery_site_other),
       (:batch if administered? && todays_batch.nil?),
+      (:location if requires_location_name?),
       (:reason if not_administered?),
       :confirm
     ].compact

--- a/app/views/gillick_assessments/location.html.erb
+++ b/app/views/gillick_assessments/location.html.erb
@@ -1,0 +1,28 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: previous_wizard_path,
+        name: "previous page",
+      ) %>
+<% end %>
+
+<% title = "Where was the vaccination given?" %>
+<% content_for :page_title, title %>
+
+<%= form_with model: @assessment,
+              url: wizard_path,
+              method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :location_name,
+                                     caption: { text: @patient.full_name, size: "l" },
+                                     legend: { size: "l", tag: "h1",
+                                               text: title } do %>
+    <% @locations.each do |location| %>
+      <%= f.govuk_radio_button :location_name, "#{location.name}, #{format_address_single_line(location)}",
+                               label: { text: location.name },
+                               hint: { text: format_address_single_line(location) } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/vaccinations/edit/location.html.erb
+++ b/app/views/vaccinations/edit/location.html.erb
@@ -1,0 +1,29 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: vaccinations_back_link_path,
+        name: "vaccination page",
+      ) %>
+<% end %>
+
+<% title = "Where was the vaccination given?" %>
+<% content_for :page_title, title %>
+
+<%= form_with model: @draft_vaccination_record,
+              url: wizard_path,
+              method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :location_name,
+                                     caption: { text: @patient.full_name, size: "l" },
+                                     legend: { size: "l", tag: "h1",
+                                               text: title } do %>
+
+    <% @locations.each do |location| %>
+      <%= f.govuk_radio_button :location_name, "#{location.name}, #{format_address_single_line(location)}",
+                               label: { text: location.name },
+                               hint: { text: format_address_single_line(location) } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -430,6 +430,8 @@ en:
           attributes:
             gillick_competent:
               inclusion: Choose if they are Gillick competent
+            location_name:
+              blank: Enter where the vaccination was given
             notes:
               blank: Enter details of your assessment
               too_long: Enter details that are less than 1000 characters long
@@ -514,6 +516,8 @@ en:
               inclusion: Choose a method of delivery
             delivery_site:
               inclusion: Choose a delivery site
+            location_name:
+              blank: Enter where the vaccination was given
             notes:
               too_long: Enter notes that are less than 1000 characters long
             reason:

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -47,7 +47,7 @@ FactoryBot.define do
     trait :generic_clinic do
       clinic
       type { :generic_clinic }
-      name { "#{team.name} Clinic" }
+      name { "Community clinics" }
       ods_code { team.ods_code }
     end
 

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -86,7 +86,7 @@ FactoryBot.define do
         Faker::Date.birthday(min_age: 7, max_age: 16)
       end
     end
-    school { session&.location }
+    school { session.location if session&.location&.school? }
     registration do
       "#{date_of_birth.year_group}#{Faker::Alphanumeric.alpha(number: 2)}"
     end

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+describe "HPV Vaccination" do
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
+
+  scenario "Administered at a clinic" do
+    given_i_am_signed_in
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_record_that_the_patient_has_been_vaccinated
+    and_i_select_the_batch
+    and_i_select_a_location
+    then_i_see_the_confirmation_page
+
+    when_i_confirm_the_details
+    then_i_see_the_record_vaccinations_page
+    and_a_success_message
+
+    when_i_go_to_the_patient
+    then_i_see_that_the_status_is_vaccinated
+    and_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+  end
+
+  def given_i_am_signed_in
+    programme = create(:programme, :hpv_all_vaccines)
+    team = create(:team, :with_one_nurse, programmes: [programme])
+    location = create(:location, :generic_clinic, team:)
+
+    @community_clinic = create(:location, :community_clinic, team:)
+
+    programme.vaccines.discontinued.each do |vaccine|
+      create(:batch, team:, vaccine:)
+    end
+
+    active_vaccine = programme.vaccines.active.first
+    @active_batch = create(:batch, team:, vaccine: active_vaccine)
+
+    @session = create(:session, team:, programme:, location:)
+    @patient =
+      create(:patient, :consent_given_triage_not_needed, session: @session)
+
+    sign_in team.users.first
+  end
+
+  def when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    visit session_triage_path(@session)
+    click_link "No triage needed"
+    click_link @patient.full_name
+  end
+
+  def and_i_record_that_the_patient_has_been_vaccinated
+    choose "Yes, they got the HPV vaccine"
+    choose "Left arm"
+    click_button "Continue"
+  end
+
+  def and_i_select_the_batch
+    choose @active_batch.name
+    click_button "Continue"
+  end
+
+  def and_i_select_a_location
+    choose @community_clinic.name
+    click_button "Continue"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content("Child#{@patient.full_name}")
+    expect(page).to have_content("Batch#{@active_batch.name}")
+    expect(page).to have_content("MethodIntramuscular")
+    expect(page).to have_content("SiteLeft arm")
+    expect(page).to have_content("OutcomeVaccinated")
+  end
+
+  def when_i_confirm_the_details
+    click_button "Confirm"
+  end
+
+  def then_i_see_the_record_vaccinations_page
+    expect(page).to have_content("Record vaccinations")
+  end
+
+  def and_a_success_message
+    expect(page).to have_content(
+      "Vaccination recorded for #{@patient.full_name}"
+    )
+  end
+
+  def when_i_go_to_the_patient
+    click_link @patient.full_name
+  end
+
+  def then_i_see_that_the_status_is_vaccinated
+    expect(page).to have_content("Vaccinated")
+  end
+
+  def and_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    expect_email_to(
+      @patient.consents.last.parent.email,
+      :confirmation_the_hpv_vaccination_has_taken_place
+    )
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+    expect_text_to(
+      @patient.consents.last.parent.phone,
+      :vaccination_has_taken_place
+    )
+  end
+end

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -69,8 +69,7 @@ describe "Manage sessions" do
         :team,
         :with_one_nurse,
         :with_generic_clinic,
-        programmes: [@programme],
-        name: "Coventry"
+        programmes: [@programme]
       )
     @location = create(:location, :secondary, team: @team)
     session =
@@ -221,13 +220,13 @@ describe "Manage sessions" do
   end
 
   def then_i_see_the_team_clinic
-    expect(page).to have_content("Coventry Clinic")
+    expect(page).to have_content("Community clinics")
   end
 
   alias_method :and_i_see_the_team_clinic, :then_i_see_the_team_clinic
 
   def when_i_click_on_the_team_clinic
-    click_on "Coventry Clinic"
+    click_on "Community clinics"
   end
 
   def then_i_see_no_children_in_the_cohort

--- a/spec/features/self_consent_clinic_spec.rb
+++ b/spec/features/self_consent_clinic_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+describe "Self-consent" do
+  after { travel_back }
+
+  scenario "Performed at a clinic" do
+    given_an_hpv_programme_is_underway
+    and_it_is_the_day_of_a_vaccination_session
+    and_there_is_a_child_without_parental_consent
+
+    when_the_nurse_assesses_the_child_as_gillick_competent
+    then_the_child_can_give_their_own_consent_that_the_nurse_records
+
+    when_the_nurse_views_the_childs_record
+    then_they_see_that_the_child_has_consent
+    and_the_details_of_the_gillick_competence_assessment_are_visible
+    and_the_child_should_be_safe_to_vaccinate
+  end
+
+  def given_an_hpv_programme_is_underway
+    programme = create(:programme, :hpv)
+    @team =
+      create(
+        :team,
+        :with_one_nurse,
+        programmes: [programme],
+        nurse_email: "nurse.joy@example.com"
+      )
+    location = create(:location, :generic_clinic, team: @team)
+    @community_clinic = create(:location, :community_clinic, team: @team)
+    @session = create(:session, :scheduled, team: @team, programme:, location:)
+    @child = create(:patient, session: @session)
+  end
+
+  def and_it_is_the_day_of_a_vaccination_session
+    travel_to(@session.dates.first.value)
+  end
+
+  def and_there_is_a_child_without_parental_consent
+    sign_in @team.users.first
+
+    visit "/dashboard"
+
+    click_on "Programmes", match: :first
+    click_on "HPV"
+    within ".app-secondary-navigation" do
+      click_on "Sessions"
+    end
+    click_on "Community clinics"
+    click_on "Check consent responses"
+
+    expect(page).to have_content("No consent ( 1 )")
+    expect(page).to have_content(@child.full_name)
+  end
+
+  def when_the_nurse_assesses_the_child_as_gillick_competent
+    click_on @child.full_name
+    click_link "Give your assessment"
+
+    click_through_guidance
+    record_competence
+    record_location
+    record_details_of_assessment
+    check_and_confirm
+  end
+
+  def click_through_guidance
+    expect(page).to have_content("Assessing Gillick competence")
+    click_button "Give your assessment"
+  end
+
+  def record_competence
+    # try submitting without filling in the form
+    click_on "Continue"
+    expect(page).to have_content("There is a problem")
+    expect(page).to have_content("Choose if they are Gillick competent")
+
+    choose "Yes, they are Gillick competent"
+    click_on "Continue"
+  end
+
+  def record_location
+    # try submitting without filling in the form
+    click_on "Continue"
+    expect(page).to have_content("Enter where the vaccination was given")
+
+    choose @community_clinic.name
+    click_on "Continue"
+  end
+
+  def record_details_of_assessment
+    # try submitting without filling in the form
+    click_on "Continue"
+    expect(page).to have_content("Enter details of your assessment")
+
+    fill_in "Details of your assessment",
+            with: "They understand the benefits and risks of the vaccine"
+    click_on "Continue"
+  end
+
+  def check_and_confirm
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content(
+      ["Are they Gillick competent?", "Yes, they are Gillick competent"].join
+    )
+    expect(page).to have_content(
+      [
+        "Details of your assessment",
+        "They understand the benefits and risks of the vaccine"
+      ].join
+    )
+    click_on "Save changes"
+  end
+
+  def then_the_child_can_give_their_own_consent_that_the_nurse_records
+    click_on "Get consent"
+
+    # record consent
+    choose "Yes, they agree"
+    click_on "Continue"
+
+    # answer the health questions
+    all("label", text: "No").each(&:click)
+    click_on "Continue"
+
+    choose "Yes, it’s safe to vaccinate"
+    click_on "Continue"
+
+    # confirmation page
+    click_on "Confirm"
+
+    expect(page).to have_content("Check consent responses")
+    expect(page).to have_content("Given ( 1 )")
+  end
+
+  def when_the_nurse_views_the_childs_record
+    click_on @child.full_name
+  end
+
+  def then_they_see_that_the_child_has_consent
+    expect(page).to have_content(
+      "#{@child.full_name} Child (Gillick competent)"
+    )
+    expect(page).to have_content("Consent given")
+  end
+
+  def and_the_details_of_the_gillick_competence_assessment_are_visible
+    expect(page).to have_content("Yes, they are Gillick competent")
+    expect(page).to have_content(
+      "They understand the benefits and risks of the vaccine"
+    )
+
+    click_on @child.full_name
+    expect(page).not_to have_content("Parent or guardian")
+    click_on "Back to patient page"
+  end
+
+  def and_the_child_should_be_safe_to_vaccinate
+    expect(page).to have_content("Safe to vaccinate")
+  end
+end


### PR DESCRIPTION
This updates the vaccination workflow to ask the user to specify where the vaccination happened if it's being recorded against a generic clinic. They are presented with a list of community clinics for that team, and required to pick from the list.

This flow is also applied to gillick assessments, although not currently in the designs, and there's still a question around whether we'll actually need this functionality, but we can remove it later.

I've based the feature tests on the existing ones but they could probably be refactored and tidied up at some point later.

## Screenshot

![Screenshot 2024-10-23 at 15 02 38](https://github.com/user-attachments/assets/89ee6a47-a13d-4aeb-993a-71be20e8422d)
