### PR TITLE
Find duplicates using full name

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -10,7 +10,7 @@ class PatientsController < ApplicationController
 
     if (@q = params[:q]).present?
       @q.strip!
-      scope = scope.search_by_name(@q)
+      scope = scope.search_by_full_name(@q)
     end
 
     @pagy, @patients = pagy(scope.order_by_name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -169,11 +169,11 @@ en:
               blank: Enter an anatomical site.
             dose_sequence:
               blank: The dose sequence number cannot be greater than 3. Enter a dose sequence number, for example, 1, 2 or 3.
+            existing_patients:
+              too_long: Two or more possible patients match the patient first name, last name, date of birth or postcode.
             organisation_code:
               blank: Enter an organisation code that matches the current organisation.
               equal_to: Enter an organisation code that matches the current organisation.
-            patient:
-              multiple_duplicate_match: Two or more possible patients match the patient first name, last name, date of birth or postcode.
             patient_date_of_birth:
               blank: Enter a date of birth in the correct format.
               inclusion: is not part of this programme

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -167,7 +167,8 @@ describe ImmunisationImportRow do
         {
           "PERSON_FORENAME" => "John",
           "PERSON_SURNAME" => "Smith",
-          "PERSON_DOB" => "19900901"
+          "PERSON_DOB" => "19900901",
+          "PERSON_POSTCODE" => "ABC DEF"
         }
       end
 
@@ -183,7 +184,7 @@ describe ImmunisationImportRow do
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
-        expect(immunisation_import_row.errors[:patient]).to eq(
+        expect(immunisation_import_row.errors[:existing_patients]).to eq(
           [
             "Two or more possible patients match the patient first name, last name, date of birth or postcode."
           ]

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -147,22 +147,62 @@ describe Patient do
       it { should include(patient) }
     end
 
-    context "with matching first name, date of birth and postcode" do
+    context "with first name and last name are similar and matching date of birth" do
       let(:nhs_number) { nil }
       let(:patient) do
-        create(:patient, given_name:, date_of_birth:, address_postcode:)
+        create(
+          :patient,
+          given_name: "Johnny",
+          family_name: "Smith",
+          date_of_birth:
+        )
       end
 
       it { should include(patient) }
     end
 
-    context "with matching last name, date of birth and postcode" do
+    context "with first name and last name are similar and matching postcode" do
       let(:nhs_number) { nil }
       let(:patient) do
-        create(:patient, family_name:, date_of_birth:, address_postcode:)
+        create(
+          :patient,
+          given_name: "John",
+          family_name: "Smyth",
+          address_postcode:
+        )
       end
 
       it { should include(patient) }
+    end
+
+    context "with matching first name, date of birth and postcode" do
+      let(:nhs_number) { nil }
+      let(:patient) do
+        create(
+          :patient,
+          given_name:,
+          family_name: "Seldon",
+          date_of_birth:,
+          address_postcode:
+        )
+      end
+
+      it { should_not include(patient) }
+    end
+
+    context "with matching last name, date of birth and postcode" do
+      let(:nhs_number) { nil }
+      let(:patient) do
+        create(
+          :patient,
+          given_name: "Hari",
+          family_name:,
+          date_of_birth:,
+          address_postcode:
+        )
+      end
+
+      it { should_not include(patient) }
     end
 
     context "when matching everything except the NHS number" do


### PR DESCRIPTION
This changes how we find duplicates to use the full name (both given and family name) to avoid a situation where twins would be treated as the same person, because their family name, date of birth and postcode would match.

To compensate for the duplicate matching to require a match on more values, we use trigram fuzzy matching to handle spelling errors or other slight variations in names.