### PR TITLE
Refactor sso_session into cis2_info, add specs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_user_location!
   before_action :authenticate_user!
-  before_action :set_user_sso_session
+  before_action :set_user_cis2_info
   before_action :set_disable_cache_headers
   before_action :set_header_path
   before_action :set_service_name
@@ -53,12 +53,6 @@ class ApplicationController < ActionController::Base
 
   def handle_unprocessable_entity
     render "errors/unprocessable_entity", status: :unprocessable_entity
-  end
-
-  def set_user_sso_session
-    return unless Flipper.enabled?(:sso_session) && current_user
-
-    current_user.sso_session = session["cis2_info"]
   end
 
   def user_not_authorized

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -76,5 +76,11 @@ module AuthenticationConcern
     def user_signed_in?
       super && (Settings.cis2.enabled ? cis2_session? : true)
     end
+
+    def set_user_cis2_info
+      return unless Settings.cis2.enabled && current_user
+
+      current_user.cis2_info = session["cis2_info"]
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@
 class User < ApplicationRecord
   include FullNameConcern
 
-  attr_accessor :sso_session
+  attr_accessor :cis2_info
 
   if Settings.cis2.enabled
     devise :omniauthable, :trackable, :timeoutable, omniauth_providers: %i[cis2]
@@ -87,14 +87,14 @@ class User < ApplicationRecord
   def is_medical_secretary?
     return email.include?("admin") unless Settings.cis2.enabled
 
-    role_codes = sso_session.dig("selected_role", "code")
-    role_codes.include?("R8006")
+    selected_role = cis2_info.dig("selected_role", "code")
+    selected_role.ends_with? "R8006"
   end
 
   def is_nurse?
     return email.include?("nurse") unless Settings.cis2.enabled
 
-    role_codes = sso_session.dig("selected_role", "code")
-    role_codes.include?("R8001")
+    selected_role = cis2_info.dig("selected_role", "code")
+    selected_role.ends_with? "R8001"
   end
 end

--- a/spec/controllers/concerns/authentication_concern_spec.rb
+++ b/spec/controllers/concerns/authentication_concern_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/VerifiedDoubles
+describe AuthenticationConcern do
+  let(:user) { @user = build(:user) }
+  let(:sample_class) do
+    Class
+      .new do # rubocop:disable Style/BlockDelimiters
+        include AuthenticationConcern
+
+        def current_user
+          @user
+        end
+      end # rubocop:disable Style/MethodCalledOnDoEndBlock
+      .new
+  end
+
+  describe "set_user_cis2_info" do
+    let(:user) { build(:user, cis2_info: nil) }
+
+    context "when cis2 is disabled" do
+      it "does not set the user's cis2_info" do
+        allow(Settings).to receive(:cis2).and_return(double(enabled: false))
+
+        sample_class.send(:set_user_cis2_info)
+
+        expect(user.cis2_info).to be_nil
+      end
+    end
+
+    context "when cis2 is enabled" do
+      it "does not set the user's cis2_info" do
+        allow(Settings).to receive(:cis2).and_return(double(enabled: true))
+
+        sample_class.send(:set_user_cis2_info)
+
+        expect(user.cis2_info).to be_nil
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/VerifiedDoubles

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -26,31 +26,55 @@
 #  index_users_on_provider_and_uid  (provider,uid) UNIQUE
 #
 FactoryBot.define do
-  factory :user, aliases: %i[assessor created_by performed_by uploaded_by] do
+  factory :user,
+          aliases: %i[nurse assessor created_by performed_by uploaded_by] do
+    transient do
+      selected_team { teams.first }
+      selected_role_code { "S8000:G8000:R8001" }
+      selected_role_name { "Nurse Access Role" }
+
+      cis2_info_hash do
+        {
+          "selected_org" => {
+            "name" => selected_team.name,
+            "code" => selected_team.ods_code
+          },
+          "selected_role" => {
+            "name" => selected_role_name,
+            "code" => selected_role_code
+          }
+        }
+      end
+    end
+
     sequence(:family_name) { |n| "User #{n}" }
     given_name { "Test" }
 
-    nurse
+    sequence(:email) { |n| "nurse-#{n}@example.com" }
     sequence(:teams) { [Team.first || create(:team)] }
     password { "power overwhelming!" }
+
+    provider { Settings.cis2.enabled ? "cis2" : nil }
+    sequence(:uid) { Settings.cis2.enabled ? _1.to_s : nil }
+    cis2_info { Settings.cis2.enabled ? cis2_info_hash : nil }
 
     trait :cis2 do
       provider { "cis2" }
       sequence(:uid, &:to_s)
-      password { nil }
+      cis2_info { cis2_info_hash }
+    end
+
+    factory :admin_staff do
+      transient do
+        selected_role_code { "S8000:G8001:R8006" }
+        selected_role_name { "Medical Secretary Access Role" }
+      end
+      sequence(:email) { |n| "admin-#{n}@example.com" }
     end
 
     trait :signed_in do
       current_sign_in_at { Time.current }
       current_sign_in_ip { "127.0.0.1" }
-    end
-
-    trait :nurse do
-      sequence(:email) { |n| "nurse-#{n}@example.com" }
-    end
-
-    trait :admin do
-      sequence(:email) { |n| "admin-#{n}@example.com" }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,4 +35,68 @@ describe User do
     it { should validate_length_of(:given_name).is_at_most(255) }
     it { should validate_length_of(:family_name).is_at_most(255) }
   end
+
+  describe "#is_medical_secretary?" do
+    subject { user.is_medical_secretary? }
+
+    context "cis2 is enabled", cis2: :enabled do
+      context "when the user is an admin" do
+        let(:user) { build(:admin_staff) }
+
+        it { should be true }
+      end
+
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be false }
+      end
+    end
+
+    context "cis2 is disabled", cis2: :disabled do
+      context "when the user is an admin" do
+        let(:user) { build(:admin_staff) }
+
+        it { should be true }
+      end
+
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be false }
+      end
+    end
+  end
+
+  describe "#is_nurse?" do
+    subject { user.is_nurse? }
+
+    context "cis2 is enabled", cis2: :enabled do
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be true }
+      end
+
+      context "when the user is admin staff" do
+        let(:user) { build(:admin_staff) }
+
+        it { should be false }
+      end
+    end
+
+    context "cis2 is disabled", cis2: :disabled do
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be true }
+      end
+
+      context "when the user is admin staff" do
+        let(:user) { build(:admin_staff) }
+
+        it { should be false }
+      end
+    end
+  end
 end

--- a/spec/support/cis2_context_helper.rb
+++ b/spec/support/cis2_context_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/VerifiedDoubles
+RSpec.configure do |config|
+  config.before(:each, cis2: :enabled) do
+    allow(Settings).to receive(:cis2).and_return(double(enabled: true))
+  end
+
+  config.before(:each, cis2: :disabled) do
+    allow(Settings).to receive(:cis2).and_return(double(enabled: false))
+  end
+end
+# rubocop:enable RSpec/VerifiedDoubles


### PR DESCRIPTION
This commit has been pulled out of a larger piece of work to make team-based authorisation work in CIS2-mode.

This is a small refactoring designed to make things a little clearer. We only have one SSO at the moment, so calling it CIS2 makes it clear what that means. This may change if we ever adopt another SSO.

Also adds testing around the related functionality with accomodation for CIS2 being enabled.