### PR TITLE
Don't move patients when they have draft records

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -119,7 +119,8 @@ class PatientSession < ApplicationRecord
   end
 
   def safe_to_destroy?
-    vaccination_records.empty? && gillick_assessments.empty?
+    VaccinationRecord.where(patient_session: self).empty? &&
+      GillickAssessment.where(patient_session: self).empty?
   end
 
   def destroy_if_safe!

--- a/spec/factories/gillick_assessments.rb
+++ b/spec/factories/gillick_assessments.rb
@@ -40,5 +40,9 @@ FactoryBot.define do
       gillick_competent { true }
       notes { "Assessed as Gillick competent" }
     end
+
+    trait :draft do
+      recorded_at { nil }
+    end
   end
 end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -195,6 +195,20 @@ describe PatientSession do
       end
     end
 
+    context "when the patient session has draft gillick assessment" do
+      before { create(:gillick_assessment, :draft, patient_session:) }
+
+      it "does not change the sesion, creates a new patient session" do
+        # stree-ignore
+        expect { confirm_transfer! }
+          .to change(patient_session, :proposed_session).to(nil)
+          .and not_change(patient_session, :session)
+          .and change(patient_session.patient.patient_sessions, :count).by(1)
+          .and change { patient_session.patient.reload.school }
+            .from(original_session.location).to(proposed_session.location)
+      end
+    end
+
     context "when the patient session is for the generic clinic" do
       let(:team) { original_session.team }
       let(:location) { create(:location, :generic_clinic, team:) }


### PR DESCRIPTION
Currently if a patient has a draft gillick assessment or vaccination record, when they are moved between schools an error is triggered. This is because the existing draft records cause a foreign key constraint error.

https://good-machine.sentry.io/issues/6028433066/

The fix in this PR is to treat draft versions of these associations the same as the recorded versions. This appears to be align with the spirit of PR #2018 which introduces the change to not move patients who have gillick assessments or vaccination records.

It's also possible the right fix is to remove these draft records, but that seems unlikely since as the #2018 states, it's unclear what actual state the patient record is in.
