### PR TITLE
Add patient search functionality

### DIFF
--- a/app/assets/stylesheets/_patients.scss
+++ b/app/assets/stylesheets/_patients.scss
@@ -6,6 +6,10 @@
   display: flex;
   flex-wrap: wrap;
 
+  & &__no-results {
+    @include nhsuk-responsive-margin(5);
+  }
+
   & &__filters {
     @include nhsuk-responsive-padding(4);
 

--- a/app/assets/stylesheets/_search.scss
+++ b/app/assets/stylesheets/_search.scss
@@ -1,0 +1,54 @@
+$button-shadow-size: 2px;
+
+.app-search {
+  @include nhsuk-responsive-padding(4);
+
+  align-items: end;
+  background-color: $color_nhsuk-grey-4;
+  display: flex;
+  gap: nhsuk-spacing(1);
+}
+
+.app-search__form-group {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.app-search__input {
+  background-image: url("data:image/svg+xml,<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path d='M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z'></path></svg>");
+  background-position: nhsuk-spacing(1) center;
+  background-repeat: no-repeat;
+  background-size: 27px;
+  padding-left: nhsuk-spacing(5);
+}
+
+.app-search__button {
+  // Reduce shadow size to align with input border
+  box-shadow: 0 $button-shadow-size 0 $nhsuk-secondary-button-shadow-color;
+
+  // Adjust bottom margin to offset shadow size given flex-end alignment
+  margin-bottom: $button-shadow-size;
+
+  // Adjust padding to match size of input
+  padding: nhsuk-spacing(1) + 1px nhsuk-spacing(3);
+
+  // Make full width at smaller breakpoints
+  width: auto;
+
+  @include mq($from: tablet) {
+    padding: nhsuk-spacing(1) nhsuk-spacing(3);
+  }
+
+  &:active {
+    top: $button-shadow-size;
+  }
+
+  &:focus {
+    box-shadow: 0 $button-shadow-size 0 $nhsuk-secondary-button-shadow-color;
+  }
+
+  // input[type=submit] seems 1px taller than button
+  &[type="submit"] {
+    padding-top: nhsuk-spacing(1) - 1px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,6 +57,7 @@ $color_app-dark-orange: darken(
 @import "panel";
 @import "password-input";
 @import "patients";
+@import "search";
 @import "secondary-navigation";
 @import "status";
 @import "summary-list";

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class AppPatientTableComponent < ViewComponent::Base
-  def initialize(patients, count:)
+  def initialize(patients, count:, heading: nil)
     super
 
     @patients = patients
     @count = count
+    @heading = heading
   end
 
   private
@@ -13,6 +14,6 @@ class AppPatientTableComponent < ViewComponent::Base
   attr_reader :patients
 
   def heading
-    I18n.t("children", count: @count)
+    @heading.presence || I18n.t("children", count: @count)
   end
 end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -6,7 +6,14 @@ class PatientsController < ApplicationController
   before_action :set_patient, except: :index
 
   def index
-    @pagy, @patients = pagy(policy_scope(Patient).not_deceased.order_by_name)
+    scope = policy_scope(Patient).not_deceased
+
+    if (@q = params[:q]).present?
+      @q.strip!
+      scope = scope.search_by_name(@q)
+    end
+
+    @pagy, @patients = pagy(scope.order_by_name)
 
     render layout: "full"
   end

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -1,5 +1,33 @@
 <%= h1 t(".title"), size: "xl" %>
 
-<%= render AppPatientTableComponent.new(@patients, count: @pagy.count) %>
+<%= form_with url: patients_path,
+              method: :get,
+              class: "app-search",
+              role: "search" do |f| %>
+  <div class="nhsuk-form-group app-search__form-group">
+    <%= f.label :q, "Search children by name", class: "nhsuk-label" %>
+    <%= f.search_field :q, value: @q, class: "nhsuk-input app-search__input" %>
+  </div>
+
+  <%= f.submit "Search", class: "nhsuk-button app-search__button" %>
+
+<% if @q.present? %>
+    <%= govuk_button_link_to "Clear search", patients_path,
+                             class: "app-search__button nhsuk-button--secondary" %>
+  <% end %>
+<% end %>
+
+<% if @patients.count.zero? %>
+  <div class="app-patients">
+    <p class="app-patients__no-results nhsuk-caption-m">No children</p>
+  </div>
+<% else %>
+  <% heading = @q.present? ?
+       "#{I18n.t("children", count: @pagy.count)} matching \"#{@q}\"" :
+       nil %>
+  <%= render AppPatientTableComponent.new(@patients,
+                                          count: @pagy.count,
+                                          heading:) %>
+<% end %>
 
 <%= govuk_pagination(pagy: @pagy) %>

--- a/spec/features/patient_search_spec.rb
+++ b/spec/features/patient_search_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+describe "Patient search" do
+  scenario "Users can search for patients" do
+    given_that_i_am_signed_in
+    when_i_visit_the_patients_page
+    then_i_see_all_patients
+
+    when_i_search_for_cas
+    then_i_see_patients_matching_cas
+    and_i_see_the_search_count
+
+    when_i_clear_the_search
+    then_i_see_all_patients
+
+    when_i_search_for_a
+    then_i_see_patients_starting_with_a
+
+    when_i_search_for_aa
+    then_i_see_patients_starting_with_aa
+  end
+
+  def given_that_i_am_signed_in
+    @team = create(:team, :with_one_nurse)
+    @user = @team.users.first
+    @cohort = create(:cohort, team: @team)
+
+    # Create test patients with various names
+    [
+      %w[Aaron Smith],
+      %w[Aardvark Jones],
+      %w[Casey Brown],
+      %w[Cassidy Wilson],
+      %w[Bob Taylor]
+    ].each do |(given_name, family_name)|
+      create(:patient, given_name:, family_name:, cohort: @cohort)
+    end
+
+    sign_in @user
+  end
+
+  def when_i_visit_the_patients_page
+    visit patients_path
+  end
+
+  def then_i_see_all_patients
+    expect(page).to have_content "Aaron Smith"
+    expect(page).to have_content "Aardvark Jones"
+    expect(page).to have_content "Casey Brown"
+    expect(page).to have_content "Cassidy Wilson"
+    expect(page).to have_content "Bob Taylor"
+  end
+
+  def when_i_search_for_cas
+    fill_in "Search children by name", with: "cas"
+    click_button "Search"
+  end
+
+  def then_i_see_patients_matching_cas
+    expect(page).to have_content "Casey Brown"
+    expect(page).to have_content "Cassidy Wilson"
+    expect(page).not_to have_content "Aaron Smith"
+    expect(page).not_to have_content "Aardvark Jones"
+    expect(page).not_to have_content "Bob Taylor"
+  end
+
+  def and_i_see_the_search_count
+    expect(page).to have_content "2 children matching \"cas\""
+  end
+
+  def when_i_clear_the_search
+    click_link "Clear search"
+  end
+
+  def when_i_search_for_a
+    fill_in "Search children by name", with: "a"
+    click_button "Search"
+  end
+
+  def then_i_see_patients_starting_with_a
+    expect(page).to have_content "Aaron Smith"
+    expect(page).to have_content "Aardvark Jones"
+    expect(page).not_to have_content "Bob Taylor"
+    expect(page).not_to have_content "Casey Brown"
+    expect(page).not_to have_content "Cassidy Wilson"
+  end
+
+  def when_i_search_for_aa
+    fill_in "Search children by name", with: "aa"
+    click_button "Search"
+  end
+
+  def then_i_see_patients_starting_with_aa
+    expect(page).to have_content "Aaron Smith"
+    expect(page).to have_content "Aardvark Jones"
+    expect(page).not_to have_content "Bob Taylor"
+    expect(page).not_to have_content "Casey Brown"
+    expect(page).not_to have_content "Cassidy Wilson"
+  end
+end


### PR DESCRIPTION
This adds a form and updates the index action to use a new `Patient#search_by_name` method. The method uses [trigram indexing](https://www.postgresql.org/docs/current/pgtrgm.html) to do fuzzy match searching if there are 3 or more letters, and regular `ILIKE` if not.


### Screenshots
![Screenshot 2024-10-30 at 09 12 51](https://github.com/user-attachments/assets/81b41555-605c-480b-9183-47369d3f0797)


![Screenshot 2024-10-30 at 09 09 19](https://github.com/user-attachments/assets/1888e7c5-c2cb-4c13-bed4-a45735918ad2)
![Screenshot 2024-10-30 at 09 09 35](https://github.com/user-attachments/assets/b8e0d6a0-db8a-4a5d-b197-a66b840245fa)
![Screenshot 2024-10-30 at 09 12 42](https://github.com/user-attachments/assets/ebf42ff7-cef2-4311-b5e7-08e91ffb8e3f)
