### PR TITLE
Propose move to generic clinic when uploading class list

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -58,20 +58,9 @@ class ClassImport < PatientImport
     # Remove unknown patients from the session and school
     unknown_patients = session.patients - patients
 
-    Patient.where(id: unknown_patients.map(&:id)).update_all(school_id: nil)
-
     session
       .patient_sessions
       .where(patient: unknown_patients)
-      .find_each(&:destroy_if_safe!)
-
-    # Add the unknown patients to the generic clinic
-    generic_clinic_session_id = team.generic_clinic_session.id
-
-    PatientSession.import!(
-      %i[patient_id session_id],
-      unknown_patients.map { [_1.id, generic_clinic_session_id] },
-      on_duplicate_key_ignore: true
-    )
+      .update_all(proposed_session_id: team.generic_clinic_session.id)
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -143,6 +143,10 @@ class PatientSession < ApplicationRecord
     PatientSession.transaction do
       PatientSession.create!(patient:, session: proposed_session)
 
+      school = proposed_session.location
+      school = nil if school.generic_clinic?
+      patient.update!(school:)
+
       safe_to_destroy? ? destroy! : update!(proposed_session: nil)
     end
   end

--- a/app/views/session_moves/index.html.erb
+++ b/app/views/session_moves/index.html.erb
@@ -70,9 +70,12 @@
             <span class="nhsuk-table-responsive__heading">
               <%= @tab == :in ? "School joined from" : "School moved to" %>
             </span>
-            <%= @tab == :in ?
-                  patient_session.session.location.name :
-                  patient_session.proposed_session.location.name %>
+            <% school = @tab == :in ?
+                 patient_session.session :
+                 patient_session.proposed_session %>
+            <%= school.location.generic_clinic? ?
+                  "Unknown school" :
+                  school.location.name %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/views/session_moves/index.html.erb
+++ b/app/views/session_moves/index.html.erb
@@ -49,7 +49,9 @@
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
           <% row.with_cell(text: "Full name") %>
-          <% row.with_cell(text: "School joined from") %>
+          <% row.with_cell(text: @tab == :in ?
+                             "School joined from" :
+                             "School moved to") %>
           <% row.with_cell(text: "Actions") %>
         <% end %>
       <% end %>
@@ -65,8 +67,12 @@
           <% end %>
 
           <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">School joined from</span>
-            <%= patient_session.session.location.name %>
+            <span class="nhsuk-table-responsive__heading">
+              <%= @tab == :in ? "School joined from" : "School moved to" %>
+            </span>
+            <%= @tab == :in ?
+                  patient_session.session.location.name :
+                  patient_session.proposed_session.location.name %>
           <% end %>
 
           <% row.with_cell do %>

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -166,8 +166,10 @@ describe PatientSession do
     it "destroys the patient session, creates one with the proposed session" do
       # stree-ignore
       expect { confirm_transfer! }
-        .to change { described_class.exists?(patient_session.id) }
-        .from(true).to(false)
+        .to change { patient_session.patient.reload.school }
+          .from(original_session.location).to(proposed_session.location)
+        .and change { described_class.exists?(patient_session.id) }
+          .from(true).to(false)
         .and not_change(patient_session.patient.patient_sessions, :count)
     end
 
@@ -188,6 +190,21 @@ describe PatientSession do
           .to change(patient_session, :proposed_session).to(nil)
           .and not_change(patient_session, :session)
           .and change(patient_session.patient.patient_sessions, :count).by(1)
+          .and change { patient_session.patient.reload.school }
+            .from(original_session.location).to(proposed_session.location)
+      end
+    end
+
+    context "when the patient session is for the generic clinic" do
+      let(:team) { original_session.team }
+      let(:location) { create(:location, :generic_clinic, team:) }
+      let(:proposed_session) { create(:session, location:, team:, programme:) }
+
+      it "updates the patient's school to nil" do
+        expect { confirm_transfer! }.to change(
+          patient_session.patient,
+          :school
+        ).to(nil)
       end
     end
   end


### PR DESCRIPTION
When users upload a class list, instead of automatically moving patients to the generic clinic, propose their move to that session.

Also update the heading/content for the column to be accurate (before it was always "School joined from" in both tabs which is wrong).

![Screenshot 2024-10-24 at 08 40 30](https://github.com/user-attachments/assets/e9c8d3e0-c7d0-4176-b1f0-7b92a8179ec1)

