### PR TITLE
Improve validation messages for consent requests

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -94,9 +94,12 @@ class Session < ApplicationRecord
             presence: true,
             comparison: {
               greater_than_or_equal_to: :earliest_send_notifications_at,
-              less_than: :earliest_date
+              less_than_or_equal_to: :latest_send_consent_requests_at
             },
-            unless: -> { earliest_date.nil? || location.generic_clinic? }
+            unless: -> do
+              earliest_send_notifications_at.nil? ||
+                latest_send_consent_requests_at.nil? || location.generic_clinic?
+            end
 
   validates :send_invitations_at,
             presence: true,
@@ -330,6 +333,11 @@ class Session < ApplicationRecord
   def earliest_send_notifications_at
     return nil if earliest_date.nil?
     earliest_date - 3.months
+  end
+
+  def latest_send_consent_requests_at
+    return nil if earliest_date.nil? || days_before_consent_reminders.nil?
+    earliest_date - days_before_consent_reminders.days - 1
   end
 
   def maximum_weeks_before_consent_reminders

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,7 +490,7 @@ en:
               missing_month: Enter a month
               missing_year: Enter a year
               greater_than_or_equal_to: Enter a date at most 3 months before the first session date (%{count})
-              less_than: Enter a date before the first session date (%{count})
+              less_than_or_equal_to: Enter a date before the first session date and first reminder (%{count})
             send_invitations_at:
               blank: Enter a date
               missing_day: Enter a day

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -47,7 +47,7 @@ describe SchoolConsentRemindersJob do
     create(
       :session,
       dates:,
-      send_consent_requests_at: dates.first - 1.week,
+      send_consent_requests_at: dates.first - 3.weeks,
       days_before_consent_reminders: 7,
       location:,
       patients:,


### PR DESCRIPTION
Currently the user is preventing from setting a consent request date _after_ the first consent reminder, however the validation error isn't clear. Currently the user will see an error about the reminders being not enough weeks before the consent requests, on the page where you can edit the consent requests, which is confusing.