### PR TITLE
Handle no clinician for vaccination events

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -83,7 +83,7 @@ class AppActivityLogComponent < ViewComponent::Base
         title: "Vaccinated with #{helpers.vaccine_heading(_1.vaccine)}",
         time: _1.created_at,
         notes: _1.notes,
-        by: _1.performed_by.full_name
+        by: _1.performed_by&.full_name
       }
     end
   end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -87,6 +87,16 @@ describe AppActivityLogComponent do
       )
 
       create(
+        :vaccination_record,
+        programme:,
+        patient_session:,
+        created_at: Time.zone.parse("2024-05-31 13:00"),
+        performed_by: nil,
+        notes: "Some notes",
+        vaccine: create(:vaccine, :gardasil, programme:)
+      )
+
+      create(
         :consent_notification,
         :request,
         programme:,
@@ -124,6 +134,11 @@ describe AppActivityLogComponent do
                      date: "31 May 2024 at 12:00pm",
                      notes: "Some notes",
                      by: "Nurse Joy"
+
+    include_examples "card",
+                     title: "Vaccinated with Gardasil (HPV)",
+                     date: "31 May 2024 at 1:00pm",
+                     notes: "Some notes"
 
     include_examples "card",
                      title: "School session reminder sent",


### PR DESCRIPTION
This follows on from 2c352edb7fbe35bef370ae93ffe87077df5070af to support rendering the activity log when we don't have a clinician available.