### PR TITLE
Add extra support health question

### DIFF
--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -39,7 +39,13 @@ namespace :vaccines do
             next_question:
               vaccine.health_questions.create!(
                 title:
-                  "Has your child ever had a severe reaction to any medicines, including vaccines?"
+                  "Has your child ever had a severe reaction to any medicines, including vaccines?",
+                next_question:
+                  vaccine.health_questions.create!(
+                    title:
+                      "Does your child need extra support during vaccination sessions?",
+                    hint: "For example, they’re autistic, or extremely anxious"
+                  )
               )
           )
       )

--- a/spec/factories/health_questions.rb
+++ b/spec/factories/health_questions.rb
@@ -59,6 +59,14 @@ FactoryBot.define do
       end
     end
 
+    trait :extra_support do
+      for_hpv_vaccine
+      title do
+        "Does your child need extra support during vaccination sessions?"
+      end
+      hint { "For example, they’re autistic, or extremely anxious" }
+    end
+
     # Flu vaccine questions
     trait :asthma do
       for_flu_vaccine

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -87,9 +87,11 @@ FactoryBot.define do
         medical_conditions =
           create(:health_question, :medical_conditions, vaccine:)
         severe_reaction = create(:health_question, :severe_reaction, vaccine:)
+        extra_support = create(:health_question, :extra_support, vaccine:)
 
-        severe_allergies.update! next_question: medical_conditions
-        medical_conditions.update! next_question: severe_reaction
+        severe_allergies.update!(next_question: medical_conditions)
+        medical_conditions.update!(next_question: severe_reaction)
+        severe_reaction.update!(next_question: extra_support)
       end
     end
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -176,6 +176,7 @@ describe "End-to-end journey" do
     find_all(".nhsuk-fieldset")[0].choose "No"
     find_all(".nhsuk-fieldset")[1].choose "No"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "Yes, it’s safe to vaccinate"

--- a/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
+++ b/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
@@ -45,6 +45,7 @@ describe "Verbal consent recorded by admin" do
               with: "moar allergies"
     find_all(".nhsuk-fieldset")[1].choose "No"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     expect(page).not_to have_content("Is it safe to vaccinate?")

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -51,6 +51,7 @@ describe "Verbal consent" do
     find_all(".nhsuk-fieldset")[0].choose "No"
     find_all(".nhsuk-fieldset")[1].choose "No"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "Yes, it’s safe to vaccinate"

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -45,6 +45,7 @@ describe "Verbal consent" do
     find_all(".nhsuk-fieldset")[2].choose "Yes"
     find_all(".nhsuk-fieldset")[2].fill_in "Give details",
               with: "moar reactions"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "No, do not vaccinate"

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -45,6 +45,7 @@ describe "Verbal consent" do
               with: "moar allergies"
     find_all(".nhsuk-fieldset")[1].choose "No"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "No, keep in triage"

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -46,6 +46,7 @@ describe "Verbal consent" do
     find_all(".nhsuk-fieldset")[1].fill_in "Give details",
               with: "moar medicines"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "Yes, it’s safe to vaccinate"

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -55,6 +55,7 @@ describe "Verbal consent" do
     find_all(".nhsuk-fieldset")[0].choose "No"
     find_all(".nhsuk-fieldset")[1].choose "No"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "Yes, it’s safe to vaccinate"
@@ -102,7 +103,7 @@ describe "Verbal consent" do
     expect(page).to have_content("Answers to health questions")
     expect(page).to have_content(
       "#{parent.relationship_to(patient: @patient).label} responded: No",
-      count: 3
+      count: 4
     )
   end
 

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -74,6 +74,7 @@ feature "Verbal consent" do
     find_all(".nhsuk-fieldset")[0].choose "No"
     find_all(".nhsuk-fieldset")[1].choose "No"
     find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
     choose "Yes, it’s safe to vaccinate"


### PR DESCRIPTION
This adds the health question "Does your child need extra support during vaccination sessions?" that exists in the prototype and paper consent form but not yet in the service.