### PR TITLE
Re-organise GOV.UK Notify templates

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -10,12 +10,15 @@ module ConsentFormMailerConcern
       mailer.confirmation_injection.deliver_later
     elsif consent_form.consent_refused?
       mailer.confirmation_refused.deliver_later
-      TextDeliveryJob.perform_later(:consent_refused, consent_form:)
+      TextDeliveryJob.perform_later(
+        :consent_confirmation_refused,
+        consent_form:
+      )
     elsif consent_form.needs_triage?
-      mailer.confirmation_needs_triage.deliver_later
+      mailer.confirmation_triage.deliver_later
     else
-      mailer.confirmation.deliver_later
-      TextDeliveryJob.perform_later(:consent_given, consent_form:)
+      mailer.confirmation_given.deliver_later
+      TextDeliveryJob.perform_later(:consent_confirmation_given, consent_form:)
     end
   end
 end

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -22,16 +22,21 @@ module TriageMailerConcern
     elsif vaccination_at_clinic?(patient_session, consent)
       TriageMailer.with(consent:, session:).vaccination_at_clinic.deliver_later
     elsif consent.triage_needed?
-      ConsentMailer
-        .with(consent:, session:)
-        .confirmation_needs_triage
-        .deliver_later
+      ConsentMailer.with(consent:, session:).confirmation_triage.deliver_later
     elsif consent.response_refused?
       ConsentMailer.with(consent:, session:).confirmation_refused.deliver_later
-      TextDeliveryJob.perform_later(:consent_refused, consent:, session:)
+      TextDeliveryJob.perform_later(
+        :consent_confirmation_refused,
+        consent:,
+        session:
+      )
     else
-      ConsentMailer.with(consent:, session:).confirmation.deliver_later
-      TextDeliveryJob.perform_later(:consent_given, consent:, session:)
+      ConsentMailer.with(consent:, session:).confirmation_given.deliver_later
+      TextDeliveryJob.perform_later(
+        :consent_confirmation_given,
+        consent:,
+        session:
+      )
     end
   end
 

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -11,17 +11,12 @@ module VaccinationMailerConcern
 
     mailer_action =
       if vaccination_record.administered?
-        :hpv_vaccination_has_taken_place
+        :confirmation_administered
       else
-        :hpv_vaccination_has_not_taken_place
+        :confirmation_not_administered
       end
 
-    text_template_name =
-      if vaccination_record.administered?
-        :vaccination_has_taken_place
-      else
-        :vaccination_didnt_happen
-      end
+    text_template_name = :"vaccination_#{mailer_action}"
 
     patient_session.consents_to_send_communication.each do |consent|
       params = { consent:, vaccination_record: }

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -14,7 +14,7 @@ class SchoolConsentRemindersJob < ApplicationJob
           :programmes,
           patients: %i[consents consent_notifications parents]
         )
-        .joins(:location)
+        .eager_load(:location)
         .merge(Location.school)
         .strict_loading
 

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -10,7 +10,7 @@ class SchoolConsentRequestsJob < ApplicationJob
       Session
         .send_consent_requests
         .includes(:programmes, patients: %i[consents consent_notifications])
-        .joins(:location)
+        .eager_load(:location)
         .merge(Location.school)
         .strict_loading
 

--- a/app/mailers/consent_mailer.rb
+++ b/app/mailers/consent_mailer.rb
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
 class ConsentMailer < ApplicationMailer
-  def confirmation
-    app_template_mail(:parental_consent_confirmation)
+  def confirmation_given
+    app_template_mail(:consent_confirmation_given)
   end
 
-  def confirmation_needs_triage
-    app_template_mail(:parental_consent_confirmation_needs_triage)
+  def confirmation_triage
+    app_template_mail(:consent_confirmation_triage)
   end
 
   def confirmation_injection
-    app_template_mail(:parental_consent_confirmation_injection)
+    app_template_mail(:consent_confirmation_injection)
   end
 
   def confirmation_refused
-    app_template_mail(:parental_consent_confirmation_refused)
+    app_template_mail(:consent_confirmation_refused)
   end
 
-  def request_for_school
-    app_template_mail(:hpv_session_consent_request_for_school)
+  def school_request
+    app_template_mail(:consent_school_request)
   end
 
