### PR TITLE
Use turbo for patient search form

### DIFF
--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -3,6 +3,7 @@
 <%= form_with url: patients_path,
               method: :get,
               class: "app-search",
+              data: { turbo: "true" },
               role: "search" do |f| %>
   <div class="nhsuk-form-group app-search__form-group">
     <%= f.label :q, "Search children by name", class: "nhsuk-label" %>


### PR DESCRIPTION
This enhances the form to replace the content of the page using Turbo, which makes the interaction feel snappier. It still requires manually hitting enter or submitting.