### PR TITLE
Always accept registration from class lists

### DIFF
--- a/app/models/class_import_row.rb
+++ b/app/models/class_import_row.rb
@@ -16,6 +16,10 @@ class ClassImportRow < PatientImportRow
 
   attr_reader :school
 
+  def stage_registration?
+    false
+  end
+
   def home_educated
     false
   end

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -18,6 +18,10 @@ class CohortImportRow < PatientImportRow
 
   private
 
+  def stage_registration?
+    true
+  end
+
   def school
     @school ||=
       unless [SCHOOL_URN_HOME_EDUCATED, SCHOOL_URN_UNKNOWN].include?(school_urn)

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -53,6 +53,10 @@ class PatientImportRow
     }.compact.merge(cohort_id: cohort&.id, school_id: school&.id)
 
     if (existing_patient = existing_patients.first)
+      unless stage_registration?
+        existing_patient.registration = attributes.delete(:registration)
+      end
+
       existing_patient.stage_changes(attributes)
       existing_patient
     else

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -137,6 +137,11 @@ describe ClassImportRow do
       it { should eq(existing_patient) }
       it { should be_male }
       it { should have_attributes(nhs_number: "0123456789") }
+
+      it "overwrites registration" do
+        expect(patient.registration).to eq("8AB")
+        expect(patient.pending_changes).not_to have_key("registration")
+      end
     end
 
     describe "#cohort" do

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -159,6 +159,28 @@ describe CohortImportRow do
       it { should have_attributes(gender_code: "not_known") }
     end
 
+    context "with an existing patient" do
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "male",
+          given_name: "Jimmy",
+          nhs_number: "1234567890"
+        )
+      end
+
+      it { should eq(existing_patient) }
+      it { should be_male }
+      it { should have_attributes(nhs_number: "1234567890") }
+
+      it "stages the registration" do
+        expect(patient.registration).not_to eq("8AB")
+        expect(patient.pending_changes).to include("registration" => "8AB")
+      end
+    end
+
     describe "#cohort" do
       subject(:cohort) { travel_to(today) { patient.cohort } }
 


### PR DESCRIPTION
Currently only class lists are likely to contain the child's registration, and that leads to a situation where once the cohort has been uploaded, when the class list is uploaded and matched against existing patients, they're all flagged needing review because the registration is added.

Instead we've decided that for class lists we will always take the registration from the file without staging the changes, even if it's different to the one we already have in the record.