-  def request_for_clinic
-    app_template_mail(:hpv_session_consent_request_for_clinic)
+  def school_initial_reminder
+    app_template_mail(:consent_school_initial_reminder)
   end
 
-  def initial_reminder
-    app_template_mail(:hpv_session_consent_reminder)
+  def school_subsequent_reminder
+    app_template_mail(:consent_school_subsequent_reminder)
   end
 
-  def subsequent_reminder
-    app_template_mail(:hpv_session_consent_reminder_subsequent)
+  def clinic_request
+    app_template_mail(:consent_clinic_request)
   end
 end

--- a/app/mailers/session_mailer.rb
+++ b/app/mailers/session_mailer.rb
@@ -2,14 +2,14 @@
 
 class SessionMailer < ApplicationMailer
   def school_reminder
-    app_template_mail(:hpv_school_session_reminder)
+    app_template_mail(:session_school_reminder)
   end
 
   def clinic_initial_invitation
-    app_template_mail(:hpv_clinic_invitation)
+    app_template_mail(:session_clinic_initial_invitation)
   end
 
   def clinic_subsequent_invitation
-    app_template_mail(:hpv_clinic_invitation_subsequent)
+    app_template_mail(:session_clinic_subsequent_invitation)
   end
 end

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class VaccinationMailer < ApplicationMailer
-  def hpv_vaccination_has_taken_place
-    app_template_mail(:confirmation_the_hpv_vaccination_has_taken_place)
+  def confirmation_administered
+    app_template_mail(:vaccination_confirmation_administered)
   end
 
-  def hpv_vaccination_has_not_taken_place
-    app_template_mail(:confirmation_the_hpv_vaccination_didnt_happen)
+  def confirmation_not_administered
+    app_template_mail(:vaccination_confirmation_not_administered)
   end
 end

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -58,7 +58,7 @@ class SessionNotification < ApplicationRecord
           .deliver_later
 
         TextDeliveryJob.perform_later(
-          :session_reminder,
+          :session_school_reminder,
           consent:,
           patient_session:
         )
@@ -66,7 +66,11 @@ class SessionNotification < ApplicationRecord
     else
       patient_session.patient.parents.each do |parent|
         SessionMailer.with(parent:, patient_session:).send(type).deliver_later
