### PR TITLE
Order session dates in consent reminder job

### DIFF
--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -14,6 +14,7 @@ class SchoolConsentRemindersJob < ApplicationJob
           :programmes,
           patients: %i[consents consent_notifications parents]
         )
+        .order("session_dates.value")
         .eager_load(:location)
         .merge(Location.school)
         .strict_loading


### PR DESCRIPTION
The ordering on the association doesn't work when the association is included when requesting the parent object.
