### PR TITLE
Rename medical_staff to admin_staff

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,7 +84,7 @@ class User < ApplicationRecord
     user.tap(&:save!)
   end
 
-  def is_medical_secretary?
+  def is_admin?
     return email.include?("admin") unless Settings.cis2.enabled
 
     selected_role = cis2_info.dig("selected_role", "code")

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,15 +9,15 @@ class ApplicationPolicy
   attr_reader :user, :record
 
   def index?
-    user.is_nurse? || user.is_medical_secretary?
+    user.is_nurse? || user.is_admin?
   end
 
   def show?
-    user.is_nurse? || user.is_medical_secretary?
+    user.is_nurse? || user.is_admin?
   end
 
   def create?
-    user.is_nurse? || user.is_medical_secretary?
+    user.is_nurse? || user.is_admin?
   end
 
   def new?
@@ -25,7 +25,7 @@ class ApplicationPolicy
   end
 
   def update?
-    user.is_nurse? || user.is_medical_secretary?
+    user.is_nurse? || user.is_admin?
   end
 
   def edit?
@@ -33,7 +33,7 @@ class ApplicationPolicy
   end
 
   def destroy?
-    user.is_nurse? || user.is_medical_secretary?
+    user.is_nurse? || user.is_admin?
   end
 
   class Scope

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -64,7 +64,7 @@ FactoryBot.define do
       cis2_info { cis2_info_hash }
     end
 
-    factory :admin_staff do
+    factory :admin do
       transient do
         selected_role_code { "S8000:G8001:R8006" }
         selected_role_name { "Medical Secretary Access Role" }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,12 +36,12 @@ describe User do
     it { should validate_length_of(:family_name).is_at_most(255) }
   end
 
-  describe "#is_medical_secretary?" do
-    subject { user.is_medical_secretary? }
+  describe "#is_admin?" do
+    subject { user.is_admin? }
 
     context "cis2 is enabled", cis2: :enabled do
       context "when the user is an admin" do
-        let(:user) { build(:admin_staff) }
+        let(:user) { build(:admin) }
 
         it { should be true }
       end
@@ -55,7 +55,7 @@ describe User do
 
     context "cis2 is disabled", cis2: :disabled do
       context "when the user is an admin" do
-        let(:user) { build(:admin_staff) }
+        let(:user) { build(:admin) }
 
         it { should be true }
       end
@@ -79,7 +79,7 @@ describe User do
       end
 
       context "when the user is admin staff" do
-        let(:user) { build(:admin_staff) }
+        let(:user) { build(:admin) }
 
         it { should be false }
       end
@@ -93,7 +93,7 @@ describe User do
       end
 
       context "when the user is admin staff" do
-        let(:user) { build(:admin_staff) }
+        let(:user) { build(:admin) }
 
         it { should be false }
       end


### PR DESCRIPTION
This commit has been pulled out of a larger piece of work to make team-based authorisation work in CIS2-mode.

We generally use "admin" instead of "medical secretary", so this change brings it closer to that. But also, medical secretary may be only one of the NHS RBAC roles that qualifies for the "admin [staff]" role in Mavis.