### PR TITLE
Configure fast_reset and web_concurrency in test

### DIFF
--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,7 @@
 allow_dev_phone_numbers: true
 disallow_database_seeding: false
+fast_reset: true
+web_concurrency: 0
 
 cis2:
   issuer: "http://localhost:4000/test/oidc"


### PR DESCRIPTION
It turns out we do run a server and use the `/reset` endpoint in `RAILS_ENV=test` for the Playwright tests, so these are in use.

Should fix the Playwright tests on CI.