### PR TITLE
Allow merging records when editing NHS numbers

### DIFF
--- a/app/views/patients/edit/nhs_number_merge.html.erb
+++ b/app/views/patients/edit/nhs_number_merge.html.erb
@@ -1,0 +1,31 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: edit_nhs_number_patient_path(@patient),
+        name: "edit NHS number",
+      ) %>
+<% end %>
+
+<% page_title = "Do you want to merge this record?" %>
+
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l"><%= @patient.full_name %></span>
+  <%= page_title %>
+<% end %>
+
+<p class="nhsuk-body">
+  Updating the NHS number for <%= @patient.full_name %> will merge their record with an existing record:
+</p>
+
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading { "Child record" } %>
+  <%= render AppPatientSummaryComponent.new(@existing_patient) %>
+<% end %>
+
+<%= form_with model: @patient, url: edit_nhs_number_merge_patient_path(@patient), method: :put do |f| %>
+  <%= f.hidden_field :nhs_number, value: @existing_patient.nhs_number %>
+
+  <div class="app-button-group">
+    <%= f.govuk_submit "Merge records" %>
+    <%= govuk_link_to "Edit NHS number", edit_nhs_number_patient_path(@patient) %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,9 @@ Rails.application.routes.draw do
       put "edit/nhs-number",
           controller: "patients/edit",
           action: "update_nhs_number"
+      put "edit/nhs-number-merge",
+          controller: "patients/edit",
+          action: "update_nhs_number_merge"
     end
   end
 

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -32,6 +32,13 @@ describe "Manage children" do
     when_i_enter_an_nhs_number
     then_i_see_the_edit_child_record_page
     and_i_see_the_nhs_number
+
+    when_i_click_on_change_nhs_number
+    and_i_enter_an_existing_nhs_number
+    then_i_see_the_merge_record_page
+
+    when_i_click_on_merge_records
+    then_i_see_the_merged_edit_child_record_page
   end
 
   scenario "Removing a child from a cohort" do
@@ -85,12 +92,13 @@ describe "Manage children" do
     create(:vaccination_record, patient:)
     create_list(:patient, 9, organisation: @organisation, school:)
 
-    create(
-      :patient,
-      given_name: "Jane",
-      family_name: "Doe",
-      cohort: @organisation.cohorts.first
-    )
+    @existing_patient =
+      create(
+        :patient,
+        given_name: "Jane",
+        family_name: "Doe",
+        cohort: @organisation.cohorts.first
+      )
   end
 
   def when_a_deceased_patient_exists
@@ -161,8 +169,29 @@ describe "Manage children" do
     fill_in "What is the child’s NHS number?", with: "123 456 7890"
     click_on "Continue"
   end
+
+  def and_i_enter_an_existing_nhs_number
+    fill_in "What is the child’s NHS number?",
+            with: @existing_patient.nhs_number
+    click_on "Continue"
+  end
+
   def and_i_see_the_nhs_number
     expect(page).to have_content("123 ‍456 ‍7890")
+  end
+
+  def then_i_see_the_merge_record_page
+    expect(page).to have_content("Do you want to merge this record?")
+    expect(page).to have_content("Jane Doe")
+  end
+
+  def when_i_click_on_merge_records
+    click_on "Merge records"
+  end
+
+  def then_i_see_the_merged_edit_child_record_page
+    expect(page).to have_title("Edit child record")
+    expect(page).to have_content("Jane Doe")
   end
 
   def and_i_see_the_cohort


### PR DESCRIPTION
This adds the functionality to allow users to edit NHS numbers, and if it matches with an existing patient, to merge the two patient records by deleting the one without an NHS number and keeping the existing patient.

## Screenshot

![Screenshot 2024-10-31 at 15 17 32](https://github.com/user-attachments/assets/49616402-b0d1-44f2-8c9d-83815eff64bc)
