### PR TITLE
Order names ignoring case

### DIFF
--- a/app/controllers/concerns/full_name_concern.rb
+++ b/app/controllers/concerns/full_name_concern.rb
@@ -3,7 +3,10 @@
 module FullNameConcern
   extend ActiveSupport::Concern
 
-  included { scope :order_by_name, -> { order(:given_name, :family_name) } }
+  included do
+    scope :order_by_name,
+          -> { order("LOWER(given_name)", "LOWER(family_name)") }
+  end
 
   def full_name
     [given_name, family_name].join(" ")

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -46,6 +46,22 @@
 #
 
 describe Patient do
+  describe "scopes" do
+    describe "#order_by_name" do
+      subject(:scope) { described_class.order_by_name }
+
+      let(:patient_a) { create(:patient, given_name: "Adam") }
+      let(:patient_b) do
+        create(:patient, given_name: "claire", family_name: "Jones")
+      end
+      let(:patient_c) do
+        create(:patient, given_name: "claire", family_name: "smith")
+      end
+
+      it { should eq([patient_a, patient_b, patient_c]) }
+    end
+  end
+
   describe "validations" do
     context "when home educated" do
       subject(:patient) { build(:patient, :home_educated) }


### PR DESCRIPTION
This updates the `order_by_name` scope used in a few places to be case-insensitive which is more useful for users. This is possible now that the fields are no longer encrypted (#2226).