### PR TITLE
Discard PatientUpdateFromPDSJob on errors

### DIFF
--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -6,6 +6,9 @@ class PatientUpdateFromPDSJob < ApplicationJob
 
   queue_as :imports
 
+  discard_on Faraday::ResourceNotFound
+  discard_on NHS::PDS::InvalidNHSNumber
+
   def perform(patient)
     raise MissingNHSNumber if patient.nhs_number.nil?
 


### PR DESCRIPTION
This makes it explicit that we can safely discard this job on a number of errors from the PDS API where retrying the job is guaranteed not to succeed, specifically where the NHS number is invalid or doesn't exist.