### PR TITLE
Use pentest not test for concurrency group

### DIFF
--- a/.github/workflows/deploy-pentest.yml
+++ b/.github/workflows/deploy-pentest.yml
@@ -13,11 +13,11 @@ jobs:
       contents: read
 
     environment:
-      name: ${{ github.event.inputs.environment || 'test' }}
+      name: pentest
       url: https://${{ steps.host-name.outputs.value }}
 
     concurrency:
-      group: ${{ github.ref }}-${{ github.event.inputs.environment || 'test' }}
+      group: pentest
       cancel-in-progress: true
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
When starting up in "test" we cancel out the other "test" deploy job.