### PR TITLE
Hide "Send consent request" button if approriate

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -42,7 +42,7 @@
   <% end %>
 <% end %>
 
-<% if patient_session.no_consent? %>
+<% if can_send_consent_request? %>
   <%= govuk_button_to "Send consent request", session_patient_request_consent_path(session, patient_id: patient.id, section: @section, tab: @tab), class: "app-button--secondary" %>
 <% end %>
 

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -27,4 +27,9 @@ class AppConsentComponent < ViewComponent::Base
         .order(sent_at: :desc)
         .first
   end
+
+  def can_send_consent_request?
+    patient_session.no_consent? && patient.send_notifications? &&
+      patient.parents.any?
+  end
 end


### PR DESCRIPTION
The "Send consent request" button currently shows even in situations where it doesn't necessarily make sense to. Even though we wouldn't send an email in these cases, it doesn't make sense to give the user the option to.