### PR TITLE
Handle invalid session dates gracefully

### DIFF
--- a/app/controllers/session_dates_controller.rb
+++ b/app/controllers/session_dates_controller.rb
@@ -8,7 +8,7 @@ class SessionDatesController < ApplicationController
   end
 
   def update
-    @session.assign_attributes(session_params)
+    @session.assign_attributes(remove_invalid_dates(session_params))
 
     render :show, status: :unprocessable_entity and return if @session.invalid?
 
@@ -41,5 +41,29 @@ class SessionDatesController < ApplicationController
 
   def any_destroyed?
     session_params[:dates_attributes].values.any? { _1[:_destroy].present? }
+  end
+
+  def remove_invalid_dates(obj, key: "dates_attributes")
+    return obj if obj[key].blank?
+
+    obj[key] = obj[key].transform_values do |value|
+      if value.key?("value(1i)") && value.key?("value(2i)") &&
+           value.key?("value(3i)")
+        begin
+          Date.new(
+            value["value(1i)"].to_i,
+            value["value(2i)"].to_i,
+            value["value(3i)"].to_i
+          )
+          value
+        rescue StandardError
+          {}
+        end
+      else
+        value
+      end
+    end
+
+    obj
   end
 end


### PR DESCRIPTION
This applies a similar change to 9ae1c594b904c2f5826027e3e6dcc64db7f5f969 to session dates to avoid a crash and instead show a validation error.

## Screenshots

![Screenshot 2024-10-28 at 13 49 09](https://github.com/user-attachments/assets/01855745-a088-45e9-b5d6-b1fa46234be3)
![Screenshot 2024-10-28 at 13 49 13](https://github.com/user-attachments/assets/4fab7bca-4d0c-48cc-aeee-b8e48e54c123)
