### PR TITLE
Tidy references to consent form session

### DIFF
--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -30,6 +30,7 @@ module ParentInterface
     end
 
     def cannot_consent_responsibility
+      @team = @consent_form.team
     end
 
     def deadline_passed

--- a/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
@@ -8,12 +8,11 @@
 <%= h1 "You cannot give or refuse consent through this service" %>
 
 <p>
-  To give or refuse consent for a child’s vaccination, you need to have parental responsibility.
+  To give or refuse consent for a child’s vaccination, you need to have
+  parental responsibility.
 </p>
 
 <p>
   If you have any questions, please contact the local health team by calling
-  <%= @session.team.phone %>, or email
-  <a class="nhsuk-link" href="mailto:<%= @session.team.email %>">
-    <%= @session.team.email %></a>.
+  <%= @team.phone %>, or email <%= mail_to @team.email %>.
 </p>


### PR DESCRIPTION
The consent form session is dynamic depending on when the parent is filling out consent, so it's safer to get the team from the consent form directly.