### PR TITLE
Add "Send consent request" functionality

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -1,9 +1,19 @@
 <%= render AppConsentStatusComponent.new(patient_session:) %>
 
 <% if patient_session.no_consent? %>
-  <p class="app-status">
-    No response yet
-  </p>
+  <% if latest_consent_request %>
+    <p class="nhsuk-body">
+      No-one responded to our requests for consent.
+    </p>
+
+    <p class="nhsuk-body">
+      A request was sent on <%= latest_consent_request.sent_at.to_fs(:long) %>.
+    </p>
+  <% else %>
+    <p class="nhsuk-body">
+      No requests have been sent.
+    </p>
+  <% end %>
 <% end %>
 
 <% if consents.present? %>
@@ -32,9 +42,8 @@
   <% end %>
 <% end %>
 
-<p>
-  <%= form_with url: session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab),
-                builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-    <%= f.govuk_submit "Get consent" %>
-  <% end %>
-</p>
+<% if patient_session.no_consent? %>
+  <%= govuk_button_to "Send consent request", session_patient_request_consent_path(session, patient_id: patient.id, section: @section, tab: @tab), class: "app-button--secondary" %>
+<% end %>
+
+<%= govuk_button_to "Get consent response", session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab), class: "app-button--secondary" %>

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -15,6 +15,16 @@ class AppConsentComponent < ViewComponent::Base
   delegate :session, to: :patient_session
 
   def consents
-    patient_session.consents.recorded.order(recorded_at: :desc)
+    @consents ||= patient_session.consents.recorded.order(recorded_at: :desc)
+  end
+
+  def latest_consent_request
+    @latest_consent_request ||=
+      patient
+        .consent_notifications
+        .request
+        .where(programme: session.programmes)
+        .order(sent_at: :desc)
+        .first
   end
 end

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -16,6 +16,29 @@ class PatientSessionsController < ApplicationController
   def log
   end
 
+  def request_consent
+    return unless @patient_session.no_consent?
+
+    @session.programmes.each do |programme|
+      ConsentNotification.create_and_send!(
+        patient: @patient,
+        programme:,
+        session: @session,
+        type: :request
+      )
+    end
+
+    redirect_to session_patient_path(
+                  @session,
+                  @patient,
+                  section: @section,
+                  tab: @tab
+                ),
+                flash: {
+                  success: "Consent request sent."
+                }
+  end
+
   private
 
   def set_patient_session

--- a/app/jobs/consent_reminders_job.rb
+++ b/app/jobs/consent_reminders_job.rb
@@ -11,12 +11,15 @@ class ConsentRemindersJob < ApplicationJob
         .send_consent_reminders
         .includes(
           :dates,
+          :location,
           :programmes,
           patients: %i[consents consent_notifications parents]
         )
         .strict_loading
 
     sessions.each do |session|
+      next if session.location.generic_clinic?
+
       session.programmes.each do |programme|
         session.patients.each do |patient|
           next unless should_send_notification?(patient:, programme:, session:)

--- a/app/jobs/consent_requests_job.rb
+++ b/app/jobs/consent_requests_job.rb
@@ -9,10 +9,16 @@ class ConsentRequestsJob < ApplicationJob
     sessions =
       Session
         .send_consent_requests
-        .includes(:programmes, patients: %i[consents consent_notifications])
+        .includes(
+          :location,
+          :programmes,
+          patients: %i[consents consent_notifications]
+        )
         .strict_loading
 
     sessions.each do |session|
+      next if session.location.generic_clinic?
+
       session.programmes.each do |programme|
         session.patients.each do |patient|
           next unless should_send_notification?(patient:, programme:)

--- a/app/jobs/session_reminders_job.rb
+++ b/app/jobs/session_reminders_job.rb
@@ -10,12 +10,14 @@ class SessionRemindersJob < ApplicationJob
 
     patient_sessions =
       PatientSession
-        .includes(:consents, :patient, :vaccination_records)
+        .includes(:consents, :location, :patient, :vaccination_records)
         .joins(:session)
         .merge(Session.has_date(date))
         .reminder_not_sent(date)
 
     patient_sessions.each do |patient_session|
+      next if patient_session.location.generic_clinic?
+
       next unless should_send_notification?(patient_session)
 
       # We create a record in the database first to avoid sending duplicate emails/texts.

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -192,7 +192,7 @@ class Session < ApplicationRecord
   end
 
   def set_consent_dates
