### PR TITLE
Autosubmit patient search form 

### DIFF
--- a/app/javascript/controllers/autosubmit_controller.js
+++ b/app/javascript/controllers/autosubmit_controller.js
@@ -18,6 +18,8 @@ export default class extends Controller {
   }
 
   setResetButtonState() {
+    if (!this.hasResetTarget) return;
+
     if (this.fieldTargets.every((f) => f.value === "")) {
       this.resetTarget.disabled = true;
     } else {

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -3,18 +3,22 @@
 <%= form_with url: patients_path,
               method: :get,
               class: "app-search",
-              data: { turbo: "true" },
+              data: { module: "autosubmit", turbo: "true" },
               role: "search" do |f| %>
   <div class="nhsuk-form-group app-search__form-group">
     <%= f.label :q, "Search children by name", class: "nhsuk-label" %>
-    <%= f.search_field :q, value: @q, class: "nhsuk-input app-search__input" %>
+    <%= f.search_field :q, value: @q, class: "nhsuk-input app-search__input",
+                           "data-action": "autosubmit#submit",
+                           "data-turbo-permanent": "true" %>
   </div>
 
-  <%= f.submit "Search", class: "nhsuk-button app-search__button" %>
+  <%= f.govuk_submit "Search", class: "app-search__button",
+                               "data-autosubmit-target": "filter" %>
 
 <% if @q.present? %>
     <%= govuk_button_link_to "Clear search", patients_path,
-                             class: "app-search__button nhsuk-button--secondary" %>
+                             class: "app-search__button nhsuk-button--secondary",
+                             data: { turbo: "false" } %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Prerequisite: https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2236.

This builds on `data-turbo=true` by adding the autosubmit module, which will submit the form on behalf of the user automatically 250ms after they stop typing.