### PR TITLE
Revert fuzzy name matching

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -10,7 +10,7 @@ class PatientsController < ApplicationController
 
     if (@q = params[:q]).present?
       @q.strip!
-      scope = scope.search_by_full_name(@q)
+      scope = scope.search_by_name(@q)
     end
 
     @pagy, @patients = pagy(scope.order_by_name)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -172,41 +172,61 @@ class Patient < ApplicationRecord
     end
 
     scope =
-      Patient
-        .where(
-          "given_name ILIKE ? AND family_name ILIKE ?",
-          given_name,
-          family_name
-        )
-        .where(date_of_birth:)
-        .or(
-          Patient.where(
-            "given_name ILIKE ? AND family_name ILIKE ?",
-            given_name,
-            family_name
-          ).where(address_postcode:)
-        )
-        .or(
-          Patient.where("given_name ILIKE ?", given_name).where(
-            date_of_birth:,
-            address_postcode:
-          )
-        )
-        .or(
-          Patient.where("family_name ILIKE ?", family_name).where(
-            date_of_birth:,
-            address_postcode:
-          )
-        )
+      Patient.where(
+        "given_name ILIKE ? AND family_name ILIKE ?",
+        given_name,
+        family_name
+      ).where(date_of_birth:)
 
-    if nhs_number.blank?
-      scope.to_a
-    else
-      # This prevents us from finding a patient that happens to have at least
-      # three of the other fields the same, but with a different NHS number,
-      # and therefore cannot be a match.
-      Patient.where(nhs_number: nil).merge(scope).to_a
+    if address_postcode.present?
+      scope =
+        scope
+          .or(
+            Patient.where(
+              "given_name ILIKE ? AND family_name ILIKE ?",
+              given_name,
+              family_name
+            ).where(address_postcode:)
+          )
+          .or(
+            Patient.where("given_name ILIKE ?", given_name).where(
+              date_of_birth:,
+              address_postcode:
+            )
+          )
+          .or(
+            Patient.where("family_name ILIKE ?", family_name).where(
+              date_of_birth:,
+              address_postcode:
+            )
+          )
     end
+
+    results =
+      if nhs_number.blank?
+        scope.to_a
+      else
+        # This prevents us from finding a patient that happens to have at least
+        # three of the other fields the same, but with a different NHS number,
+        # and therefore cannot be a match.
+        Patient.where(nhs_number: nil).merge(scope).to_a
+      end
+
+    if address_postcode.present?
+      # Check for an exact match of all four datapoints, we do this in memory
+      # to avoid an extra query to the database for each record.
+      exact_results =
+        results.select do
+          _1.given_name.downcase == given_name.downcase &&
+            _1.family_name.downcase == family_name.downcase &&
+            _1.date_of_birth == date_of_birth &&
+            _1.address_postcode == UKPostcode.parse(address_postcode).to_s
+        end
+
+      return exact_results if exact_results.length == 1
+    end
+
+    results
   end
 
   def relationship_to(parent:)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -114,32 +114,22 @@ class Patient < ApplicationRecord
 
   scope :with_pending_changes, -> { where.not(pending_changes: {}) }
 
-  # Trigram matching requires at least 3 characters
-  scope :search_by_full_name,
+  scope :search_by_name,
         ->(query) do
+          # Trigram matching requires at least 3 characters
           if query.length < 3
             where(
               "given_name ILIKE :like_query OR family_name ILIKE :like_query",
               like_query: "#{query}%"
             )
           else
-            where("given_name % :query OR family_name % :query", query:)
-          end
-        end
-  scope :search_by_given_name,
-        ->(query) do
-          if query.length < 3
-            where("given_name ILIKE :query", query:)
-          else
-            where("given_name % :query", query:)
-          end
-        end
-  scope :search_by_family_name,
-        ->(query) do
-          if query.length < 3
-            where("family_name ILIKE :query", query:)
-          else
-            where("family_name % :query", query:)
+            where(
+              "given_name % :query OR " \
+                "family_name % :query OR " \
+                "similarity(given_name, :query) > 0.3 OR " \
+                "similarity(family_name, :query) > 0.3",
+              query:
+            )
           end
         end
 
@@ -182,16 +172,32 @@ class Patient < ApplicationRecord
     end
 
     scope =
-      Patient.search_by_given_name(given_name).search_by_family_name(
-        family_name
-      )
-
-    scope =
-      if address_postcode.present?
-        scope.where(address_postcode:).or(scope.where(date_of_birth:))
-      else
-        scope.where(date_of_birth:)
-      end
+      Patient
+        .where(
+          "given_name ILIKE ? AND family_name ILIKE ?",
+          given_name,
+          family_name
+        )
+        .where(date_of_birth:)
+        .or(
+          Patient.where(
+            "given_name ILIKE ? AND family_name ILIKE ?",
+            given_name,
+            family_name
+          ).where(address_postcode:)
+        )
+        .or(
+          Patient.where("given_name ILIKE ?", given_name).where(
+            date_of_birth:,
+            address_postcode:
+          )
+        )
+        .or(
+          Patient.where("family_name ILIKE ?", family_name).where(
+            date_of_birth:,
+            address_postcode:
+          )
+        )
 
     if nhs_number.blank?
       scope.to_a

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -160,7 +160,9 @@ describe Patient do
     context "with matching first name, last name and postcode not provided" do
       let(:nhs_number) { nil }
       let(:address_postcode) { nil }
-      let(:patient) { create(:patient, given_name:, family_name:) }
+      let(:patient) do
+        create(:patient, given_name:, family_name:, address_postcode: nil)
+      end
 
       it { should_not include(patient) }
     end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -165,62 +165,22 @@ describe Patient do
       it { should_not include(patient) }
     end
 
-    context "with first name and last name are similar and matching date of birth" do
-      let(:nhs_number) { nil }
-      let(:patient) do
-        create(
-          :patient,
-          given_name: "Johnny",
-          family_name: "Smith",
-          date_of_birth:
-        )
-      end
-
-      it { should include(patient) }
-    end
-
-    context "with first name and last name are similar and matching postcode" do
-      let(:nhs_number) { nil }
-      let(:patient) do
-        create(
-          :patient,
-          given_name: "John",
-          family_name: "Smyth",
-          address_postcode:
-        )
-      end
-
-      it { should include(patient) }
-    end
-
     context "with matching first name, date of birth and postcode" do
       let(:nhs_number) { nil }
       let(:patient) do
-        create(
-          :patient,
-          given_name:,
-          family_name: "Seldon",
-          date_of_birth:,
-          address_postcode:
-        )
+        create(:patient, given_name:, date_of_birth:, address_postcode:)
       end
 
-      it { should_not include(patient) }
+      it { should include(patient) }
     end
 
     context "with matching last name, date of birth and postcode" do
       let(:nhs_number) { nil }
       let(:patient) do
-        create(
-          :patient,
-          given_name: "Hari",
-          family_name:,
-          date_of_birth:,
-          address_postcode:
-        )
+        create(:patient, family_name:, date_of_birth:, address_postcode:)
       end
 
-      it { should_not include(patient) }
+      it { should include(patient) }
     end
 
     context "when matching everything except the NHS number" do


### PR DESCRIPTION
This reverts #2264 which has a few specific problems that causes more problems, specifically related to streets with similarly named children. Instead we're going to introduce a match against all four datapoints first, to hopefully reduce the risk of the multiple matching validation error.

The introduction of #2276 also helps to avoid problems related to twins being considered duplicates.