### PR TITLE
Use POST for search endpoint 

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -15,7 +15,7 @@ class PatientsController < ApplicationController
 
     @pagy, @patients = pagy(scope.order_by_name)
 
-    render layout: "full"
+    render layout: "full", status: request.post? ? :created : :ok
   end
 
   def show

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -1,7 +1,6 @@
 <%= h1 t(".title"), size: "xl" %>
 
 <%= form_with url: patients_path,
-              method: :get,
               class: "app-search",
               data: { module: "autosubmit", turbo: "true" },
               role: "search" do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,9 @@ Rails.application.routes.draw do
 
   resources :notices, only: :index
 
-  resources :patients, only: %i[index show update]
+  resources :patients, only: %i[index show update] do
+    post "", action: :index, on: :collection
+  end
 
   resources :programmes, only: %i[index show], param: :type do
     get "sessions", on: :member


### PR DESCRIPTION
This moves the `q` parameter to POST params which are hidden from the URL and won't end up in the browser history. This is necessary to prevent the leaking of patient PII.

It adds a `POST /patients` route that returns with a `201 CREATED` status to comply with some Turbo caveats: https://turbo.hotwired.dev/handbook/drive#redirecting-after-a-form-submission

One interesting bit of this is that it makes the JS version perform better than non-JS, as the JS version does not trigger the "Confirm form resubmission" browser dialog.