### PR TITLE
Handle delay vaccination by inviting the patient to a clinic

### DIFF
--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -19,7 +19,7 @@
         ) %>
     <%= f.govuk_radio_button(
           :status, :delay_vaccination,
-          label: { text: "No, delay vaccination to a later date" },
+          label: { text: "No, delay vaccination (and invite to clinic)" },
         ) %>
     <%= f.govuk_radio_button(
           :status, :needs_follow_up,

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -102,7 +102,10 @@ class ManageConsentsController < ApplicationController
 
   def handle_confirm
     ActiveRecord::Base.transaction do
+      @triage.process! if @triage&.persisted?
+
       send_triage_confirmation(@patient_session, @consent)
+
       if @triage&.new_record?
         # We need to discard the draft triage record so that the patient
         # session can be saved.
@@ -117,6 +120,7 @@ class ManageConsentsController < ApplicationController
       @consent.recorded_at = Time.zone.now
       @consent.save!
     end
+
     session.delete(:manage_consents_new_or_existing_parent_id)
   end
 

--- a/app/mailers/triage_mailer.rb
+++ b/app/mailers/triage_mailer.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class TriageMailer < ApplicationMailer
+  def vaccination_at_clinic
+    app_template_mail(:triage_vaccination_at_clinic)
+  end
+
   def vaccination_will_happen
     app_template_mail(:triage_vaccination_will_happen)
   end

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -53,4 +53,12 @@ class Triage < ApplicationRecord
   encrypts :notes
 
   validates :notes, length: { maximum: 1000 }
+
+  def process!
+    return unless delay_vaccination?
+
+    patient.patient_sessions.find_or_create_by!(
+      session: team.generic_clinic_session
+    )
+  end
 end

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -21,6 +21,7 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   parental_consent_confirmation_needs_triage:
     "604ee667-c996-471e-b986-79ab98d0767c",
   parental_consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",
+  triage_vaccination_at_clinic: "9faef718-bd76-4c30-93ea-fbe8584388a6",
   triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
   triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f"
 }.freeze

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -45,6 +45,21 @@ describe TriageMailerConcern do
       end
     end
 
+    context "when the parents agree, triage is required and vaccination should be delayed" do
+      let(:patient_session) { create(:patient_session, :delay_vaccination) }
+
+      it "sends an email saying triage was needed but vaccination won't happen" do
+        expect { send_triage_confirmation }.to have_enqueued_mail(
+          TriageMailer,
+          :vaccination_at_clinic
+        ).with(params: { consent:, session: }, args: [])
+      end
+
+      it "doesn't send a text message" do
+        expect { send_triage_confirmation }.not_to have_enqueued_text
+      end
+    end
+
     context "when the parents agree and triage is not required" do
       let(:patient_session) do
         create(:patient_session, :consent_given_triage_not_needed)

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -20,6 +20,9 @@ describe "Triage" do
     when_i_view_the_child_record
     then_they_should_have_the_status_banner_delay_vaccination
     and_i_am_able_to_record_a_vaccination
+
+    when_i_go_to_the_community_clinics
+    then_i_see_a_patient_in_the_session
   end
 
   def given_a_programme_with_a_running_session
@@ -100,5 +103,15 @@ describe "Triage" do
 
   def and_i_am_able_to_record_a_vaccination
     choose "Yes, they got the HPV vaccine"
+  end
+
+  def when_i_go_to_the_community_clinics
+    click_on "Sessions"
+    click_on "Unscheduled"
+    click_on "Community clinics"
+  end
+
+  def then_i_see_a_patient_in_the_session
+    expect(page).to have_content("1 child in this session")
   end
 end

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -60,7 +60,7 @@ describe "Triage" do
 
   def and_i_enter_a_note_and_delay_vaccination
     fill_in "Triage notes (optional)", with: "Delaying vaccination for 2 weeks"
-    choose "No, delay vaccination to a later date"
+    choose "No, delay vaccination (and invite to clinic)"
     click_button "Save triage"
   end
 

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -9,6 +9,7 @@ describe "Triage" do
     when_i_click_on_a_patient
     and_i_enter_a_note_and_delay_vaccination
     then_i_see_an_alert_saying_the_record_was_saved
+    and_a_vaccination_at_clinic_email_is_sent_to_the_parent
 
     when_i_go_to_the_triage_completed_tab
     then_i_see_the_patient
@@ -70,6 +71,11 @@ describe "Triage" do
     )
   end
 
+  def and_a_vaccination_at_clinic_email_is_sent_to_the_parent
+    expect_email_to @patient.consents.first.parent.email,
+                    :triage_vaccination_at_clinic
+  end
+
   def when_i_go_to_the_triage_completed_tab
     click_link "Triage completed"
   end
