### PR TITLE
Don't send emails to parents without an email address

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -147,6 +147,10 @@ class Consent < ApplicationRecord
     response_given? && health_answers_require_follow_up?
   end
 
+  def contactable?
+    parent&.contactable? || false
+  end
+
   def parent_relationship
     (draft_parent || parent)&.relationship_to(patient:)
   end

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -77,10 +77,12 @@ class ConsentNotification < ApplicationRecord
       end
 
     parents.each do |parent|
-      ConsentMailer
-        .with(parent:, patient:, programme:, session:, sent_by: current_user)
-        .send(mailer_action)
-        .deliver_later
+      unless parent.email.nil?
+        ConsentMailer
+          .with(parent:, patient:, programme:, session:, sent_by: current_user)
+          .send(mailer_action)
+          .deliver_later
+      end
 
       TextDeliveryJob.perform_later(
         text_template,

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -82,6 +82,10 @@ class Parent < ApplicationRecord
     end
   end
 
+  def contactable?
+    email.present? || phone.present?
+  end
+
   def label
     full_name.presence || "Parent or guardian (name unknown)"
   end

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -77,10 +77,12 @@ class SessionNotification < ApplicationRecord
 
     if type == :school_reminder
       contacts.each do |consent|
-        SessionMailer
-          .with(consent:, patient_session:, sent_by: current_user)
-          .school_reminder
-          .deliver_later
+        if consent.parent.email.present?
+          SessionMailer
+            .with(consent:, patient_session:, sent_by: current_user)
+            .school_reminder
+            .deliver_later
+        end
 
         TextDeliveryJob.perform_later(
           :session_school_reminder,
@@ -91,10 +93,12 @@ class SessionNotification < ApplicationRecord
       end
     else
       contacts.each do |parent|
-        SessionMailer
-          .with(parent:, patient_session:, sent_by: current_user)
-          .send(type)
-          .deliver_later
+        if parent.email.present?
+          SessionMailer
+            .with(parent:, patient_session:, sent_by: current_user)
+            .send(type)
+            .deliver_later
+        end
 
         TextDeliveryJob.perform_later(
           :"session_#{type}",

--- a/spec/factories/parents.rb
+++ b/spec/factories/parents.rb
@@ -31,6 +31,11 @@ FactoryBot.define do
     phone { "07700 900#{rand(0..999).to_s.rjust(3, "0")}" }
     phone_receive_updates { phone.present? }
 
+    trait :non_contactable do
+      phone { nil }
+      email { nil }
+    end
+
     trait :contact_method_any do
       contact_method_type { "any" }
     end

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -68,6 +68,30 @@ describe Consent do
     end
   end
 
+  describe "#contactable?" do
+    subject(:contactable?) { consent.contactable? }
+
+    context "without a parent" do
+      let(:consent) { build(:consent) }
+
+      it { should be(false) }
+    end
+
+    context "with a non-contactable parent" do
+      let(:consent) do
+        build(:consent, parent: build(:parent, :non_contactable))
+      end
+
+      it { should be(false) }
+    end
+
+    context "with a contactable parent" do
+      let(:consent) { build(:consent, parent: build(:parent)) }
+
+      it { should be(true) }
+    end
+  end
+
   describe "#from_consent_form!" do
     describe "the created consent object" do
       subject(:consent) do

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -39,6 +39,34 @@ describe Parent do
   it { should normalize(:phone).from(" 01234 567890 ").to("01234567890") }
   it { should normalize(:phone).from("").to(nil) }
 
+  describe "#contactable?" do
+    subject(:contactable?) { parent.contactable? }
+
+    context "without a phone number or email address" do
+      let(:parent) { build(:parent, phone: nil, email: nil) }
+
+      it { should be(false) }
+    end
+
+    context "with a phone number" do
+      let(:parent) { build(:parent, email: nil) }
+
+      it { should be(true) }
+    end
+
+    context "with an email address" do
+      let(:parent) { build(:parent, phone: nil) }
+
+      it { should be(true) }
+    end
+
+    context "with a phone number and an email address" do
+      let(:parent) { build(:parent) }
+
+      it { should be(true) }
+    end
+  end
+
   describe "#label" do
     subject(:label) { parent.label }
 

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -55,6 +55,8 @@ describe SessionNotification do
       let(:type) { :school_reminder }
 
       it "creates a record" do
+        consent # ensure it exists
+
         expect { create_and_send! }.to change(described_class, :count).by(1)
 
         session_notification = described_class.last


### PR DESCRIPTION
This refactors how the emails are sent to avoid trying to send emails to parents who we don't have an email address for, which ends up raising an error recorded in Sentry. We [already do this for text messages](https://github.com/nhsuk/manage-vaccinations-in-schools/blob/2f244f1e4ab3e0e47b3875ba2be22433a0fb1cca/app/jobs/text_delivery_job.rb#L21-L23).

I've also made a change to the way `SessionNotification` and `ConsentNotification`s are recorded, to only record them if we have parent contact details and therefore sent an email. This improves the accuracy of the record, making it clear that these only exist when they were sent, but it also means the system will automatically send emails that were missed once we have contact details. For example, if a consent request was attempted but we had no contact details, and the next day contact details are provided, the consent request would then get sent out.

https://good-machine.sentry.io/issues/6037796885/