-        TextDeliveryJob.perform_later(type, parent:, patient_session:)
+        TextDeliveryJob.perform_later(
+          :"session_#{type}",
+          parent:,
+          patient_session:
+        )
       end
     end
   end

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -1,40 +1,35 @@
 # frozen_string_literal: true
 
 GOVUK_NOTIFY_EMAIL_TEMPLATES = {
-  confirmation_the_hpv_vaccination_didnt_happen:
-    "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
-  confirmation_the_hpv_vaccination_has_taken_place:
-    "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
-  hpv_clinic_invitation: "fc99ac81-9eeb-4df8-9aa0-04f0eb48e37f",
-  hpv_clinic_invitation_subsequent: "eee59c1b-3af4-4ccd-8653-940887066390",
-  hpv_school_session_reminder: "79e131b2-7816-46d0-9c74-ae14956dd77d",
-  hpv_session_consent_reminder: "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
-  hpv_session_consent_reminder_subsequent:
-    "6410145f-dac1-46ba-82f3-a49cad0f66a6",
-  hpv_session_consent_request_for_school:
-    "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
-  hpv_session_consent_request_for_clinic:
-    "14e88a09-4281-4257-9574-6afeaeb42715",
-  parental_consent_confirmation: "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
-  parental_consent_confirmation_injection:
-    "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
-  parental_consent_confirmation_needs_triage:
-    "604ee667-c996-471e-b986-79ab98d0767c",
-  parental_consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",
+  consent_clinic_request: "14e88a09-4281-4257-9574-6afeaeb42715",
+  consent_confirmation_given: "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
+  consent_confirmation_injection: "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
+  consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",
+  consent_confirmation_triage: "604ee667-c996-471e-b986-79ab98d0767c",
+  consent_school_initial_reminder: "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
+  consent_school_request: "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
+  consent_school_subsequent_reminder: "6410145f-dac1-46ba-82f3-a49cad0f66a6",
+  session_clinic_initial_invitation: "fc99ac81-9eeb-4df8-9aa0-04f0eb48e37f",
+  session_clinic_subsequent_invitation: "eee59c1b-3af4-4ccd-8653-940887066390",
+  session_school_reminder: "79e131b2-7816-46d0-9c74-ae14956dd77d",
   triage_vaccination_at_clinic: "9faef718-bd76-4c30-93ea-fbe8584388a6",
   triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
-  triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f"
+  triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f",
+  vaccination_confirmation_administered: "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
+  vaccination_confirmation_not_administered:
+    "130fe52a-014a-45dd-9f53-8e65c1b8bb79"
 }.freeze
 
 GOVUK_NOTIFY_TEXT_TEMPLATES = {
-  clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
-  clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
-  consent_given: "25473aa7-2d7c-4d1d-b0c6-2ac492f737c3",
-  consent_refused: "eb34f3ab-0c58-4e56-b6b1-2c179270dfc3",
-  consent_reminder: "ee3d36b1-4682-4eb0-a74a-7e0f6c9d0598",
-  consent_request_for_clinic: "c7bd8150-d09e-4607-817d-db75c9a6a966",
-  consent_request_for_school: "03a0d572-ca5b-417e-87c3-838872a9eabc",
-  school_session_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
-  vaccination_didnt_happen: "aae061e0-b847-4d4c-a87a-12508f95a302",
-  vaccination_has_taken_place: "69612d3a-d6eb-4f04-8b99-ed14212e7245"
+  consent_clinic_request: "03a0d572-ca5b-417e-87c3-838872a9eabc",
+  consent_confirmation_given: "25473aa7-2d7c-4d1d-b0c6-2ac492f737c3",
+  consent_confirmation_refused: "eb34f3ab-0c58-4e56-b6b1-2c179270dfc3",
+  consent_school_reminder: "ee3d36b1-4682-4eb0-a74a-7e0f6c9d0598",
+  consent_school_request: "c7bd8150-d09e-4607-817d-db75c9a6a966",
+  session_clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
+  session_clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
+  session_school_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
+  vaccination_confirmation_administered: "69612d3a-d6eb-4f04-8b99-ed14212e7245",
+  vaccination_confirmation_not_administered:
+    "aae061e0-b847-4d4c-a87a-12508f95a302"
 }.freeze

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -13,13 +13,13 @@ describe ConsentFormMailerConcern do
     it "sends a confirmation email" do
       expect { send_consent_form_confirmation }.to have_enqueued_mail(
         ConsentMailer,
-        :confirmation
+        :confirmation_given
       ).with(params: { consent_form: }, args: [])
     end
 
     it "sends a consent given text" do
       expect { send_consent_form_confirmation }.to have_enqueued_text(
-        :consent_given
+        :consent_confirmation_given
       ).with(consent_form:)
     end
 
@@ -50,7 +50,7 @@ describe ConsentFormMailerConcern do
 
       it "sends a consent refused text" do
         expect { send_consent_form_confirmation }.to have_enqueued_text(
-          :consent_refused
+          :consent_confirmation_refused
         ).with(consent_form:)
       end
     end
@@ -61,7 +61,7 @@ describe ConsentFormMailerConcern do
       it "sends an confirmation needs triage email" do
         expect { send_consent_form_confirmation }.to have_enqueued_mail(
           ConsentMailer,
-          :confirmation_needs_triage
+          :confirmation_triage
         ).with(params: { consent_form: }, args: [])
       end
 

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -68,13 +68,13 @@ describe TriageMailerConcern do
       it "sends an email saying vaccination will happen" do
         expect { send_triage_confirmation }.to have_enqueued_mail(
           ConsentMailer,
-          :confirmation
+          :confirmation_given
         ).with(params: { consent:, session: }, args: [])
       end
 
       it "sends a text message" do
         expect { send_triage_confirmation }.to have_enqueued_text(
-          :consent_given
+          :consent_confirmation_given
         ).with(consent:, session:)
       end
     end
