### PR TITLE
Auto-deploy to pentest

### DIFF
--- a/.github/workflows/deploy-pentest.yml
+++ b/.github/workflows/deploy-pentest.yml
@@ -1,0 +1,48 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  copilot:
+    name: AWS Copilot deploy
+
+    permissions:
+      id-token: write
+      contents: read
+
+    environment:
+      name: ${{ github.event.inputs.environment || 'test' }}
+      url: https://${{ steps.host-name.outputs.value }}
+
+    concurrency:
+      group: ${{ github.ref }}-${{ github.event.inputs.environment || 'test' }}
+      cancel-in-progress: true
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::393416225559:role/GitHubActionsRole
+          aws-region: eu-west-2
+
+      - name: Install and Verify AWS Copilot
+        run: |
+          curl -Lo /tmp/copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+          chmod +x /tmp/copilot
+          mv /tmp/copilot /usr/local/bin/copilot
+          copilot --version
+
+      - name: Deploy the application using AWS Copilot
+        run: |
+          copilot svc deploy --name webapp --env pentest
+
+      - name: Get host name
+        id: host-name
+        run: |
+          echo "value=pentest" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This is horrible, but also the fastest way to implement this for now. The horribleness is that it will have to build and deploy out the artifact a second time, in addition to the "test" env deploy, in fact there may be a race condition as a result of having two of these. However, reusing the image from the other deploy is non-trivial.

Creating as draft so we can discuss if it might be better to:

- Trigger this deploy to pentest on the completion of the main deploy workflow triggered by PR merge, but we probably want to not deploy to pentest if the main deploy was manually triggered.
- Add the deploy to the existing deploy workflow, but we probably want to disable deploying to pentest when triggered manually.
- Something fancier like trigger this deploy workflow again at the end of the first auto-deploy to test.