### PR TITLE
Show total unmatched consent forms

### DIFF
--- a/app/views/consent_forms/index.html.erb
+++ b/app/views/consent_forms/index.html.erb
@@ -1,7 +1,7 @@
 <%= h1 t(".title"), size: "xl" %>
 
 <%= render AppCardComponent.new do |card|
-      card.with_heading { pluralize(@consent_forms.count, "consent response") }
+      card.with_heading { pluralize(@pagy.count, "consent response") }
     
       govuk_table(classes: "nhsuk-u-margin-0") do |table|
         table.with_head do |head|


### PR DESCRIPTION
Currently we show only the number visible on the page whereas we would want to show the total across all pages.