### PR TITLE
Add ability to edit NHS number 

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -5,7 +5,8 @@ class AppPatientSummaryComponent < ViewComponent::Base
     patient,
     show_preferred_name: false,
     show_address: false,
-    show_parent_or_guardians: false
+    show_parent_or_guardians: false,
+    change_links: {}
   )
     super
 
@@ -14,6 +15,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
     @show_preferred_name = show_preferred_name
     @show_address = show_address
     @show_parent_or_guardians = show_parent_or_guardians
+    @change_links = change_links
   end
 
   def call
@@ -21,6 +23,13 @@ class AppPatientSummaryComponent < ViewComponent::Base
       summary_list.with_row do |row|
         row.with_key { "NHS number" }
         row.with_value { format_nhs_number }
+        if (href = @change_links[:nhs_number])
+          row.with_action(
+            text: "Change",
+            href:,
+            visually_hidden_text: "NHS number"
+          )
+        end
       end
       summary_list.with_row do |row|
         row.with_key { "Full name" }

--- a/app/controllers/patients/edit_controller.rb
+++ b/app/controllers/patients/edit_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Patients::EditController < ApplicationController
+  before_action :set_patient
+
+  def edit_nhs_number
+    render :nhs_number
+  end
+
+  def update_nhs_number
+    if @patient.update(nhs_number_params)
+      redirect_to edit_patient_path(@patient)
+    else
+      render :nhs_number, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_patient
+    @patient = policy_scope(Patient).find(params[:id])
+  end
+
+  def nhs_number_params
+    params.require(:patient).permit(:nhs_number)
+  end
+end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -22,6 +22,9 @@ class PatientsController < ApplicationController
     @sessions = policy_scope(Session).joins(:patients).where(patients: @patient)
   end
 
+  def edit
+  end
+
   def update
     cohort = @patient.cohort
 

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -12,9 +12,15 @@
   <%= page_title %>
 <% end %>
 
