### PR TITLE
Show next consent reminder instead of first

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -252,7 +252,8 @@ class Session < ApplicationRecord
   def send_consent_reminders_at
     return nil if dates.empty? || days_before_consent_reminders.nil?
 
-    earliest_date - days_before_consent_reminders.days
+    reminder_dates = dates.map { _1.value - days_before_consent_reminders.days }
+    reminder_dates.find(&:future?) || reminder_dates.last
   end
 
   def close_consent_at

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -50,7 +50,7 @@
             row.with_value do
               safe_join([
                 "Send #{pluralize(@session.weeks_before_consent_reminders, "week")} before each session",
-                tag.span("First: #{send_consent_reminders_at.to_fs(:long_day_of_week)}", class: "nhsuk-u-secondary-text-color"),
+                tag.span("Next: #{send_consent_reminders_at.to_fs(:long_day_of_week)}", class: "nhsuk-u-secondary-text-color"),
               ], tag.br)
             end
             if @session.can_change_consent_notification_dates?

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -131,7 +131,7 @@ describe "End-to-end journey" do
     expect(page).to have_content(
       "Consent remindersSend 1 week before each session"
     )
-    expect(page).to have_content("First: Friday 23 February 2024")
+    expect(page).to have_content("Next: Friday 23 February 2024")
 
     click_on "Continue"
   end


### PR DESCRIPTION
This allows users to see when the next consent reminder is going to be sent rather than just the first one. I have changed the label from `First` to `Next` which is different to how this appears in the designs.