### PR TITLE
Authorise CIS2 users based on their team

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -7,7 +7,7 @@ class BatchesController < ApplicationController
   before_action :set_batch, except: %i[new create make_default]
 
   def new
-    @batch = Batch.new(team: current_user.team, vaccine:)
+    @batch = Batch.new(team: current_user.selected_team, vaccine:)
   end
 
   def create
@@ -25,7 +25,7 @@ class BatchesController < ApplicationController
     @batch =
       Batch.archived.find_or_initialize_by(
         name: batch_params[:name],
-        team: current_user.team,
+        team: current_user.selected_team,
         expiry:,
         vaccine:
       )

--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -14,7 +14,7 @@ class ClassImportsController < ApplicationController
     @class_import =
       ClassImport.new(
         session: @session,
-        team: current_user.team,
+        team: current_user.selected_team,
         uploaded_by: current_user,
         **class_import_params
       )

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -14,7 +14,7 @@ class CohortImportsController < ApplicationController
     @cohort_import =
       CohortImport.new(
         programme: @programme,
-        team: current_user.team,
+        team: current_user.selected_team,
         uploaded_by: current_user,
         **cohort_import_params
       )

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -14,7 +14,7 @@ class ImmunisationImportsController < ApplicationController
     @immunisation_import =
       ImmunisationImport.new(
         programme: @programme,
-        team: current_user.team,
+        team: current_user.selected_team,
         uploaded_by: current_user,
         **immunisation_import_params
       )

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -25,7 +25,7 @@ class ImportsController < ApplicationController
   private
 
   def set_team
-    @team = current_user.team
+    @team = current_user.selected_team
   end
 
   def set_programme

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -4,6 +4,6 @@ class TeamsController < ApplicationController
   skip_after_action :verify_policy_scoped
 
   def show
-    @team = current_user.team
+    @team = current_user.selected_team
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,14 @@ class User < ApplicationRecord
     teams.first
   end
 
+  def selected_team
+    if Settings.cis2.enabled
+      Team.find_by(ods_code: cis2_info.dig("selected_org", "code"))
+    else
+      teams.first
+    end
+  end
+
   def requires_email_and_password?
     provider.blank? || uid.blank?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,11 +61,6 @@ class User < ApplicationRecord
   scope :recently_active,
         -> { where(last_sign_in_at: 1.week.ago..Time.current) }
 
-  def team
-    # TODO: Update the app to properly support multiple teams per user
-    teams.first
-  end
-
   def selected_team
     if Settings.cis2.enabled
       Team.find_by(ods_code: cis2_info.dig("selected_org", "code"))

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -3,7 +3,7 @@
 class BatchPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.unarchived.where(team: user.teams)
+      scope.unarchived.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/class_import_policy.rb
+++ b/app/policies/class_import_policy.rb
@@ -3,7 +3,7 @@
 class ClassImportPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/cohort_import_policy.rb
+++ b/app/policies/cohort_import_policy.rb
@@ -3,7 +3,7 @@
 class CohortImportPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/cohort_policy.rb
+++ b/app/policies/cohort_policy.rb
@@ -3,7 +3,7 @@
 class CohortPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/consent_form_policy.rb
+++ b/app/policies/consent_form_policy.rb
@@ -3,7 +3,7 @@
 class ConsentFormPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/consent_policy.rb
+++ b/app/policies/consent_policy.rb
@@ -3,7 +3,7 @@
 class ConsentPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/immunisation_import_policy.rb
+++ b/app/policies/immunisation_import_policy.rb
@@ -3,7 +3,7 @@
 class ImmunisationImportPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -3,7 +3,7 @@
 class LocationPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -5,8 +5,8 @@ class PatientPolicy < ApplicationPolicy
     def resolve
       scope
         .left_outer_joins(:cohort, :school)
-        .where(cohort: { team: user.teams })
-        .or(Patient.where(school: { team: user.teams }))
+        .where(cohort: { team: user.selected_team })
+        .or(Patient.where(school: { team: user.selected_team }))
     end
   end
 end

--- a/app/policies/patient_session_policy.rb
+++ b/app/policies/patient_session_policy.rb
@@ -3,7 +3,7 @@
 class PatientSessionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.joins(:session).where(session: { team: user.teams })
+      scope.joins(:session).where(session: { team: user.selected_team })
     end
   end
 end

--- a/app/policies/programme_policy.rb
+++ b/app/policies/programme_policy.rb
@@ -3,7 +3,7 @@
 class ProgrammePolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(id: user.programmes.ids)
+      scope.where(id: user.selected_team.programmes.ids)
     end
   end
 end

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -3,7 +3,7 @@
 class SessionPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/triage_policy.rb
+++ b/app/policies/triage_policy.rb
@@ -11,7 +11,7 @@ class TriagePolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(team: user.teams)
+      scope.where(team: user.selected_team)
     end
   end
 end

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -19,7 +19,7 @@ class VaccinationRecordPolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.joins(:session).where(session: { team: user.teams })
+      scope.joins(:session).where(session: { team: user.selected_team })
     end
   end
 end

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :cohorts) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.selected_team, active: :cohorts) %>
 
 <%= govuk_button_link_to "Import child records", new_programme_cohort_import_path(@programme), class: "app-button--secondary" %>
 

--- a/app/views/import_issues/index.html.erb
+++ b/app/views/import_issues/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :import_issues) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.selected_team, active: :import_issues) %>
 
 <% if @import_issues.any? %>
   <div class="nhsuk-table__panel-with-heading-tab">

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -14,7 +14,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(
       @programme,
-      team: current_user.team,
+      team: current_user.selected_team,
       active: :imports,
     ) %>
 

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :sessions) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.selected_team, active: :sessions) %>
 
 <% [[@scheduled_sessions, "Sessions scheduled"],
     [@completed_sessions, "All sessions completed"],

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -8,4 +8,4 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :overview) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.selected_team, active: :overview) %>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.team, active: :vaccination_records) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.selected_team, active: :vaccination_records) %>
 
 <%= govuk_button_link_to "Import vaccination records", new_programme_immunisation_import_path, class: "app-button--secondary" %>
 

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -21,9 +21,8 @@ describe "Parental consent" do
 
   def given_a_patient_without_consent_exists
     programme = create(:programme, :hpv)
-
-    @user = create(:user, given_name: "Test", family_name: "User")
-    @team = create(:team, programmes: [programme], users: [@user])
+    @team = create(:team, :with_one_nurse, programmes: [programme])
+    @user = @team.users.first
 
     location = create(:location, :generic_clinic, team: @team)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,6 +36,24 @@ describe User do
     it { should validate_length_of(:family_name).is_at_most(255) }
   end
 
+  describe "#selected_team" do
+    subject { user.selected_team }
+
+    context "cis2 is disabled", cis2: :disabled do
+      let(:team) { build(:team) }
+      let(:user) { build(:user, teams: [team]) }
+
+      it { should eq user.teams.first }
+    end
+
+    context "cis2 is enabled", cis2: :enabled do
+      let(:team) { create(:team) }
+      let(:user) { create(:user, selected_team: team) }
+
+      it { should eq team }
+    end
+  end
+
   describe "#is_admin?" do
     subject { user.is_admin? }
 


### PR DESCRIPTION
This commit has been pulled out of a larger piece of work to make team-based authorisation work in CIS2-mode.

Users select a team when they authenticate with CIS2, and should only see data related the selected team. We don't have a mechanism to do this with the current password login, so we still support the old 'teams.first' in those (non-production) environments where we don't use CIS2. We can decide whether we want to be smarter about that later.
