### PR TITLE
Allow filtering on postcodes

### DIFF
--- a/app/components/app_session_patient_table_component.html.erb
+++ b/app/components/app_session_patient_table_component.html.erb
@@ -8,15 +8,26 @@
                           turbo_action: "replace" },
                   builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_fieldset legend: { text: "Filter results", size: "s" } do %>
-        <%= f.govuk_text_field :name, label: { text: "By name" },
-                                      value: params[:name],
-                                      autocomplete: "off",
-                                      "data-autosubmit-target": "field",
-                                      "data-action": "autosubmit#submit",
-                                      "data-turbo-permanent": "true" %>
+        <% if @columns.include?(:name) %>
+          <%= f.govuk_text_field :name, label: { text: "Name" },
+                                        value: params[:name],
+                                        autocomplete: "off",
+                                        "data-autosubmit-target": "field",
+                                        "data-action": "autosubmit#submit",
+                                        "data-turbo-permanent": "true" %>
+        <% end %>
 
-        <% if year_groups.present? %>
-          <%= f.govuk_check_boxes_fieldset :year_groups, legend: { text: "By year group", size: "s" } do %>
+        <% if @columns.include?(:postcode) %>
+          <%= f.govuk_text_field :postcode, label: { text: "Postcode" },
+                                            value: params[:postcode],
+                                            autocomplete: "off",
+                                            "data-autosubmit-target": "field",
+                                            "data-action": "autosubmit#submit",
+                                            "data-turbo-permanent": "true" %>
+        <% end %>
+
+        <% if @columns.include?(:year_group) %>
+          <%= f.govuk_check_boxes_fieldset :year_groups, legend: { text: "Year group", size: "s" } do %>
             <% year_groups.each do |year_group| %>
               <%= f.govuk_check_box :year_groups,
                                     year_group,

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -39,11 +39,11 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     {
       action: "Action needed",
       name: "Full name",
-      year_group: "Year group",
-      reason: "Reason for refusal",
       outcome: "Outcome",
       postcode: "Postcode",
-      select_for_matching: "Action"
+      reason: "Reason for refusal",
+      select_for_matching: "Action",
+      year_group: "Year group"
     }[
       column
     ]
@@ -136,6 +136,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
               session_section_tab_path(
                 direction:,
                 name: params[:name],
+                postcode: params[:postcode],
                 section: params[:section],
                 session_id: params[:session_id],
                 sort: column,

--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -16,6 +16,8 @@ module PatientSortingConcern
       patient_sessions.sort_by! { _1.patient.full_name }
     when "outcome"
       patient_sessions.sort_by!(&:state)
+    when "postcode"
+      patient_sessions.sort_by! { _1.patient.address_postcode }
     when "year_group"
       patient_sessions.sort_by! do
         [_1.patient.year_group, _1.patient.registration]
@@ -26,16 +28,20 @@ module PatientSortingConcern
   end
 
   def filter_patients!(patient_sessions)
-    if params[:name].present?
+    if (name = params[:name]).present?
       patient_sessions.select! do
-        _1.patient.full_name.downcase.include?(params[:name].downcase)
+        _1.patient.full_name.downcase.include?(name.downcase)
       end
     end
 
-    if params[:year_groups].present?
+    if (postcode = params[:postcode]).present?
       patient_sessions.select! do
-        _1.patient.year_group.to_s.in?(params[:year_groups])
+        _1.patient.address_postcode&.downcase&.include?(postcode.downcase)
       end
+    end
+
+    if (year_groups = params[:year_groups]).present?
+      patient_sessions.select! { _1.patient.year_group.to_s.in?(year_groups) }
     end
   end
 end

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -14,9 +14,30 @@ describe PatientSortingConcern do
     end
   end
 
-  let(:alex) { create(:patient, given_name: "Alex", year_group: 8) }
-  let(:blair) { create(:patient, given_name: "Blair", year_group: 9) }
-  let(:casey) { create(:patient, given_name: "Casey", year_group: 10) }
+  let(:alex) do
+    create(
+      :patient,
+      given_name: "Alex",
+      year_group: 8,
+      address_postcode: "SW1A 1AA"
+    )
+  end
+  let(:blair) do
+    create(
+      :patient,
+      given_name: "Blair",
+      year_group: 9,
+      address_postcode: "SW2A 1AA"
+    )
+  end
+  let(:casey) do
+    create(
+      :patient,
+      given_name: "Casey",
+      year_group: 10,
+      address_postcode: "SW3A 1AA"
+    )
+  end
 
   let(:programme) { create(:programme) }
   let(:session) { create(:session, programme:) }
@@ -81,6 +102,17 @@ describe PatientSortingConcern do
       end
     end
 
+    context "when sort parameter is 'postcode'" do
+      let(:params) { { sort: "postcode", direction: "desc" } }
+
+      it "sorts patient sessions by name in ascending order" do
+        subject.sort_patients!(patient_sessions)
+        expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
+          %w[Casey Blair Alex]
+        )
+      end
+    end
+
     context "when sort parameter is missing" do
       let(:params) { {} }
 
@@ -101,6 +133,16 @@ describe PatientSortingConcern do
         subject.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Alex")
+      end
+    end
+
+    context "when filtering by postcode" do
+      let(:params) { { postcode: "SW2A" } }
+
+      it "filters patient sessions by date of birth" do
+        subject.filter_patients!(patient_sessions)
+        expect(patient_sessions.size).to eq(1)
+        expect(patient_sessions.first.patient.given_name).to eq("Blair")
       end
     end
 

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -104,7 +104,7 @@ describe "Patient sorting and filtering" do
                :then_i_see_patients_ordered_by_name_desc
 
   def when_i_filter_by_names_starting_with_cas
-    fill_in "By name", with: "cas"
+    fill_in "Name", with: "cas"
   end
 
   def and_i_click_filter
@@ -132,7 +132,7 @@ describe "Patient sorting and filtering" do
                :then_i_see_patients_with_names_starting_with_cas_by_name_asc
 
   def and_by_name_contains_cas
-    expect(page).to have_field("By name", with: "cas")
+    expect(page).to have_field("Name", with: "cas")
   end
 
   def when_i_filter_by_year_group_10


### PR DESCRIPTION
When displaying the session patient table we want to allow the users to be able to filter on postcodes when displaying the list for the global consent matching page.