### PR TITLE
Don't filter consents and triage on programme 

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -41,27 +41,22 @@ class PatientSession < ApplicationRecord
            -> { draft },
            class_name: "GillickAssessment"
 
-  has_many :vaccination_records,
-           -> { recorded },
-           class_name: "VaccinationRecord"
+  has_many :vaccination_records, -> { recorded }
   has_many :draft_vaccination_records,
            -> { draft },
            class_name: "VaccinationRecord"
 
   has_many :consents,
            -> { recorded.where(programme: _1.programmes).includes(:parent) },
-           through: :patient,
-           class_name: "Consent"
+           through: :patient
 
   has_many :triages,
            -> { where(programme: _1.programmes).order(:updated_at) },
-           through: :patient,
-           class_name: "Triage"
+           through: :patient
 
   has_many :session_notifications,
            -> { where(session_id: _1.session_id) },
-           through: :patient,
-           class_name: "SessionNotification"
+           through: :patient
 
   has_and_belongs_to_many :immunisation_imports
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -46,13 +46,11 @@ class PatientSession < ApplicationRecord
            -> { draft },
            class_name: "VaccinationRecord"
 
-  has_many :consents,
-           -> { recorded.where(programme: _1.programmes).includes(:parent) },
-           through: :patient
+  # TODO: Only fetch consents and triages for the relevant programme.
 
-  has_many :triages,
-           -> { where(programme: _1.programmes).order(:updated_at) },
-           through: :patient
+  has_many :consents, -> { recorded.includes(:parent) }, through: :patient
+
+  has_many :triages, through: :patient
 
   has_many :session_notifications,
            -> { where(session_id: _1.session_id) },


### PR DESCRIPTION
This should improve performance by removing the need to have a reference to the patient session when performing the join, which prevents Rails from being able to run a single query to avoid N+1 issues. This does slightly break functionality, but since we're only running with one programme at the moment, and other functionality is broken with regards to multiple programmes, it seems like a reasonable fix for now.