### PR TITLE
Add PatientMerger

### DIFF
--- a/app/jobs/patient_nhs_number_lookup_job.rb
+++ b/app/jobs/patient_nhs_number_lookup_job.rb
@@ -2,7 +2,6 @@
 
 class PatientNHSNumberLookupJob < ApplicationJob
   include NHSAPIConcurrencyConcern
-  include MergePatientsConcern
 
   queue_as :imports
 
@@ -28,7 +27,7 @@ class PatientNHSNumberLookupJob < ApplicationJob
              :patient_sessions
            ).find_by(nhs_number: pds_patient.nhs_number)
        )
-      merge_patients!(existing_patient, patient)
+      PatientMerger.call(to_keep: existing_patient, to_destroy: patient)
       existing_patient.update_from_pds!(pds_patient)
     else
       patient.nhs_number = pds_patient.nhs_number

--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -2,7 +2,6 @@
 
 class PatientUpdateFromPDSJob < ApplicationJob
   include NHSAPIConcurrencyConcern
-  include MergePatientsConcern
 
   queue_as :pds
 
@@ -26,7 +25,7 @@ class PatientUpdateFromPDSJob < ApplicationJob
                :patient_sessions
              ).find_by(nhs_number: pds_patient.nhs_number)
          )
-        merge_patients!(existing_patient, patient)
+        PatientMerger.call(to_keep: existing_patient, to_destroy: patient)
         existing_patient.update_from_pds!(pds_patient)
       else
         patient.nhs_number = pds_patient.nhs_number

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+describe PatientMerger do
+  describe "#call" do
+    subject(:call) do
+      described_class.call(
+        to_keep: patient_to_keep,
+        to_destroy: patient_to_destroy
+      )
+    end
+
+    let(:programme) { create(:programme) }
+    let(:session) { create(:session, programme:) }
+
+    let!(:patient_to_keep) { create(:patient) }
+    let!(:patient_to_destroy) { create(:patient) }
+
+    let(:consent) { create(:consent, patient: patient_to_destroy, programme:) }
+    let(:gillick_assessment) { create(:gillick_assessment, patient_session:) }
+    let(:parent_relationship) do
+      create(:parent_relationship, patient: patient_to_destroy)
+    end
+    let(:patient_session) do
+      create(:patient_session, session:, patient: patient_to_destroy)
+    end
+    let(:triage) { create(:triage, patient: patient_to_destroy, programme:) }
+    let(:vaccination_record) do
+      create(:vaccination_record, patient_session:, programme:)
+    end
+
+    it "destroys one of the patients" do
+      expect { call }.to change(Patient, :count).by(-1)
+      expect { patient_to_destroy.reload }.to raise_error(
+        ActiveRecord::RecordNotFound
+      )
+    end
+
+    it "moves consents" do
+      expect { call }.to change { consent.reload.patient }.to(patient_to_keep)
+    end
+
+    it "moves gillick assessments" do
+      expect { call }.to change { gillick_assessment.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves parent relationships" do
+      expect { call }.to change { parent_relationship.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves patient sessions" do
+      expect { call }.to change { patient_session.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves triages" do
+      expect { call }.to change { triage.reload.patient }.to(patient_to_keep)
+    end
+
+    it "moves vaccination records" do
+      expect { call }.to change { vaccination_record.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+  end
+end


### PR DESCRIPTION
This refactors how the patient merging logic is implemented to provide a separate service class rather than being a job concern. This allows us to use it as the result of an action by a nurse.