### PR TITLE
Change logic for clinic invitations

### DIFF
--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -36,9 +36,7 @@ class SchoolSessionRemindersJob < ApplicationJob
   end
 
   def should_send_notification?(patient_session:)
-    patient = patient_session.patient
-
-    return false unless patient.send_notifications?
+    return false unless patient_session.send_notifications?
 
     return false if patient_session.vaccination_administered?
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -63,6 +63,11 @@ class PatientSession < ApplicationRecord
            through: :patient,
            class_name: "Triage"
 
+  has_many :session_notifications,
+           -> { where(session_id: _1.session_id) },
+           through: :patient,
+           class_name: "SessionNotification"
+
   has_and_belongs_to_many :immunisation_imports
 
   scope :notification_not_sent,
@@ -82,6 +87,8 @@ class PatientSession < ApplicationRecord
         end
 
   scope :pending_transfer, -> { where.not(proposed_session_id: nil) }
+
+  delegate :send_notifications?, to: :patient
 
   def draft_vaccination_record
     # HACK: this code will need to be revisited in future as it only really

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -83,6 +83,14 @@ class Session < ApplicationRecord
             SessionDate.for_session.select("MIN(value)")
           )
         end
+  scope :send_invitations,
+        -> do
+          scheduled.where(
+            "? >= (?)",
+            3.weeks.from_now,
+            SessionDate.for_session.select("MIN(value)")
+          )
+        end
 
   validates :programmes, presence: true
   validate :programmes_part_of_team


### PR DESCRIPTION
Instead of only sending the invitations exactly 3 weeks before each date, we will instead repeatedly try to send these notifications each day, which allows patients that have been newly added to the community clinic to receive an invitiation as soon as possible (i.e. the next morning).

The reminders will be sent automatically once a session date has passed, meaning we should know by then if a patient was vaccinated or not and avoid sending unnecessary emails.