### PR TITLE
Don't send email if consent is not provided

### DIFF
--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -22,7 +22,7 @@ module TriageMailerConcern
     elsif consent.response_refused?
       ConsentMailer.with(params).confirmation_refused.deliver_later
       TextDeliveryJob.perform_later(:consent_confirmation_refused, **params)
-    else
+    elsif consent.response_given?
       ConsentMailer.with(params).confirmation_given.deliver_later
       TextDeliveryJob.perform_later(:consent_confirmation_given, **params)
     end

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -109,6 +109,18 @@ describe TriageMailerConcern do
       end
     end
 
+    context "when the patient didn't response" do
+      let(:patient_session) { create(:patient_session, :consent_not_provided) }
+
+      it "doesn't send an email" do
+        expect { send_triage_confirmation }.not_to have_enqueued_email
+      end
+
+      it "doesn't send a text message" do
+        expect { send_triage_confirmation }.not_to have_enqueued_text
+      end
+    end
+
     context "when the parents have verbally refused consent" do
       let(:patient_session) { create(:patient_session, :consent_refused) }
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -78,6 +78,17 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_not_provided do
+      patient do
+        association :patient,
+                    :consent_not_provided,
+                    performed_by: user,
+                    programme:,
+                    organisation:,
+                    school: session.location
+      end
+    end
+
     trait :consent_conflicting do
       patient do
         association :patient,

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -244,6 +244,22 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_not_provided do
+      consents do
+        [
+          association(
+            :consent,
+            :recorded,
+            :not_provided,
+            :from_mum,
+            patient: instance,
+            organisation:,
+            programme:
+          )
+        ]
+      end
+    end
+
     trait :triage_ready_to_vaccinate do
       triages do
         [


### PR DESCRIPTION
Currently we send an email and a text saying consent was given if the user has selected the consent not provided option which is incorrect and could lead to confusion.