### PR TITLE
Vaccination administration time validations

### DIFF
--- a/app/controllers/vaccination_records/edit_controller.rb
+++ b/app/controllers/vaccination_records/edit_controller.rb
@@ -52,7 +52,6 @@ class VaccinationRecords::EditController < ApplicationController
         )
 
       unless validator.date_params_valid?
-        @vaccination_record.administered_at = validator.date_params_as_struct
         render_wizard nil, status: :unprocessable_entity
       end
     end

--- a/app/controllers/vaccination_records/edit_controller.rb
+++ b/app/controllers/vaccination_records/edit_controller.rb
@@ -51,7 +51,12 @@ class VaccinationRecords::EditController < ApplicationController
           params: update_params
         )
 
-      unless validator.date_params_valid?
+      hour = Integer(update_params["administered_at(4i)"], exception: false)
+      minute = Integer(update_params["administered_at(5i)"], exception: false)
+      time_valid = hour&.between?(0, 23) && minute&.between?(0, 59)
+
+      unless validator.date_params_valid? && time_valid
+        @vaccination_record.errors.add(:administered_at, :invalid)
         render_wizard nil, status: :unprocessable_entity
       end
     end

--- a/app/views/vaccination_records/edit/date_and_time.html.erb
+++ b/app/views/vaccination_records/edit/date_and_time.html.erb
@@ -28,7 +28,7 @@
         </div>
 
         <div class="nhsuk-date-input__item">
-          <%= f.govuk_text_field :"administered_at(5i)", class: date_input_class, label: { text: "Minute", class: "nhsuk-date-input__label" }, value: @vaccination_record.administered_at&.min, width: 2 %>
+          <%= f.govuk_text_field :"administered_at(5i)", class: date_input_class, label: { text: "Minute", class: "nhsuk-date-input__label" }, value: @vaccination_record.administered_at&.min&.to_s&.rjust(2, "0"), width: 2 %>
         </div>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -552,6 +552,7 @@ en:
               missing_day: Enter a day
               missing_month: Enter a month
               missing_year: Enter a year
+              invalid: Enter a valid date and time
             batch_id:
               blank: Choose a batch
               incorrect_vaccine: Choose a batch of the %{vaccine_brand} vaccine

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -21,8 +21,15 @@ describe "Edit vaccination record" do
     when_i_click_on_change_date
     then_i_should_see_the_date_time_form
 
-    when_i_fill_in_the_date
-    and_i_fill_in_the_time
+    when_i_fill_in_an_invalid_date
+    and_i_click_continue
+    then_i_see_the_date_time_form_with_errors
+
+    when_i_fill_in_an_invalid_time
+    and_i_click_continue
+    then_i_see_the_date_time_form_with_errors
+
+    when_i_fill_in_a_valid_date_and_time
     and_i_click_continue
     then_i_see_the_edit_vaccination_record_page
     and_i_should_see_the_updated_date_time
@@ -109,15 +116,35 @@ describe "Edit vaccination record" do
     expect(page).to have_content("Time")
   end
 
-  def when_i_fill_in_the_date
+  def when_i_fill_in_a_valid_date_and_time
     fill_in "Year", with: "2023"
     fill_in "Month", with: "9"
     fill_in "Day", with: "1"
-  end
 
-  def and_i_fill_in_the_time
     fill_in "Hour", with: "12"
     fill_in "Minute", with: "00"
+  end
+
+  def when_i_fill_in_an_invalid_date
+    fill_in "Year", with: "3023"
+    fill_in "Month", with: "19"
+    fill_in "Day", with: "33"
+
+    fill_in "Hour", with: "23"
+    fill_in "Minute", with: "15"
+  end
+
+  def when_i_fill_in_an_invalid_time
+    fill_in "Year", with: "2025"
+    fill_in "Month", with: "5"
+    fill_in "Day", with: "1"
+
+    fill_in "Hour", with: "25"
+    fill_in "Minute", with: "61"
+  end
+
+  def then_i_see_the_date_time_form_with_errors
+    expect(page).to have_content("There is a problem")
   end
 
   def and_i_click_continue


### PR DESCRIPTION
Improvements to the vaccination administration editing form:
* handle when the entered time is invalid
* show minutes with leading zeros, so they appear in a more recognisable format
* add missing error message