### PR TITLE
Fix N+1 issue on programme overview page

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -33,7 +33,10 @@ class ProgrammesController < ApplicationController
 
     stats =
       PatientSessionStats.new(
-        PatientSession.where(patient: patients, session: sessions)
+        PatientSession
+          .where(patient: patients, session: sessions)
+          .preload_for_state
+          .strict_loading
       )
 
     @consent_given_percentage =
@@ -67,7 +70,8 @@ class ProgrammesController < ApplicationController
   private
 
   def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:type])
+    @programme =
+      policy_scope(Programme).strict_loading.find_by!(type: params[:type])
   end
 
   def percentage_of(numerator, denominator)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -36,16 +36,7 @@ class SessionsController < ApplicationController
 
   def show
     patient_sessions =
-      @session
-        .patient_sessions
-        .includes(
-          :consents,
-          :triages,
-          :vaccination_records,
-          :latest_gillick_assessment,
-          :latest_vaccination_record
-        )
-        .strict_loading
+      @session.patient_sessions.preload_for_state.strict_loading
 
     @stats = PatientSessionStats.new(patient_sessions)
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -88,6 +88,17 @@ class PatientSession < ApplicationRecord
 
   scope :pending_transfer, -> { where.not(proposed_session_id: nil) }
 
+  scope :preload_for_state,
+        -> do
+          preload(
+            :consents,
+            :triages,
+            :vaccination_records,
+            :latest_gillick_assessment,
+            :latest_vaccination_record
+          )
+        end
+
   delegate :send_notifications?, to: :patient
 
   def draft_vaccination_record


### PR DESCRIPTION
When loading the patient sessions, to determine the state and avoid N+1 issues we should preload various related records. I've put this in a common scope as it's used in a few places.