@@ -87,7 +87,7 @@ describe TriageMailerConcern do
       it "sends an email saying triage is required" do
         expect { send_triage_confirmation }.to have_enqueued_mail(
           ConsentMailer,
-          :confirmation_needs_triage
+          :confirmation_triage
         ).with(params: { consent:, session: }, args: [])
       end
 
@@ -108,7 +108,7 @@ describe TriageMailerConcern do
 
       it "sends a text message" do
         expect { send_triage_confirmation }.to have_enqueued_text(
-          :consent_refused
+          :consent_confirmation_refused
         ).with(consent:, session:)
       end
     end

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -22,13 +22,13 @@ describe VaccinationMailerConcern do
       it "sends an email" do
         expect { send_vaccination_confirmation }.to have_enqueued_mail(
           VaccinationMailer,
-          :hpv_vaccination_has_taken_place
+          :confirmation_administered
         ).with(params: { consent:, vaccination_record: }, args: [])
       end
 
       it "sends a text message" do
         expect { send_vaccination_confirmation }.to have_enqueued_text(
-          :vaccination_has_taken_place
+          :vaccination_confirmation_administered
         ).with(consent:, vaccination_record:)
       end
     end
@@ -46,13 +46,13 @@ describe VaccinationMailerConcern do
       it "sends an email" do
         expect { send_vaccination_confirmation }.to have_enqueued_mail(
           VaccinationMailer,
-          :hpv_vaccination_has_not_taken_place
+          :confirmation_not_administered
         ).with(params: { consent:, vaccination_record: }, args: [])
       end
 
       it "sends a text message" do
         expect { send_vaccination_confirmation }.to have_enqueued_text(
-          :vaccination_didnt_happen
+          :vaccination_confirmation_not_administered
         ).with(consent:, vaccination_record:)
       end
     end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -90,14 +90,14 @@ describe "HPV Vaccination" do
   def and_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :confirmation_the_hpv_vaccination_has_taken_place
