### PR TITLE
Fix PDS rake tasks

### DIFF
--- a/lib/tasks/pds.rake
+++ b/lib/tasks/pds.rake
@@ -13,7 +13,7 @@ namespace :pds do
         puts ""
         puts response.headers.map { "#{_1}: #{_2}" }
         puts ""
-        puts JSON.pretty_generate(JSON.parse(response.body))
+        puts JSON.pretty_generate(response.body)
       else
         puts response.body
       end
@@ -29,11 +29,11 @@ namespace :pds do
         "given" => ENV["given"],
         "family" => ENV["family"],
         "gender" => ENV["gender"],
-        "birthdate" => ENV["birthdate"],
+        "birthdate" => ENV["birthdate"], # e.g. eq2014-02-18
         "death-date" => ENV["death_date"],
         "email" => ENV["email"],
         "phone" => ENV["phone"],
-        "address-postcode" => ENV["address_postcode"],
+        "address-postalcode" => ENV["address_postalcode"],
         "general-practitioner" => ENV["general_practitioner"]
       }.compact
 
@@ -45,7 +45,7 @@ namespace :pds do
         puts ""
         puts response.headers.map { "#{_1}: #{_2}" }
         puts ""
-        puts JSON.pretty_generate(JSON.parse(response.body))
+        puts JSON.pretty_generate(response.body)
       else
         puts response.body
       end


### PR DESCRIPTION
I do like the idea of having these, they do make PDS testing easier (and other NHS API things). For example the `nhs:access_token` task made it convenient to diagnose the NHS API key issue we had earlier. But at the same time not entirely sure of the value of them.

In any case here's a fix that makes them continue to work. Here's how they work:

Pulling up a patient using their NHS number:
```
$ rails pds:patient:find[9449306540]
https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/9449306540

date: Tue, 05 Nov 2024 22:21:12 GMT
content-type: application/fhir+json
content-length: 3256
connection: keep-alive
server: XXXXXX
etag: W/"21"
strict-transport-security: max-age=31536000; includeSubDomains
x-request-id: 8165136d-8395-4875-9077-d43087969a2c

{
  "address": [
    {
      "id": "63F2B3F4",
      "line": [
        "Riverdale Court",
        "Bush Hill",
        "LONDON"
      ],
     ...
```

----
Using the search and getting PDS errors (too many matches):
```
$ rails pds:patient:find_by given=john family=smithg birthdate="eq2010-01-10"
https://int.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient?birthdate=eq2010-01-10&family=smithg&given=john

date: Tue, 05 Nov 2024 22:24:46 GMT
content-type: application/fhir+json
content-length: 534
connection: keep-alive
server: XXXXXX
etag: "1ca6ec7451331e883b23fc704a83a87ef69eaae1"
strict-transport-security: max-age=31536000; includeSubDomains
x-request-id: 16659548-32e6-4123-b2cf-4ce1f18756d4

{
  "issue": [
    {
      "code": "multiple-matches",
      "details": {
        "coding": [
          {
            "code": "TOO_MANY_MATCHES",
            "display": "Too Many Matches",
            "system": "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
            "version": "1"
          }
        ]
      },
      "severity": "information"
    }
  ],
  "resourceType": "OperationOutcome"
}
```

