### PR TITLE
Normalise parent phone numbers with Phonelib

### DIFF
--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -42,7 +42,12 @@ class Parent < ApplicationRecord
   encrypts :email, :full_name, :phone, deterministic: true
   encrypts :contact_method_other_details
 
-  normalizes :phone, with: -> { _1.blank? ? nil : _1.to_s.gsub(/\s/, "") }
+  normalizes :phone,
+             with: ->(phone) do
+               Phonelib
+                 .parse(phone)
+                 .then { |p| p.country == "GB" ? p.national : p.international }
+             end
   normalizes :email, with: -> { _1.blank? ? nil : _1.to_s.downcase.strip }
 
   validates :phone,

--- a/spec/components/app_parent_summary_component_spec.rb
+++ b/spec/components/app_parent_summary_component_spec.rb
@@ -29,7 +29,7 @@ describe AppParentSummaryComponent do
     let(:parent) { create(:parent, phone: "07987654321") }
 
     it { should have_content("Phone number") }
-    it { should have_content("07987654321") }
+    it { should have_content("07987 654321") }
   end
 
   context "when the patient is restricted" do

--- a/spec/features/scheduled_consent_requests_spec.rb
+++ b/spec/features/scheduled_consent_requests_spec.rb
@@ -121,9 +121,9 @@ describe "Scheduled consent requests" do
     expect_email_to("parent1.child2@example.com", :consent_school_request, :any)
     expect_email_to("parent2.child2@example.com", :consent_school_request, :any)
 
-    expect_text_to("07700900000", :consent_school_request, :any)
-    expect_text_to("07700900001", :consent_school_request, :any)
-    expect_text_to("07700900002", :consent_school_request, :any)
-    expect_text_to("07700900003", :consent_school_request, :any)
+    expect_text_to("07700 900000", :consent_school_request, :any)
+    expect_text_to("07700 900001", :consent_school_request, :any)
+    expect_text_to("07700 900002", :consent_school_request, :any)
+    expect_text_to("07700 900003", :consent_school_request, :any)
   end
 end

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -80,7 +80,7 @@ describe "Verbal consent" do
     expect(page).to have_content(["Name", "Jane Smith"].join)
     expect(page).to have_content(%w[Relationship Mum].join)
     expect(page).to have_content(["Email address", "jsmith@example.com"].join)
-    expect(page).to have_content(["Phone number", "07987654321"].join)
+    expect(page).to have_content(["Phone number", "07987 654321"].join)
   end
 
   def then_an_email_is_sent_to_the_parent_confirming_their_consent

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -38,7 +38,7 @@ describe TextDeliveryJob do
     let(:template_name) { GOVUK_NOTIFY_TEXT_TEMPLATES.keys.first }
     let(:programme) { create(:programme) }
     let(:session) { create(:session, programme:) }
-    let(:parent) { create(:parent, phone: "01234567890") }
+    let(:parent) { create(:parent, phone: "01234 567890") }
     let(:consent) { nil }
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
@@ -62,7 +62,7 @@ describe TextDeliveryJob do
 
     it "sends a text using GOV.UK Notify" do
       expect(notifications_client).to receive(:send_sms).with(
-        phone_number: "01234567890",
+        phone_number: "01234 567890",
         template_id: GOVUK_NOTIFY_TEXT_TEMPLATES[template_name],
         personalisation: an_instance_of(Hash)
       )
@@ -74,7 +74,7 @@ describe TextDeliveryJob do
 
       notify_log_entry = NotifyLogEntry.last
       expect(notify_log_entry).to be_sms
-      expect(notify_log_entry.recipient).to eq("01234567890")
+      expect(notify_log_entry.recipient).to eq("01234 567890")
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_TEXT_TEMPLATES[template_name]
       )

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -67,7 +67,7 @@ describe ClassImportRow do
       expect(parents.count).to eq(1)
       expect(parents.first).to have_attributes(
         email: "john@example.com",
-        phone: "07412345678",
+        phone: "07412 345678",
         phone_receive_updates: false
       )
     end
@@ -79,11 +79,11 @@ describe ClassImportRow do
         expect(parents.count).to eq(2)
         expect(parents.first).to have_attributes(
           email: "john@example.com",
-          phone: "07412345678"
+          phone: "07412 345678"
         )
         expect(parents.second).to have_attributes(
           email: "jenny@example.com",
-          phone: "07412345678"
+          phone: "07412 345678"
         )
       end
     end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -179,7 +179,7 @@ describe ClassImport do
 
       expect(Patient.first.parents.first).to have_attributes(
         full_name: nil,
-        phone: "07412345678",
+        phone: "07412 345678",
         email: "susan@example.com"
       )
 