+      :vaccination_confirmation_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_text_to(
       @patient.consents.last.parent.phone,
-      :vaccination_has_taken_place
+      :vaccination_confirmation_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -98,14 +98,14 @@ describe "HPV Vaccination" do
   def and_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :confirmation_the_hpv_vaccination_has_taken_place
+      :vaccination_confirmation_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_text_to(
       @patient.consents.last.parent.phone,
-      :vaccination_has_taken_place
+      :vaccination_confirmation_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -73,14 +73,14 @@ describe "HPV Vaccination" do
   def and_an_email_is_sent_to_the_parent_confirming_the_delay
     expect_email_to(
       @patient.consents.last.parent.email,
-      :confirmation_the_hpv_vaccination_didnt_happen
+      :vaccination_confirmation_not_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_delay
     expect_text_to(
       @patient.consents.last.parent.phone,
-      :vaccination_didnt_happen
+      :vaccination_confirmation_not_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -77,14 +77,14 @@ describe "HPV Vaccination" do
   def and_an_email_is_sent_saying_the_vaccination_didnt_happen
     expect_email_to(
       @patient.consents.last.parent.email,
-      :confirmation_the_hpv_vaccination_didnt_happen
+      :vaccination_confirmation_not_administered
     )
   end
 
   def and_a_text_is_sent_saying_the_vaccination_didnt_happen
     expect_text_to(
       @patient.consents.last.parent.phone,
-      :vaccination_didnt_happen
+      :vaccination_confirmation_not_administered
     )
   end
 end

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -122,11 +122,11 @@ describe "Parental consent" do
   end
 
   def and_i_receive_an_email_confirming_that_my_child_wont_be_vaccinated
-    expect_email_to "jane@example.com", :parental_consent_confirmation_refused
+    expect_email_to "jane@example.com", :consent_confirmation_refused
   end
 
   def and_i_receive_a_text_confirming_that_my_child_wont_be_vaccinated
-    expect_text_to "07123456789", :consent_refused
+    expect_text_to "07123456789", :consent_confirmation_refused
   end
 
   def when_the_nurse_checks_the_consent_responses

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -55,10 +55,10 @@ describe "Parental consent" do
   end
 
   def and_an_email_is_sent_to_the_parent
-    expect_email_to(@parent.email, :hpv_session_consent_request_for_clinic)
+    expect_email_to(@parent.email, :consent_clinic_request)
   end
 
   def and_a_text_is_sent_to_the_parent
-    expect_text_to(@parent.phone, :consent_request_for_clinic)
+    expect_text_to(@parent.phone, :consent_clinic_request)
   end
 end

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -142,11 +142,11 @@ describe "Parental consent" do
       "#{@child.full_name} will get their HPV vaccination at school"
     )
 
-    expect_email_to("jane@example.com", :parental_consent_confirmation)
+    expect_email_to("jane@example.com", :consent_confirmation_given)
   end
 
   def and_i_get_a_confirmation_text
-    expect_text_to("07123456789", :consent_given)
+    expect_text_to("07123456789", :consent_confirmation_given)
   end
 
   def when_the_nurse_checks_the_consent_responses

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -99,10 +99,10 @@ describe "Triage" do
 
   def and_needs_triage_emails_are_sent_to_both_parents
     expect_email_to @patient.consents.first.parent.email,
-                    :parental_consent_confirmation_needs_triage,
+                    :consent_confirmation_triage,
                     :any
     expect_email_to @patient.consents.second.parent.email,
-                    :parental_consent_confirmation_needs_triage,
+                    :consent_confirmation_triage,
                     :any
   end
 

--- a/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
+++ b/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
@@ -63,9 +63,6 @@ describe "Verbal consent recorded by admin" do
   end
 
   def then_an_email_is_sent_to_the_parent_about_triage
-    expect_email_to(
-      @patient.parents.first.email,
-      :parental_consent_confirmation_needs_triage
-    )
+    expect_email_to(@patient.parents.first.email, :consent_confirmation_triage)
   end
 end

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -79,10 +79,10 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_confirming_their_consent
-    expect_email_to("jsmith@example.com", :parental_consent_confirmation)
+    expect_email_to("jsmith@example.com", :consent_confirmation_given)
   end
 
   def and_i_a_text_is_sent_to_the_parent_confirming_their_consent
-    expect_text_to("07987654321", :consent_given)
+    expect_text_to("07987654321", :consent_confirmation_given)
   end
 end

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -63,9 +63,6 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_about_triage
-    expect_email_to(
-      @patient.parents.first.email,
-      :parental_consent_confirmation_needs_triage
-    )
+    expect_email_to(@patient.parents.first.email, :consent_confirmation_triage)
   end
 end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -107,13 +107,10 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_confirming_their_consent
-    expect_email_to(
-      @patient.parents.first.email,
-      :parental_consent_confirmation
-    )
+    expect_email_to(@patient.parents.first.email, :consent_confirmation_given)
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_their_consent
-    expect_text_to(@patient.parents.first.phone, :consent_given)
+    expect_text_to(@patient.parents.first.phone, :consent_confirmation_given)
   end
 end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -89,11 +89,11 @@ feature "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_confirming_their_consent
-    expect_email_to(@refusing_parent.email, :parental_consent_confirmation)
+    expect_email_to(@refusing_parent.email, :consent_confirmation_given)
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_their_consent
-    expect_text_to(@refusing_parent.phone, :consent_given)
+    expect_text_to(@refusing_parent.phone, :consent_confirmation_given)
   end
 
   def and_the_child_is_shown_as_having_consent_given

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -99,11 +99,10 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_confirming_the_refusal
-    expect_email_to @patient.parents.first.email,
-                    :parental_consent_confirmation_refused
+    expect_email_to @patient.parents.first.email, :consent_confirmation_refused
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_refusal
-    expect_text_to @patient.parents.first.phone, :consent_refused
+    expect_text_to @patient.parents.first.phone, :consent_confirmation_refused
   end
 end

--- a/spec/mailers/consent_mailer_spec.rb
+++ b/spec/mailers/consent_mailer_spec.rb
@@ -25,14 +25,14 @@ describe ConsentMailer do
     end
   end
 
-  describe "#request_for_school" do
+  describe "#school_request" do
     subject(:mail) do
       described_class.with(
         session:,
         patient:,
         parent:,
         programme:
-      ).request_for_school
+      ).school_request
     end
 
     let(:patient) { create(:patient) }
@@ -63,14 +63,14 @@ describe ConsentMailer do
     end
   end
 
-  describe "#request_for_clinic" do
+  describe "#clinic_request" do
     subject(:mail) do
       described_class.with(
         session:,
         patient:,
         parent:,
         programme:
-      ).request_for_clinic
+      ).clinic_request
     end
 
     let(:patient) { create(:patient) }
@@ -97,14 +97,14 @@ describe ConsentMailer do
     end
   end
 
-  describe "#initial_reminder" do
+  describe "#school_initial_reminder" do
     subject(:mail) do
       described_class.with(
         session:,
         patient:,
         parent:,
         programme:
-      ).initial_reminder
+      ).school_initial_reminder
     end
 
     let(:patient) { create(:patient) }
