### PR TITLE
Small reductions in queries to the database

### DIFF
--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -17,7 +17,7 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   attr_reader :sessions
 
   def cohort_count(session:)
-    (count = session.patient_sessions.count).zero? ? "None" : count
+    (count = session.patient_sessions.length).zero? ? "None" : count
   end
 
   def number_stat(session:, key:)
@@ -25,7 +25,7 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   end
 
   def percentage_stat(session:, key:)
-    count = session.patient_sessions.count
+    count = session.patient_sessions.length
     return nil if count.zero?
 
     value = @stats.dig(session, key) / count.to_f * 100.0

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -12,7 +12,7 @@ class ConsentsController < ApplicationController
         .patient_sessions
         .strict_loading
         .includes(
-          :latest_gillick_assessment,
+          :gillick_assessments,
           :programmes,
           :triages,
           :vaccination_records,

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -43,8 +43,8 @@ class ProgrammesController < ApplicationController
       percentage_of(stats[:with_consent_given], @consents.count)
     @responses_received_and_triaged_percentage =
       percentage_of(
-        patients.count - (stats[:without_a_response] + stats[:needing_triage]),
-        patients.count
+        @patients_count - (stats[:without_a_response] + stats[:needing_triage]),
+        @patients_count
       )
   end
 

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -57,8 +57,7 @@ class ProgrammesController < ApplicationController
           :session_dates,
           patient_sessions: %i[
             consents
-            latest_gillick_assessment
-            latest_vaccination_record
+            gillick_assessments
             triages
             vaccination_records
           ]

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -20,8 +20,7 @@ class TriagesController < ApplicationController
         .strict_loading
         .includes(
           :programmes,
-          :latest_gillick_assessment,
-          :latest_vaccination_record,
+          :gillick_assessments,
           :vaccination_records,
           patient: :cohort
         )

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -26,8 +26,7 @@ class VaccinationsController < ApplicationController
         .strict_loading
         .includes(
           :programmes,
-          :latest_gillick_assessment,
-          :latest_vaccination_record,
+          :gillick_assessments,
           :vaccination_records,
           patient: :cohort
         )

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -10,8 +10,7 @@ class SchoolSessionRemindersJob < ApplicationJob
       PatientSession
         .includes(
           :consents,
-          :latest_gillick_assessment,
-          :latest_vaccination_record,
+          :gillick_assessments,
           :triages,
           :vaccination_records,
           patient: :parents

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -39,9 +39,6 @@ class PatientSession < ApplicationRecord
   has_many :draft_gillick_assessments,
            -> { draft },
            class_name: "GillickAssessment"
-  has_one :latest_gillick_assessment,
-          -> { recorded.order(created_at: :desc) },
-          class_name: "GillickAssessment"
 
   has_many :vaccination_records,
            -> { recorded },
@@ -49,9 +46,6 @@ class PatientSession < ApplicationRecord
   has_many :draft_vaccination_records,
            -> { draft },
            class_name: "VaccinationRecord"
-  has_one :latest_vaccination_record,
-          -> { recorded.order(created_at: :desc) },
-          class_name: "VaccinationRecord"
 
   has_many :consents,
            -> { recorded.where(programme: _1.programmes).includes(:parent) },
@@ -92,10 +86,9 @@ class PatientSession < ApplicationRecord
         -> do
           preload(
             :consents,
+            :gillick_assessments,
             :triages,
-            :vaccination_records,
-            :latest_gillick_assessment,
-            :latest_vaccination_record
+            :vaccination_records
           )
         end
 
@@ -143,8 +136,16 @@ class PatientSession < ApplicationRecord
       .map { |_, consents| consents.max_by(&:recorded_at) }
   end
 
+  def latest_gillick_assessment
+    gillick_assessments.max_by(&:created_at)
+  end
+
   def latest_triage
     triages.max_by(&:updated_at)
+  end
+
+  def latest_vaccination_record
+    vaccination_records.max_by(&:created_at)
   end
 
   def consents_to_send_communication

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,11 +62,12 @@ class User < ApplicationRecord
         -> { where(last_sign_in_at: 1.week.ago..Time.current) }
 
   def selected_team
-    if Settings.cis2.enabled
-      Team.find_by(ods_code: cis2_info.dig("selected_org", "code"))
-    else
-      teams.first
-    end
+    @selected_team ||=
+      if Settings.cis2.enabled
+        Team.find_by(ods_code: cis2_info.dig("selected_org", "code"))
+      else
+        teams.first
+      end
   end
 
   def requires_email_and_password?


### PR DESCRIPTION
The new sessions and programmes pages now show more statistics than before which has lead to more queries to the database, this tries to reduce that number and improve performance. See individual commits for more details.