### PR TITLE
A failed Gillick assessment does not automatically mean the patient can't be vaccinated

### DIFF
--- a/app/controllers/concerns/patient_tabs_concern.rb
+++ b/app/controllers/concerns/patient_tabs_concern.rb
@@ -16,7 +16,6 @@ module PatientTabsConcern
         consent_given_triage_not_needed
         vaccinated
         unable_to_vaccinate
-        unable_to_vaccinate_not_gillick_competent
       ]
     },
     vaccinations: {
@@ -28,7 +27,6 @@ module PatientTabsConcern
         delay_vaccination
         triaged_do_not_vaccinate
         unable_to_vaccinate
-        unable_to_vaccinate_not_gillick_competent
       ]
     }
   }.with_indifferent_access.freeze

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -10,8 +10,6 @@ module PatientSessionStateConcern
           "vaccinated"
         elsif triage_delay_vaccination? || vaccination_can_be_delayed?
           "delay_vaccination"
-        elsif not_gillick_competent?
-          "unable_to_vaccinate_not_gillick_competent"
         elsif vaccination_not_administered?
           "unable_to_vaccinate"
         elsif triage_keep_in_triage?
@@ -43,7 +41,6 @@ module PatientSessionStateConcern
       triaged_do_not_vaccinate
       triaged_kept_in_triage
       unable_to_vaccinate
-      unable_to_vaccinate_not_gillick_competent
       delay_vaccination
       vaccinated
     ].each { |state| define_method("#{state}?") { self.state == state } }
@@ -101,10 +98,6 @@ module PatientSessionStateConcern
 
     def vaccination_not_administered?
       vaccination_records.any?(&:not_administered?)
-    end
-
-    def not_gillick_competent?
-      latest_gillick_assessment&.gillick_competent == false
     end
 
     def vaccination_can_be_delayed?

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -118,7 +118,7 @@ class PatientSession < ApplicationRecord
   end
 
   def able_to_vaccinate?
-    !unable_to_vaccinate? && !unable_to_vaccinate_not_gillick_competent?
+    !unable_to_vaccinate?
   end
 
   def safe_to_destroy?

--- a/app/models/patient_session_stats.rb
+++ b/app/models/patient_session_stats.rb
@@ -55,8 +55,7 @@ class PatientSessionStats
       patient_session.delay_vaccination? || patient_session.consent_refused? ||
         patient_session.consent_conflicts? ||
         patient_session.triaged_do_not_vaccinate? ||
-        patient_session.unable_to_vaccinate? ||
-        patient_session.unable_to_vaccinate_not_gillick_competent?
+        patient_session.unable_to_vaccinate?
     end
   end
 end

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -59,11 +59,6 @@ en:
         gave_consent: "Their %{who_responded} gave consent"
         triaged_do_not_vaccinate: "Do not vaccinate in programme"
         unable_to_vaccinate: "Refused vaccine"
-    unable_to_vaccinate_not_gillick_competent:
-      colour: red
-      text: Not vaccinated
-      banner_title: Not vaccinated
-      banner_explanation: No-one responded to our requests for consent. When assessed, the child was not Gillick competent.
     vaccinated:
       colour: green
       text: Vaccinated

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -41,14 +41,6 @@ describe PatientTabsConcern do
   let(:unable_to_vaccinate) do
     create(:patient_session, :unable_to_vaccinate, programme:, session:)
   end
-  let(:unable_to_vaccinate_not_gillick_competent) do
-    create(
-      :patient_session,
-      :unable_to_vaccinate_not_gillick_competent,
-      programme:,
-      session:
-    )
-  end
   let(:vaccinated) do
     create(:patient_session, :vaccinated, programme:, session:)
   end
@@ -65,7 +57,6 @@ describe PatientTabsConcern do
       triaged_kept_in_triage,
       triaged_ready_to_vaccinate,
       unable_to_vaccinate,
-      unable_to_vaccinate_not_gillick_competent,
       vaccinated
     ]
   end
@@ -88,7 +79,6 @@ describe PatientTabsConcern do
             triaged_kept_in_triage,
             triaged_ready_to_vaccinate,
             unable_to_vaccinate,
