### PR TITLE
Add texts for clinics

### DIFF
--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -47,6 +47,17 @@ class ConsentNotification < ApplicationRecord
         type
       end
 
+    text_template =
+      if type == :request
+        if session.location.clinic?
+          :consent_request_for_clinic
+        else
+          :consent_request_for_school
+        end
+      else
+        :consent_reminder
+      end
+
     patient.parents.each do |parent|
       ConsentMailer
         .with(parent:, patient:, programme:, session:)
@@ -54,7 +65,7 @@ class ConsentNotification < ApplicationRecord
         .deliver_later
 
       TextDeliveryJob.perform_later(
-        type == :request ? :consent_request : :consent_reminder,
+        text_template,
         parent:,
         patient:,
         programme:,

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -66,6 +66,7 @@ class SessionNotification < ApplicationRecord
     else
       patient_session.patient.parents.each do |parent|
         SessionMailer.with(parent:, patient_session:).send(type).deliver_later
+        TextDeliveryJob.perform_later(type, parent:, patient_session:)
       end
     end
   end

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -26,11 +26,14 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
 }.freeze
 
 GOVUK_NOTIFY_TEXT_TEMPLATES = {
+  clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
+  clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
   consent_given: "25473aa7-2d7c-4d1d-b0c6-2ac492f737c3",
   consent_refused: "eb34f3ab-0c58-4e56-b6b1-2c179270dfc3",
   consent_reminder: "ee3d36b1-4682-4eb0-a74a-7e0f6c9d0598",
-  consent_request: "03a0d572-ca5b-417e-87c3-838872a9eabc",
-  session_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
+  consent_request_for_clinic: "c7bd8150-d09e-4607-817d-db75c9a6a966",
+  consent_request_for_school: "03a0d572-ca5b-417e-87c3-838872a9eabc",
+  school_session_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
   vaccination_didnt_happen: "aae061e0-b847-4d4c-a87a-12508f95a302",
   vaccination_has_taken_place: "69612d3a-d6eb-4f04-8b99-ed14212e7245"
 }.freeze

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -59,6 +59,6 @@ describe "Parental consent" do
   end
 
   def and_a_text_is_sent_to_the_parent
-    expect_text_to(@parent.phone, :consent_request)
+    expect_text_to(@parent.phone, :consent_request_for_clinic)
   end
 end

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -78,13 +78,13 @@ describe ConsentNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :consent_request
+          :consent_request_for_school
         ).with(
           parent: parents.first,
           patient:,
           programme:,
           session:
-        ).and have_enqueued_text(:consent_request).with(
+        ).and have_enqueued_text(:consent_request_for_school).with(
                 parent: parents.second,
                 patient:,
                 programme:,
@@ -132,13 +132,13 @@ describe ConsentNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :consent_request
+          :consent_request_for_clinic
         ).with(
           parent: parents.first,
           patient:,
           programme:,
           session:
-        ).and have_enqueued_text(:consent_request).with(
+        ).and have_enqueued_text(:consent_request_for_clinic).with(
                 parent: parents.second,
                 patient:,
                 programme:,

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -104,8 +104,12 @@ describe SessionNotification do
               )
       end
 
-      it "doesn't enqueue a text" do
-        expect { create_and_send! }.not_to have_enqueued_text
+      it "enqueues a text per parent" do
+        expect { create_and_send! }.to have_enqueued_text(
+          :clinic_initial_invitation
+        ).with(parent: parents.first, patient_session:).and have_enqueued_text(
+                :clinic_initial_invitation
+              ).with(parent: parents.second, patient_session:)
       end
     end
 
@@ -144,8 +148,12 @@ describe SessionNotification do
               )
       end
 
-      it "doesn't enqueue a text" do
-        expect { create_and_send! }.not_to have_enqueued_text
+      it "enqueues a text per parent" do
+        expect { create_and_send! }.to have_enqueued_text(
+          :clinic_subsequent_invitation
+        ).with(parent: parents.first, patient_session:).and have_enqueued_text(
+                :clinic_subsequent_invitation
+              ).with(parent: parents.second, patient_session:)
       end
     end
   end


### PR DESCRIPTION
This adds three text messages that are sent when we send out invitations for booking in to a clinic, and when manual requests for consent are sent.