### PR TITLE
Ensure parents are loaded in notification jobs

### DIFF
--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -9,11 +9,11 @@ class ClinicSessionInvitationsJob < ApplicationJob
         .send_invitations
         .includes(
           :programmes,
-          patient_sessions: %i[
-            consents
-            patient
-            session_notifications
-            vaccination_records
+          patient_sessions: [
+            :consents,
+            :session_notifications,
+            :vaccination_records,
+            { patient: :parents }
           ]
         )
         .preload(:dates)

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -7,7 +7,10 @@ class SchoolConsentRequestsJob < ApplicationJob
     sessions =
       Session
         .send_consent_requests
-        .includes(:programmes, patients: %i[consents consent_notifications])
+        .includes(
+          :programmes,
+          patients: %i[consents consent_notifications parents]
+        )
         .eager_load(:location)
         .merge(Location.school)
         .strict_loading

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -12,9 +12,9 @@ class SchoolSessionRemindersJob < ApplicationJob
           :consents,
           :latest_gillick_assessment,
           :latest_vaccination_record,
-          :patient,
           :triages,
-          :vaccination_records
+          :vaccination_records,
+          patient: :parents
         )
         .joins(:location, :session)
         .merge(Location.school)


### PR DESCRIPTION
This allows the `create_and_send!` method of the notification class to get the parents to send an email for without needing to perform an extra database query. The tests were passing as we stubbed the `create_and_send!` method, so we should probably refactor those to be more complete.