### PR TITLE
Don't get given name from PDS

### DIFF
--- a/app/models/pds/patient.rb
+++ b/app/models/pds/patient.rb
@@ -4,7 +4,6 @@ class PDS::Patient
   include ActiveModel::Model
 
   attr_accessor :nhs_number,
-                :given_name,
                 :family_name,
                 :date_of_birth,
                 :date_of_death,
@@ -37,7 +36,6 @@ class PDS::Patient
     def from_pds_fhir_response(response)
       new(
         nhs_number: response["id"],
-        given_name: response["name"][0]["given"][0],
         family_name: response["name"][0]["family"],
         date_of_birth: Date.parse(response["birthDate"]),
         date_of_death:

--- a/spec/models/pds/patient_spec.rb
+++ b/spec/models/pds/patient_spec.rb
@@ -24,7 +24,6 @@ describe PDS::Patient do
     it "parses the patient information" do
       expect(find).to have_attributes(
         nhs_number: "9000000009",
-        given_name: "Jane",
         family_name: "Smith",
         date_of_birth: Date.new(2010, 10, 22),
         date_of_death: Date.new(2010, 10, 22),
@@ -73,7 +72,6 @@ describe PDS::Patient do
     it "parses the patient information" do
       expect(search).to have_attributes(
         nhs_number: "9449306168",
-        given_name: "ELDREDA",
         family_name: "LAWMAN",
         date_of_birth: Date.new(1939, 1, 9),
         date_of_death: nil,


### PR DESCRIPTION
In rare scenarios this is not available to us and can lead to an error. Since we're not currently using it anywhere we can safely remove it from the `PDS::Patient` model.

https://good-machine.sentry.io/issues/6016479502/