### PR TITLE
Allow editing consent request and reminder dates

### DIFF
--- a/app/controllers/session_dates_controller.rb
+++ b/app/controllers/session_dates_controller.rb
@@ -9,10 +9,10 @@ class SessionDatesController < ApplicationController
 
   def update
     @session.assign_attributes(remove_invalid_dates(session_params))
+    @session.set_consent_dates
 
     render :show, status: :unprocessable_entity and return if @session.invalid?
 
-    @session.set_consent_dates
     @session.save!
 
     if params.include?(:add_another)

--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class Sessions::EditController < ApplicationController
+  before_action :set_session
+
+  def edit_send_consent_requests_at
+    render :send_consent_requests_at
+  end
+
+  def update_send_consent_requests_at
+    if !send_consent_requests_at_validator.date_params_valid?
+      @session.send_consent_requests_at =
+        send_consent_requests_at_validator.date_params_as_struct
+      render :send_consent_requests_at, status: :unprocessable_entity
+    elsif !@session.update(send_consent_requests_at_params)
+      render :send_consent_requests_at, status: :unprocessable_entity
+    else
+      redirect_to edit_session_path(@session)
+    end
+  end
+
+  private
+
+  def set_session
+    @session = policy_scope(Session).find_by!(slug: params[:slug])
+  end
+
+  def send_consent_requests_at_validator
+    @send_consent_requests_at_validator ||=
+      DateParamsValidator.new(
+        field_name: :send_consent_requests_at,
+        object: @session,
+        params: send_consent_requests_at_params
+      )
+  end
+
+  def send_consent_requests_at_params
+    params.require(:session).permit(:send_consent_requests_at)
+  end
+end

--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -19,6 +19,18 @@ class Sessions::EditController < ApplicationController
     end
   end
 
+  def edit_weeks_before_consent_reminders
+    render :weeks_before_consent_reminders
+  end
+
+  def update_weeks_before_consent_reminders
+    if @session.update(weeks_before_consent_reminders_params)
+      redirect_to edit_session_path(@session)
+    else
+      render :weeks_before_consent_reminders, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def set_session
@@ -36,5 +48,9 @@ class Sessions::EditController < ApplicationController
 
   def send_consent_requests_at_params
     params.require(:session).permit(:send_consent_requests_at)
+  end
+
+  def weeks_before_consent_reminders_params
+    params.require(:session).permit(:weeks_before_consent_reminders)
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -225,7 +225,7 @@ class Session < ApplicationRecord
   def send_consent_reminders_at
     return nil if dates.empty? || days_before_consent_reminders.nil?
 
-    dates.map(&:value).min - team.days_before_consent_reminders.days
+    dates.map(&:value).min - days_before_consent_reminders.days
   end
 
   def close_consent_at

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -38,6 +38,9 @@
           summary_list.with_row do |row|
             row.with_key { "Consent requests" }
             row.with_value { "Send on #{send_consent_requests_at.to_fs(:long_day_of_week)}" }
+            if @session.can_change_consent_notification_dates?
+              row.with_action(text: "Change", href: edit_send_consent_requests_at_session_path(@session), visually_hidden_text: "consent requests")
+            end
           end
         end
       

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -53,6 +53,9 @@
                 tag.span("First: #{send_consent_reminders_at.to_fs(:long_day_of_week)}", class: "nhsuk-u-secondary-text-color"),
               ], tag.br)
             end
+            if @session.can_change_consent_notification_dates?
+              row.with_action(text: "Change", href: edit_weeks_before_consent_reminders_session_path(@session), visually_hidden_text: "consent reminders")
+            end
           end
         end
       end %>

--- a/app/views/sessions/edit/send_consent_requests_at.html.erb
+++ b/app/views/sessions/edit/send_consent_requests_at.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: session_path(@session),
+        name: @session.location.name,
+      ) %>
+<% end %>
+
+<% legend = "When should parents get a request to give consent?" %>
+<% content_for :page_title, legend %>
+
+<%= form_with model: @session, url: edit_send_consent_requests_at_session_path(@session), method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_date_field :send_consent_requests_at,
+                         caption: { text: @session.location.name, size: "l" },
+                         legend: {
+                           tag: "h1",
+                           text: legend,
+                           size: "l",
+                         },
+                         hint: { text: "For example, 27 3 2017" } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/sessions/edit/weeks_before_consent_reminders.html.erb
+++ b/app/views/sessions/edit/weeks_before_consent_reminders.html.erb
@@ -5,20 +5,23 @@
       ) %>
 <% end %>
 
-<% legend = "When should parents get a request to give consent?" %>
+<% legend = "When should parents get a reminder to give consent?" %>
 <% content_for :page_title, legend %>
 
-<%= form_with model: @session, url: edit_send_consent_requests_at_session_path(@session), method: :put do |f| %>
+<%= form_with model: @session, url: edit_weeks_before_consent_reminders_session_path(@session), method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_date_field :send_consent_requests_at,
+  <%= f.govuk_text_field :weeks_before_consent_reminders,
+                         inputmode: "numeric",
+                         suffix_text: "weeks",
+                         width: 2,
                          caption: { text: @session.location.name, size: "l" },
