### PR TITLE
Find or create patient sessions

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -148,7 +148,7 @@ class PatientSession < ApplicationRecord
     return unless pending_transfer?
 
     PatientSession.transaction do
-      PatientSession.create!(patient:, session: proposed_session)
+      PatientSession.find_or_create_by!(patient:, session: proposed_session)
 
       school = proposed_session.location
       school = nil if school.generic_clinic?


### PR DESCRIPTION
There's a unique constraint on patient sessions which means this will fail if the patient was added to the proposed session in the meantime before the move was confirmed.