### PR TITLE
Link to service guidance

### DIFF
--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -56,14 +56,25 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card__content",
       ("app-card__content" unless @data),
-      ("nhsuk-card__content--feature" if @feature)
+      ("nhsuk-card__content--feature" if @feature),
+      ("nhsuk-card__content--secondary" if @secondary)
     ].compact.join(" ")
+  end
+
+  def heading_size
+    if @data
+      "xs"
+    elsif @secondary
+      "s"
+    else
+      "m"
+    end
   end
 
   def heading_classes
     [
       "nhsuk-card__heading",
-      (@data ? "nhsuk-heading-xs" : "nhsuk-heading-m"),
+      "nhsuk-heading-#{heading_size}",
       ("nhsuk-card__heading--feature" if @feature)
     ].compact.join(" ")
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -68,4 +68,11 @@
       <% card.with_description { "Manage your organisation’s settings" } %>
     <% end %>
   </li>
+
+  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    <%= render AppCardComponent.new(link_to: t("service.guide"), secondary: true) do |card| %>
+      <% card.with_heading { t("guide.show.title") } %>
+      <% card.with_description { "How to use this service" } %>
+    <% end %>
+  </li>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,6 +58,9 @@
                   <%= link_to "Privacy policy", :privacy_policy, classes: "nhsuk-footer__list-item-link" %>
                 <% end %>
               </li>
+              <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item">
+                <%= link_to "#{t("guide.show.title")} (opens in a new tab)", t("service.guide"), classes: "nhsuk-footer__list-item-link", target: "_blank" %>
+              </li>
             </ul>
             <p class="nhsuk-footer__copyright">&copy; NHS England</p>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -645,6 +645,9 @@ en:
         other: Why are they refusing to give consent?
         personal_choice: Why are they refusing to give consent?
         will_be_vaccinated_elsewhere: Where will their child get their vaccination?
+  guide:
+    show:
+      title: Service guidance
   imports:
     index:
       title: Imports
@@ -734,6 +737,7 @@ en:
         unscheduled: No sessions scheduled
   service:
     email: england.mavis@nhs.net
+    guide: https://guide.manage-vaccinations-in-schools.nhs.uk
   sessions:
     index:
       title: Sessions


### PR DESCRIPTION
- Adds link to service guidance from footer (opens in a new tab)
- Adds link to service guidance from dashboard
- Fix appearance of secondary card (shouldn’t have content padding), and use smaller heading size for secondary cards

<img width="1240" alt="Screenshot of dashboard" src="https://github.com/user-attachments/assets/dccbe6a5-bc3e-4d59-86bb-1234a1819483">
 