### PR TITLE
Add BulkUpdatePatientsFromPDSJob

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class BulkUpdatePatientsFromPDSJob < ApplicationJob
+  include GoodJob::ActiveJobExtensions::Concurrency
+
+  queue_as :pds
+
+  good_job_control_concurrency_with perform_limit: 1
+
+  def perform
+    patients = Patient.with_nhs_number.not_invalidated.not_deceased
+
+    patients
+      .where(updated_from_pds_at: nil)
+      .find_each { |patient| PatientUpdateFromPDSJob.perform_later(patient) }
+
+    patients
+      .where("updated_from_pds_at < ?", 6.hours.ago)
+      .order(:updated_from_pds_at)
+      .find_each { |patient| PatientUpdateFromPDSJob.perform_later(patient) }
+  end
+end

--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -4,7 +4,7 @@ class PatientUpdateFromPDSJob < ApplicationJob
   include NHSAPIConcurrencyConcern
   include MergePatientsConcern
 
-  queue_as :imports
+  queue_as :pds
 
   discard_on NHS::PDS::InvalidNHSNumber
   discard_on NHS::PDS::PatientNotFound

--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -6,8 +6,8 @@ class PatientUpdateFromPDSJob < ApplicationJob
 
   queue_as :imports
 
-  discard_on Faraday::ResourceNotFound
   discard_on NHS::PDS::InvalidNHSNumber
+  discard_on NHS::PDS::PatientNotFound
 
   def perform(patient)
     raise MissingNHSNumber if patient.nhs_number.nil?

--- a/app/lib/nhs/pds.rb
+++ b/app/lib/nhs/pds.rb
@@ -23,6 +23,9 @@ module NHS::PDS
   class InvalidNHSNumber < StandardError
   end
 
