### PR TITLE
Reset unused vaccination record fields

### DIFF
--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -49,6 +49,8 @@ class VaccinationRecord < ApplicationRecord
 
   audited associated_with: :patient_session
 
+  before_save :reset_unused_fields
+
   attr_accessor :delivery_site_other, :todays_batch
 
   DELIVERY_SITE_SNOMED_CODES_AND_TERMS = {
@@ -243,5 +245,15 @@ class VaccinationRecord < ApplicationRecord
     return if batch&.vaccine_id == vaccine_id
 
     errors.add(:batch_id, :incorrect_vaccine, vaccine_brand: vaccine&.brand)
+  end
+
+  def reset_unused_fields
+    if administered?
+      self.reason = nil
+    else
+      self.delivery_method = nil
+      self.delivery_site = nil
+      self.batch_id = nil
+    end
   end
 end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -50,7 +50,11 @@ FactoryBot.define do
 
     programme
     patient_session do
-      association :patient_session, programme:, patient:, session:
+      association :patient_session,
+                  programme:,
+                  patient:,
+                  session:,
+                  strategy: :create
     end
 
     recorded_at { "2023-06-09" }
@@ -58,7 +62,10 @@ FactoryBot.define do
     delivery_method { "intramuscular" }
     vaccine { programme.vaccines.active.first }
     batch do
-      association :batch, organisation: patient_session.organisation, vaccine:
+      association :batch,
+                  organisation: patient_session.organisation,
+                  vaccine:,
+                  strategy: :create
     end
 
     performed_by

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -182,12 +182,10 @@ describe GovukNotifyPersonalisation do
         recorded_at: Date.new(2024, 1, 1)
       )
     end
-    let(:batch) { vaccination_record.batch }
 
     it do
       expect(personalisation).to match(
         hash_including(
-          batch_name: batch.name,
           day_month_year_of_vaccination: "01/01/2024",
           reason_did_not_vaccinate: "the nurse decided John was not well",
           show_additional_instructions: "yes",

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -114,4 +114,32 @@ describe VaccinationRecord do
       it { should be_nil }
     end
   end
+
+  describe "#reset_unused_fields" do
+    subject(:save!) { vaccination_record.save! }
+
+    context "when administered" do
+      let(:vaccination_record) { build(:vaccination_record, reason: :not_well) }
+
+      it "clears the reason" do
+        expect { save! }.to change(vaccination_record, :reason).to(nil)
+      end
+    end
+
+    context "when not administered" do
+      let(:vaccination_record) { build(:vaccination_record, :not_administered) }
+
+      it "clears the deliver method" do
+        expect { save! }.to change(vaccination_record, :delivery_method).to(nil)
+      end
+
+      it "clears the deliver site" do
+        expect { save! }.to change(vaccination_record, :delivery_site).to(nil)
+      end
+
+      it "clears the batch" do
+        expect { save! }.to change(vaccination_record, :batch_id).to(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This handles the situation where going back to edit previously set values on a vaccination record and this method ensures the record is consistent.

To support the tests I've had to set a `create` strategy on the associations to ensure that building a vaccination record has a valid state, without this various `has_one` through associations end up being `nil` which leads to validation errors.