@@ -197,7 +197,7 @@ describe ClassImport do
 
       expect(Patient.second.parents.first).to have_attributes(
         full_name: "John Smith",
-        phone: "07412345678",
+        phone: "07412 345678",
         email: "john@example.com"
       )
 
@@ -217,7 +217,7 @@ describe ClassImport do
 
       expect(Patient.third.parents.first).to have_attributes(
         full_name: "Jane Doe",
-        phone: "07412345679",
+        phone: "07412 345679",
         email: "jane@example.com"
       )
 

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -91,7 +91,7 @@ describe CohortImportRow do
         expect(parents.first).to have_attributes(
           full_name: "John Smith",
           email: "john@example.com",
-          phone: "07412345678",
+          phone: "07412 345678",
           phone_receive_updates: false
         )
       end
@@ -105,12 +105,12 @@ describe CohortImportRow do
         expect(parents.first).to have_attributes(
           full_name: "John Smith",
           email: "john@example.com",
-          phone: "07412345678"
+          phone: "07412 345678"
         )
         expect(parents.second).to have_attributes(
           full_name: "Jenny Smith",
           email: "jenny@example.com",
-          phone: "07412345678"
+          phone: "07412 345678"
         )
       end
     end

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -185,7 +185,7 @@ describe CohortImport do
 
       expect(Patient.second.parents.first).to have_attributes(
         full_name: "John Smith",
-        phone: "07412345678",
+        phone: "07412 345678",
         email: "john@example.com"
       )
 
@@ -205,13 +205,13 @@ describe CohortImport do
 
       expect(Patient.third.parents.first).to have_attributes(
         full_name: "Jane Doe",
-        phone: "07412345679",
+        phone: "07412 345679",
         email: "jane@example.com"
       )
 
       expect(Patient.third.parents.first).to have_attributes(
         full_name: "Jane Doe",
-        phone: "07412345679",
+        phone: "07412 345679",
         email: "jane@example.com"
       )
 

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -120,7 +120,7 @@ describe Consent do
         expect(consent.parent).to have_attributes(
           full_name: consent_form.parent_full_name,
           email: consent_form.parent_email,
-          phone: consent_form.parent_phone,
+          phone: Phonelib.parse(consent_form.parent_phone).national,
           phone_receive_updates: consent_form.parent_phone_receive_updates
         )
       end
@@ -144,7 +144,7 @@ describe Consent do
           expect(consent.parent).to have_attributes(
             full_name: consent_form.parent_full_name,
             email: consent_form.parent_email,
-            phone: consent_form.parent_phone,
+            phone: Phonelib.parse(consent_form.parent_phone).national,
             phone_receive_updates: consent_form.parent_phone_receive_updates
           )
         end

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -36,7 +36,9 @@ describe Parent do
   it { should normalize(:email).from("  joHn@doe.com ").to("john@doe.com") }
   it { should normalize(:email).from("").to(nil) }
 
-  it { should normalize(:phone).from(" 01234 567890 ").to("01234567890") }
+  it { should normalize(:phone).from(" 01234 567890 ").to("01234 567890") }
+  it { should normalize(:phone).from("1234567890").to("01234 567890") } # leading zero lost by Excel, say
+  it { should normalize(:phone).from("+35361234567").to("+353 61 234 567") }
   it { should normalize(:phone).from("").to(nil) }
 
   describe "#contactable?" do
@@ -101,7 +103,7 @@ describe Parent do
     context "with a phone number" do
       let(:parent) { create(:parent, email: nil, phone: "07700900123") }
 
-      it { should eq("07700900123") }
+      it { should eq("07700 900123") }
     end
 
     context "with both" do
@@ -109,7 +111,7 @@ describe Parent do
         create(:parent, email: "test@example.com", phone: "07700900123")
       end
 
-      it { should eq("test@example.com / 07700900123") }
+      it { should eq("test@example.com / 07700 900123") }
     end
   end
 


### PR DESCRIPTION
* format national numbers with spaces
* save non-GB numbers in an international format
* handle leading zeros being stripped (when handling CSVs in Excel, for instance)