### PR TITLE
Allow submitting consent on last day of consent period

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -267,7 +267,7 @@ class Session < ApplicationRecord
   end
 
   def open_for_consent?
-    close_consent_at&.future?
+    close_consent_at&.today? || close_consent_at&.future? || false
   end
 
   def patient_sessions_moving_from_this_session

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -482,4 +482,32 @@ describe Session do
       end
     end
   end
+
+  describe "#open_for_consent?" do
+    subject(:open_for_consent?) { session.open_for_consent? }
+
+    context "without a close consent period" do
+      let(:session) { create(:session, date: nil) }
+
+      it { should be(false) }
+    end
+
+    context "when the consent period closes today" do
+      let(:session) { create(:session, date: Date.tomorrow) }
+
+      it { should be(true) }
+    end
+
+    context "when the consent period closes tomorrow" do
+      let(:session) { create(:session, date: Date.tomorrow + 1.day) }
+
+      it { should be(true) }
+    end
+
+    context "when the consent period closed yesterday" do
+      let(:session) { create(:session, date: Date.current) }
+
+      it { should be(false) }
+    end
+  end
 end


### PR DESCRIPTION
This allows users to submit consent on the last day of the consent period, which is the day before the last session date. This matches up with the wording in our email which implies the user has until this date to submit consent.