### PR TITLE
Add consent requests for clinics

### DIFF
--- a/app/mailers/consent_mailer.rb
+++ b/app/mailers/consent_mailer.rb
@@ -17,8 +17,12 @@ class ConsentMailer < ApplicationMailer
     app_template_mail(:parental_consent_confirmation_refused)
   end
 
-  def request
-    app_template_mail(:hpv_session_consent_request)
+  def request_for_school
+    app_template_mail(:hpv_session_consent_request_for_school)
+  end
+
+  def request_for_clinic
+    app_template_mail(:hpv_session_consent_request_for_clinic)
   end
 
   def initial_reminder

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -40,10 +40,17 @@ class ConsentNotification < ApplicationRecord
 
     ConsentNotification.create!(programme:, patient:, type:)
 
+    mailer_action =
+      if type == :request
+        session.location.clinic? ? :request_for_clinic : :request_for_school
+      else
+        type
+      end
+
     patient.parents.each do |parent|
       ConsentMailer
         .with(parent:, patient:, programme:, session:)
-        .send(type)
+        .send(mailer_action)
         .deliver_later
 
       TextDeliveryJob.perform_later(

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -8,7 +8,10 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   hpv_session_consent_reminder: "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
   hpv_session_consent_reminder_subsequent:
     "6410145f-dac1-46ba-82f3-a49cad0f66a6",
-  hpv_session_consent_request: "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
+  hpv_session_consent_request_for_school:
+    "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
+  hpv_session_consent_request_for_clinic:
+    "14e88a09-4281-4257-9574-6afeaeb42715",
   hpv_session_session_reminder: "79e131b2-7816-46d0-9c74-ae14956dd77d",
   parental_consent_confirmation: "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
   parental_consent_confirmation_injection:

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -19,7 +19,9 @@ describe "Parental consent" do
     programme = create(:programme, :hpv)
     @team = create(:team, :with_one_nurse, programmes: [programme])
 
-    @session = create(:session, team: @team, programme:)
+    location = create(:location, :generic_clinic, team: @team)
+
+    @session = create(:session, team: @team, programme:, location:)
     @patient = create(:patient, session: @session)
     @parent = @patient.parents.first
   end
@@ -53,7 +55,7 @@ describe "Parental consent" do
   end
 
   def and_an_email_is_sent_to_the_parent
-    expect_email_to(@parent.email, :hpv_session_consent_request)
+    expect_email_to(@parent.email, :hpv_session_consent_request_for_clinic)
   end
 
   def and_a_text_is_sent_to_the_parent


### PR DESCRIPTION
This adds a custom email that we send when request consent for a clinic, which is triggered manually once someone has booked on to the clinic.

The template already exists in GOV.UK Notify.