### PR TITLE
Hide release 1b behind a feature flag

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -46,4 +46,6 @@
   <%= govuk_button_to "Send consent request", session_patient_request_consent_path(session, patient_id: patient.id, section: @section, tab: @tab), class: "app-button--secondary" %>
 <% end %>
 
-<%= govuk_button_to "Get consent response", session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab), class: "app-button--secondary" %>
+<% if Flipper.enabled?(:release_1b) %>
+  <%= govuk_button_to "Get consent response", session_patient_manage_consents_path(session, patient_id: patient.id, section: @section, tab: @tab), class: "app-button--secondary" %>
+<% end %>

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -64,35 +64,37 @@
   <% end %>
 <% end %>
 
-<% if @patient_session.triages.any? %>
-  <%= render AppCardComponent.new do |c| %>
-    <% c.with_heading { "Triage notes" } %>
-    <%= render AppTriageNotesComponent.new(patient_session:) %>
+<% if Flipper.enabled?(:release_1b) %>
+  <% if @patient_session.triages.any? %>
+    <%= render AppCardComponent.new do |c| %>
+      <% c.with_heading { "Triage notes" } %>
+      <%= render AppTriageNotesComponent.new(patient_session:) %>
+    <% end %>
   <% end %>
-<% end %>
 
-<% if helpers.policy(Triage).create? && @patient_session.next_step == :triage %>
-  <%= render AppCardComponent.new do %>
-    <%= render AppTriageFormComponent.new(
-          patient_session: @patient_session,
-          url: session_patient_triages_path(
-            session,
-            patient,
-            @triage,
-            section: @section,
-            tab: @tab,
-          ),
-          triage: @triage,
-          legend: :bold,
+  <% if helpers.policy(Triage).create? && @patient_session.next_step == :triage %>
+    <%= render AppCardComponent.new do %>
+      <%= render AppTriageFormComponent.new(
+            patient_session: @patient_session,
+            url: session_patient_triages_path(
+              session,
+              patient,
+              @triage,
+              section: @section,
+              tab: @tab,
+            ),
+            triage: @triage,
+            legend: :bold,
+          ) %>
+    <% end %>
+  <% end %>
+
+  <% if helpers.policy(VaccinationRecord).create? %>
+    <%= render AppVaccinateFormComponent.new(
+          patient_session:,
+          vaccination_record: @vaccination_record,
+          section: @section,
+          tab: @tab,
         ) %>
   <% end %>
-<% end %>
-
-<% if helpers.policy(VaccinationRecord).create? %>
-  <%= render AppVaccinateFormComponent.new(
-        patient_session:,
-        vaccination_record: @vaccination_record,
-        section: @section,
-        tab: @tab,
-      ) %>
 <% end %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -35,7 +35,8 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def gillick_assessment_can_be_recorded?
-    patient_session.session.today? && helpers.policy(GillickAssessment).new?
+    Flipper.enabled?(:release_1b) && patient_session.session.today? &&
+      helpers.policy(GillickAssessment).new?
   end
 
   def gillick_assessment_recorded?

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -57,12 +57,14 @@
                       aria: { current: request.path.start_with?(patients_path) ?
                         "true" : nil } %>
         </li>
-        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-          <%= link_to t("vaccines.index.title"), vaccines_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(vaccines_path) ?
-                        "true" : nil } %>
-        </li>
+        <% if Flipper.enabled?(:release_1b) %>
+          <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
+            <%= link_to t("vaccines.index.title"), vaccines_path,
+                        class: "nhsuk-header__navigation-link",
+                        aria: { current: request.path.start_with?(vaccines_path) ?
+                          "true" : nil } %>
+          </li>
+        <% end %>
         <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
           <%= link_to t("consent_forms.index.title_short"), consent_forms_path,
                       class: "nhsuk-header__navigation-link",

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -39,12 +39,14 @@
 </ul>
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
-  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: vaccines_path, secondary: true) do |card| %>
-      <% card.with_heading { t("vaccines.index.title") } %>
-      <% card.with_description { "Add and edit vaccine batches" } %>
-    <% end %>
-  </li>
+  <% if Flipper.enabled?(:release_1b) %>
+    <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+      <%= render AppCardComponent.new(link_to: vaccines_path, secondary: true) do |card| %>
+        <% card.with_heading { t("vaccines.index.title") } %>
+        <% card.with_description { "Add and edit vaccine batches" } %>
+      <% end %>
+    </li>
+  <% end %>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: consent_forms_path, secondary: true) do |card| %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -49,6 +49,7 @@
           <% end %>
         </li>
       <% end %>
