### PR TITLE
Disable PDS jobs on non-test envs

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -59,6 +59,7 @@ environments:
       MAVIS__HOST: "accessibility.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "accessibility.mavistesting.com"
       MAVIS__CIS2__ENABLED: false
+      MAVIS__PDS__PERFORM_JOBS: false
   pentest:
     http:
       alias:
@@ -71,6 +72,7 @@ environments:
       MAVIS__HOST: "pentest.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "pentest.mavistesting.com"
       MAVIS__CIS2__ENABLED: false
+      MAVIS__PDS__PERFORM_JOBS: false
   test:
     http:
       alias:
@@ -93,6 +95,7 @@ environments:
       MAVIS__HOST: "training.manage-vaccinations-in-schools.nhs.uk"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "training.manage-vaccinations-in-schools.nhs.uk"
       MAVIS__CIS2__ENABLED: false
+      MAVIS__PDS__PERFORM_JOBS: false
   production:
     http:
       alias:


### PR DESCRIPTION
These environments all contain fully synthetic data that won't exist on PDS anyway.