-    if dates.empty?
+    if dates.empty? || location.generic_clinic?
       self.days_before_consent_reminders = nil
       self.send_consent_requests_at = nil
     else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,7 @@ Rails.application.routes.draw do
                 as: :patient,
                 only: %i[show] do
         get "log"
+        post "request-consent", action: :request_consent
 
         post "consents", to: "manage_consents#create", as: :manage_consents
         resources :manage_consents,

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -85,6 +85,22 @@ describe AppActivityLogComponent do
         performed_by: user,
         notes: "Some notes"
       )
+
+      create(
+        :consent_notification,
+        :request,
+        programme:,
+        patient:,
+        sent_at: Date.new(2024, 5, 10)
+      )
+
+      create(
+        :session_notification,
+        session:,
+        patient:,
+        sent_at: Date.new(2024, 5, 30)
+      )
+
       render_inline(component)
     end
 
@@ -99,6 +115,10 @@ describe AppActivityLogComponent do
                      date: "31 May 2024 at 12:00pm",
                      notes: "Some notes",
                      by: "Nurse Joy"
+
+    include_examples "card",
+                     title: "Session reminder sent",
+                     date: "30 May 2024 at 12:00am"
 
     include_examples "card",
                      title: "Triaged decision: Safe to vaccinate",
@@ -122,6 +142,10 @@ describe AppActivityLogComponent do
     include_examples "card",
                      title: "Added to session at Hogwarts",
                      date: "29 May 2024 at 12:00pm"
+
+    include_examples "card",
+                     title: "Consent request sent for HPV",
+                     date: "10 May 2024 at 12:00am"
   end
 
   describe "self-consent" do

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -16,7 +16,7 @@ describe AppConsentComponent, type: :component do
     it { should_not have_css("p.app-status", text: "Consent (given|refused)") }
     it { should_not have_css("details", text: /Consent (given|refused) by/) }
     it { should_not have_css("details", text: "Responses to health questions") }
-    it { should have_css("p", text: "No response yet") }
+    it { should have_css("p", text: "No requests have been sent.") }
     it { should have_css("button", text: "Get consent") }
   end
 

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe AppPatientPageComponent, type: :component do
+describe AppPatientPageComponent do
   subject(:rendered) { render_inline(component) }
 
   def stub_authorization(allowed:)

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -35,9 +35,13 @@ FactoryBot.define do
     team { association(:team, programmes:) }
     location { association :location, :school, team: }
 
-    days_before_consent_reminders { team.days_before_consent_reminders if date }
+    days_before_consent_reminders do
+      team.days_before_consent_reminders if date && !location.generic_clinic?
+    end
     send_consent_requests_at do
-      (date - team.days_before_consent_requests.days) if date
+      if date && !location.generic_clinic?
+        (date - team.days_before_consent_requests.days)
+      end
     end
 
     after(:create) do |session, evaluator|

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+describe "Parental consent" do
+  scenario "Send request" do
+    given_a_patient_without_consent_exists
+    and_i_am_signed_in
+
+    when_i_go_to_a_patient_without_consent
+    then_i_see_no_requests_sent
+
+    when_i_click_send_consent_request
+    then_i_see_the_confirmation_banner
+    and_i_see_a_consent_request_has_been_sent
+    and_an_email_is_sent_to_the_parent
+    and_a_text_is_sent_to_the_parent
+  end
+
+  def given_a_patient_without_consent_exists
+    programme = create(:programme, :hpv)
+    @team = create(:team, :with_one_nurse, programmes: [programme])
+
+    @session = create(:session, team: @team, programme:)
+    @patient = create(:patient, session: @session)
+    @parent = @patient.parents.first
+  end
+
+  def and_i_am_signed_in
+    sign_in @team.users.first
+  end
+
+  def when_i_go_to_a_patient_without_consent
+    visit session_consents_path(@session)
+    click_link @patient.full_name
+  end
+
+  def then_i_see_no_requests_sent
+    expect(page).to have_content("No requests have been sent.")
+  end
+
+  def when_i_click_send_consent_request
+    click_on "Send consent request"
+  end
+
+  def then_i_see_the_confirmation_banner
+    expect(page).to have_content("Consent request sent.")
+  end
+
+  def and_i_see_a_consent_request_has_been_sent
+    expect(page).to have_content(
+      "No-one responded to our requests for consent."
+    )
+    expect(page).to have_content("A request was sent on")
+  end
+
+  def and_an_email_is_sent_to_the_parent
+    expect_email_to(@parent.email, :hpv_session_consent_request)
+  end
+
+  def and_a_text_is_sent_to_the_parent
+    expect_text_to(@parent.phone, :consent_request)
+  end
+end

