### PR TITLE
Discard jobs on ActiveJob::DeserializationError

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,6 +4,5 @@ class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError
 end


### PR DESCRIPTION
If we get this error it means the object that the job was queued for no longer exists in the database, so we can safely discard the job as it will never succeed.