### PR TITLE
Incorrect status shown when a SAIS team member records a refusal

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -102,13 +102,8 @@ class ManageConsentsController < ApplicationController
 
   def handle_confirm
     ActiveRecord::Base.transaction do
-      if @consent.response_refused?
-        @triage.update!(status: "do_not_vaccinate", performed_by: current_user)
-      end
-
-      if @triage.persisted?
-        send_triage_confirmation(@patient_session, @consent)
-      else
+      send_triage_confirmation(@patient_session, @consent)
+      unless @triage.persisted?
         # We need to discard the draft triage record so that the patient
         # session can be saved.
         @triage.destroy!

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -8,7 +8,7 @@ describe "Verbal consent" do
 
     then_an_email_is_sent_to_the_parent_confirming_the_refusal
     and_a_text_is_sent_to_the_parent_confirming_the_refusal
-    and_the_patients_status_is_do_not_vaccinate
+    and_the_patients_status_is_consent_refused
     and_i_can_see_the_consent_response_details
   end
 
@@ -60,9 +60,12 @@ describe "Verbal consent" do
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def and_the_patients_status_is_do_not_vaccinate
+  def and_the_patients_status_is_consent_refused
     click_link @patient.full_name
-    expect(page).to have_content("Could not vaccinate")
+
+    relation = @patient.parents.first.relationship_to(patient: @patient).label
+    expect(page).to have_content("Consent refused")
+    expect(page).to have_content("#{relation} refused to give consent.")
   end
 
   def and_i_can_see_the_consent_response_details


### PR DESCRIPTION
When a SAIS team member was recording a refusal from a parent/guardian (likely verbal or paper), Mavis was inappropriately displaying that that staff member had made a decision not to vaccinate that patient, when in fact the staff member had not actually taken that decision.

Under the hood, this was happening as a result of a 'do not vaccinate' triage decision being recorded automatically, in addition to the consent refusal.

This change aligns Mavis consent refusals with refusals through the parent form. 
It reverses the change introduced in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/1108 (commit 8a7c186c41496c740de2fd09b28d64c3b13aaa11) – I'm not sure why we made that decision at the time.