### PR TITLE
Date validation fixes

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -176,9 +176,9 @@ class ConsentForm < ApplicationRecord
     validates :date_of_birth,
               presence: true,
               comparison: {
-                less_than: Time.zone.today,
-                greater_than_or_equal_to: 22.years.ago.to_date,
-                less_than_or_equal_to: 3.years.ago.to_date
+                less_than: -> { Time.zone.today },
+                greater_than_or_equal_to: -> { 22.years.ago.to_date },
+                less_than_or_equal_to: -> { 3.years.ago.to_date }
               }
   end
 

--- a/config/initializers/i18n_nhs_design_system_date_interpolation.rb
+++ b/config/initializers/i18n_nhs_design_system_date_interpolation.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This custom interpolation is used to format interpolated dates in error messages
+# so they align to the NHS design system.
+module I18n
+  module NHSDesignSystemDateInterpolation
+    def interpolate(locale, string, values = {})
+      values = values.dup # Duplicate to avoid mutating the original hash
+
+      # Check if :count is a Date
+      values[:count] = values[:count].to_fs(:long) if values[:count].is_a?(Date)
+
+      # Call the original interpolate method with modified values
+      super(locale, string, values)
+    end
+  end
+
+  # Include the custom interpolation module in the backend
+  Backend::Simple.include(NHSDesignSystemDateInterpolation)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,6 +476,8 @@ en:
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year
+              greater_than_or_equal_to: Enter a date on or after the start of the school year (%{count})
+              less_than_or_equal_to: Enter a date on or before the end of the current school year (%{count})
         triage:
           attributes:
             notes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,7 +375,7 @@ en:
               blank: Enter their date of birth
               greater_than_or_equal_to: The child cannot be older than 22. Enter a date after %{count}.
               less_than: The date is in the future. Enter a date in the past.
-              less_than_or_equal_to: The child cannot be younger than 3. Enter a date after %{count}.
+              less_than_or_equal_to: The child cannot be younger than 3. Enter a date before %{count}.
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -127,7 +127,7 @@ describe ConsentForm do
           subject.date_of_birth = 2.years.ago.to_date
           subject.valid?(:update)
           expect(subject.errors[:date_of_birth]).to contain_exactly(
-            "The child cannot be younger than 3. Enter a date after 2019-01-01."
+            "The child cannot be younger than 3. Enter a date before 2019-01-01."
           )
         end
       end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -126,8 +126,10 @@ describe ConsentForm do
         it "has the correct error message" do
           subject.date_of_birth = 2.years.ago.to_date
           subject.valid?(:update)
+          # the date formatting below relies on the
+          # custom interpolation from I18n::CustomInterpolation
           expect(subject.errors[:date_of_birth]).to contain_exactly(
-            "The child cannot be younger than 3. Enter a date before 2019-01-01."
+            "The child cannot be younger than 3. Enter a date before 1 January 2019."
           )
         end
       end
@@ -138,8 +140,10 @@ describe ConsentForm do
         it "has the correct error message" do
           subject.date_of_birth = 23.years.ago.to_date
           subject.valid?(:update)
+          # the date formatting below relies on the
+          # custom interpolation from I18n::CustomInterpolation
           expect(subject.errors[:date_of_birth]).to contain_exactly(
-            "The child cannot be older than 22. Enter a date after 2000-01-01."
+            "The child cannot be older than 22. Enter a date after 1 January 2000."
           )
         end
       end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -119,11 +119,30 @@ describe ConsentForm do
       end
 
       it { should validate_presence_of(:date_of_birth).on(:update) }
-      # it { should validate_comparison_of(:date_of_birth)
-      #       .is_less_than(Time.zone.today)
-      #       .is_greater_than_or_equal_to(22.years.ago.to_date)
-      #       .is_less_than_or_equal_to(3.years.ago.to_date)
-      #       .on(:update) }
+
+      context "with a date of birth that's too young" do
+        before { travel_to(Date.new(2022, 1, 1)) }
+
+        it "has the correct error message" do
+          subject.date_of_birth = 2.years.ago.to_date
+          subject.valid?(:update)
+          expect(subject.errors[:date_of_birth]).to contain_exactly(
+            "The child cannot be younger than 3. Enter a date after 2019-01-01."
+          )
+        end
+      end
+
+      context "with a date of birth that's too old" do
+        before { travel_to(Date.new(2022, 1, 1)) }
+
+        it "has the correct error message" do
+          subject.date_of_birth = 23.years.ago.to_date
+          subject.valid?(:update)
+          expect(subject.errors[:date_of_birth]).to contain_exactly(
+            "The child cannot be older than 22. Enter a date after 2000-01-01."
+          )
+        end
+      end
     end
 
     context "when wizard_step is :parent" do


### PR DESCRIPTION
* Format dates in ActiveRecord validation error messages; show D MMM YYYY format, instead of YYYY-MM-DD. This is applied globally
* Some attribute-specific validation fixes on children's dates of birth on the consent form, and on session date validations

Best reviewed commit-by-commit.

## Child's date of birth

### Before

<img width="795" alt="image" src="https://github.com/user-attachments/assets/ad4a5d9f-26cc-4212-abf6-1bb9b7adb6b3">

<img width="794" alt="image" src="https://github.com/user-attachments/assets/d4a39923-6a56-43a1-a411-2d18d157240c">

### After

<img width="796" alt="image" src="https://github.com/user-attachments/assets/740d00ed-0523-4d87-971e-9e6e8074bcfb">

<img width="802" alt="image" src="https://github.com/user-attachments/assets/f6dc7255-187f-44fb-8a5f-c4a5f8e1f96d">

## Session dates

### Before

<img width="795" alt="image" src="https://github.com/user-attachments/assets/3bfeef9a-ee2a-4468-9a65-33b9032bad66">

<img width="794" alt="image" src="https://github.com/user-attachments/assets/bdf29415-1827-498e-8114-04de48a63f46">

### After

<img width="792" alt="image" src="https://github.com/user-attachments/assets/eab437d3-82a3-444b-81bc-06ea7bfd63d7">

<img width="809" alt="image" src="https://github.com/user-attachments/assets/f1e0fbfa-29c9-41ee-ba3f-34a2032ff775">
