### PR TITLE
Show responses received and triaged

### DIFF
--- a/app/models/patient_session_stats.rb
+++ b/app/models/patient_session_stats.rb
@@ -2,7 +2,8 @@
 
 class PatientSessionStats
   def initialize(patient_sessions)
-    @patient_sessions = patient_sessions
+    @patient_sessions =
+      patient_sessions.sort_by(&:created_at).reverse.uniq(&:patient_id)
     @stats = calculate_stats
   end
 

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -28,7 +28,7 @@
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: programme_vaccination_records_path(@programme), colour: "reversed", data: true) do |card| %>
       <% card.with_heading { "Vaccinations" } %>
-      <% card.with_description { @vaccination_records_count.to_s } %>
+      <% card.with_description { @vaccinations_count.to_s } %>
     <% end %>
   </div>
 
@@ -43,6 +43,13 @@
     <%= render AppCardComponent.new(data: true) do |card| %>
       <% card.with_heading { "Consent given (versus refused or no response)" } %>
       <% card.with_description { number_to_percentage(@consent_given_percentage, precision: 0) } %>
+    <% end %>
+  </div>
+
+  <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    <%= render AppCardComponent.new(data: true) do |card| %>
+      <% card.with_heading { "Responses received and triaged" } %>
+      <% card.with_description { number_to_percentage(@responses_received_and_triaged_percentage, precision: 0) } %>
     <% end %>
   </div>
 </div>

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -22,7 +22,15 @@ describe PatientSessionStats do
 
     context "with patient sessions" do
       before do
-        create(:patient_session, :consent_refused, programme:, session:) # consent refused
+        patient =
+          create(
+            :patient_session,
+            :consent_refused,
+            programme:,
+            session:
+          ).patient # consent refused
+        create(:patient_session, :consent_refused, programme:, patient:) # duplicate is ignored
+
         create(:patient_session, :added_to_session, programme:, session:) # without a response
         create(
           :patient_session,


### PR DESCRIPTION
This adds a new statistics box on the programme overview tab showing the percentage of responses that have been received and triaged (the idea being that this number should be as close to 100% as possible).

I'd quite like to refactor the programme-level statistics code, but at the moment we're not sure exactly which statistics we're going to show so I'll leave it for now and we refactor when we're more confident.

## Screenshot

![Screenshot 2024-10-30 at 10 37 04](https://github.com/user-attachments/assets/f2f66d1a-f4fc-46dc-8be8-27684da298dc)
