### PR TITLE
Remove unused patient relationship

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -66,7 +66,6 @@ class Patient < ApplicationRecord
   has_one :latest_triage, -> { order(created_at: :desc) }, class_name: "Triage"
 
   has_many :parents, through: :parent_relationships
-  has_many :programmes, through: :sessions
   has_many :sessions, through: :patient_sessions
   has_many :vaccination_records, through: :patient_sessions
 


### PR DESCRIPTION
This removes Patient#programmes which is not used anywhere and isn't correctly defined anyway since it depends on `sessions` which is defined below it.