### PR TITLE
Improve performance of calculating statistics

### DIFF
--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -8,7 +8,10 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
 
     @stats =
       sessions.index_with do |session|
-        PatientSessionStats.new(session.patient_sessions).to_h
+        PatientSessionStats.new(
+          session.patient_sessions,
+          keys: %i[without_a_response needing_triage vaccinated]
+        ).to_h
       end
   end
 

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -36,7 +36,8 @@ class ProgrammesController < ApplicationController
         PatientSession
           .where(patient: patients, session: sessions)
           .preload_for_state
-          .strict_loading
+          .strict_loading,
+        keys: %i[with_consent_given without_a_response needing_triage]
       )
 
     @consent_given_percentage =

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -5,31 +5,32 @@ module PatientSessionStateConcern
 
   included do
     def state
-      if vaccination_administered?
-        "vaccinated"
-      elsif triage_delay_vaccination? || vaccination_can_be_delayed?
-        "delay_vaccination"
-      elsif not_gillick_competent?
-        "unable_to_vaccinate_not_gillick_competent"
-      elsif vaccination_not_administered?
-        "unable_to_vaccinate"
-      elsif triage_keep_in_triage?
-        "triaged_kept_in_triage"
-      elsif triage_ready_to_vaccinate?
-        "triaged_ready_to_vaccinate"
-      elsif triage_do_not_vaccinate?
-        "triaged_do_not_vaccinate"
-      elsif consent_given? && triage_needed?
-        "consent_given_triage_needed"
-      elsif consent_given? && triage_not_needed?
-        "consent_given_triage_not_needed"
-      elsif consent_refused?
-        "consent_refused"
-      elsif consent_conflicts?
-        "consent_conflicts"
-      else
-        "added_to_session"
-      end
+      @state ||=
+        if vaccination_administered?
+          "vaccinated"
+        elsif triage_delay_vaccination? || vaccination_can_be_delayed?
+          "delay_vaccination"
+        elsif not_gillick_competent?
+          "unable_to_vaccinate_not_gillick_competent"
+        elsif vaccination_not_administered?
+          "unable_to_vaccinate"
+        elsif triage_keep_in_triage?
+          "triaged_kept_in_triage"
+        elsif triage_ready_to_vaccinate?
+          "triaged_ready_to_vaccinate"
+        elsif triage_do_not_vaccinate?
+          "triaged_do_not_vaccinate"
+        elsif consent_given? && triage_needed?
+          "consent_given_triage_needed"
+        elsif consent_given? && triage_not_needed?
+          "consent_given_triage_not_needed"
+        elsif consent_refused?
+          "consent_refused"
+        elsif consent_conflicts?
+          "consent_conflicts"
+        else
+          "added_to_session"
+        end
     end
 
     %w[

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -132,21 +132,22 @@ class PatientSession < ApplicationRecord
   end
 
   def latest_consents
-    consents
-      .group_by(&:name)
-      .map { |_, consents| consents.max_by(&:recorded_at) }
+    @latest_consents ||=
+      consents
+        .group_by(&:name)
+        .map { |_, consents| consents.max_by(&:recorded_at) }
   end
 
   def latest_gillick_assessment
-    gillick_assessments.max_by(&:created_at)
+    @latest_gillick_assessment ||= gillick_assessments.max_by(&:created_at)
   end
 
   def latest_triage
-    triages.max_by(&:updated_at)
+    @latest_triage ||= triages.max_by(&:updated_at)
   end
 
   def latest_vaccination_record
-    vaccination_records.max_by(&:created_at)
+    @latest_vaccination_record ||= vaccination_records.max_by(&:created_at)
   end
 
   def consents_to_send_communication


### PR DESCRIPTION
This is shown in a number of places now and it can take a while to calculate statistics on lots of patient sessions. This makes a number of small improvements, specifically around reducing unnecessary calculations and memoizing values already calculated.