### PR TITLE
Revert "Remove "not provided" response"

### DIFF
--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -65,7 +65,8 @@ module PatientSessionStateConcern
     end
 
     def no_consent?
-      consents.empty? || consents.all?(&:invalidated?)
+      consents.empty? || consents.all?(&:response_not_provided?) ||
+        consents.all?(&:invalidated?)
     end
 
     def triage_needed?

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -71,8 +71,7 @@ class Consent < ApplicationRecord
   scope :withdrawn, -> { where.not(withdrawn_at: nil) }
   scope :not_withdrawn, -> { where(withdrawn_at: nil) }
 
-  enum :response, %w[given refused], prefix: true
-
+  enum :response, %w[given refused not_provided], prefix: true
   enum :reason_for_refusal,
        %w[
          contains_gelatine

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -133,6 +133,7 @@ class PatientSession < ApplicationRecord
     @latest_consents ||=
       consents
         .select(&:not_invalidated?)
+        .select { _1.response_given? || _1.response_refused? }
         .group_by(&:name)
         .map { |_, consents| consents.max_by(&:recorded_at) }
   end

--- a/app/views/consents/edit/agree.html.erb
+++ b/app/views/consents/edit/agree.html.erb
@@ -20,6 +20,11 @@
                              label: { text: "Yes, they agree" }, link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",
                              label: { text: "No, they do not agree" } %>
+    <% unless @consent.via_self_consent? %>
+      <%= f.govuk_radio_divider %>
+      <%= f.govuk_radio_button :response, "not_provided",
+                               label: { text: "No response" } %>
+    <% end %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,7 @@ en:
           will_be_vaccinated_elsewhere: Vaccine will be given elsewhere
         responses:
           given: consent given
+          not_provided: not provided
           refused: consent refused
         routes:
           in_person: In person

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -109,6 +109,18 @@ describe TriageMailerConcern do
       end
     end
 
+    context "when the patient didn't response" do
+      let(:patient_session) { create(:patient_session, :consent_not_provided) }
+
+      it "doesn't send an email" do
+        expect { send_triage_confirmation }.not_to have_enqueued_email
+      end
+
+      it "doesn't send a text message" do
+        expect { send_triage_confirmation }.not_to have_enqueued_text
+      end
+    end
+
     context "when the parents have verbally refused consent" do
       let(:patient_session) { create(:patient_session, :consent_refused) }
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -78,6 +78,17 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_not_provided do
+      patient do
+        association :patient,
+                    :consent_not_provided,
+                    performed_by: user,
+                    programme:,
+                    organisation:,
+                    school: session.location
+      end
+    end
+
     trait :consent_conflicting do
       patient do
         association :patient,

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -244,6 +244,22 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_not_provided do
+      consents do
+        [
+          association(
+            :consent,
+            :recorded,
+            :not_provided,
+            :from_mum,
+            patient: instance,
+            organisation:,
+            programme:
+          )
+        ]
+      end
+    end
+
     trait :triage_ready_to_vaccinate do
       triages do
         [


### PR DESCRIPTION
This reverts commit 915d58367b1a44ac60b1eca0a3121c370390011f.

We actually do need this feature to avoid the nursing team from repeatedly contacting a parent who might not be available.

I think it would be good to add some feature test coverage to this, but we can do that in a later PR.