### PR TITLE
Make Consent#name more robust

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -140,7 +140,9 @@ class Consent < ApplicationRecord
   delegate :restricted?, to: :patient
 
   def name
-    via_self_consent? ? patient.full_name : parent.label
+    return patient.full_name if via_self_consent?
+
+    (recorded? ? parent : draft_parent)&.label || "Unknown"
   end
 
   def triage_needed?


### PR DESCRIPTION
This avoids trying to get the label for a `nil` parent.

https://good-machine.sentry.io/issues/6033335850/?environment=test&project=4505625073876992&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=2