### PR TITLE
Add filters to programme patients view

### DIFF
--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -100,7 +100,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
   def patient_link(patient)
     session = @patient_sessions[patient]&.session
 
-    if @section == :matching || session.nil?
+    if @section == :matching || @section == :patients || session.nil?
       patient.full_name
     else
       govuk_link_to patient.full_name,

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -15,7 +15,11 @@ class AppSessionPatientTableComponent < ViewComponent::Base
 
     if patient_sessions && !patients
       @patients = patient_sessions.map(&:patient)
-      @patient_sessions = patient_sessions.map { [_1.patient, _1] }.to_h
+      @patient_sessions =
+        patient_sessions
+          .group_by(&:patient)
+          .map { [_1, _2.max_by(&:created_at)] }
+          .to_h
     elsif patients && !patient_sessions
       @patients = patients
       @patient_sessions = {}

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -9,6 +9,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     params: {},
     patient_sessions: nil,
     patients: nil,
+    programme: nil,
     year_groups: []
   )
     super
@@ -31,6 +32,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     @columns = columns
     @consent_form = consent_form
     @params = params
+    @programme = programme
     @section = section
     @year_groups = year_groups
   end
@@ -143,6 +145,8 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     path =
       if @section == :matching
         consent_form_path(@consent_form, **filter_params)
+      elsif @section == :patients
+        programme_patients_path(@programme, **filter_params)
       else
         session_section_tab_path(
           session_slug: params[:session_slug],
@@ -158,6 +162,8 @@ class AppSessionPatientTableComponent < ViewComponent::Base
   def form_url
     if @section == :matching
       consent_form_path(@consent_form)
+    elsif @section == :patients
+      programme_patients_path(@programme)
     else
       session_section_tab_path(
         session_slug: params[:session_slug],

--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -31,8 +31,8 @@ module PatientSortingConcern
       obj.try(:address_postcode) || obj.patient.address_postcode
     when "year_group"
       [
-        obj.try(:year_group) || obj.patient.year_group,
-        obj.try(:registration) || obj.patient.registration
+        obj.try(:year_group) || obj.patient.year_group || "",
+        obj.try(:registration) || obj.patient.registration || ""
       ]
     end
   end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -10,16 +10,11 @@ class ConsentsController < ApplicationController
     all_patient_sessions =
       @session
         .patient_sessions
+        .preload_for_state
+        .preload(consents: :parent)
+        .eager_load(patient: :cohort)
+        .order_by_name
         .strict_loading
-        .includes(
-          :gillick_assessments,
-          :programmes,
-          :triages,
-          :vaccination_records,
-          consents: :parent,
-          patient: :cohort
-        )
-        .sort_by { |ps| ps.patient.full_name }
 
     tab_patient_sessions =
       group_patient_sessions_by_conditions(

--- a/app/controllers/programme/patients_controller.rb
+++ b/app/controllers/programme/patients_controller.rb
@@ -1,12 +1,32 @@
 # frozen_string_literal: true
 
+require "pagy/extras/array"
+
 class Programme::PatientsController < ApplicationController
   include Pagy::Backend
+  include PatientSortingConcern
 
   before_action :set_programme
 
   def index
-    @pagy, @patients = pagy(@programme.patients.not_deceased.order_by_name)
+    patients =
+      policy_scope(Patient).where(
+        cohort: policy_scope(Cohort).for_year_groups(@programme.year_groups)
+      ).not_deceased
+
+    sessions = policy_scope(Session).has_programme(@programme)
+
+    patient_sessions =
+      PatientSession
+        .where(patient: patients, session: sessions)
+        .preload_for_state
+        .eager_load(:session, patient: :cohort)
+        .order_by_name
+        .strict_loading
+        .to_a
+
+    sort_and_filter_patients!(patient_sessions)
+    @pagy, @patient_sessions = pagy_array(patient_sessions)
 
     render layout: "full"
   end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -17,15 +17,10 @@ class TriagesController < ApplicationController
     all_patient_sessions =
       @session
         .patient_sessions
+        .preload_for_state
+        .eager_load(patient: :cohort)
+        .order_by_name
         .strict_loading
-        .includes(
-          :programmes,
-          :gillick_assessments,
-          :vaccination_records,
-          patient: :cohort
-        )
-        .preload(:consents, :triages)
-        .order("patients.given_name", "patients.family_name")
 
     @current_tab = TAB_PATHS[:triage][params[:tab]]
     tab_patient_sessions =

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -23,15 +23,10 @@ class VaccinationsController < ApplicationController
     all_patient_sessions =
       @session
         .patient_sessions
+        .preload_for_state
+        .eager_load(patient: :cohort)
+        .order_by_name
         .strict_loading
-        .includes(
-          :programmes,
-          :gillick_assessments,
-          :vaccination_records,
-          patient: :cohort
-        )
-        .preload(:consents, :triages)
-        .order("patients.given_name", "patients.family_name")
 
     grouped_patient_sessions =
       group_patient_sessions_by_state(

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -86,6 +86,11 @@ class PatientSession < ApplicationRecord
           )
         end
 
+  scope :order_by_name,
+        -> do
+          order("LOWER(patients.given_name)", "LOWER(patients.family_name)")
+        end
+
   delegate :send_notifications?, to: :patient
 
   def draft_vaccination_record

--- a/app/views/programme/patients/index.html.erb
+++ b/app/views/programme/patients/index.html.erb
@@ -19,6 +19,16 @@
                          new_programme_cohort_import_path(@programme),
                          class: "app-button--secondary" %>
 
-<%= render AppPatientTableComponent.new(@patients, count: @pagy.count) %>
+<%= render AppSessionPatientTableComponent.new(
+      caption: t("children", count: @pagy.count),
+      columns: %i[name dob year_group outcome],
+      params:,
+      patient_sessions: @patient_sessions,
+      programme: @programme,
+      section: :patients,
+      year_groups: @programme.year_groups,
+    ) %>
 
-<%= govuk_pagination(pagy: @pagy) %>
+<div class="nhsuk-u-margin-top-6">
+  <%= govuk_pagination(pagy: @pagy) %>
+</div>


### PR DESCRIPTION
This switches the programme patients view to use the `AppSessionPatientTableComponent` to allow users to filter and sort patients. I haven't added tests for this specific component since it's covered elsewhere, and we have a feature test for this page already.

## Screenshots

![Screenshot 2024-11-05 at 10 11 35](https://github.com/user-attachments/assets/d652f5ba-83ec-46a9-8dbe-dc140ce6e908)
![Screenshot 2024-11-05 at 10 11 38](https://github.com/user-attachments/assets/34df381b-8878-423f-a695-d7b1a6d224b8)
![Screenshot 2024-11-05 at 10 11 47](https://github.com/user-attachments/assets/6eb49700-0347-447d-8ac5-ea9d069dfb36)
