### PR TITLE
Add restrictions on batches

### DIFF
--- a/app/controllers/vaccination_records/edit_controller.rb
+++ b/app/controllers/vaccination_records/edit_controller.rb
@@ -147,7 +147,11 @@ class VaccinationRecords::EditController < ApplicationController
     end
 
     if (id = todays_batch_id).present?
-      @vaccination_record.todays_batch = policy_scope(Batch).find_by(id:)
+      @vaccination_record.todays_batch =
+        policy_scope(Batch)
+          .where(vaccine: @vaccination_record.vaccine)
+          .not_expired
+          .find_by(id:)
     end
   end
 
@@ -178,9 +182,10 @@ class VaccinationRecords::EditController < ApplicationController
 
   def set_batches
     @batches =
-      policy_scope(Batch).where(
-        vaccine: @vaccination_record.vaccine
-      ).order_by_name_and_expiration
+      policy_scope(Batch)
+        .where(vaccine: @vaccination_record.vaccine)
+        .not_expired
+        .order_by_name_and_expiration
   end
 
   def set_locations

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -46,13 +46,16 @@ class Batch < ApplicationRecord
 
   validates :expiry,
             presence: true,
-            comparison: {
-              greater_than: -> { Date.new(Date.current.year - 15, 1, 1) },
-              less_than: -> { Date.new(Date.current.year + 15, 1, 1) }
-            },
             uniqueness: {
               scope: %i[organisation_id name vaccine_id]
             }
+
+  validates :expiry,
+            comparison: {
+              greater_than: -> { Date.current },
+              less_than: -> { Date.current + 15.years }
+            },
+            unless: :archived?
 
   def archived?
     archived_at != nil

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -35,6 +35,9 @@ class Batch < ApplicationRecord
   scope :archived, -> { where.not(archived_at: nil) }
   scope :unarchived, -> { where(archived_at: nil) }
 
+  scope :expired, -> { where("expiry <= ?", Time.current) }
+  scope :not_expired, -> { where("expiry > ?", Time.current) }
+
   has_many :vaccination_records
 
   has_and_belongs_to_many :immunisation_imports

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -314,7 +314,7 @@ class ImmunisationImportRow
     return unless valid? && administered
 
     @batch ||=
