### PR TITLE
Show activity log on global child view

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -65,10 +65,10 @@ class Patient < ApplicationRecord
 
   has_one :latest_triage, -> { order(created_at: :desc) }, class_name: "Triage"
 
-  has_many :sessions, through: :patient_sessions
-  has_many :vaccination_records, through: :patient_sessions
   has_many :parents, through: :parent_relationships
   has_many :programmes, through: :sessions
+  has_many :sessions, through: :patient_sessions
+  has_many :vaccination_records, through: :patient_sessions
 
   has_many :upcoming_sessions,
            -> { upcoming },

--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -15,4 +15,4 @@
       nav.with_item(href: session_patient_log_path, text: "Activity log", selected: true)
     end %>
 
-<%= render AppActivityLogComponent.new(@patient_session) %>
+<%= render AppActivityLogComponent.new(patient_session: @patient_session) %>

--- a/app/views/patients/log.html.erb
+++ b/app/views/patients/log.html.erb
@@ -1,0 +1,17 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: programmes_path },
+                                          { text: t("patients.index.title"), href: patients_path },
+                                        ]) %>
+<% end %>
+
+<%= h1 page_title: @patient.initials do %>
+  <%= @patient.full_name %>
+<% end %>
+
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(href: patient_path(@patient), text: "Child record")
+      nav.with_item(href: log_patient_path(@patient), text: "Activity log", selected: true)
+    end %>
+
+<%= render AppActivityLogComponent.new(patient: @patient) %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -9,6 +9,11 @@
   <%= @patient.full_name %>
 <% end %>
 
+<%= render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(href: patient_path(@patient), text: "Child record", selected: true)
+      nav.with_item(href: log_patient_path(@patient), text: "Activity log")
+    end %>
+
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child record" } %>
   <%= render AppPatientSummaryComponent.new(@patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,7 @@ Rails.application.routes.draw do
 
   resources :patients, only: %i[index show update] do
     post "", action: :index, on: :collection
+    get "log", on: :member
   end
 
   resources :programmes, only: %i[index show], param: :type do

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -25,7 +25,7 @@ describe AppActivityLogComponent do
       created_at: Time.zone.parse("2024-05-29 12:00")
     )
   end
-  let(:component) { described_class.new(patient_session) }
+  let(:component) { described_class.new(patient_session:) }
   let(:user) do
     create(
       :user,

--- a/spec/components/previews/app_activity_log_component_preview.rb
+++ b/spec/components/previews/app_activity_log_component_preview.rb
@@ -6,7 +6,7 @@ class AppActivityLogComponentPreview < ViewComponent::Preview
   def default
     setup
 
-    render AppActivityLogComponent.new(patient_session)
+    render AppActivityLogComponent.new(patient_session:)
   end
 
   private

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -11,6 +11,9 @@ describe "Manage children" do
 
     when_i_click_on_a_child
     then_i_see_the_child
+
+    when_i_click_on_activity_log
+    then_i_see_the_activity_log
   end
 
   scenario "Removing a child from a cohort" do
@@ -53,13 +56,15 @@ describe "Manage children" do
 
   def given_patients_exist
     school = create(:location, :school, organisation: @organisation)
-    create(
-      :patient,
-      organisation: @organisation,
-      given_name: "John",
-      family_name: "Smith",
-      school:
-    )
+    patient =
+      create(
+        :patient,
+        organisation: @organisation,
+        given_name: "John",
+        family_name: "Smith",
+        school:
+      )
+    create(:vaccination_record, patient:)
     create_list(:patient, 9, organisation: @organisation, school:)
 
     create(
@@ -104,6 +109,15 @@ describe "Manage children" do
   def then_i_see_the_child
     expect(page).to have_title("JS")
     expect(page).to have_content("John Smith")
+  end
+
+  def when_i_click_on_activity_log
+    click_on "Activity log"
+  end
+
+  def then_i_see_the_activity_log
+    expect(page).to have_content("Added to session")
+    expect(page).to have_content("Vaccinated")
   end
 
   def and_i_see_the_cohort


### PR DESCRIPTION
This allows the user to see an activity log for a child record separate from the sessions view.

## Screenshot

<img width="861" alt="Screenshot 2024-10-30 at 18 53 32" src="https://github.com/user-attachments/assets/7dbe2608-283d-4349-be98-f512a4df366a">