+
       <% if @session.unscheduled? %>
         <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: edit_session_path) do |c| %>
@@ -68,24 +69,28 @@
             <% end %>
           <% end %>
         </li>
-        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
-            <% c.with_heading { "Triage health questions" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @counts[:needing_triage]) %> needing triage
+
+        <% if Flipper.enabled?(:release_1b) %>
+          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+            <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
+              <% c.with_heading { "Triage health questions" } %>
+              <% c.with_description do %>
+                <%= t("children", count: @counts[:needing_triage]) %> needing triage
+              <% end %>
             <% end %>
-          <% end %>
-        </li>
-        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
-            <% c.with_heading { "Record vaccinations" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
-              <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
-              <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
+          </li>
+
+          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+            <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
+              <% c.with_heading { "Record vaccinations" } %>
+              <% c.with_description do %>
+                <%= t("children", count: @counts[:vaccinate]) %> to vaccinate<br>
+                <%= t("children", count: @counts[:vaccinated]) %> vaccinated<br>
+                <%= t("children", count: @counts[:could_not_vaccinate]) %> could not be vaccinated
+              <% end %>
             <% end %>
-          <% end %>
-        </li>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -26,6 +26,6 @@
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Vaccination details" } %>
   <%= render AppVaccinationRecordSummaryComponent.new(
-        @vaccination_record, change_links: true,
+        @vaccination_record, change_links: Flipper.enabled?(:release_1b),
       ) %>
 <% end %>

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -17,7 +17,13 @@ describe AppConsentComponent, type: :component do
     it { should_not have_css("details", text: /Consent (given|refused) by/) }
     it { should_not have_css("details", text: "Responses to health questions") }
     it { should have_css("p", text: "No requests have been sent.") }
-    it { should have_css("button", text: "Get consent") }
+
+    context "in release 1b" do
+      before { Flipper.enable(:release_1b) }
+      after { Flipper.disable(:release_1b) }
+
+      it { should have_css("button", text: "Get consent") }
+    end
   end
 
   context "consent is not present and session is not in progress" do

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -26,6 +26,9 @@ describe AppPatientPageComponent do
   end
 
   context "session in progress, patient in triage" do
+    before { Flipper.enable(:release_1b) }
+    after { Flipper.disable(:release_1b) }
+
     let(:patient_session) do
       create(
         :patient_session,
@@ -68,6 +71,9 @@ describe AppPatientPageComponent do
   end
 
   context "session in progress, patient ready to vaccinate" do
+    before { Flipper.enable(:release_1b) }
+    after { Flipper.disable(:release_1b) }
+
     let(:patient_session) do
       create(
         :patient_session,
@@ -108,6 +114,9 @@ describe AppPatientPageComponent do
   end
 
   context "session in progress, patient without consent, no Gillick assessment" do
+    before { Flipper.enable(:release_1b) }
+    after { Flipper.disable(:release_1b) }
+
     let(:patient_session) do
       create(:patient_session, :session_in_progress, programme:)
     end

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "End-to-end journey" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Cohorting, session creation, verbal consent, vaccination" do

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Edit vaccination record" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "User edits the date/time" do
     given_i_am_signed_in
     and_an_hpv_programme_is_underway

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "HPV Vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Administered" do

--- a/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "HPV vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "cannot be recorded by an admin" do

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "HPV Vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Administered at a clinic" do

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "HPV Vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
   scenario "Default batch" do

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "HPV Vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Delayed" do
     given_i_am_signed_in
     when_i_go_to_a_patient_that_is_ready_to_vaccinate

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "HPV Vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Not administered" do
     given_i_am_signed_in
     when_i_go_to_a_patient_that_is_ready_to_vaccinate

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Manage batches" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   around { |example| travel_to(Time.zone.local(2024, 2, 29)) { example.run } }
 
   scenario "Adding and editing batches" do

--- a/spec/features/manage_vaccines_spec.rb
+++ b/spec/features/manage_vaccines_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Manage vaccines" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Viewing a vaccine" do
     given_my_team_is_running_an_hpv_vaccination_programme
 

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
+  after { Flipper.disable(:release_1b) }
+
   scenario "Refused" do
     given_an_hpv_programme_is_underway
     and_requests_can_be_made_to_pds
@@ -20,6 +22,8 @@ describe "Parental consent" do
 
     when_the_nurse_checks_the_consent_responses
     then_they_see_that_the_child_has_consent_refused
+
+    given_release_1b_is_enabled
     and_the_action_in_the_vaccination_session_is_to_check_refusal
   end
 
@@ -36,6 +40,10 @@ describe "Parental consent" do
         location:
       )
     @child = create(:patient, session: @session)
+  end
+
+  def given_release_1b_is_enabled
+    Flipper.enable(:release_1b)
   end
 
   def and_requests_can_be_made_to_pds

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
+  after { Flipper.disable(:release_1b) }
+
   scenario "Consent form exactly matches the cohort" do
     given_an_hpv_programme_is_underway
     and_requests_can_be_made_to_pds
@@ -22,6 +24,7 @@ describe "Parental consent" do
     then_they_see_that_the_child_has_consent
     and_they_see_the_full_consent_form
 
+    given_release_1b_is_enabled
     when_they_check_triage
     then_the_patient_should_be_ready_to_vaccinate
   end
@@ -39,6 +42,10 @@ describe "Parental consent" do
         location:
       )
     @child = create(:patient, session: @session)
+  end
+
+  def given_release_1b_is_enabled
+    Flipper.enable(:release_1b)
   end
 
   def and_requests_can_be_made_to_pds

--- a/spec/features/self_consent_clinic_spec.rb
+++ b/spec/features/self_consent_clinic_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 describe "Self-consent" do
-  after { travel_back }
+  before { Flipper.enable(:release_1b) }
+
+  after do
+    Flipper.disable(:release_1b)
+    travel_back
+  end
 
   scenario "Performed at a clinic" do
     given_an_hpv_programme_is_underway

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 describe "Self-consent" do
-  after { travel_back }
+  before { Flipper.enable(:release_1b) }
+
+  after do
+    Flipper.disable(:release_1b)
+    travel_back
+  end
 
   scenario "No consent from parent, the child is Gillick competent so can self-consent" do
     given_an_hpv_programme_is_underway

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 describe "Not Gillick competent" do
-  after { travel_back }
+  before { Flipper.enable(:release_1b) }
+
+  after do
+    Flipper.disable(:release_1b)
+    travel_back
+  end
 
   scenario "No consent from parent, the child is not Gillick competent" do
     given_an_hpv_programme_is_underway

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Triage" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "delay vaccination" do
     given_a_programme_with_a_running_session
     and_i_am_signed_in

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Triage" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "nurse can triage a patient" do
     given_a_programme_with_a_running_session
     when_i_go_to_the_patient_that_needs_triage

--- a/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
+++ b/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent recorded by admin" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given with some freetext health answers" do
     given_i_am_signed_in_as_an_admin
 

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given by a parental contact not on the system" do
     given_i_am_signed_in
 

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given, do not vaccinate" do
     given_i_am_signed_in
 

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given, keep in triage" do
     given_i_am_signed_in
 

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given, with health notes but safe to vaccinate" do
     given_i_am_signed_in
 

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given" do
     given_i_am_signed_in
 

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 feature "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Given when previously refused" do
     given_an_hpv_programme_is_underway
     and_a_parent_has_refused_consent_for_their_child

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
   scenario "Refused" do
     given_i_am_signed_in
 

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -28,13 +28,15 @@ test("Accessibility", async ({ page }) => {
   await expect(page.locator("h1")).toContainText("Mavis");
   await checkAccessibility(page);
 
+  // RE-ENABLE FOR RELEASE 1B
+
   // Vaccines page
-  await page.getByRole("heading", { name: "Vaccines" }).click();
-  await expect(page.locator("h1")).toContainText("Vaccines");
-  await checkAccessibility(page);
+  // await page.getByRole("heading", { name: "Vaccines" }).click();
+  // await expect(page.locator("h1")).toContainText("Vaccines");
+  // await checkAccessibility(page);
 
   // Vaccine page
-  await page.getByRole("link", { name: "Gardasil 9" }).click();
-  await expect(page.locator("h1")).toContainText("Gardasil 9");
-  await checkAccessibility(page);
+  // await page.getByRole("link", { name: "Gardasil 9" }).click();
+  // await expect(page.locator("h1")).toContainText("Gardasil 9");
+  // await checkAccessibility(page);
 });


### PR DESCRIPTION
This moves a number of features releated to release 1b (the release after the current focus of release 1a) to be behind a feature flag, so we can test and release product under the current scope without seeing future scope.