### PR TITLE
Refactor access token expiration calculation

### DIFF
--- a/app/lib/nhs/api.rb
+++ b/app/lib/nhs/api.rb
@@ -52,7 +52,7 @@ module NHS::API
         sub: apikey,
         aud: token_endpoint,
         jti: SecureRandom.uuid,
-        exp: 1.minute.from_now.to_i
+        exp: 3.minutes.from_now.to_i
       }
 
       JWT.encode(payload, private_key, "RS512", header)


### PR DESCRIPTION
This refactors the implementation to rely on our server time, in case there's a mismatch between the API server time and our local server time. It also simplifies the code by using seconds everywhere rather than needing to convert between seconds and milliseconds.

I'm hoping this will fix the 401 errors we've been seeing when using the API.