### PR TITLE
Display patient's initials instead of full name in activity log page title

### DIFF
--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -5,7 +5,7 @@
       ) %>
 <% end %>
 
-<%= h1 page_title: @patient.full_name do %>
+<%= h1 page_title: @patient.initials do %>
   <span class="nhsuk-caption-l"><%= patient_school(@patient) %></span>
   <%= @patient.full_name %>
 <% end %>


### PR DESCRIPTION
The name is PII that shouldn't be left in SAIS team's browser history