@@ -135,14 +135,14 @@ describe ConsentMailer do
     end
   end
 
-  describe "#subsequent_reminder" do
+  describe "#school_subsequent_reminder" do
     subject(:mail) do
       described_class.with(
         session:,
         patient:,
         parent:,
         programme:
-      ).subsequent_reminder
+      ).school_subsequent_reminder
     end
 
     let(:patient) { create(:patient) }

--- a/spec/mailers/vaccination_mailer_spec.rb
+++ b/spec/mailers/vaccination_mailer_spec.rb
@@ -6,12 +6,12 @@ describe VaccinationMailer do
   let(:consent) { patient.consents.last }
   let(:parent) { consent.parent }
 
-  describe "#hpv_vaccination_has_taken_place" do
+  describe "#confirmation_administered" do
     subject(:mail) do
       described_class.with(
         consent:,
         vaccination_record:
-      ).hpv_vaccination_has_taken_place
+      ).confirmation_administered
     end
 
     let(:patient) do
@@ -26,9 +26,9 @@ describe VaccinationMailer do
       expect(mail).to have_attributes(
         to: [parent.email],
         template_id:
-          GOVUK_NOTIFY_EMAIL_TEMPLATES[
-            :confirmation_the_hpv_vaccination_has_taken_place
-          ]
+          GOVUK_NOTIFY_EMAIL_TEMPLATES.fetch(
+            :vaccination_confirmation_administered
+          )
       )
     end
 
@@ -91,12 +91,12 @@ describe VaccinationMailer do
     end
   end
 
-  describe "#hpv_vaccination_has_not_place" do
+  describe "#confirmation_not_administered" do
     subject(:mail) do
       described_class.with(
         consent:,
         vaccination_record:
-      ).hpv_vaccination_has_not_taken_place
+      ).confirmation_not_administered
     end
 
     let(:patient) do
