### PR TITLE
Show recorded vaccination records

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -89,6 +89,13 @@
     <% end %>
   <% end %>
 
+  <% @patient_session.vaccination_records.each do |vaccination_record| %>
+    <%= render AppCardComponent.new do |c| %>
+      <% c.with_heading { "Vaccination details" } %>
+      <%= render AppVaccinationRecordSummaryComponent.new(vaccination_record) %>
+    <% end %>
+  <% end %>
+
   <% if helpers.policy(VaccinationRecord).create? %>
     <%= render AppVaccinateFormComponent.new(
           patient_session:,

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -19,6 +19,7 @@ describe "HPV Vaccination" do
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_vaccinated
+    and_i_see_the_vaccination_details
     and_an_email_is_sent_to_the_parent_confirming_the_vaccination
     and_a_text_is_sent_to_the_parent_confirming_the_vaccination
   end
@@ -89,6 +90,10 @@ describe "HPV Vaccination" do
 
   def then_i_see_that_the_status_is_vaccinated
     expect(page).to have_content("Vaccinated")
+  end
+
+  def and_i_see_the_vaccination_details
+    expect(page).to have_content("Vaccination details")
   end
 
   def and_an_email_is_sent_to_the_parent_confirming_the_vaccination


### PR DESCRIPTION
When looking at the details for a patient, we should be showing the vaccination details if a vaccination has been recorded for that patient.