### PR TITLE
Don't return 404 is today's batch not found

### DIFF
--- a/app/controllers/vaccinations/edit_controller.rb
+++ b/app/controllers/vaccinations/edit_controller.rb
@@ -94,12 +94,13 @@ class Vaccinations::EditController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record = @patient_session.draft_vaccination_record
+
     if (session[:delivery_site_other] = "true")
       @draft_vaccination_record.delivery_site_other = true
     end
-    if todays_batch_id.present?
-      @draft_vaccination_record.todays_batch =
-        policy_scope(Batch).find(todays_batch_id)
+
+    if (id = todays_batch_id).present?
+      @draft_vaccination_record.todays_batch = policy_scope(Batch).find_by(id:)
     end
   end
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -61,8 +61,8 @@ class VaccinationsController < ApplicationController
          create_params.merge(performed_by: current_user)
        )
       session[:delivery_site_other] = "true" if delivery_site_param_other?
-      @draft_vaccination_record.todays_batch =
-        todays_batch_id if todays_batch_id.present?
+
+      @draft_vaccination_record.todays_batch = @todays_batch
 
       redirect_to session_patient_vaccinations_edit_path(
                     @session,


### PR DESCRIPTION
It could have been archived in the mean time, and that would result in it not being found, instead we can return `nil` which requires the nurse to choose a new batch.