### PR TITLE
Show patient sessions on global patient view page

### DIFF
--- a/app/components/app_patient_cohort_table_component.html.erb
+++ b/app/components/app_patient_cohort_table_component.html.erb
@@ -1,0 +1,30 @@
+<% if cohort %>
+  <%= govuk_table(html_attributes: {
+                    class: "nhsuk-table-responsive",
+                  }) do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Name") %>
+        <% row.with_cell(text: "Actions") %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell do %>
+          <span class="nhsuk-table-responsive__heading">Name</span>
+          <%= helpers.format_year_group(cohort.year_group) %>
+        <% end %>
+        <% row.with_cell do %>
+          <span class="nhsuk-table-responsive__heading">Actions</span>
+          <%= form_with model: @patient, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+            <%= f.hidden_field :cohort_id, value: "" %>
+            <%= f.govuk_submit "Remove from cohort", class: "app-button--secondary-warning app-button--small" %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p class="nhsuk-body">No cohorts</p>
+<% end %>

--- a/app/components/app_patient_cohort_table_component.rb
+++ b/app/components/app_patient_cohort_table_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AppPatientCohortTableComponent < ViewComponent::Base
+  def initialize(patient)
+    super
+
+    @patient = patient
+  end
+
+  private
+
+  attr_reader :patient
+
+  delegate :cohort, to: :patient
+end

--- a/app/components/app_patient_session_table_component.html.erb
+++ b/app/components/app_patient_session_table_component.html.erb
@@ -1,0 +1,24 @@
+<% if sessions.present? %>
+  <%= govuk_table(html_attributes: {
+                    class: "nhsuk-table-responsive",
+                  }) do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Location") %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% sessions.each do |session| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell do %>
+            <span class="nhsuk-table-responsive__heading">Location</span>
+            <%= link_to session.location.name, session_path(session) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p class="nhsuk-body">No sessions</p>
+<% end %>

--- a/app/components/app_patient_session_table_component.rb
+++ b/app/components/app_patient_session_table_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AppPatientSessionTableComponent < ViewComponent::Base
+  def initialize(patient, sessions:)
+    super
+
+    @patient = patient
+    @sessions = sessions
+  end
+
+  private
+
+  attr_reader :patient, :sessions
+end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -19,6 +19,7 @@ class PatientsController < ApplicationController
   end
 
   def show
+    @sessions = policy_scope(Session).joins(:patients).where(patients: @patient)
   end
 
   def update

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -23,3 +23,8 @@
   <% c.with_heading { "Cohorts" } %>
   <%= render AppPatientCohortTableComponent.new(@patient) %>
 <% end %>
+
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Sessions" } %>
+  <%= render AppPatientSessionTableComponent.new(@patient, sessions: @sessions) %>
+<% end %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -21,35 +21,5 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Cohorts" } %>
-
-  <% if (cohort = @patient.cohort) %>
-    <%= govuk_table(html_attributes: {
-                      class: "nhsuk-table-responsive",
-                    }) do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: "Name") %>
-          <% row.with_cell(text: "Actions") %>
-        <% end %>
-      <% end %>
-
-      <% table.with_body do |body| %>
-        <% body.with_row do |row| %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Name</span>
-            <%= format_year_group(cohort.year_group) %>
-          <% end %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Actions</span>
-            <%= form_with model: @patient do |f| %>
-              <%= f.hidden_field :cohort_id, value: "" %>
-              <%= f.govuk_submit "Remove from cohort", class: "app-button--secondary-warning app-button--small" %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
-  <% else %>
-    <p class="nhsuk-body">No cohorts</p>
-  <% end %>
+  <%= render AppPatientCohortTableComponent.new(@patient) %>
 <% end %>

--- a/spec/components/app_patient_cohort_table_component_spec.rb
+++ b/spec/components/app_patient_cohort_table_component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe AppPatientCohortTableComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(patient) }
+
+  context "without a cohort" do
+    let(:patient) { create(:patient, cohort: nil) }
+
+    it { should have_content("No cohorts") }
+  end
+
+  context "with a cohort" do
+    let(:cohort) { create(:cohort, year_group: 8) }
+    let(:patient) { create(:patient, cohort:) }
+
+    it { should have_content("Year 8") }
+    it { should have_content("Remove from cohort") }
+  end
+end

--- a/spec/components/app_patient_session_table_component_spec.rb
+++ b/spec/components/app_patient_session_table_component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe AppPatientSessionTableComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(patient, sessions:) }
+
+  let(:patient) { create(:patient) }
+
+  context "without a session" do
+    let(:sessions) { [] }
+
+    it { should have_content("No sessions") }
+  end
+
+  context "with a session" do
+    let(:location) { create(:location, :school, name: "Waterloo Road") }
+    let(:sessions) { create_list(:session, 1, location:, patients: [patient]) }
+
+    it { should have_content("Location") }
+    it { should have_link("Waterloo Road") }
+  end
+end

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -21,7 +21,10 @@
 #
 FactoryBot.define do
   factory :cohort do
+    transient { year_group { 5 } }
+
     organisation
-    birth_academic_year { Time.zone.today.year - 10 }
+
+    birth_academic_year { Date.current.academic_year - year_group - 5 }
   end
 end

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -109,6 +109,8 @@ describe "Manage children" do
   def then_i_see_the_child
     expect(page).to have_title("JS")
     expect(page).to have_content("John Smith")
+    expect(page).to have_content("Cohorts")
+    expect(page).to have_content("Sessions")
   end
 
   def when_i_click_on_activity_log


### PR DESCRIPTION
This adds a new table when looking at a patient that shows the sessions they belong to, matching the designs in the prototype.

## Screenshot

![Screenshot 2024-10-31 at 10 17 24](https://github.com/user-attachments/assets/67041c65-8a37-4a7b-af82-7e27c74a1545)