--- a/spec/jobs/consent_reminders_job_spec.rb
+++ b/spec/jobs/consent_reminders_job_spec.rb
@@ -43,14 +43,19 @@ describe ConsentRemindersJob do
 
   let(:dates) { [Date.new(2024, 1, 12), Date.new(2024, 1, 15)] }
 
+  let(:team) { create(:team, programmes: [programme]) }
+  let(:location) { create(:location, :school, team:) }
+
   let!(:session) do
     create(
       :session,
       date: nil,
       dates: dates.map { build(:session_date, value: _1) },
+      days_before_consent_reminders: 7,
+      location:,
       patients:,
       programme:,
-      days_before_consent_reminders: 7
+      team:
     )
   end
 
@@ -80,6 +85,15 @@ describe ConsentRemindersJob do
 
     it "records a notification" do
       expect { perform_now }.to change(ConsentNotification, :count).by(1)
+    end
+
+    context "when location is a generic clinic" do
+      let(:location) { create(:location, :generic_clinic, team:) }
+
+      it "doesn't send any notifications" do
+        expect(ConsentNotification).not_to receive(:create_and_send!)
+        perform_now
+      end
     end
   end
 

--- a/spec/jobs/consent_requests_job_spec.rb
+++ b/spec/jobs/consent_requests_job_spec.rb
@@ -76,5 +76,24 @@ describe ConsentRequestsJob do
       )
       perform_now
     end
+
+    context "when location is a generic clinic" do
+      let(:team) { create(:team, programmes: [programme]) }
+      let(:location) { create(:location, :generic_clinic, team:) }
+      let(:session) do
+        create(
+          :session,
+          patients:,
+          programme:,
+          send_consent_requests_at: Date.current,
+          team:
+        )
+      end
+
+      it "doesn't send any notifications" do
+        expect(ConsentNotification).not_to receive(:create_and_send!)
+        perform_now
+      end
+    end
   end
 end

--- a/spec/jobs/session_reminders_job_spec.rb
+++ b/spec/jobs/session_reminders_job_spec.rb
@@ -144,6 +144,34 @@ describe SessionRemindersJob do
     end
   end
 
+  context "for a generic clinic session tomorrow" do
+    let(:team) { create(:team, programmes: [programme]) }
+    let(:location) { create(:location, :generic_clinic, team:) }
+
+    before do
+      create(
+        :session,
+        programme:,
+        date: Date.tomorrow,
+        patients: [patient],
+        team:,
+        location:
+      )
+    end
+
+    it "doesn't send a reminder email" do
+      expect { perform_now }.not_to have_enqueued_mail(SessionMailer, :reminder)
+    end
+
+    it "doesn't sent a reminder text" do
+      expect { perform_now }.not_to have_enqueued_text(:session_reminder)
+    end
+
+    it "doesn't record a notification" do
+      expect { perform_now }.not_to change(SessionNotification, :count)
+    end
+  end
+
   context "for a session today" do
     before do
       create(:session, programme:, date: Time.zone.today, patients: [patient])


### PR DESCRIPTION
This adds the ability to manually send a consent request to the parents of a patient, this is most relevant for clinics but will also be available in school sessions.

We show to the user if a request has already been sent out, and when that was, so they can make a decision on whether to re-send the request.

## Screenshots

![Screenshot 2024-10-23 at 18 30 33](https://github.com/user-attachments/assets/8b295f17-dc5c-42a9-88bc-048f6a9b0b00)
![Screenshot 2024-10-23 at 18 30 28](https://github.com/user-attachments/assets/b7128f3d-7109-4e60-a5c1-1f16c051eafc)
![Screenshot 2024-10-23 at 18 30 23](https://github.com/user-attachments/assets/5f476aef-6a1c-4b1f-b807-114ae5b72d53)
