### PR TITLE
Refactor Session#dates

### DIFF
--- a/app/components/app_programme_session_table_component.html.erb
+++ b/app/components/app_programme_session_table_component.html.erb
@@ -34,7 +34,7 @@
                 <% if session.unscheduled? %>
                   No sessions scheduled
                 <% elsif session.completed? || session.closed? %>
-                  Last session completed <%= session.dates.last&.value&.to_fs(:long) %>
+                  Last session completed <%= session.dates.max&.to_fs(:long) %>
                 <% else %>
                   <% if session.started? %>
                     Next session starts <%= session.today_or_future_dates.first.to_fs(:long) %>

--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -61,7 +61,7 @@ class AppSessionSummaryComponent < ViewComponent::Base
   def dates
     if (dates = @session.dates).present?
       tag.ul(class: "nhsuk-list") do
-        safe_join(dates.map { tag.li(_1.value.to_fs(:long)) })
+        safe_join(dates.map { tag.li(_1.to_fs(:long)) })
       end
     else
       "Not provided"

--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -37,7 +37,7 @@
               <% if (dates = session.dates).present? %>
                 <ul class="nhsuk-list">
                   <% dates.each do |date| %>
-                    <li><%= date.value.to_fs(:long) %></li>
+                    <li><%= date.to_fs(:long) %></li>
                   <% end %>
                 </ul>
               <% else %>

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -54,7 +54,7 @@ class DevController < ApplicationController
       end
 
       team_sessions.each do |team_session|
-        team_session.dates.destroy_all
+        team_session.session_dates.destroy_all
         team_session.destroy!
       end
 

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -51,7 +51,7 @@ class ProgrammesController < ApplicationController
         .has_programme(@programme)
         .eager_load(:location)
         .preload(
-          :dates,
+          :session_dates,
           patient_sessions: %i[
             consents
             latest_gillick_assessment

--- a/app/controllers/session_dates_controller.rb
+++ b/app/controllers/session_dates_controller.rb
@@ -4,7 +4,7 @@ class SessionDatesController < ApplicationController
   before_action :set_session
 
   def show
-    @session.dates.build if @session.dates.empty?
+    @session.session_dates.build if @session.session_dates.empty?
   end
 
   def update
@@ -19,13 +19,13 @@ class SessionDatesController < ApplicationController
     # the model has been saved due to how `accepts_nested_attributes_for`
     # works.
     if any_destroyed?
-      @session.dates.reload
+      @session.session_dates.reload
       @session.set_notification_dates
       @session.save!
     end
 
     if params.include?(:add_another)
-      @session.dates.build
+      @session.session_dates.build
       render :show
     else
       redirect_to(
@@ -45,14 +45,18 @@ class SessionDatesController < ApplicationController
   end
 
   def session_params
-    params.require(:session).permit(dates_attributes: %i[id value _destroy])
+    params.require(:session).permit(
+      session_dates_attributes: %i[id value _destroy]
+    )
   end
 
   def any_destroyed?
-    session_params[:dates_attributes].values.any? { _1[:_destroy].present? }
+    session_params[:session_dates_attributes].values.any? do
+      _1[:_destroy].present?
+    end
   end
 
-  def remove_invalid_dates(obj, key: "dates_attributes")
+  def remove_invalid_dates(obj, key: "session_dates_attributes")
     return obj if obj[key].blank?
 
     obj[key] = obj[key].transform_values do |value|

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -78,7 +78,7 @@ class SessionsController < ApplicationController
   end
 
   def make_in_progress
-    @session.dates.find_or_create_by!(value: Date.current)
+    @session.session_dates.find_or_create_by!(value: Date.current)
 
     redirect_to session_path, flash: { success: "Session is now in progress" }
   end
@@ -93,9 +93,9 @@ class SessionsController < ApplicationController
 
   def sessions_scope
     policy_scope(Session).includes(
-      :dates,
       :location,
       :programmes,
+      :session_dates,
       team: :programmes
     ).strict_loading
   end

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -46,7 +46,7 @@ class VaccinationRecordsController < ApplicationController
           :performed_by_user,
           :programme,
           patient: [:cohort, :school, { parents: :parent_relationships }],
-          session: %i[dates],
+          session: %i[session_dates],
           vaccine: :programme
         )
         .where(programme:)

--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -16,7 +16,7 @@ class ClinicSessionInvitationsJob < ApplicationJob
             { patient: :parents }
           ]
         )
-        .preload(:dates)
+        .preload(:session_dates)
         .joins(:location)
         .merge(Location.clinic)
         .strict_loading

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -11,7 +11,7 @@ class SchoolConsentRemindersJob < ApplicationJob
           :programmes,
           patients: %i[consents consent_notifications parents]
         )
