### PR TITLE
Retry PDS jobs on server errors

### DIFF
--- a/app/jobs/concerns/nhs_api_concurrency_concern.rb
+++ b/app/jobs/concerns/nhs_api_concurrency_concern.rb
@@ -22,5 +22,7 @@ module NHSAPIConcurrencyConcern
     retry_on Faraday::TooManyRequestsError,
              attempts: :unlimited,
              wait: ->(_) { rand(0.5..5) }
+
+    retry_on Faraday::ServerError, wait: :polynomially_longer
   end
 end


### PR DESCRIPTION
This helps the jobs which look up information in PDS to be more robust by retrying in the case of intermittent network or server errors.