### PR TITLE
Don't send emails for closed sessions

### DIFF
--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -17,6 +17,8 @@ class SchoolConsentRemindersJob < ApplicationJob
         .strict_loading
 
     sessions.each do |session|
+      next unless session.open_for_consent?
+
       session.programmes.each do |programme|
         session.patients.each do |patient|
           next unless should_send_notification?(patient:, programme:, session:)

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -11,11 +11,14 @@ class SchoolConsentRequestsJob < ApplicationJob
           :programmes,
           patients: %i[consents consent_notifications parents]
         )
+        .preload(:session_dates)
         .eager_load(:location)
         .merge(Location.school)
         .strict_loading
 
     sessions.each do |session|
+      next unless session.open_for_consent?
+
       session.programmes.each do |programme|
         session.patients.each do |patient|
           next unless should_send_notification?(patient:, programme:)


### PR DESCRIPTION
This is an unlikely scenario where patients are added to a session after the consent period has closed and would end up receiving an email that they then can't use. It's possible to construct this scenario by scheduled a session for today and then tomorrow an email goes out to all patients with a link that doesn't work, although in reality it's unlikely this would ever happen.