### PR TITLE
Use programme type instead of ID in URLs

### DIFF
--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -58,7 +58,7 @@ class CohortImportsController < ApplicationController
   private
 
   def set_programme
-    @programme = policy_scope(Programme).find(params[:programme_id])
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 
   def set_cohort_import

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -34,6 +34,6 @@ class CohortsController < ApplicationController
   private
 
   def set_programme
-    @programme = policy_scope(Programme).find(params[:programme_id])
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/immunisation_imports/duplicates_controller.rb
+++ b/app/controllers/immunisation_imports/duplicates_controller.rb
@@ -29,8 +29,8 @@ class ImmunisationImports::DuplicatesController < ApplicationController
 
   def set_programme
     @programme =
-      policy_scope(Programme).includes(:immunisation_imports).find(
-        params[:programme_id]
+      policy_scope(Programme).includes(:immunisation_imports).find_by!(
+        type: params[:programme_type]
       )
   end
 

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -78,7 +78,7 @@ class ImmunisationImportsController < ApplicationController
   private
 
   def set_programme
-    @programme = policy_scope(Programme).find(params[:programme_id])
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 
   def set_immunisation_import

--- a/app/controllers/import_issues_controller.rb
+++ b/app/controllers/import_issues_controller.rb
@@ -27,7 +27,7 @@ class ImportIssuesController < ApplicationController
   private
 
   def set_programme
-    @programme = policy_scope(Programme).find(params[:programme_id])
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 
   def set_import_issues

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -29,6 +29,6 @@ class ImportsController < ApplicationController
   end
 
   def set_programme
-    @programme = policy_scope(Programme).find(params[:programme_id])
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -52,7 +52,7 @@ module ParentInterface
 
     def set_session_and_programme
       @session = Session.find(params[:session_id])
-      @programme = @session.programmes.find(params[:programme_id])
+      @programme = @session.programmes.find_by!(type: params[:programme_type])
       @team = @session.team
     end
 

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -28,6 +28,6 @@ class ProgrammesController < ApplicationController
   private
 
   def set_programme
-    @programme = policy_scope(Programme).find(params[:id])
+    @programme = policy_scope(Programme).find_by!(type: params[:type])
   end
 end

--- a/app/controllers/vaccination_records/edit_controller.rb
+++ b/app/controllers/vaccination_records/edit_controller.rb
@@ -29,8 +29,8 @@ class VaccinationRecords::EditController < ApplicationController
   def set_vaccination_record
     @vaccination_record =
       policy_scope(VaccinationRecord)
-        .where(programme: params[:programme_id])
-        .includes(:programme)
+        .eager_load(:programme)
+        .where(programme: { type: params[:programme_type] })
         .find(params[:vaccination_record_id])
   end
 

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -32,7 +32,8 @@ class VaccinationRecordsController < ApplicationController
   private
 
   def programme
-    @programme ||= policy_scope(Programme).find(params[:programme_id])
+    @programme ||=
+      policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 
   def vaccination_records

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -48,4 +48,8 @@ class Programme < ApplicationRecord
   def year_groups
     YEAR_GROUPS_BY_TYPE.fetch(type)
   end
+
+  def to_param
+    type
+  end
 end

--- a/app/views/parent_interface/consent_forms/start.html.erb
+++ b/app/views/parent_interface/consent_forms/start.html.erb
@@ -8,6 +8,6 @@
 
 <%= form_with url: url_for(action: :create) do |f| %>
   <%= hidden_field_tag :session_id, @session.id %>
-  <%= hidden_field_tag :programme_id, @programme.id %>
+  <%= hidden_field_tag :programme_type, @programme.type %>
   <%= f.govuk_submit "Start now" %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,8 +74,8 @@ Rails.application.routes.draw do
   namespace :parent_interface, path: "/" do
     resources :consent_forms, path: "/consents", only: %i[create] do
       collection do
-        get ":session_id/:programme_id/start", action: "start", as: :start
-        get ":session_id/:programme_id/deadline-passed",
+        get ":session_id/:programme_type/start", action: "start", as: :start
+        get ":session_id/:programme_type/deadline-passed",
             action: "deadline_passed",
             as: :deadline_passed
       end
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
 
   resources :patients, only: %i[index show update]
 
-  resources :programmes, only: %i[index show] do
+  resources :programmes, only: %i[index show], param: :type do
     get "sessions", on: :member
 
     resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -89,7 +89,7 @@ describe "User authorisation" do
   end
 
   def when_i_go_to_the_sessions_page_filtered_by_programme
-    visit "/programmes/#{@programme.id}/sessions"
+    visit "/programmes/#{@programme.type}/sessions"
   end
 
   def then_i_should_only_see_my_sessions

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -46,8 +46,7 @@ describe GovukNotifyPersonalisation do
       {
         catch_up: "no",
         consent_deadline: "Wednesday 31 December",
-        consent_link:
-          "http://localhost:4000/consents/#{session.id}/#{programme.id}/start",
+        consent_link: "http://localhost:4000/consents/#{session.id}/hpv/start",
         full_and_preferred_patient_name: "John Smith",
         location_name: "Hogwarts",
         next_session_date: "Thursday 1 January",


### PR DESCRIPTION
This improves the readability of our URLs by using the programme type (which is a unique string either `hpv` or `flu`) instead of the ID which is an auto-incrementing integer.

The main advantage of this is when it comes to sharing links to consent forms for patients, the phrase `hpv` or `flu` will appear in the URL, meaning they're easier to type out if they're copying the link from a text.