### PR TITLE
Propose moves from consent forms

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -72,6 +72,9 @@ class Patient < ApplicationRecord
            -> { upcoming },
            through: :patient_sessions,
            source: :session
+  has_many :proposed_sessions,
+           through: :patient_sessions,
+           source: :proposed_session
 
   has_and_belongs_to_many :class_imports
   has_and_belongs_to_many :cohort_imports

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -807,16 +807,14 @@ describe ConsentForm do
         )
       end
 
-      it "removes the patient from the old session" do
+      it "marks the patient with a proposed move" do
         expect(patient.sessions).to contain_exactly(session)
-        match_with_patient!
-        expect(patient.reload.sessions).not_to include(session)
-      end
+        expect(patient.proposed_sessions).to be_empty
 
-      it "adds the patient to the new session" do
-        expect(patient.sessions).not_to include(new_session)
         match_with_patient!
-        expect(patient.reload.sessions).to contain_exactly(new_session)
+
+        expect(patient.reload.sessions).to include(session)
+        expect(patient.proposed_sessions).to contain_exactly(new_session)
       end
 
       context "if the session is a clinic" do
@@ -868,16 +866,14 @@ describe ConsentForm do
         )
       end
 
-      it "removes the patient from the old session" do
+      it "marks the patient with a proposed move" do
         expect(patient.sessions).to contain_exactly(session)
-        match_with_patient!
-        expect(patient.reload.sessions).not_to include(session)
-      end
+        expect(patient.proposed_sessions).to be_empty
 
-      it "adds the patient to the generic clinic" do
-        expect(patient.sessions).not_to include(new_session)
         match_with_patient!
-        expect(patient.reload.sessions).to contain_exactly(new_session)
+
+        expect(patient.reload.sessions).to include(session)
+        expect(patient.proposed_sessions).to contain_exactly(new_session)
       end
     end
   end


### PR DESCRIPTION
This updates how school moves are handled after the consent forms, to propose the move rather than actually perform the move. This means the nurses are required to confirm the move as it will be shown in the "moves in" and "moves out" tabs on the sessions.