### PR TITLE
Add ability to edit invitation date

### DIFF
--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -19,6 +19,22 @@ class Sessions::EditController < ApplicationController
     end
   end
 
+  def edit_send_invitations_at
+    render :send_invitations_at
+  end
+
+  def update_send_invitations_at
+    if !send_invitations_at_validator.date_params_valid?
+      @session.send_invitations_at =
+        send_invitations_at_validator.date_params_as_struct
+      render :send_invitations_at, status: :unprocessable_entity
+    elsif !@session.update(send_invitations_at_params)
+      render :send_invitations_at, status: :unprocessable_entity
+    else
+      redirect_to edit_session_path(@session)
+    end
+  end
+
   def edit_weeks_before_consent_reminders
     render :weeks_before_consent_reminders
   end
@@ -48,6 +64,19 @@ class Sessions::EditController < ApplicationController
 
   def send_consent_requests_at_params
     params.require(:session).permit(:send_consent_requests_at)
+  end
+
+  def send_invitations_at_validator
+    @send_invitations_at_validator ||=
+      DateParamsValidator.new(
+        field_name: :send_invitations_at,
+        object: @session,
+        params: send_invitations_at_params
+      )
+  end
+
+  def send_invitations_at_params
+    params.require(:session).permit(:send_invitations_at)
   end
 
   def weeks_before_consent_reminders_params

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -96,6 +96,13 @@ class Session < ApplicationRecord
             },
             unless: -> { earliest_date.nil? || location.generic_clinic? }
 
+  validates :send_invitations_at,
+            presence: true,
+            comparison: {
+              less_than: :earliest_date
+            },
+            if: -> { earliest_date.present? && location.generic_clinic? }
+
   validates :weeks_before_consent_reminders,
             presence: true,
             comparison: {
@@ -162,7 +169,7 @@ class Session < ApplicationRecord
     dates.select(&:future?)
   end
 
-  def can_change_consent_notification_dates?
+  def can_change_notification_dates?
     consent_notifications.empty? && session_notifications.empty?
   end
 

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -38,7 +38,7 @@
           summary_list.with_row do |row|
             row.with_key { "Consent requests" }
             row.with_value { "Send on #{send_consent_requests_at.to_fs(:long_day_of_week)}" }
-            if @session.can_change_consent_notification_dates?
+            if @session.can_change_notification_dates?
               row.with_action(text: "Change", href: edit_send_consent_requests_at_session_path(@session), visually_hidden_text: "consent requests")
             end
           end
@@ -53,7 +53,7 @@
                 tag.span("Next: #{send_consent_reminders_at.to_fs(:long_day_of_week)}", class: "nhsuk-u-secondary-text-color"),
               ], tag.br)
             end
-            if @session.can_change_consent_notification_dates?
+            if @session.can_change_notification_dates?
               row.with_action(text: "Change", href: edit_weeks_before_consent_reminders_session_path(@session), visually_hidden_text: "consent reminders")
             end
           end
@@ -63,6 +63,9 @@
           summary_list.with_row do |row|
             row.with_key { "Invitations" }
             row.with_value { "Send on #{send_invitations_at.to_fs(:long_day_of_week)}" }
+            if @session.can_change_notification_dates?
+              row.with_action(text: "Change", href: edit_send_invitations_at_session_path(@session), visually_hidden_text: "invitations")
+            end
           end
         end
       end %>

--- a/app/views/sessions/edit/send_invitations_at.html.erb
+++ b/app/views/sessions/edit/send_invitations_at.html.erb
@@ -1,0 +1,24 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: edit_session_path(@session),
+        name: "edit session",
+      ) %>
+<% end %>
+
+<% legend = "When should parents get an invitation?" %>
+<% content_for :page_title, legend %>
+
+<%= form_with model: @session, url: edit_send_invitations_at_session_path(@session), method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_date_field :send_invitations_at,
+                         caption: { text: @session.location.name, size: "l" },
+                         legend: {
+                           tag: "h1",
+                           text: legend,
+                           size: "l",
+                         },
+                         hint: { text: "For example, 27 3 2017" } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -485,6 +485,12 @@ en:
               missing_month: Enter a month
               missing_year: Enter a year
               less_than: Enter a date before the first session date (%{count})
+            send_invitations_at:
+              blank: Enter a date
+              missing_day: Enter a day
+              missing_month: Enter a month
+              missing_year: Enter a year
+              less_than: Enter a date before the first session date (%{count})
             weeks_before_consent_reminders:
               blank: Enter weeks before a session takes place
               greater_than_or_equal_to: Enter %{count} or more weeks before a session

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,13 @@ Rails.application.routes.draw do
           controller: "sessions/edit",
           action: "update_send_consent_requests_at"
 
+      get "edit/send-invitations-at",
+          controller: "sessions/edit",
+          action: "edit_send_invitations_at"
+      put "edit/send-invitations-at",
+          controller: "sessions/edit",
+          action: "update_send_invitations_at"
+
       get "edit/weeks-before-consent-reminders",
           controller: "sessions/edit",
           action: "edit_weeks_before_consent_reminders"

--- a/spec/features/manage_clinic_sessions_spec.rb
+++ b/spec/features/manage_clinic_sessions_spec.rb
@@ -24,6 +24,11 @@ describe "Manage clinic sessions" do
     when_i_choose_the_dates
     then_i_see_the_confirmation_page
 
+    when_i_click_on_change_invitations
+    then_i_see_the_change_invitations_page
+    and_i_change_invitations_date
+    and_i_confirm
+
     when_i_confirm
     then_i_should_see_the_session_details
 
@@ -149,6 +154,20 @@ describe "Manage clinic sessions" do
   def then_i_see_the_confirmation_page
     expect(page).to have_content("Edit session")
     expect(page).to have_content("InvitationsSend on Sunday 18 February 2024")
+  end
+
+  def when_i_click_on_change_invitations
+    click_on "Change invitations"
+  end
+
+  def then_i_see_the_change_invitations_page
+    expect(page).to have_content("When should parents get an invitation?")
+  end
+
+  def and_i_change_invitations_date
+    fill_in "Day", with: "1"
+    fill_in "Month", with: "3"
+    fill_in "Year", with: "2024"
   end
 
   def when_i_confirm


### PR DESCRIPTION
This adds the ability to edit the date when invitations are sent out for clinics, based on the designs for editing when consent requests are sent out.

## Screenshots

<img width="751" alt="Screenshot 2024-10-30 at 13 56 26" src="https://github.com/user-attachments/assets/d6f5a94c-f5f9-4ef4-8bc3-03eb0f6b630a">
<img width="836" alt="Screenshot 2024-10-30 at 13 56 22" src="https://github.com/user-attachments/assets/ab0972a6-595e-436a-ba94-78a2f748a977">
