### PR TITLE
Use safe navigation in settings 

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,9 +17,9 @@ cis2:
 govuk_notify:
   enabled: true
   mode: live
-  test_key: <%= Rails.application.credentials.govuk_notify.test_key %>
-  team_key: <%= Rails.application.credentials.govuk_notify.team_key %>
-  live_key: <%= Rails.application.credentials.govuk_notify.live_key %>
+  test_key: <%= Rails.application.credentials.govuk_notify&.test_key %>
+  team_key: <%= Rails.application.credentials.govuk_notify&.team_key %>
+  live_key: <%= Rails.application.credentials.govuk_notify&.live_key %>
 
 mesh:
   base_url: "https://msg.intspineservices.nhs.uk"
@@ -55,8 +55,8 @@ mesh:
     -----END CERTIFICATE-----
   dps_mailbox: N1G3BOT002
   mailbox: N1G3BOT001
-  password: <%= Rails.application.credentials.mesh.password %>
-  shared_key: <%= Rails.application.credentials.mesh.shared_key %>
+  password: <%= Rails.application.credentials.mesh&.password %>
+  shared_key: <%= Rails.application.credentials.mesh&.shared_key %>
 
 nhs_api:
   base_url: "https://int.api.service.nhs.uk"


### PR DESCRIPTION
When building the docker container, RAILS_MASTER_KEY does not exist, so asset precompilation fails because it can't read certain secrets.