### PR TITLE
Document restoring a snapshot to an environment

### DIFF
--- a/copilot/environments/addons/db.yml
+++ b/copilot/environments/addons/db.yml
@@ -117,7 +117,7 @@ Resources:
         ]
       DatabaseName: !Ref dbDBName
       Engine: "aurora-postgresql"
-      EngineVersion: "14.4"
+      EngineVersion: "14.9"
       DBClusterParameterGroupName: !Ref dbDBClusterParameterGroup
       DBSubnetGroupName: !Ref dbDBSubnetGroup
       Port: 5432

--- a/copilot/environments/addons/db.yml
+++ b/copilot/environments/addons/db.yml
@@ -133,6 +133,13 @@ Resources:
       DeletionProtection: true # Keep this to protect the cluster from deletion. This also applies to the databases that are a part of this cluster.
       BackupRetentionPeriod: 7 # Store the snapshots for 7 days.
 
+      # DISASTER RECOVERY: Uncomment the SnapshotIdentifier line to restore from
+      # a manual snapshot. Enabling this and deploying the copilot environment
+      # will most likely destroy any existing databases in that environment, so
+      # make sure they are fresh or don't contain important data.
+
+      # SnapshotIdentifier: ARN_OF_MANUAL_SNAPSHOT
+
   dbDBWriterInstance:
     Metadata:
       "aws:copilot:description": "The db Aurora Serverless v2 writer instance"


### PR DESCRIPTION
This makes use of the optional `SnapshotIdentifier` option that can be specified in `db.yml`.

Also bump Aurora postgres engine version to align to what's being used (otherwise the snapshot restore fails).