@@ -116,9 +116,9 @@ describe VaccinationMailer do
       expect(mail).to have_attributes(
         to: [parent.email],
         template_id:
-          GOVUK_NOTIFY_EMAIL_TEMPLATES[
-            :confirmation_the_hpv_vaccination_didnt_happen
-          ]
+          GOVUK_NOTIFY_EMAIL_TEMPLATES.fetch(
+            :vaccination_confirmation_not_administered
+          )
       )
     end
 

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -56,7 +56,7 @@ describe ConsentNotification do
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_enqueued_mail(
           ConsentMailer,
-          :request_for_school
+          :school_request
         ).with(
           params: {
             parent: parents.first,
@@ -65,7 +65,7 @@ describe ConsentNotification do
             session:
           },
           args: []
-        ).and have_enqueued_mail(ConsentMailer, :request_for_school).with(
+        ).and have_enqueued_mail(ConsentMailer, :school_request).with(
                 params: {
                   parent: parents.second,
                   patient:,
@@ -78,13 +78,13 @@ describe ConsentNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :consent_request_for_school
+          :consent_school_request
         ).with(
           parent: parents.first,
           patient:,
           programme:,
           session:
-        ).and have_enqueued_text(:consent_request_for_school).with(
+        ).and have_enqueued_text(:consent_school_request).with(
                 parent: parents.second,
                 patient:,
                 programme:,
@@ -110,7 +110,7 @@ describe ConsentNotification do
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_enqueued_mail(
           ConsentMailer,
-          :request_for_clinic
+          :clinic_request
         ).with(
           params: {
             parent: parents.first,
@@ -119,7 +119,7 @@ describe ConsentNotification do
             session:
           },
           args: []
-        ).and have_enqueued_mail(ConsentMailer, :request_for_clinic).with(
+        ).and have_enqueued_mail(ConsentMailer, :clinic_request).with(
                 params: {
                   parent: parents.second,
                   patient:,
@@ -132,13 +132,13 @@ describe ConsentNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :consent_request_for_clinic
+          :consent_clinic_request
         ).with(
           parent: parents.first,
           patient:,
           programme:,
           session:
-        ).and have_enqueued_text(:consent_request_for_clinic).with(
+        ).and have_enqueued_text(:consent_clinic_request).with(
                 parent: parents.second,
                 patient:,
                 programme:,
@@ -163,7 +163,7 @@ describe ConsentNotification do
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_enqueued_mail(
           ConsentMailer,
-          :initial_reminder
+          :school_initial_reminder
         ).with(
           params: {
             parent: parents.first,
@@ -172,7 +172,7 @@ describe ConsentNotification do
             session:
           },
           args: []
-        ).and have_enqueued_mail(ConsentMailer, :initial_reminder).with(
+        ).and have_enqueued_mail(ConsentMailer, :school_initial_reminder).with(
                 params: {
                   parent: parents.second,
                   patient:,
@@ -185,13 +185,13 @@ describe ConsentNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :consent_reminder
+          :consent_school_reminder
         ).with(
           parent: parents.first,
           patient:,
           programme:,
           session:
-        ).and have_enqueued_text(:consent_reminder).with(
+        ).and have_enqueued_text(:consent_school_reminder).with(
                 parent: parents.second,
                 patient:,
                 programme:,
@@ -216,7 +216,7 @@ describe ConsentNotification do
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_enqueued_mail(
           ConsentMailer,
-          :subsequent_reminder
+          :school_subsequent_reminder
         ).with(
           params: {
             parent: parents.first,
@@ -225,7 +225,10 @@ describe ConsentNotification do
             session:
           },
           args: []
-        ).and have_enqueued_mail(ConsentMailer, :subsequent_reminder).with(
+        ).and have_enqueued_mail(
+                ConsentMailer,
+                :school_subsequent_reminder
+              ).with(
                 params: {
                   parent: parents.second,
                   patient:,
@@ -238,13 +241,13 @@ describe ConsentNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :consent_reminder
+          :consent_school_reminder
         ).with(
           parent: parents.first,
           patient:,
           programme:,
           session:
-        ).and have_enqueued_text(:consent_reminder).with(
+        ).and have_enqueued_text(:consent_school_reminder).with(
                 parent: parents.second,
                 patient:,
                 programme:,

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -64,7 +64,7 @@ describe SessionNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :session_reminder
+          :session_school_reminder
         ).with(consent:, patient_session:)
       end
     end
@@ -106,9 +106,9 @@ describe SessionNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :clinic_initial_invitation
+          :session_clinic_initial_invitation
         ).with(parent: parents.first, patient_session:).and have_enqueued_text(
-                :clinic_initial_invitation
+                :session_clinic_initial_invitation
               ).with(parent: parents.second, patient_session:)
       end
     end
@@ -150,9 +150,9 @@ describe SessionNotification do
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_enqueued_text(
-          :clinic_subsequent_invitation
+          :session_clinic_subsequent_invitation
         ).with(parent: parents.first, patient_session:).and have_enqueued_text(
-                :clinic_subsequent_invitation
+                :session_clinic_subsequent_invitation
               ).with(parent: parents.second, patient_session:)
       end
     end

--- a/spec/support/email_expectations.rb
+++ b/spec/support/email_expectations.rb
@@ -2,7 +2,7 @@
 
 module EmailExpectations
   def expect_email_to(to, template_name, nth = :first)
-    template_id = GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+    template_id = GOVUK_NOTIFY_EMAIL_TEMPLATES.fetch(template_name)
 
     email =
       if nth == :any


### PR DESCRIPTION
This renames the labels used to reference the templates so that the mailer class actions, email and text templates all match and use a similar naming convention.

This makes it easier when we come to create a log of all emails and texts to have a consistent template name to show the user.

Unfortunately it's a lot of small changes, but these were mostly done automatically, but it does make it a little difficult to review the changes.