### PR TITLE
Retry jobs on Faraday::TooManyRequestsError

### DIFF
--- a/app/jobs/concerns/nhs_api_concurrency_concern.rb
+++ b/app/jobs/concerns/nhs_api_concurrency_concern.rb
@@ -18,5 +18,9 @@ module NHSAPIConcurrencyConcern
     retry_on GoodJob::ActiveJobExtensions::Concurrency::ConcurrencyExceededError,
              attempts: :unlimited,
              wait: ->(_) { rand(0.5..5) }
+
+    retry_on Faraday::TooManyRequestsError,
+             attempts: :unlimited,
+             wait: ->(_) { rand(0.5..5) }
   end
 end


### PR DESCRIPTION
We will get this error if we make too many requests and hit the rate limit on the PDS API, so we should retry in a short period of time.