### PR TITLE
Add basic programme patients view

### DIFF
--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -32,6 +32,12 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
       )
 
       nav.with_item(
+        href: programme_patients_path(programme),
+        text: I18n.t("patients.index.title"),
+        selected: active == :patients
+      )
+
+      nav.with_item(
         href: programme_vaccination_records_path(programme),
         text: I18n.t("vaccination_records.index.title"),
         selected: active == :vaccination_records

--- a/app/controllers/programme/patients_controller.rb
+++ b/app/controllers/programme/patients_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Programme::PatientsController < ApplicationController
+  include Pagy::Backend
+
+  before_action :set_programme
+
+  def index
+    @pagy, @patients = pagy(@programme.patients.not_deceased.order_by_name)
+
+    render layout: "full"
+  end
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/views/programme/patients/index.html.erb
+++ b/app/views/programme/patients/index.html.erb
@@ -1,0 +1,24 @@
+<%= content_for :page_title, "#{@programme.name} – #{t("patients.index.title")}" %>
+
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(
+        items: [
+          { text: t("programmes.index.title"), href: programmes_path },
+          { text: @programme.name, href: programme_path(@programme) },
+        ],
+      ) %>
+<% end %>
+
+<h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
+
+<%= render AppProgrammeNavigationComponent.new(@programme,
+                                               team: current_user.selected_team,
+                                               active: :patients) %>
+
+<%= govuk_button_link_to "Import child records",
+                         new_programme_cohort_import_path(@programme),
+                         class: "app-button--secondary" %>
+
+<%= render AppPatientTableComponent.new(@patients, count: @pagy.count) %>
+
+<%= govuk_pagination(pagy: @pagy) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
 
     resources :cohorts, only: %i[index show]
 
+    resources :patients, only: %i[index], module: "programme"
+
     resources :immunisation_imports,
               path: "immunisation-imports",
               except: %i[index destroy]


### PR DESCRIPTION
This adds a link within a programme to view the children that are part of it. The table isn't aligned to the prototype yet, that's coming in a follow-up PR.

### Screenshots

![Screenshot 2024-10-30 at 12 32 04](https://github.com/user-attachments/assets/0ccf2e9a-c4bf-47bd-a28a-fa0b21e66200)
