### PR TITLE
Allow staging nil values

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -139,7 +139,10 @@ class AppPatientSummaryComponent < ViewComponent::Base
   end
 
   def format_school
-    highlight_if(@patient.school&.name, @patient.school_id_changed?)
+    highlight_if(
+      helpers.patient_school(@patient),
+      @patient.school_id_changed? || @patient.home_educated_changed?
+    )
   end
 
   def format_year_group

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -24,9 +24,9 @@ module PatientsHelper
     if (school = patient.school).present?
       school.name
     elsif patient.home_educated
-      "Home educated"
+      "Home-schooled"
     else
-      "Unknown school"
+      tag.i("Unknown")
     end
   end
 

--- a/app/models/concerns/pending_changes_concern.rb
+++ b/app/models/concerns/pending_changes_concern.rb
@@ -9,8 +9,7 @@ module PendingChangesConcern
     new_pending_changes =
       attributes.each_with_object({}) do |(attr, new_value), staged_changes|
         current_value = public_send(attr)
-        staged_changes[attr.to_s] = new_value if new_value.present? &&
-          new_value != current_value
+        staged_changes[attr.to_s] = new_value if new_value != current_value
       end
 
     if new_pending_changes.any?

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -433,18 +433,10 @@ class ConsentForm < ApplicationRecord
             end
 
           if move_patient_to_session
-            existing_patient_sessions =
-              patient.patient_sessions.where(session: original_session)
-
-            if existing_patient_sessions.exists?
-              existing_patient_sessions.update_all(
-                proposed_session_id: move_patient_to_session.id
-              )
-            else
-              patient.patient_sessions.find_or_create_by!(
-                session: move_patient_to_session
-              )
-            end
+            patient.move_to_session!(
+              move_patient_to_session,
+              from: original_session
+            )
           end
         end
       end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -376,7 +376,7 @@ class ImmunisationImportRow
       given_name: patient_first_name,
       gender_code: patient_gender_code,
       nhs_number: patient_nhs_number
-    }
+    }.compact
   end
 
   def school_urn_inclusion

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -270,6 +270,20 @@ class Patient < ApplicationRecord
     end
   end
 
+  def move_to_session!(new_session, from:)
+    return if deceased? || invalidated?
+
+    old_session = from
+
+    existing_patient_sessions = patient_sessions.where(session: old_session)
+
+    if existing_patient_sessions.exists?
+      existing_patient_sessions.update_all(proposed_session_id: new_session.id)
+    else
+      patient_sessions.find_or_create_by!(session_id: new_session.id)
+    end
+  end
+
   class NHSNumberMismatch < StandardError
   end
 

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -42,7 +42,6 @@ class PatientImportRow
       address_line_2:,
       address_postcode:,
       address_town:,
-      cohort_id: cohort&.id,
       date_of_birth:,
       family_name: last_name,
       gender_code:,
@@ -51,9 +50,8 @@ class PatientImportRow
       nhs_number:,
       preferred_family_name: preferred_last_name,
       preferred_given_name: preferred_first_name,
-      registration:,
-      school_id: school&.id
-    }.compact
+      registration:
+    }.compact.merge(cohort_id: cohort&.id, school_id: school&.id)
 
     if (existing_patient = existing_patients.first)
       existing_patient.stage_changes(attributes)

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe PatientsHelper do
     context "without a school" do
       let(:patient) { create(:patient) }
 
-      it { should eq("Unknown school") }
+      it { should eq("<i>Unknown</i>") }
     end
 
     context "with a school" do
@@ -54,7 +54,7 @@ RSpec.describe PatientsHelper do
     context "when home educated" do
       let(:patient) { create(:patient, :home_educated) }
 
-      it { should eq("Home educated") }
+      it { should eq("Home-schooled") }
     end
   end
 

--- a/spec/models/concerns/pending_changes_concern_spec.rb
+++ b/spec/models/concerns/pending_changes_concern_spec.rb
@@ -34,16 +34,6 @@ describe PendingChangesConcern do
       expect(model.pending_changes).to eq({ "family_name" => "Smith" })
     end
 
-    it "does not stage blank values" do
-      model.stage_changes(
-        given_name: "",
-        family_name: nil,
-        address_line_1: "123 New St"
-      )
-
-      expect(model.pending_changes).to eq({ "address_line_1" => "123 New St" })
-    end
-
     it "updates the pending_changes attribute" do
       expect { model.stage_changes(given_name: "Jane") }.to change {
         model.reload.pending_changes

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -341,18 +341,6 @@ describe Patient do
       expect(patient.pending_changes).to eq({ "family_name" => "Smith" })
     end
 
-    it "does not stage blank values" do
-      patient.stage_changes(
-        given_name: "",
-        family_name: nil,
-        address_line_1: "123 New St"
-      )
-
-      expect(patient.pending_changes).to eq(
-        { "address_line_1" => "123 New St" }
-      )
-    end
-
     it "updates the pending_changes attribute" do
       expect { patient.stage_changes(given_name: "Jane") }.to change {
         patient.reload.pending_changes


### PR DESCRIPTION
This makes it possible to stage a `nil` value in the pending changes for a particular record, this is needed to handle when a patient moves out of schools (either because they're home-schooled, or because the school is unknown).

## Screenshots
<img width="1234" alt="Screenshot 2024-10-31 at 08 08 05" src="https://github.com/user-attachments/assets/203e160a-45a3-4d7e-a873-5432d4006a8f">
<img width="1286" alt="Screenshot 2024-10-31 at 08 08 12" src="https://github.com/user-attachments/assets/1e5f30f8-23bf-4759-873d-7332752495f5">

