### PR TITLE
Ignore trailing blank rows when importing CSV files

### DIFF
--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -174,7 +174,7 @@ describe "Import child records" do
 
   def then_i_should_the_errors_page_with_invalid_fields
     expect(page).to have_content("How to format your CSV for child records")
-    expect(page).to have_content("Row 2")
+    expect(page).to have_content("Row 1")
   end
 
   def when_it_is_a_litte_bit_later

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -146,7 +146,7 @@ describe "Import class lists" do
 
   def then_i_should_the_errors_page_with_invalid_fields
     expect(page).to have_content("How to format your CSV for class lists")
-    expect(page).to have_content("Row 2")
+    expect(page).to have_content("Row 1")
   end
 
   def when_i_go_back_to_the_upload_page

--- a/spec/fixtures/class_import/valid.csv
+++ b/spec/fixtures/class_import/valid.csv
@@ -3,3 +3,4 @@ PARENT_1_NAME,PARENT_1_RELATIONSHIP,PARENT_1_EMAIL,PARENT_1_PHONE,PARENT_2_NAME,
 John Smith,Father,john@example.com,07412345678,,,,,Jimmy,Smith,Jim,02/01/2010,10 Downing Street,,London,SW1A 1AA,ABC,123 456 7891
 Jane Doe,Mother,jane@example.com,07412345679,Richard Doe,Father,richard@example.com,,Mark,Doe,,2010-01-03,11 Downing Street,,London,SW1A 1AA,DEF,1234567892
 ,,peter@example.com,07412345678,,,,,Gae,Thorne-Smith,,2010-04-09,,,,SW1A 1AA,GHI,
+,,,,,,,,,,,,,,,,,

--- a/spec/fixtures/cohort_import/valid.csv
+++ b/spec/fixtures/cohort_import/valid.csv
@@ -2,3 +2,4 @@ CHILD_SCHOOL_URN,PARENT_1_NAME,PARENT_1_RELATIONSHIP,PARENT_1_EMAIL,PARENT_1_PHO
 123456,,,,,,,,,Jennifer,Clarke,Jenny,2010-01-01,10 Downing Street,,London,SW1A 1AA,1234567890
 123456,John Smith,Father,john@example.com,07412345678,,,,,Jimmy,Smith,Jim,02/01/2010,10 Downing Street,,London,SW1A 1AA,123 456 7891
 123456,Jane Doe,Mother,jane@example.com,07412345679,Richard Doe,Father,richard@example.com,,Mark,Doe,,2010-01-03,11 Downing Street,,London,SW1A 1AA,
+,,,,,,,,,,,,,,,,,

--- a/spec/fixtures/immunisation_import/valid_flu.csv
+++ b/spec/fixtures/immunisation_import/valid_flu.csv
@@ -10,3 +10,4 @@ R1L,120026,shaftesbury junior school ,3017356345,Trudie,Chadwick,20120919,Female
 R1L,144012,Home Schooled,5404296666,Alecia,Ainsworth,20120920,Female,LE7 2DA,no,20240514,,,,,,,Vaccination Contraindicated,,LocalPatient9,www.LocalPatient9
 R1L,999999,Home Schooled,6401122986,Lily,Fletcher,20120921,Female,LE7 2PX,no,20240514,,,,,,,Unwell,,LocalPatient10,www.LocalPatient10
 R1L,888888,Unknown School,1234567890,Pete,Jones,20120922,Male,LE7 2FF,no,20240514,,,,,,,Unwell,,LocalPatient11,www.LocalPatient11
+,,,,,,,,,,,,,,,,,,,,

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -10,3 +10,4 @@ R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,202304
 R1L,110158,,9999148581,Harold,Andrew,20101002,Not known,SW11 1AA,20230113,Gardasil,OU1731,20241015,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525156,Martial,Dare,20101002,Not known,SW11 1AA,20230126,Gardasil,OZ2022,20241010,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525157,Harold,Dare,20101002,Not known,SW11 1AA,20220126,Gardasil,SA6880,20241012,left upper arm,1,LocalPatient7,www.LocalPatient7,1
+,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
If the CSV import encounters a trailing row that's completely blank then it's likely that this was an attempt to remove the row by the user, but rather than remove the row they removed all the values in the row. We should treat this as though the row isn't there and not import it.