### PR TITLE
Mark patients as invalid when NHS number is invalid

### DIFF
--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -5,7 +5,6 @@ class PatientUpdateFromPDSJob < ApplicationJob
 
   queue_as :pds
 
-  discard_on NHS::PDS::InvalidNHSNumber
   discard_on NHS::PDS::PatientNotFound
 
   def perform(patient)
@@ -34,7 +33,7 @@ class PatientUpdateFromPDSJob < ApplicationJob
     else
       patient.update_from_pds!(pds_patient)
     end
-  rescue NHS::PDS::InvalidatedResource
+  rescue NHS::PDS::InvalidatedResource, NHS::PDS::InvalidNHSNumber
     patient.invalidate!
   end
 

--- a/spec/jobs/patient_update_from_pds_job_spec.rb
+++ b/spec/jobs/patient_update_from_pds_job_spec.rb
@@ -96,5 +96,27 @@ describe PatientUpdateFromPDSJob do
         perform_now
       end
     end
+
+    context "when the NHS number is invalid" do
+      before do
+        stub_request(
+          :get,
+          "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9000000009"
+        ).to_return(
+          body: file_fixture("pds/invalid-nhs-number-response.json"),
+          status: 400,
+          headers: {
+            "Content-Type" => "application/fhir+json"
+          }
+        )
+      end
+
+      let(:patient) { create(:patient, nhs_number: "9000000009") }
+
+      it "marks the patient as invalid" do
+        expect(patient).to receive(:invalidate!)
+        perform_now
+      end
+    end
   end
 end


### PR DESCRIPTION
If the NHS number itself is invalid we can mark the patient as invalid. This extends the definition of an invalid patient from the definition in PDS to include these cases.

An advantage of this is that we can avoid checking PDS for patients we know will never succeed by excluding all types of invalid patients. A potential disadvantage is that these patients will appear in the notices, although I’d argue they are still "invalid".