### PR TITLE
Show clinic invitations in activity log

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -55,8 +55,14 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def session_notification_events
-    @patient_session.patient.session_notifications.map do
-      { title: "Session reminder sent", time: _1.sent_at }
+    @patient_session.patient.session_notifications.map do |notification|
+      title =
+        if notification.school_reminder?
+          "School session reminder sent"
+        elsif notification.clinic_invitation?
+          "Clinic invitation sent"
+        end
+      { title:, time: notification.sent_at }
     end
   end
 

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -36,6 +36,10 @@ class SessionNotification < ApplicationRecord
        ],
        validate: true
 
+  def clinic_invitation?
+    clinic_initial_invitation? || clinic_subsequent_invitation?
+  end
+
   def self.create_and_send!(patient_session:, session_date:, type:)
     # We create a record in the database first to avoid sending duplicate emails/texts.
     # If a problem occurs while the emails/texts are sent, they will be in the job

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -102,6 +102,14 @@ describe AppActivityLogComponent do
         sent_at: Date.new(2024, 5, 30)
       )
 
+      create(
+        :session_notification,
+        :clinic_initial_invitation,
+        session:,
+        patient:,
+        sent_at: Date.new(2024, 5, 30)
+      )
+
       render_inline(component)
     end
 
@@ -118,7 +126,11 @@ describe AppActivityLogComponent do
                      by: "Nurse Joy"
 
     include_examples "card",
-                     title: "Session reminder sent",
+                     title: "School session reminder sent",
+                     date: "30 May 2024 at 12:00am"
+
+    include_examples "card",
+                     title: "Clinic invitation sent",
                      date: "30 May 2024 at 12:00am"
 
     include_examples "card",


### PR DESCRIPTION
We already show session notifications, but the wording is incorrect for clinic invitations.