-      Batch.find_or_create_by!(
+      Batch.create_with(archived_at: Time.current).find_or_create_by!(
         expiry: batch_expiry_date,
         name: batch_number,
         organisation:,

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -16,10 +16,10 @@ describe AppVaccinationRecordSummaryComponent do
   let(:patient_session) { create(:patient_session, session:, patient:) }
   let(:vaccine) { programme.vaccines.first }
   let(:batch) do
-    create(:batch, name: "ABC", expiry: Date.new(2020, 1, 1), vaccine:)
+    create(:batch, name: "ABC", expiry: Date.new(2026, 1, 1), vaccine:)
   end
   let(:other_batch) do
-    create(:batch, name: "DEF", expiry: Date.new(2021, 1, 1), vaccine:)
+    create(:batch, name: "DEF", expiry: Date.new(2027, 1, 1), vaccine:)
   end
   let(:notes) { "Some notes." }
   let(:location_name) { nil }
@@ -163,7 +163,7 @@ describe AppVaccinationRecordSummaryComponent do
     it do
       expect(rendered).to have_css(
         ".nhsuk-summary-list__row",
-        text: "Batch expiry date\n1 January 2020"
+        text: "Batch expiry date\n1 January 2026"
       )
     end
 
@@ -276,7 +276,7 @@ describe AppVaccinationRecordSummaryComponent do
       expect(rendered).to have_css(".app-highlight", text: "Nasal spray")
       expect(rendered).to have_css(".app-highlight", text: "Nose")
       expect(rendered).to have_css(".app-highlight", text: "DEF")
-      expect(rendered).to have_css(".app-highlight", text: "1 January 2021")
+      expect(rendered).to have_css(".app-highlight", text: "1 January 2027")
     end
   end
 end

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -35,6 +35,10 @@ FactoryBot.define do
     name { "#{prefix}#{Faker::Number.number(digits: 4)}" }
     expiry { Faker::Time.forward(days: 50) }
 
+    trait :expired do
+      expiry { Date.yesterday }
+    end
+
     trait :archived do
       archived_at { Time.current }
     end

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -56,6 +56,7 @@ describe "End-to-end journey" do
     @batch =
       create(
         :batch,
+        expiry: Date.new(2024, 4, 1),
         organisation: @organisation,
         vaccine: @programme.vaccines.first
       )

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -11,6 +11,7 @@ describe "HPV Vaccination" do
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_record_that_the_patient_has_been_vaccinated
+    and_i_see_only_not_expired_batches
     and_i_select_the_batch
     then_i_see_the_confirmation_page
 
@@ -46,6 +47,8 @@ describe "HPV Vaccination" do
 
     active_vaccine = programme.vaccines.active.first
     @active_batch = create(:batch, organisation:, vaccine: active_vaccine)
+    @expired_batch =
+      create(:batch, :expired, organisation:, vaccine: active_vaccine)
 
     @session = create(:session, organisation:, programme:, location:)
     @patient =
@@ -64,6 +67,11 @@ describe "HPV Vaccination" do
     choose "Yes, they got the HPV vaccine"
     choose "Left arm"
     click_button "Continue"
+  end
+
+  def and_i_see_only_not_expired_batches
+    expect(page).not_to have_content(@expired_batch.name)
+    expect(page).to have_content(@active_batch.name)
   end
 
   def and_i_select_the_batch

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -47,8 +47,13 @@ describe "HPV Vaccination" do
 
     active_vaccine = programme.vaccines.active.first
     @active_batch = create(:batch, organisation:, vaccine: active_vaccine)
+    @archived_batch =
+      create(:batch, :archived, organisation:, vaccine: active_vaccine)
+
+    # To get around expiration date validation on the model.
     @expired_batch =
-      create(:batch, :expired, organisation:, vaccine: active_vaccine)
+      build(:batch, :expired, organisation:, vaccine: active_vaccine)
+    @expired_batch.save!(validate: false)
 
     @session = create(:session, organisation:, programme:, location:)
     @patient =
@@ -71,6 +76,7 @@ describe "HPV Vaccination" do
 
   def and_i_see_only_not_expired_batches
     expect(page).not_to have_content(@expired_batch.name)
+    expect(page).not_to have_content(@archived_batch.name)
     expect(page).to have_content(@active_batch.name)
   end
 

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -109,13 +109,7 @@ describe "Immunisation imports duplicates" do
         session: @session
       )
     @vaccine = @programme.vaccines.find_by(nivs_name: "Gardasil9")
-    @batch =
-      create(
-        :batch,
-        vaccine: @vaccine,
-        expiry: Date.new(2024, 7, 30),
-        name: "SomethingElse"
-      )
+    @batch = create(:batch, vaccine: @vaccine, name: "SomethingElse")
     @previous_vaccination_record =
       create(
         :vaccination_record,

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -55,10 +55,10 @@ describe Batch do
     it do
       travel_to(Date.new(2024, 9, 1)) do
         expect(batch).to validate_comparison_of(:expiry).is_greater_than(
-          Date.new(2009, 1, 1)
+          Date.new(2024, 9, 1)
         )
         expect(batch).to validate_comparison_of(:expiry).is_less_than(
-          Date.new(2039, 1, 1)
+          Date.new(2039, 9, 1)
         )
       end
     end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -948,4 +948,12 @@ describe ImmunisationImportRow do
       end
     end
   end
+
+  describe "#batch" do
+    subject(:batch) { immunisation_import_row.to_vaccination_record.batch }
+
+    let(:data) { valid_data }
+
+    it { should be_archived }
+  end
 end


### PR DESCRIPTION
This adds a number of restrictions on batches to prevent the creation of invalid batches and to prevent invalid batches from being chosen when recording a vaccination.