@@ -82,10 +88,6 @@ describe "Triage" do
     click_on @school.name, match: :first
     click_on "Record vaccinations"
     click_on "Could not vaccinate"
-  end
-
-  def then_i_see_the_patient
-    expect(page).to have_content(@patient.full_name)
   end
 
   def when_i_view_the_child_record

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -14,7 +14,7 @@ describe "Triage" do
     and_needs_triage_emails_are_sent_to_both_parents
 
     when_i_go_to_the_patient
-    and_i_delay_the_vaccination
+    and_i_do_not_vaccinate
     then_i_see_the_triage_page
     and_vaccination_wont_happen_emails_are_sent_to_both_parents
 
@@ -72,8 +72,8 @@ describe "Triage" do
     click_button "Save triage"
   end
 
-  def and_i_delay_the_vaccination
-    choose "No, delay vaccination to a later date"
+  def and_i_do_not_vaccinate
+    choose "No, do not vaccinate"
     click_button "Save triage"
   end
 

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -3,6 +3,33 @@
 describe TriageMailer do
   let(:session) { patient_session.session }
 
+  describe "#vaccination_at_clinic" do
+    subject(:mail) do
+      described_class.with(consent:, session:).vaccination_at_clinic
+    end
+
+    let(:patient_session) { create(:patient_session, :delay_vaccination) }
+    let(:consent) { patient_session.patient.consents.first }
+
+    it { should have_attributes(to: [consent.parent.email]) }
+
+    describe "personalisation" do
+      subject(:personalisation) do
+        mail.message.header["personalisation"].unparsed_value.keys
+      end
+
+      it do
+        expect(personalisation).to include(
+          :full_and_preferred_patient_name,
+          :short_patient_name,
+          :team_name,
+          :team_email,
+          :team_phone
+        )
+      end
+    end
+  end
+
   describe "#vaccination_will_happen" do
     subject(:mail) do
       described_class.with(consent:, session:).vaccination_will_happen
@@ -16,7 +43,9 @@ describe TriageMailer do
     it { should have_attributes(to: [consent.parent.email]) }
 
     describe "personalisation" do
-      subject { mail.message.header["personalisation"].unparsed_value }
+      subject(:personalisation) do
+        mail.message.header["personalisation"].unparsed_value
+      end
 
       it { should include(parent_full_name: consent.parent.full_name) }
     end
@@ -33,7 +62,9 @@ describe TriageMailer do
     it { should have_attributes(to: [consent.parent.email]) }
 
     describe "personalisation" do
-      subject { mail.message.header["personalisation"].unparsed_value }
+      subject(:personalisation) do
+        mail.message.header["personalisation"].unparsed_value
+      end
 
       it { should include(parent_full_name: consent.parent.full_name) }
     end

--- a/spec/models/triage_spec.rb
+++ b/spec/models/triage_spec.rb
@@ -36,4 +36,51 @@ describe Triage do
     it { should_not validate_presence_of(:notes) }
     it { should validate_length_of(:notes).is_at_most(1000) }
   end
+
+  describe "#process!" do
+    subject(:process!) { triage.process! }
+
+    let(:programme) { create(:programme) }
+    let(:team) { create(:team, programmes: [programme]) }
+    let(:triage) { create(:triage, status, team:, programme:) }
+
+    context "when ready to vaccinate" do
+      let(:status) { :ready_to_vaccinate }
+
+      it "doesn't create any patient sessions" do
+        expect { process! }.not_to change(PatientSession, :count)
+      end
+    end
+
+    context "when do not vaccinate" do
+      let(:status) { :do_not_vaccinate }
+
+      it "doesn't create any patient sessions" do
+        expect { process! }.not_to change(PatientSession, :count)
+      end
+    end
+
+    context "when needs follow up" do
+      let(:status) { :needs_follow_up }
+
+      it "doesn't create any patient sessions" do
+        expect { process! }.not_to change(PatientSession, :count)
+      end
+    end
+
+    context "when delay vaccination" do
+      let(:status) { :delay_vaccination }
+
+      it "adds the patient to the generic clinic" do
+        expect { process! }.to change(
+          triage.patient.upcoming_sessions,
+          :count
+        ).by(1)
+
+        expect(
+          triage.patient.upcoming_sessions.last.location
+        ).to be_generic_clinic
+      end
+    end
+  end
 end


### PR DESCRIPTION
If a nurse chooses a "Delay vaccination" outcome, this triggers an email to go out to the parents requesting them to book in to a clinic, and adds the patient to the session for the generic clinic.