+  class PatientNotFound < StandardError
+  end
+
   class << self
     def get_patient(nhs_number)
       NHS::API.connection.get(
@@ -37,6 +40,8 @@ module NHS::PDS
     rescue Faraday::ResourceNotFound => e
       if is_error?(e, "INVALIDATED_RESOURCE")
         raise InvalidatedResource, nhs_number
+      elsif is_error?(e, "RESOURCE_NOT_FOUND")
+        raise PatientNotFound, nhs_number
       else
         raise
       end

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -144,7 +144,7 @@ module CSVImportable
       if patient.nhs_number.nil?
         PatientNHSNumberLookupJob.perform_later(patient)
       else
-        PatientUpdateFromPDSJob.perform_later(patient)
+        PatientUpdateFromPDSJob.set(queue: :imports).perform_later(patient)
       end
     end
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -80,7 +80,8 @@ class Patient < ApplicationRecord
   # https://www.datadictionary.nhs.uk/attributes/person_gender_code.html
   enum :gender_code, { not_known: 0, male: 1, female: 2, not_specified: 9 }
 
-  scope :without_nhs_number, -> { where(nhs_number: [nil, ""]) }
+  scope :with_nhs_number, -> { where.not(nhs_number: nil) }
+  scope :without_nhs_number, -> { where(nhs_number: nil) }
 
   scope :not_deceased, -> { where(date_of_death: nil) }
   scope :deceased, -> { where.not(date_of_death: nil) }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -122,6 +122,11 @@ Rails.application.configure do
 
   config.good_job.enable_cron = true
   config.good_job.cron = {
+    bulk_update_patients_from_pds: {
+      cron: "every day at 00:00 and 6:00 and 12:00 and 18:00",
+      class: "BulkUpdatePatientsFromPDSJob",
+      description: "Keep patient details up to date with PDS."
+    },
     clinic_invitation: {
       cron: "every day at 9am",
       class: "ClinicSessionInvitationsJob",

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,6 +5,11 @@ require Rails.root.join("config/environments/production")
 Rails.application.configure do
   config.good_job.enable_cron = true
   config.good_job.cron = {
+    bulk_update_patients_from_pds: {
+      cron: "every day at 00:00 and 6:00 and 12:00 and 18:00",
+      class: "BulkUpdatePatientsFromPDSJob",
+      description: "Keep patient details up to date with PDS."
+    },
     mesh_validate_mailbox: {
       cron: "every day at 1am",
       class: "MESHValidateMailboxJob",

--- a/spec/fixtures/files/pds/not-found-patient-response.json
+++ b/spec/fixtures/files/pds/not-found-patient-response.json
@@ -1,0 +1,20 @@
+{
+  "resourceType": "OperationOutcome",
+  "issue": [
+    {
+      "severity": "error",
+      "code": "structure",
+      "details": {
+        "coding": [
+          {
+            "system": "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+            "version": "1",
+            "code": "RESOURCE_NOT_FOUND",
+            "display": "Resource not found"
+          }
+        ]
+      },
+      "diagnostics": "Resource not found"
+    }
+  ]
+}

--- a/spec/jobs/bulk_update_patients_from_pds_job_spec.rb
+++ b/spec/jobs/bulk_update_patients_from_pds_job_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+describe BulkUpdatePatientsFromPDSJob do
+  subject(:perform_now) { described_class.perform_now }
+
+  let!(:invalidated_patient) { create(:patient, :invalidated) }
+  let!(:deceased_patient) { create(:patient, :deceased) }
+  let!(:restricted_patient) { create(:patient, :restricted) }
+  let!(:recently_updated_patient) do
+    create(:patient, updated_from_pds_at: Time.current)
+  end
+  let!(:not_recently_updated_patient) do
+    create(:patient, updated_from_pds_at: 3.days.ago)
+  end
+  let!(:never_updated_patient) { create(:patient, updated_from_pds_at: nil) }
+
+  it "only queues jobs for the approriate patients" do
+    expect { perform_now }.to have_enqueued_job(
+      PatientUpdateFromPDSJob
+    ).exactly(3).times
+  end
+
+  it "doesn't queue a job for the invalidated patient" do
+    expect { perform_now }.not_to have_enqueued_job(
+      PatientUpdateFromPDSJob
+    ).with(invalidated_patient)
+  end
+
+  it "doesn't queue a job for the deceased patient" do
+    expect { perform_now }.not_to have_enqueued_job(
+      PatientUpdateFromPDSJob
+    ).with(deceased_patient)
+  end
+
+  it "doesn't queue a job for the recently updated patient" do
+    expect { perform_now }.not_to have_enqueued_job(
+      PatientUpdateFromPDSJob
+    ).with(recently_updated_patient)
+  end
+
+  it "queues a job for the restricted patient" do
+    expect { perform_now }.to have_enqueued_job(PatientUpdateFromPDSJob).with(
+      restricted_patient
+    )
+  end
+
+  it "queues a job for the not recently updated patient" do
+    expect { perform_now }.to have_enqueued_job(PatientUpdateFromPDSJob).with(
+      not_recently_updated_patient
+    )
+  end
+
+  it "queues a job for the never updated patient" do
+    expect { perform_now }.to have_enqueued_job(PatientUpdateFromPDSJob).with(
+      never_updated_patient
+    )
+  end
+end

--- a/spec/lib/nhs/pds_spec.rb
+++ b/spec/lib/nhs/pds_spec.rb
@@ -60,6 +60,25 @@ describe NHS::PDS do
         expect { get_patient }.to raise_error(NHS::PDS::InvalidatedResource)
       end
     end
+
+    context "with a resource not found response" do
+      before do
+        stub_request(
+          :get,
+          "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9000000009"
+        ).to_return(
+          body: file_fixture("pds/not-found-patient-response.json"),
+          status: 404,
+          headers: {
+            "Content-Type" => "application/fhir+json"
+          }
+        )
+      end
+
+      it "raises an error" do
+        expect { get_patient }.to raise_error(NHS::PDS::PatientNotFound)
+      end
+    end
   end
 
   describe "#search_patients" do


### PR DESCRIPTION
This adds a job which regularly queues jobs to fetch information from PDS about patients to ensure they stay up to date and accurate.