### PR TITLE
Render outcome banner with no clinician

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -80,7 +80,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
     if clinician == @current_user
       "You (#{clinician.full_name})"
     else
-      clinician.full_name
+      clinician&.full_name || "Unknown"
     end
   end
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -152,8 +152,7 @@ class VaccinationRecord < ApplicationRecord
             :performed_by_given_name,
             absence: {
               if: :performed_by_user
-            },
-            if: :recorded?
+            }
 
   validate :batch_vaccine_matches_vaccine, if: -> { recorded? && administered? }
 

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -57,6 +57,12 @@ describe AppOutcomeBannerComponent do
 
       it { should have_text("Date\nToday (#{date})") }
     end
+
+    context "when it's unknown who performed the vaccination" do
+      before { vaccination_record.update!(performed_by_user: nil) }
+
+      it { should have_text("Vaccinator\nUnknown") }
+    end
   end
 
   context "state is triaged_do_not_vaccinate" do


### PR DESCRIPTION
Sometimes this won't be available, specifically for historical records, if we've imported HPV records we don't always have a record of who performed the vaccination so we should handle this gracefully.

https://good-machine.sentry.io/issues/5858514071/