-                         legend: {
+                         label: {
                            tag: "h1",
                            text: legend,
                            size: "l",
                          },
-                         hint: { text: "For example, 27 3 2017" } %>
+                         hint: { text: "Enter the number of weeks before a session takes place" } %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -476,12 +476,17 @@ en:
               match_type: Vaccines must be suitable for the programme type
         session:
           attributes:
+            send_consent_reminders_at:
+              greater_than: Enter fewer weeks than when consent requests are sent
             send_consent_requests_at:
               blank: Enter a date
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year
               less_than: Enter a date before the first session date (%{count})
+            weeks_before_consent_reminders:
+              blank: Enter weeks before a session takes place
+              greater_than_or_equal_to: Enter 1 or more weeks before a session
         session_date:
           attributes:
             value:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,6 +474,14 @@ en:
             vaccines:
               blank: Choose the vaccines this programme administers
               match_type: Vaccines must be suitable for the programme type
+        session:
+          attributes:
+            send_consent_requests_at:
+              blank: Enter a date
+              missing_day: Enter a day
+              missing_month: Enter a month
+              missing_year: Enter a year
+              less_than: Enter a date before the first session date (%{count})
         session_date:
           attributes:
             value:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,7 +149,14 @@ Rails.application.routes.draw do
       get "close", action: "edit_close"
       post "close", action: "update_close"
 
-      get "consent-form"
+      get "consent-form", action: "consent_form"
+
+      get "edit/send-consent-requests-at",
+          controller: "sessions/edit",
+          action: "edit_send_consent_requests_at"
+      put "edit/send-consent-requests-at",
+          controller: "sessions/edit",
+          action: "update_send_consent_requests_at"
 
       constraints -> { Flipper.enabled?(:dev_tools) } do
         put "make-in-progress", to: "sessions#make_in_progress"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,13 @@ Rails.application.routes.draw do
           controller: "sessions/edit",
           action: "update_send_consent_requests_at"
 
+      get "edit/weeks-before-consent-reminders",
+          controller: "sessions/edit",
+          action: "edit_weeks_before_consent_reminders"
+      put "edit/weeks-before-consent-reminders",
+          controller: "sessions/edit",
+          action: "update_weeks_before_consent_reminders"
+
       constraints -> { Flipper.enabled?(:dev_tools) } do
         put "make-in-progress", to: "sessions#make_in_progress"
       end

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -27,6 +27,11 @@ describe "Manage sessions" do
     and_i_change_consent_requests_date
     and_i_confirm
 
+    when_i_click_on_change_consent_reminders
+    then_i_see_the_change_consent_reminders_page
+    and_i_change_consent_reminders_weeks
+    and_i_confirm
+
     when_i_confirm
     then_i_should_see_the_session_details
 
@@ -182,6 +187,20 @@ describe "Manage sessions" do
     fill_in "Day", with: "1"
     fill_in "Month", with: "3"
     fill_in "Year", with: "2024"
+  end
+
+  def when_i_click_on_change_consent_reminders
+    click_on "Change consent reminders"
+  end
+
+  def then_i_see_the_change_consent_reminders_page
+    expect(page).to have_content(
+      "When should parents get a reminder to give consent?"
+    )
+  end
+
+  def and_i_change_consent_reminders_weeks
+    fill_in "When should parents get a reminder to give consent?", with: "1"
   end
 
   def when_i_confirm

--- a/spec/features/manage_sessions_spec.rb
+++ b/spec/features/manage_sessions_spec.rb
@@ -22,6 +22,11 @@ describe "Manage sessions" do
     when_i_choose_the_dates
     then_i_see_the_confirmation_page
 
+    when_i_click_on_change_consent_requests
+    then_i_see_the_change_consent_requests_page
+    and_i_change_consent_requests_date
+    and_i_confirm
+
     when_i_confirm
     then_i_should_see_the_session_details
 
@@ -163,9 +168,27 @@ describe "Manage sessions" do
     expect(page).to have_content("Edit session")
   end
 
+  def when_i_click_on_change_consent_requests
+    click_on "Change consent requests"
+  end
+
+  def then_i_see_the_change_consent_requests_page
+    expect(page).to have_content(
+      "When should parents get a request to give consent?"
+    )
+  end
+
+  def and_i_change_consent_requests_date
+    fill_in "Day", with: "1"
+    fill_in "Month", with: "3"
+    fill_in "Year", with: "2024"
+  end
+
   def when_i_confirm
     click_on "Continue"
   end
+
+  alias_method :and_i_confirm, :when_i_confirm
 
   def then_i_should_see_the_session_details
     expect(page).to have_content(@location.name.to_s)


### PR DESCRIPTION
This adds the ability to edit the consent request and reminder dates of a session after the dates have been added to the session, beyond the defaults.

![Screenshot 2024-10-28 at 19 17 33](https://github.com/user-attachments/assets/ab5bb24f-3ee9-49e0-b904-bf728679f0e2)
![Screenshot 2024-10-28 at 19 52 40](https://github.com/user-attachments/assets/36554318-fb84-4a32-a38d-012dbf8bb21f)
