### PR TITLE
Schedule emails in staging environments

### DIFF
--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -4,8 +4,6 @@ class ClinicSessionInvitationsJob < ApplicationJob
   queue_as :notifications
 
   def perform
-    return unless Flipper.enabled?(:scheduled_emails)
-
     sessions =
       Session
         .send_invitations

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -4,8 +4,6 @@ class SchoolConsentRemindersJob < ApplicationJob
   queue_as :notifications
 
   def perform
-    return unless Flipper.enabled?(:scheduled_emails)
-
     sessions =
       Session
         .send_consent_reminders

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -4,8 +4,6 @@ class SchoolConsentRequestsJob < ApplicationJob
   queue_as :notifications
 
   def perform
-    return unless Flipper.enabled?(:scheduled_emails)
-
     sessions =
       Session
         .send_consent_requests

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -4,8 +4,6 @@ class SchoolSessionRemindersJob < ApplicationJob
   queue_as :notifications
 
   def perform
-    return unless Flipper.enabled?(:scheduled_emails)
-
     date = Date.tomorrow
 
     patient_sessions =

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,13 +3,7 @@
 require Rails.root.join("config/environments/production")
 
 Rails.application.configure do
-  config.good_job.enable_cron = true
-  config.good_job.cron = {
-    bulk_update_patients_from_pds: {
-      cron: "every day at 00:00 and 6:00 and 12:00 and 18:00",
-      class: "BulkUpdatePatientsFromPDSJob",
-      description: "Keep patient details up to date with PDS."
-    },
+  config.good_job.cron.merge!(
     mesh_validate_mailbox: {
       cron: "every day at 1am",
       class: "MESHValidateMailboxJob",
@@ -24,11 +18,6 @@ Rails.application.configure do
       cron: "every day at 3am",
       class: "MESHTrackDPSExportsJob",
       description: "Track the status of DPS exports"
-    },
-    remove_import_csv: {
-      cron: "every day at 1am",
-      class: "RemoveImportCSVJob",
-      description: "Remove CSV data from old cohort and immunisation imports"
     }
-  }
+  )
 end

--- a/spec/jobs/clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/clinic_session_invitations_job_spec.rb
@@ -3,9 +3,6 @@
 describe ClinicSessionInvitationsJob do
   subject(:perform_now) { described_class.perform_now }
 
-  before { Flipper.enable(:scheduled_emails) }
-  after { Flipper.disable(:scheduled_emails) }
-
   let(:programme) { create(:programme) }
   let(:team) { create(:team, programmes: [programme]) }
   let(:parents) { create_list(:parent, 2, :recorded) }

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -3,9 +3,6 @@
 describe SchoolConsentRemindersJob do
   subject(:perform_now) { described_class.perform_now }
 
-  before { Flipper.enable(:scheduled_emails) }
-  after { Flipper.disable(:scheduled_emails) }
-
   let(:programme) { create(:programme) }
 
   let(:parents) { create_list(:parent, 2) }

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -3,9 +3,6 @@
 describe SchoolConsentRequestsJob do
   subject(:perform_now) { described_class.perform_now }
 
-  before { Flipper.enable(:scheduled_emails) }
-  after { Flipper.disable(:scheduled_emails) }
-
   let(:programme) { create(:programme) }
 
   let(:parents) { create_list(:parent, 2) }

--- a/spec/jobs/school_session_reminders_job_spec.rb
+++ b/spec/jobs/school_session_reminders_job_spec.rb
@@ -3,9 +3,6 @@
 describe SchoolSessionRemindersJob do
   subject(:perform_now) { described_class.perform_now }
 
-  before { Flipper.enable(:scheduled_emails) }
-  after { Flipper.disable(:scheduled_emails) }
-
   let(:programme) { create(:programme) }
   let(:parents) { create_list(:parent, 2, :recorded) }
   let(:patient) do


### PR DESCRIPTION
This ensures the configuration for our scheduled emails is set up in all our deployed environments, not just production, allowing us to easily test the scheduled emails.