### PR TITLE
Fix strict load error on session reminders job

### DIFF
--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -9,13 +9,14 @@ class SchoolSessionRemindersJob < ApplicationJob
     patient_sessions =
       PatientSession
         .includes(
-          :consents,
           :gillick_assessments,
           :triages,
           :vaccination_records,
+          consents: :parent,
           patient: :parents
         )
-        .joins(:location, :session)
+        .eager_load(:session)
+        .joins(:location)
         .merge(Location.school)
         .merge(Session.has_date(date))
         .notification_not_sent(date)


### PR DESCRIPTION
This wasn't caught by the tests because we stub `create_and_send!`, I think it probably is a good idea to add some feature tests for this, but that can be done in a follow up PR.

https://good-machine.sentry.io/issues/6046554728/