### PR TITLE
Add programme session table

### DIFF
--- a/app/components/app_programme_session_table_component.html.erb
+++ b/app/components/app_programme_session_table_component.html.erb
@@ -1,0 +1,103 @@
+<div class="nhsuk-table__panel-with-heading-tab">
+  <h3 class="nhsuk-table__heading-tab"><%= pluralize(sessions.count, "session") %></h3>
+
+  <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Details") %>
+        <% row.with_cell(text: "Cohort") %>
+        <% row.with_cell(text: "No response") %>
+        <% row.with_cell(text: "Triage needed") %>
+        <% row.with_cell(text: "Vaccinated", numeric: true) %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% sessions.each do |session| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Details</span>
+
+            <div>
+              <p>
+                <%= govuk_link_to session.location.name, session_path(session) %>
+
+                <% if session.location.has_address? %>
+                  <br />
+                  <span class="nhsuk-u-secondary-text-color">
+                    <%= helpers.format_address_single_line(session.location) %>
+                  </span>
+                <% end %>
+              </p>
+
+              <p>
+                <% if session.unscheduled? %>
+                  No sessions scheduled
+                <% elsif session.completed? || session.closed? %>
+                  Last session completed <%= session.dates.last&.value&.to_fs(:long) %>
+                <% else %>
+                  <% if session.started? %>
+                    Next session starts <%= session.today_or_future_dates.first.to_fs(:long) %>
+                  <% else %>
+                    First session starts <%= session.today_or_future_dates.first.to_fs(:long) %>
+                  <% end %>
+
+                  <br />
+                  Consent period <%= helpers.session_consent_period(session).downcase %>
+                <% end %>
+              </p>
+            </div>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Cohort</span>
+            <div>
+              <span class="nhsuk-u-font-size-36 nhsuk-u-font-weight-bold">
+                <%= cohort_count(session:) %>
+              </span>
+            </div>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">No response</span>
+            <div>
+              <span class="nhsuk-u-font-size-36 nhsuk-u-font-weight-bold">
+                <%= no_response_count(session:) %>
+              </span>
+
+              <br />
+
+              <span class="nhsuk-u-secondary-text-color">
+                <%= no_response_percentage(session:) %>
+              </span>
+            </div>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Triage needed</span>
+            <div>
+              <span class="nhsuk-u-font-size-36 nhsuk-u-font-weight-bold">
+                <%= triage_needed_count(session:) %>
+              </span>
+            </div>
+          <% end %>
+
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Vaccinated</span>
+            <div>
+              <span class="nhsuk-u-font-size-36 nhsuk-u-font-weight-bold">
+                <%= vaccinated_count(session:) %>
+              </span>
+
+              <br />
+
+              <span class="nhsuk-u-secondary-text-color">
+                <%= vaccinated_percentage(session:) %>
+              </span>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class AppProgrammeSessionTableComponent < ViewComponent::Base
+  def initialize(sessions)
+    super
+
+    @sessions = sessions
+
+    @stats =
+      sessions.index_with do |session|
+        PatientSessionStats.new(session.patient_sessions).to_h
+      end
+  end
+
+  private
+
+  attr_reader :sessions
+
+  def cohort_count(session:)
+    (count = session.patient_sessions.count).zero? ? "None" : count
+  end
+
+  def number_stat(session:, key:)
+    @stats.dig(session, key).to_s
+  end
+
+  def percentage_stat(session:, key:)
+    count = session.patient_sessions.count
+    return nil if count.zero?
+
+    value = @stats.dig(session, key) / count.to_f * 100.0
+    number_to_percentage(value, precision: 0)
+  end
+
+  def no_response_count(session:)
+    number_stat(session:, key: :without_a_response)
+  end
+
+  def no_response_percentage(session:)
+    percentage_stat(session:, key: :without_a_response)
+  end
+
+  def triage_needed_count(session:)
+    number_stat(session:, key: :needing_triage)
+  end
+
+  def vaccinated_count(session:)
+    number_stat(session:, key: :vaccinated)
+  end
+
+  def vaccinated_percentage(session:)
+    percentage_stat(session:, key: :vaccinated)
+  end
+end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -35,16 +35,22 @@ class ProgrammesController < ApplicationController
   end
 
   def sessions
-    sessions_for_programme =
+    @sessions =
       policy_scope(Session)
         .has_programme(@programme)
-        .includes(:dates, :location)
+        .eager_load(:location)
+        .preload(
+          :dates,
+          patient_sessions: %i[
+            consents
+            latest_gillick_assessment
+            latest_vaccination_record
+            triages
+            vaccination_records
+          ]
+        )
+        .order("locations.name")
         .strict_loading
-
-    @closed_sessions = sessions_for_programme.closed.sort
-    @completed_sessions = sessions_for_programme.completed.sort
-    @scheduled_sessions = sessions_for_programme.scheduled.sort
-    @unscheduled_sessions = sessions_for_programme.unscheduled.sort
   end
 
   private

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -137,6 +137,11 @@ class Session < ApplicationRecord
     Date.current > dates.map(&:value).max
   end
 
+  def started?
+    return false if dates.empty?
+    Date.current > dates.map(&:value).min
+  end
+
   def closed?
     closed_at != nil
   end

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -11,11 +11,4 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, team: current_user.selected_team, active: :sessions) %>
 
-<% [[@scheduled_sessions, "Sessions scheduled"],
-    [@completed_sessions, "All sessions completed"],
-    [@unscheduled_sessions, "No sessions scheduled"],
-    [@closed_sessions, "Sessions closed"]]
-     .select { |sessions, _| sessions.any? }.each do |sessions, heading| %>
-
-  <%= render AppSessionTableComponent.new(sessions, heading:, show_dates: true, show_consent_period: true) %>
-<% end %>
+<%= render AppProgrammeSessionTableComponent.new(@sessions) %>

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe AppProgrammeSessionTableComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(sessions) }
+
+  let(:programme) { create(:programme) }
+
+  let(:location) { create(:location, :school, name: "Waterloo Road") }
+
+  let(:session) { create(:session, programme:, location:) }
+
+  let(:sessions) { [session] + create_list(:session, 2, programme:) }
+
+  let(:patient_session) { create(:patient_session, session:) }
+
+  before do
+    create_list(:patient_session, 4, session:)
+
+    create(
+      :consent,
+      :given,
+      :recorded,
+      programme:,
+      patient: patient_session.patient
+    )
+    create(:vaccination_record, programme:, patient_session:)
+  end
+
+  it { should have_content("3 sessions") }
+
+  it do
+    expect(rendered).to have_content(
+      "Details\nCohort\nNo response\nTriage needed\nVaccinated"
+    )
+  end
+
+  it { should have_content("Waterloo Road") }
+  it { should have_content(/Cohort(\s+)5/) }
+  it { should have_content(/No response(\s+)4(\s+)80%/) }
+  it { should have_content(/Vaccinated(\s+)1(\s+)20%/) }
+end


### PR DESCRIPTION
This adds a new table component which is rendered on the sessions page for each programme as per the designs in the prototype. It allows the user to see useful headline stats about each session.

## Screenshot

![Screenshot 2024-10-30 at 10 07 45](https://github.com/user-attachments/assets/aed887a3-d73a-4214-824c-a87e69181fa6)
