### PR TITLE
Rename pentest deploy task

### DIFF
--- a/.github/workflows/deploy-pentest.yml
+++ b/.github/workflows/deploy-pentest.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy (pentest)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   copilot:
-    name: AWS Copilot deploy
+    name: AWS Copilot
 
     permissions:
       id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   copilot:
-    name: AWS Copilot deploy
+    name: AWS Copilot
 
     permissions:
       id-token: write


### PR DESCRIPTION
Makes it easier to differentiate in the list of checks on `main`.