### PR TITLE
Update VaccinePolicy to use selected_organisation

### DIFF
--- a/app/policies/vaccine_policy.rb
+++ b/app/policies/vaccine_policy.rb
@@ -3,7 +3,9 @@
 class VaccinePolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.joins(:programme).where(programme: user.programmes)
+      scope.joins(:programme).where(
+        programme: user.selected_organisation.programmes
+      )
     end
   end
 end


### PR DESCRIPTION
This was breaking in cis2 mode because it relied on `user.progammes`, which uses the `organisations_users` join table, which isn't used in cis2 mode as cis2 provides us with the organisation-to-user mapping.

Really, any code that relies on that join table should not be a part of the code-paths that can run in cis2-mode.

Tests will be updated in a follow-up PR.
