### PR TITLE
Ensure session notifications sent date is validated

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -93,6 +93,7 @@ class Session < ApplicationRecord
   validates :send_consent_requests_at,
             presence: true,
             comparison: {
+              greater_than_or_equal_to: :earliest_send_notifications_at,
               less_than: :earliest_date
             },
             unless: -> { earliest_date.nil? || location.generic_clinic? }
@@ -100,6 +101,7 @@ class Session < ApplicationRecord
   validates :send_invitations_at,
             presence: true,
             comparison: {
+              greater_than_or_equal_to: :earliest_send_notifications_at,
               less_than: :earliest_date
             },
             if: -> { earliest_date.present? && location.generic_clinic? }
@@ -325,9 +327,13 @@ class Session < ApplicationRecord
     dates.min
   end
 
+  def earliest_send_notifications_at
+    return nil if earliest_date.nil?
+    earliest_date - 3.months
+  end
+
   def maximum_weeks_before_consent_reminders
     return nil if earliest_date.nil? || send_consent_requests_at.nil?
-
     (earliest_date - send_consent_requests_at).to_i / 7
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -484,12 +484,14 @@ en:
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year
+              greater_than_or_equal_to: Enter a date at most 3 months before the first session date (%{count})
               less_than: Enter a date before the first session date (%{count})
             send_invitations_at:
               blank: Enter a date
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year
+              greater_than_or_equal_to: Enter a date at most 3 months before the first session date (%{count})
               less_than: Enter a date before the first session date (%{count})
             weeks_before_consent_reminders:
               blank: Enter weeks before a session takes place


### PR DESCRIPTION
This improves the validation around editing when the consent requests and invitations are sent out to prevent the user from choosing a value that's not within a reasonable limit.

3 months was picked arbitrarily, happy for other suggestions.