### PR TITLE
Default user role to Nurse if CIS2 is disabled

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,7 @@ class User < ApplicationRecord
   end
 
   def is_nurse?
-    return email.include?("nurse") unless Settings.cis2.enabled
+    return true unless Settings.cis2.enabled
 
     selected_role = cis2_info.dig("selected_role", "code")
     selected_role.ends_with? "R8001"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -114,7 +114,7 @@ describe User do
       context "when the user is admin staff" do
         let(:user) { build(:admin) }
 
-        it { should be false }
+        it { should be true }
       end
     end
   end


### PR DESCRIPTION
We need to allow users in the Training environment to access nurse-related functionality, but their emails don't contain the word `nurse`. So this is a stopgap to fix that.