### PR TITLE
Don't propose moves if already proposed

### DIFF
--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -60,7 +60,7 @@ class ClassImport < PatientImport
 
     session
       .patient_sessions
-      .where(patient: unknown_patients)
+      .where(patient: unknown_patients, proposed_session_id: nil)
       .update_all(proposed_session_id: team.generic_clinic_session.id)
   end
 end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -409,6 +409,18 @@ describe ClassImport do
           )
         ).to include(existing_patient)
       end
+
+      it "doesn't propose a move if patient already has a proposed move" do
+        existing_session = create(:session, team:, programme:)
+
+        existing_patient_session =
+          PatientSession.find_by!(patient: existing_patient, session:)
+        existing_patient_session.update!(proposed_session: existing_session)
+
+        expect { record! }.not_to(
+          change { existing_patient_session.reload.proposed_session }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This handles the situation where a patient already has a proposed move from a different import that hasn't been confirmed yet, we wouldn't want to overwrite that proposed move to the generic clinic when it's likely they're being moved to a school.