-        .preload(:dates)
+        .preload(:session_dates)
         .eager_load(:location)
         .merge(Location.school)
         .strict_loading
@@ -48,8 +48,7 @@ class SchoolConsentRemindersJob < ApplicationJob
 
     return if date_index_to_send_reminder_for >= session.dates.length
 
-    date_to_send_reminder_for =
-      session.dates[date_index_to_send_reminder_for].value
+    date_to_send_reminder_for = session.dates[date_index_to_send_reminder_for]
     earliest_date_to_send_reminder =
       date_to_send_reminder_for - session.days_before_consent_reminders.days
 

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -133,7 +133,7 @@ class ImmunisationImportRow
             session.programmes << @programme
           end
 
-          session.dates.find_or_create_by!(value: session_date)
+          session.session_dates.find_or_create_by!(value: session_date)
         end
   end
 

--- a/app/views/session_dates/show.html.erb
+++ b/app/views/session_dates/show.html.erb
@@ -12,19 +12,19 @@
 
   <div class="app-add-another">
     <ol class="nhsuk-list app-add-another__list">
-      <%= f.fields_for :dates do |date_f| %>
+      <%= f.fields_for :session_dates do |date_f| %>
         <li class="app-add-another__list-item">
           <%= date_f.govuk_date_field :value,
                                       legend: { size: "m", text: "Session date" },
                                       hint: { text: "For example, 27 3 2024" } %>
 
-          <% if date_f.object.persisted? || @session.dates.length > 1 %>
+          <% if date_f.object.persisted? || @session.session_dates.length > 1 %>
             <% button_class = "nhsuk-button app-add-another__delete app-button--secondary-warning app-button--small" %>
 
             <% if date_f.object.new_record? %>
               <%= link_to "Delete", session_dates_path(@session), class: button_class %>
             <% else %>
-              <%= f.govuk_submit "Delete", name: "session[dates_attributes][#{date_f.index}][_destroy]", value: "true", class: button_class %>
+              <%= f.govuk_submit "Delete", name: "session[session_dates_attributes][#{date_f.index}][_destroy]", value: "true", class: button_class %>
             <% end %>
           <% end %>
         </li>

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -24,7 +24,7 @@
       
           if (dates = @session.dates).present?
             row.with_value do
-              safe_join(dates.map { _1.value.to_fs(:long_day_of_week) }, tag.br)
+              safe_join(dates.map { _1.to_fs(:long_day_of_week) }, tag.br)
             end
             row.with_action(text: "Change", href: session_dates_path(@session), visually_hidden_text: "session dates")
           else

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -104,8 +104,8 @@ def create_session(user, team, completed:)
 
   session = FactoryBot.create(:session, date:, team:, programme:, location:)
 
-  session.dates.create!(value: date - 1.day)
-  session.dates.create!(value: date + 1.day)
+  session.session_dates.create!(value: date - 1.day)
+  session.session_dates.create!(value: date + 1.day)
 
   patients_without_consent =
     FactoryBot.create_list(:patient_session, 4, programme:, session:, user:)

