### PR TITLE
Reduce a potential gap between PDS updates and comms being sent

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,7 +123,7 @@ Rails.application.configure do
   config.good_job.enable_cron = true
   config.good_job.cron = {
     bulk_update_patients_from_pds: {
-      cron: "every day at 00:00 and 6:00 and 12:00 and 18:00",
+      cron: "every day at 00:00 and 8:00 and 12:00 and 18:00",
       class: "BulkUpdatePatientsFromPDSJob",
       description: "Keep patient details up to date with PDS."
     },


### PR DESCRIPTION
Start a PDS check from 8am ahead of scheduled comms going out at 9am.