### PR TITLE
Don't replace patient's gender if already known

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -8,7 +8,11 @@ class PatientImportRow
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :nhs_number, length: { is: 10 }, allow_blank: true
-  validates :gender_code, inclusion: { in: Patient.gender_codes.keys }
+  validates :gender_code,
+            inclusion: {
+              in: Patient.gender_codes.keys,
+              allow_nil: true
+            }
   validates :year_group,
             inclusion: {
               in: :year_groups
@@ -166,8 +170,7 @@ class PatientImportRow
   end
 
   def gender_code
-    @data["CHILD_GENDER"]&.strip&.downcase&.gsub(" ", "_").presence ||
-      "not_known"
+    @data["CHILD_GENDER"]&.strip&.downcase&.gsub(" ", "_").presence
   end
 
   def address_line_1

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -124,15 +124,16 @@ describe ClassImportRow do
       let!(:existing_patient) do
         create(
           :patient,
-          nhs_number: "0123456789",
-          given_name: "Jimmy",
+          address_postcode: "SW1A 1AA",
           family_name: "Smith",
-          address_postcode: "SW1A 1AA"
+          gender_code: "male",
+          given_name: "Jimmy",
+          nhs_number: "0123456789"
         )
       end
 
       it { should eq(existing_patient) }
-
+      it { should be_male }
       it { should have_attributes(nhs_number: "0123456789") }
     end
 


### PR DESCRIPTION
This follows on from 350e97cc4cfda1c492d46fc5fb442f615714139d to ensure that we don't replace the gender code of a patient if we're importing new information and we match with an existing patient and there's no gender information available.