### PR TITLE
Make it possible to delete all session dates

### DIFF
--- a/app/views/session_dates/show.html.erb
+++ b/app/views/session_dates/show.html.erb
@@ -18,7 +18,7 @@
                                       legend: { size: "m", text: "Session date" },
                                       hint: { text: "For example, 27 3 2024" } %>
 
-          <% if @session.dates.length != 1 %>
+          <% if date_f.object.persisted? || @session.dates.length > 1 %>
             <% button_class = "nhsuk-button app-add-another__delete app-button--secondary-warning app-button--small" %>
 
             <% if date_f.object.new_record? %>


### PR DESCRIPTION
This updates the view to manage session dates to allow deleting the first date if it's been added to the session, whereas currently the delete button is hidden.