### PR TITLE
Only show recorded vaccinations on programme index

### DIFF
--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -33,7 +33,7 @@
 
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccinations</span>
-            <%= policy_scope(VaccinationRecord).where(programme:).count %>
+            <%= policy_scope(VaccinationRecord).recorded.where(programme:).count %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
We don't want to show draft vaccinations as they're not visible anywhere and means the numbers are confusing.