### PR TITLE
Fix patient merge when patient session already exists

### DIFF
--- a/app/jobs/concerns/merge_patients_concern.rb
+++ b/app/jobs/concerns/merge_patients_concern.rb
@@ -16,10 +16,10 @@ module MergePatientsConcern
                )
            )
           patient_session.gillick_assessments.update_all(
-            patient_session: existing_patient_session
+            patient_session_id: existing_patient_session.id
           )
           patient_session.vaccination_records.update_all(
-            patient_session: existing_patient_session
+            patient_session_id: existing_patient_session.id
           )
         else
           patient_session.update!(patient: patient_to_keep)


### PR DESCRIPTION
We were calling `update_all` and passing in a patient session which is not supported, and there was no test for this scenario so it wasn't caught.

https://good-machine.sentry.io/issues/6016479286/