### PR TITLE
Remove draft records when moving patient

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -154,6 +154,9 @@ class PatientSession < ApplicationRecord
       school = nil if school.generic_clinic?
       patient.update!(school:)
 
+      draft_vaccination_records.destroy_all
+      draft_gillick_assessments.destroy_all
+
       safe_to_destroy? ? destroy! : update!(proposed_session: nil)
     end
   end

--- a/spec/factories/gillick_assessments.rb
+++ b/spec/factories/gillick_assessments.rb
@@ -40,5 +40,9 @@ FactoryBot.define do
       gillick_competent { true }
       notes { "Assessed as Gillick competent" }
     end
+
+    trait :draft do
+      recorded_at { nil }
+    end
   end
 end


### PR DESCRIPTION
Patients may have draft gillick assessments or vaccination recrods which need to be removed before they can be moved to a new session.

This replaces the previous PR (#2229) which would copy patient record instead of moving it if it had any draft records. (didn't realise renaming the branch would close it)