### PR TITLE
Add explicit cancel link on the 'Edit session dates' page

### DIFF
--- a/app/views/session_dates/show.html.erb
+++ b/app/views/session_dates/show.html.erb
@@ -34,5 +34,8 @@
     <%= f.govuk_submit "Add another date", name: "add_another", class: "nhsuk-button app-add-another__add app-button--secondary" %>
   </div>
 
-  <%= f.govuk_submit "Continue" %>
+  <div class="app-button-group">
+    <%= f.govuk_submit "Continue" %>
+    <%= govuk_link_to "Cancel", edit_session_path(@session) %>
+  </div>
 <% end %>


### PR DESCRIPTION
Without this, the only way off the page is to find the dinky 'Back' link right at the top of a potentially long page.

![image](https://github.com/user-attachments/assets/b3e029bb-b6fb-4aa6-8d98-b55f80d7c6dc)
