### PR TITLE
Remove "not provided" response

### DIFF
--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -68,7 +68,7 @@ module PatientSessionStateConcern
     end
 
     def no_consent?
-      consents.empty? || consents.all?(&:response_not_provided?)
+      consents.empty?
     end
 
     def triage_needed?

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -65,7 +65,7 @@ class Consent < ApplicationRecord
 
   scope :for_patient, -> { where("patient_id = patients.id") }
 
-  enum :response, %w[given refused not_provided], prefix: true
+  enum :response, %w[given refused], prefix: true
   enum :reason_for_refusal,
        %w[
          contains_gelatine

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -84,7 +84,7 @@ class ConsentForm < ApplicationRecord
   has_one :team, through: :location
   has_many :eligible_schools, through: :organisation, source: :schools
 
-  enum :response, %w[given refused not_provided], prefix: "consent"
+  enum :response, %w[given refused], prefix: "consent"
   enum :reason,
        %w[
          contains_gelatine

--- a/app/views/manage_consents/agree.html.erb
+++ b/app/views/manage_consents/agree.html.erb
@@ -24,10 +24,6 @@
                              label: { text: "Yes, they agree" }, link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",
                              label: { text: "No, they do not agree" } %>
-    <% unless @consent.via_self_consent? %>
-      <%= f.govuk_radio_button :response, "not_provided",
-                               label: { text: "No response" } %>
-    <% end %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,7 +235,6 @@ en:
           will_be_vaccinated_elsewhere: Vaccine will be given elsewhere
         responses:
           given: consent given
-          not_provided: not provided
           refused: consent refused
         routes:
           in_person: In person
@@ -257,7 +256,6 @@ en:
           will_be_vaccinated_elsewhere: Vaccine will be given elsewhere
         responses:
           given: Consent given
-          not_provided: Not provided
           refused: Consent refused
       notify_log_entry:
         types:

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -109,18 +109,6 @@ describe TriageMailerConcern do
       end
     end
 
-    context "when the patient didn't response" do
-      let(:patient_session) { create(:patient_session, :consent_not_provided) }
-
-      it "doesn't send an email" do
-        expect { send_triage_confirmation }.not_to have_enqueued_email
-      end
-
-      it "doesn't send a text message" do
-        expect { send_triage_confirmation }.not_to have_enqueued_text
-      end
-    end
-
     context "when the parents have verbally refused consent" do
       let(:patient_session) { create(:patient_session, :consent_refused) }
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -78,17 +78,6 @@ FactoryBot.define do
       end
     end
 
-    trait :consent_not_provided do
-      patient do
-        association :patient,
-                    :consent_not_provided,
-                    performed_by: user,
-                    programme:,
-                    organisation:,
-                    school: session.location
-      end
-    end
-
     trait :consent_conflicting do
       patient do
         association :patient,

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -244,22 +244,6 @@ FactoryBot.define do
       end
     end
 
-    trait :consent_not_provided do
-      consents do
-        [
-          association(
-            :consent,
-            :recorded,
-            :not_provided,
-            :from_mum,
-            patient: instance,
-            organisation:,
-            programme:
-          )
-        ]
-      end
-    end
-
     trait :triage_ready_to_vaccinate do
       triages do
         [


### PR DESCRIPTION
This response on consent and consent forms was used in the pilot but no longer exists in the prototype and should be removed. This also avoids a problem where consent given emails were being sent out if consent was recorded as "not provided".

Replaces #2352