### PR TITLE
Disable the auto-deploy for test

### DIFF
--- a/.github/workflows/deploy-pentest.yml
+++ b/.github/workflows/deploy-pentest.yml
@@ -1,8 +1,8 @@
 name: Deploy
 
-on:
-  push:
-    branches: [main]
+# on:
+#   push:
+#     branches: [main]
 
 jobs:
   copilot:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy
 run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', inputs.environment) || null }}
 
 on:
-  push:
-    branches: [main]
+  # push:
+  #   branches: [main]
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Only to be merged when we're ready to start the change freeze.

We may need to also disable the deploys to pentest depending on whether all the testers are able to authenticate with CIS2, currently one of the testers is still unable to do so and relies on testing in the pentest env without CIS2.