### PR TITLE
Use actual session in consent notifications

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -23,7 +23,8 @@ class GovukNotifyPersonalisation
       programme || vaccination_record&.programme || consent_form&.programme ||
         consent&.programme
     @session =
-      session || consent_form&.original_session || patient_session&.session
+      session || consent_form&.actual_upcoming_session ||
+        consent_form&.original_session || patient_session&.session
     @team =
       session&.team || patient_session&.team || consent_form&.team ||
         consent&.team || vaccination_record&.team

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -125,18 +125,37 @@ describe GovukNotifyPersonalisation do
       create(
         :consent_form,
         :refused,
-        session: create(:session, programme:),
+        session:,
         recorded_at: Date.new(2024, 1, 1)
       )
     end
 
     it do
-      expect(personalisation).to match(
-        hash_including(
-          reason_for_refusal: "of personal choice",
-          survey_deadline_date: "8 January 2024"
-        )
+      expect(personalisation).to include(
+        reason_for_refusal: "of personal choice",
+        survey_deadline_date: "8 January 2024",
+        location_name: "Hogwarts"
       )
+    end
+
+    context "where the school is different" do
+      let(:session) { nil }
+      let(:school) { create(:location, :school, name: "Waterloo Road") }
+
+      let(:consent_form) do
+        create(
+          :consent_form,
+          :given,
+          :recorded,
+          session: create(:session, location:, programme:, team:),
+          school_confirmed: false,
+          school:
+        )
+      end
+
+      before { create(:session, location: school, programme:, team:) }
+
+      it { should include(location_name: "Waterloo Road") }
     end
   end
 


### PR DESCRIPTION
If the parent has told us that their child goes to a different school, we need to show that new school (and it's approriate session) in the emails and texts.