### PR TITLE
Only show recorded items in activity log

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -39,7 +39,7 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def consent_events
-    consents.map do
+    consents.recorded.map do
       {
         title: "Consent #{_1.response} by #{_1.name} (#{_1.who_responded})",
         time: _1.recorded_at
@@ -81,7 +81,7 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def vaccination_events
-    vaccination_records.map do
+    vaccination_records.recorded.map do
       {
         title: "Vaccinated with #{helpers.vaccine_heading(_1.vaccine)}",
         time: _1.created_at,

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -64,6 +64,10 @@ describe AppActivityLogComponent do
         parent: dad,
         recorded_at: Time.zone.parse("2024-05-30 13:00")
       )
+
+      # draft consent should not show
+      create(:consent, :given, programme:, patient:, parent: nil)
+
       create(
         :triage,
         :needs_follow_up,
@@ -124,9 +128,13 @@ describe AppActivityLogComponent do
     end
 
     it "renders headings in correct order" do
-      expect(subject).to have_css("h2:nth-of-type(1)", text: "31 May 2024")
-      expect(subject).to have_css("h2:nth-of-type(2)", text: "30 May 2024")
-      expect(subject).to have_css("h2:nth-of-type(3)", text: "29 May 2024")
+      expect(page).to have_css("h2:nth-of-type(1)", text: "31 May 2024")
+      expect(page).to have_css("h2:nth-of-type(2)", text: "30 May 2024")
+      expect(page).to have_css("h2:nth-of-type(3)", text: "29 May 2024")
+    end
+
+    it "has cards" do
+      expect(page).to have_css(".nhsuk-card", count: 8)
     end
 
     include_examples "card",


### PR DESCRIPTION
This ensures that we are only show consents and vaccination records that have been fully recorded in the database.

https://good-machine.sentry.io/issues/6033335850/?environment=test&project=4505625073876992&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=2