### PR TITLE
Update content when vaccination is not administered

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -110,12 +110,19 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def vaccination_events
-    vaccination_records.recorded.map do
+    vaccination_records.recorded.map do |vaccination_record|
+      title =
+        if vaccination_record.administered?
+          "Vaccinated with #{helpers.vaccine_heading(vaccination_record.vaccine)}"
+        else
+          "Unable to vaccinate: #{vaccination_record.human_enum_name(:reason)}"
+        end
+
       {
-        title: "Vaccinated with #{helpers.vaccine_heading(_1.vaccine)}",
-        time: _1.created_at,
-        notes: _1.notes,
-        by: _1.performed_by&.full_name
+        title:,
+        time: vaccination_record.created_at,
+        notes: vaccination_record.notes,
+        by: vaccination_record.performed_by&.full_name
       }
     end
   end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -179,6 +179,27 @@ describe AppActivityLogComponent do
                      by: "Nurse Joy"
   end
 
+  describe "vaccination not administered" do
+    before do
+      create(
+        :vaccination_record,
+        :not_administered,
+        programme:,
+        patient_session:,
+        created_at: Time.zone.local(2024, 5, 31, 13),
+        performed_by: user,
+        notes: "Some notes.",
+        vaccine: create(:vaccine, :gardasil, programme:)
+      )
+    end
+
+    include_examples "card",
+                     title: "Unable to vaccinate: Unwell",
+                     date: "31 May 2024 at 1:00pm",
+                     notes: "Some notes.",
+                     by: "Nurse Joy"
+  end
+
   describe "self-consent" do
     before do
       create(


### PR DESCRIPTION
In the activity log, currently vaccinations are recorded as having been given even if they weren't administered which is incorrect.