--- a/script/generate_model_office_data.rb
+++ b/script/generate_model_office_data.rb
@@ -65,7 +65,7 @@ def create_vaccination_record(
     patient_session:,
     programme:,
     vaccine:,
-    administered_at: session.dates.first.value + rand(8..16).hours,
+    administered_at: session.dates.min + rand(8..16).hours,
     batch:,
     dose_sequence:,
     location_name:

--- a/spec/factories/session_notifications.rb
+++ b/spec/factories/session_notifications.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     patient
     session
 
-    session_date { session.dates.map(&:value).min || Date.current }
+    session_date { session.dates.min || Date.current }
 
     traits_for_enum :type
   end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
   factory :session do
     transient do
       date { Date.current }
+      dates { [] }
       programme { association :programme }
     end
 
@@ -53,9 +54,14 @@ FactoryBot.define do
       end
     end
 
-    after(:create) do |session, evaluator|
-      next if (date = evaluator.date).nil?
-      session.dates.create!(value: date)
+    session_dates do
+      if dates.present?
+        dates.map { build(:session_date, session: instance, value: _1) }
+      elsif date.present?
+        [build(:session_date, session: instance, value: date)]
+      else
+        []
+      end
     end
 
     trait :today do

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -116,7 +116,7 @@ describe "Immunisation imports duplicates" do
       create(
         :vaccination_record,
         programme: @programme,
-        administered_at: @session.dates.first.value.in_time_zone + 12.hours,
+        administered_at: @session.dates.min.in_time_zone + 12.hours,
         notes: "Foo",
         recorded_at: Time.zone.yesterday,
         batch: @batch,

--- a/spec/features/self_consent_clinic_spec.rb
+++ b/spec/features/self_consent_clinic_spec.rb
@@ -38,7 +38,7 @@ describe "Self-consent" do
   end
 
   def and_it_is_the_day_of_a_vaccination_session
-    travel_to(@session.dates.first.value)
+    travel_to(@session.dates.min)
   end
 
   def and_there_is_a_child_without_parental_consent

--- a/spec/features/self_consent_gillick_competent_spec.rb
+++ b/spec/features/self_consent_gillick_competent_spec.rb
@@ -37,7 +37,7 @@ describe "Self-consent" do
   end
 
   def and_it_is_the_day_of_a_vaccination_session
-    travel_to(@session.dates.first.value)
+    travel_to(@session.dates.min)
   end
 
   def and_there_is_a_child_without_parental_consent

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -32,7 +32,7 @@ describe "Not Gillick competent" do
   end
 
   def and_it_is_the_day_of_a_vaccination_session
-    travel_to(@session.dates.first.value)
+    travel_to(@session.dates.min)
   end
 
   def and_there_is_a_child_without_parental_consent

--- a/spec/jobs/clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/clinic_session_invitations_job_spec.rb
@@ -39,7 +39,7 @@ describe ClinicSessionInvitationsJob do
       end
 
       context "with a second date a week later" do
-        before { session.dates.create!(value: date + 1.week) }
+        before { session.session_dates.create!(value: date + 1.week) }
 
         let(:today) { date + 1.day }
 

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -46,8 +46,7 @@ describe SchoolConsentRemindersJob do
   let!(:session) do
     create(
       :session,
-      date: nil,
-      dates: dates.map { build(:session_date, value: _1) },
+      dates:,
       send_consent_requests_at: dates.first - 1.week,
       days_before_consent_reminders: 7,
       location:,

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -38,7 +38,7 @@ describe SchoolConsentRequestsJob do
     end
   end
 
-  context "when session is in the future" do
+  context "when requests should be sent in the future" do
     let(:session) do
       create(
         :session,
@@ -54,12 +54,13 @@ describe SchoolConsentRequestsJob do
     end
   end
 
-  context "when the session is today" do
+  context "when requests should be sent today" do
     let(:session) do
       create(
         :session,
         patients:,
         programme:,
+        date: 3.weeks.from_now.to_date,
         send_consent_requests_at: Date.current
       )
     end

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -79,7 +79,7 @@ describe GovukNotifyPersonalisation do
   end
 
   context "with multiple dates" do
-    before { session.dates.create!(value: Date.new(2026, 1, 2)) }
+    before { session.session_dates.create!(value: Date.new(2026, 1, 2)) }
 
     it do
       expect(personalisation).to match(

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -253,9 +253,7 @@ describe ImmunisationImport do
         expect(immunisation_import.sessions.count).to eq(5)
 
         session = immunisation_import.sessions.first
-        expect(session.dates.map(&:value)).to contain_exactly(
-          Date.new(2024, 5, 14)
-        )
+        expect(session.dates).to contain_exactly(Date.new(2024, 5, 14))
       end
 
       it "records the vaccination records" do

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -46,7 +46,7 @@ describe SessionNotification do
     let(:team) { create(:team, programmes: [programme]) }
     let(:location) { create(:location, :school, team:) }
     let(:session) { create(:session, location:, programme:, team:) }
-    let(:session_date) { session.dates.first.value }
+    let(:session_date) { session.dates.min }
     let(:patient_session) { create(:patient_session, patient:, session:) }
     let(:consent) { create(:consent, :given, :recorded, patient:, programme:) }
     let(:current_user) { create(:user) }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -181,9 +181,7 @@ describe Session do
       [Date.new(2024, 1, 1), Date.new(2024, 1, 2), Date.new(2024, 1, 3)]
     end
 
-    let(:session) { create(:session, academic_year: 2023, date: nil) }
-
-    before { dates.each { |value| session.dates.create!(value:) } }
+    let(:session) { create(:session, academic_year: 2023, dates:) }
 
     context "on the first day" do
       let(:today) { dates.first }
@@ -228,7 +226,7 @@ describe Session do
     context "with two dates" do
       let(:date) { Date.new(2020, 1, 2) }
 
-      before { session.dates.create!(value: date + 1.day) }
+      before { session.session_dates.create!(value: date + 1.day) }
 
       it { should eq(Date.new(2020, 1, 2)) }
     end


### PR DESCRIPTION
This refactors the relationship between sessions and session dates to provide a convenience method `dates` which returns `Date` objects rather than instances of `SessionDate` which in most cases is most useful.