### PR TITLE
Force preload on session dates rather than a join

### DIFF
--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -10,7 +10,6 @@ class ClinicSessionInvitationsJob < ApplicationJob
       Session
         .send_invitations
         .includes(
-          :dates,
           :programmes,
           patient_sessions: %i[
             consents
@@ -19,6 +18,7 @@ class ClinicSessionInvitationsJob < ApplicationJob
             vaccination_records
           ]
         )
+        .preload(:dates)
         .joins(:location)
         .merge(Location.clinic)
         .strict_loading

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -10,11 +10,10 @@ class SchoolConsentRemindersJob < ApplicationJob
       Session
         .send_consent_reminders
         .includes(
-          :dates,
           :programmes,
           patients: %i[consents consent_notifications parents]
         )
-        .order("session_dates.value")
+        .preload(:dates)
         .eager_load(:location)
         .merge(Location.school)
         .strict_loading


### PR DESCRIPTION
We can't join on the dates as there can be more than one which would result in the same session being returned multiple times for different dates.