-<%= render AppCardComponent.new do |c| %>
-  <% c.with_heading { "Record details" } %>
-  <%= render AppPatientSummaryComponent.new(@patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading { "Record details" } %>
+  <%= render AppPatientSummaryComponent.new(
+        @patient,
+        show_preferred_name: true,
+        show_address: true,
+        show_parent_or_guardians: true,
+        change_links: { nhs_number: edit_nhs_number_patient_path(@patient) },
+      ) %>
 <% end %>
 
 <%= govuk_button_link_to "Continue", patient_path(@patient) %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -1,0 +1,20 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: patient_path(@patient),
+        name: @patient.full_name,
+      ) %>
+<% end %>
+
+<% page_title = "Edit child record" %>
+
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l"><%= @patient.full_name %></span>
+  <%= page_title %>
+<% end %>
+
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Record details" } %>
+  <%= render AppPatientSummaryComponent.new(@patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>
+<% end %>
+
+<%= govuk_button_link_to "Continue", patient_path(@patient) %>

--- a/app/views/patients/edit/nhs_number.html.erb
+++ b/app/views/patients/edit/nhs_number.html.erb
@@ -1,0 +1,23 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: edit_patient_path(@patient),
+        name: "edit patient",
+      ) %>
+<% end %>
+
+<% legend = "What is the child’s NHS number?" %>
+<% content_for :page_title, legend %>
+
+<%= form_with model: @patient, url: edit_nhs_number_patient_path(@patient), method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_text_field :nhs_number,
+                         caption: { text: @patient.full_name, size: "l" },
+                         label: {
+                           tag: "h1",
+                           text: legend,
+                           size: "l",
+                         } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -17,6 +17,7 @@
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child record" } %>
   <%= render AppPatientSummaryComponent.new(@patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>
+  <%= govuk_button_link_to "Edit child record", edit_patient_path(@patient), class: "app-button--secondary" %>
 <% end %>
 
 <%= render AppCardComponent.new do |c| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -469,6 +469,11 @@ en:
             contact_method_other_details:
               blank: Enter details about how to contact you
               too_long: Enter details that are less than 300 characters long
+        patient:
+          attributes:
+            nhs_number:
+              invalid: Enter a valid NHS number
+              taken: NHS number is already assigned to a different patient
         programme:
           attributes:
             type:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,17 @@ Rails.application.routes.draw do
 
   resources :patients, only: %i[index show edit update] do
     post "", action: :index, on: :collection
-    get "log", on: :member
+
+    member do
+      get "log"
+
+      get "edit/nhs-number",
+          controller: "patients/edit",
+          action: "edit_nhs_number"
+      put "edit/nhs-number",
+          controller: "patients/edit",
+          action: "update_nhs_number"
+    end
   end
 
   resources :programmes, only: %i[index show], param: :type do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
 
   resources :notices, only: :index
 
-  resources :patients, only: %i[index show update] do
+  resources :patients, only: %i[index show edit update] do
     post "", action: :index, on: :collection
     get "log", on: :member
   end

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -16,6 +16,17 @@ describe "Manage children" do
     then_i_see_the_activity_log
   end
 
+  scenario "Adding an NHS number" do
+    given_patients_exist
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+    then_i_see_the_child
+
+    when_i_click_on_edit_child_record
+    then_i_see_the_edit_child_record_page
+  end
+
   scenario "Removing a child from a cohort" do
     given_patients_exist
 
@@ -120,6 +131,16 @@ describe "Manage children" do
   def then_i_see_the_activity_log
     expect(page).to have_content("Added to session")
     expect(page).to have_content("Vaccinated")
+  end
+
+  def when_i_click_on_edit_child_record
+    click_on "Edit child record"
+  end
+
+  def then_i_see_the_edit_child_record_page
+    expect(page).to have_title("Edit child record")
+    expect(page).to have_content("John Smith")
+    expect(page).to have_content("Record details")
   end
 
   def and_i_see_the_cohort

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -25,6 +25,13 @@ describe "Manage children" do
 
     when_i_click_on_edit_child_record
     then_i_see_the_edit_child_record_page
+
+    when_i_click_on_change_nhs_number
+    then_i_see_the_edit_nhs_number_page
+
+    when_i_enter_an_nhs_number
+    then_i_see_the_edit_child_record_page
+    and_i_see_the_nhs_number
   end
 
   scenario "Removing a child from a cohort" do
@@ -141,6 +148,21 @@ describe "Manage children" do
     expect(page).to have_title("Edit child record")
     expect(page).to have_content("John Smith")
     expect(page).to have_content("Record details")
+  end
+
+  def when_i_click_on_change_nhs_number
+    click_on "Change NHS number"
+  end
+  def then_i_see_the_edit_nhs_number_page
+    expect(page).to have_content("What is the child’s NHS number?")
+  end
+
+  def when_i_enter_an_nhs_number
+    fill_in "What is the child’s NHS number?", with: "123 456 7890"
+    click_on "Continue"
+  end
+  def and_i_see_the_nhs_number
+    expect(page).to have_content("123 ‍456 ‍7890")
   end
 
   def and_i_see_the_cohort


### PR DESCRIPTION
This adds a page that allows users to edit the NHS number of a patient. If the NHS number already exists for another patient, the user is presented with a validation error, which will be replaced with the ability to merge the patient records.

## Screenshots

![Screenshot 2024-10-31 at 13 54 44](https://github.com/user-attachments/assets/e6839e87-9ebf-4f88-8cd9-ef3f413a50c9)
![Screenshot 2024-10-31 at 14 19 39](https://github.com/user-attachments/assets/3c4fc9bd-6687-4fa7-8b03-f05b1ce49d1b)
![Screenshot 2024-10-31 at 14 19 42](https://github.com/user-attachments/assets/e5ee3947-0ae3-485a-ac26-fd847c3c78a2)
![Screenshot 2024-10-31 at 14 19 56](https://github.com/user-attachments/assets/07bc96fa-8f43-4ae0-8463-939c1bc1814d)