-            unable_to_vaccinate_not_gillick_competent,
             vaccinated
           ],
           consent_refused: [consent_refused],
@@ -139,7 +129,6 @@ describe PatientTabsConcern do
               consent_given_triage_not_needed,
               consent_refused,
               unable_to_vaccinate,
-              unable_to_vaccinate_not_gillick_competent,
               vaccinated
             ]
           }.with_indifferent_access
@@ -167,8 +156,7 @@ describe PatientTabsConcern do
               consent_refused,
               delay_vaccination,
               triaged_do_not_vaccinate,
-              unable_to_vaccinate,
-              unable_to_vaccinate_not_gillick_competent
+              unable_to_vaccinate
             ]
           }.with_indifferent_access
         )

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -182,31 +182,6 @@ FactoryBot.define do
       end
     end
 
-    trait :unable_to_vaccinate_not_gillick_competent do
-      patient do
-        association :patient,
-                    :consent_given_triage_needed,
-                    :triage_ready_to_vaccinate,
-                    performed_by: user,
-                    programme:,
-                    organisation:,
-                    school: session.location
-      end
-
-      after(:create) do |patient_session, evaluator|
-        create(:gillick_assessment, :not_competent, patient_session:)
-
-        create(
-          :vaccination_record,
-          :not_administered,
-          patient_session:,
-          programme: evaluator.programme,
-          performed_by: evaluator.user,
-          reason: :already_had
-        )
-      end
-    end
-
     trait :vaccinated do
       patient do
         association :patient,

--- a/spec/features/self_consent_not_gillick_competent_spec.rb
+++ b/spec/features/self_consent_not_gillick_competent_spec.rb
@@ -15,6 +15,7 @@ describe "Not Gillick competent" do
 
     when_the_nurse_assesses_the_child_as_not_being_gillick_competent
     then_the_child_cannot_give_their_own_consent
+    and_the_childs_status_reflects_that_there_is_no_consent
   end
 
   def given_an_hpv_programme_is_underway
@@ -89,5 +90,10 @@ describe "Not Gillick competent" do
     expect(page).not_to have_content(
       "Do they agree to them having the HPV vaccination?"
     )
+    click_on "Back"
+  end
+
+  def and_the_childs_status_reflects_that_there_is_no_consent
+    expect(page).to have_content("No response")
   end
 end

--- a/spec/models/concerns/patient_session_state_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_concern_spec.rb
@@ -25,7 +25,6 @@ describe PatientSessionStateConcern do
         consent_refused?: false,
         consent_conflicts?: false,
         no_consent?: false,
-        not_gillick_competent?: false,
         triage_needed?: false,
         triage_not_needed?: false,
         triage_ready_to_vaccinate?: false,
@@ -65,10 +64,6 @@ describe PatientSessionStateConcern do
     it_behaves_like "it supports the state",
                     state: :consent_conflicts,
                     conditions: [:consent_conflicts]
-
-    it_behaves_like "it supports the state",
-                    state: :unable_to_vaccinate_not_gillick_competent,
-                    conditions: [:not_gillick_competent]
 
     it_behaves_like "it supports the state",
                     state: :triaged_ready_to_vaccinate,


### PR DESCRIPTION
## What's the issue?

### To reproduce

1. Find a patient with given consent from a parent
2. Start recording a Gillick competency assessment
3. Record that the child isn’t Gillick compentent

### Actual

Child’s status is shown as: “Not vaccinated - no-one responded to our requests for consent. When assessed, the child was not Gillick competent.”

This is wrong in a number of ways:

* A failed Gillick competency assessment shouldn’t override the parent’s consent – it should just be ignored in the determination whether consent is present or not
* A failed Gillick competency assessment shouldn’t prevent vaccination recording.
* The message “no-one responded to our requests for consent” is inaccurate, as there’s definitely a consent response from a parent

### Expected

Gillick assessment result recorded, child’s vaccination can still be recorded as there is consent available. If there isn't any consent available, the status should remain as "No response".

## What's the technical change?

Remove the `unable_to_vaccinate_not_gillick_competent` state completely.

