### PR TITLE
Add table of consent refused statistics

### DIFF
--- a/app/components/app_consent_refused_table_component.html.erb
+++ b/app/components/app_consent_refused_table_component.html.erb
@@ -1,0 +1,26 @@
+<div class="nhsuk-table__panel-with-heading-tab">
+  <h3 class="nhsuk-table__heading-tab">Reasons for refusal</h3>
+
+  <%= govuk_table do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Reason for refusal") %>
+        <% row.with_cell(text: "Frequency") %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% Consent.reason_for_refusals.keys.each do |reason_for_refusal| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <%= VaccinationRecord.human_enum_name(:reason_for_refusal, reason_for_refusal) %>
+          <% end %>
+
+          <% row.with_cell do %>
+            <%= number_to_percentage(percentage_for(reason_for_refusal), precision: 1) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/app_consent_refused_table_component.rb
+++ b/app/components/app_consent_refused_table_component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AppConsentRefusedTableComponent < ViewComponent::Base
+  def initialize(consents)
+    super
+
+    @grouped_by_reason_for_refusal =
+      consents.response_refused.group(:reason_for_refusal).count
+    @total_count = consents.count
+  end
+
+  def percentage_for(reason_for_refusal)
+    @grouped_by_reason_for_refusal.fetch(reason_for_refusal, 0) /
+      @total_count.to_f * 100.0
+  end
+end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -10,13 +10,17 @@ class ProgrammesController < ApplicationController
   end
 
   def show
-    @patients_count =
+    patients =
       policy_scope(Patient).where(
         cohort: policy_scope(Cohort).for_year_groups(@programme.year_groups)
-      ).count
+      )
+
+    @patients_count = patients.count
     @sessions_count = policy_scope(Session).has_programme(@programme).count
     @vaccination_records_count =
       policy_scope(VaccinationRecord).where(programme: @programme).count
+
+    @consents = Consent.where(patient: patients)
   end
 
   def sessions

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -32,3 +32,5 @@
     <% end %>
   </div>
 </div>
+
+<%= render AppConsentRefusedTableComponent.new(@consents) %>

--- a/spec/components/app_consent_refused_table_component_spec.rb
+++ b/spec/components/app_consent_refused_table_component_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe AppConsentRefusedTableComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(Consent.all) }
+
+  let(:programme) { create(:programme) }
+
+  before do
+    create(
+      :consent,
+      :refused,
+      programme:,
+      reason_for_refusal: :contains_gelatine
+    )
+    create(
+      :consent,
+      :refused,
+      programme:,
+      reason_for_refusal: :already_vaccinated
+    )
+    create(
+      :consent,
+      :refused,
+      programme:,
+      reason_for_refusal: :will_be_vaccinated_elsewhere
+    )
+    create(:consent, :refused, programme:, reason_for_refusal: :medical_reasons)
+    create(:consent, :refused, programme:, reason_for_refusal: :personal_choice)
+    create(:consent, :refused, programme:, reason_for_refusal: :other)
+    create_list(:consent, 4, :given, programme:)
+  end
+
+  it { should have_content("Contains gelatine\n\n            10.0%") }
+  it { should have_content("Already vaccinated\n\n            10.0%") }
+
+  it do
+    expect(rendered).to have_content(
+      "Will be vaccinated elsewhere\n\n            10.0%"
+    )
+  end
+
+  it { should have_content("Medical reasons\n\n            10.0%") }
+  it { should have_content("Personal choice\n\n            10.0%") }
+  it { should have_content("Other\n\n            10.0%") }
+end


### PR DESCRIPTION
This adds a table showing the reasons for consent refusal.

## Screenshot

![Screenshot 2024-10-29 at 14 19 47](https://github.com/user-attachments/assets/61bb7349-22db-4f92-a88d-0dfaa1134bbb)
