### PR TITLE
Ignore changes on the patient record when uploading vaccinations for existing patients

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -108,13 +108,7 @@ class ImmunisationImportRow
   def patient
     return unless valid?
 
-    @patient ||=
-      if (existing_patient = existing_patients.first)
-        existing_patient.stage_changes(patient_attributes)
-        existing_patient
-      else
-        Patient.create!(patient_attributes)
-      end
+    @patient ||= existing_patients.first || Patient.create!(patient_attributes)
   end
 
   def session

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -20,15 +20,15 @@ describe "Immunisation imports duplicates" do
     when_i_choose_to_keep_the_duplicate_record
     and_i_confirm_my_selection
     then_i_should_see_a_success_message
-    and_the_first_record_should_be_updated
+    and_the_first_patient_should_be_updated_and_have_a_vaccination_record
 
     when_i_review_the_second_duplicate_record
     then_i_should_see_the_second_duplicate_record
 
-    when_i_choose_to_keep_the_duplicate_record
+    when_i_choose_to_keep_the_previously_uploaded_record
     and_i_confirm_my_selection
     then_i_should_see_a_success_message
-    and_the_second_record_should_be_updated
+    and_the_second_record_should_not_be_updated
 
     when_i_go_to_the_programme
     then_i_should_see_import_issues_with_the_count
@@ -154,6 +154,10 @@ describe "Immunisation imports duplicates" do
     choose "Use duplicate record"
   end
 
+  def when_i_choose_to_keep_the_previously_uploaded_record
+    choose "Keep previously uploaded record"
+  end
+
   def when_i_submit_the_form_without_choosing_anything
     click_on "Resolve duplicate"
   end
@@ -180,11 +184,18 @@ describe "Immunisation imports duplicates" do
     expect(page).to have_content("MethodNasal spray")
   end
 
-  def and_the_first_record_should_be_updated
+  def and_the_first_patient_should_be_updated_and_have_a_vaccination_record
     @existing_patient.reload
     expect(@existing_patient.given_name).to eq("Chyna")
     expect(@existing_patient.family_name).to eq("Pickle")
     expect(@existing_patient.pending_changes).to eq({})
+    expect(@existing_patient.vaccination_records.count).to eq(1)
+    vaccs_record = @existing_patient.vaccination_records.first
+    expect(vaccs_record.administered_at).to eq(
+      Time.new(2024, 5, 14, 12, 0, 0, "+01:00")
+    )
+    expect(vaccs_record.delivery_method).to eq("intramuscular")
+    expect(vaccs_record.delivery_site).to eq("left_buttock")
   end
 
   def then_i_should_see_a_validation_error
@@ -195,10 +206,10 @@ describe "Immunisation imports duplicates" do
     click_on "Review Caden Attwater"
   end
 
-  def and_the_second_record_should_be_updated
+  def and_the_second_record_should_not_be_updated
     @previous_vaccination_record.reload
-    expect(@previous_vaccination_record.delivery_method).to eq("intramuscular")
-    expect(@previous_vaccination_record.delivery_site).to eq("left_thigh")
+    expect(@previous_vaccination_record.delivery_method).to eq("nasal_spray")
+    expect(@previous_vaccination_record.delivery_site).to eq("nose")
     expect(@previous_vaccination_record.pending_changes).to eq({})
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -346,6 +346,15 @@ describe ImmunisationImportRow do
       it { should eq(other_patient) }
     end
 
+    context "with an existing matching patient but different patient data" do
+      let(:data) { valid_data }
+
+      it "does not stage any changes as vaccs history data is potentially out of date" do
+        create(:patient, nhs_number:, address_postcode: "CB1 1AA")
+        expect(subject.pending_changes).to be_empty
+      end
+    end
+
     describe "#cohort" do
       subject(:cohort) { patient.cohort }
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -277,64 +277,73 @@ describe ImmunisationImportRow do
     context "with an existing patient matching NHS number" do
       let(:data) { valid_data }
 
-      let(:patient) { create(:patient, nhs_number:) }
+      let(:other_patient) { create(:patient, nhs_number:) }
 
-      it { should eq(patient) }
+      it { should eq(other_patient) }
     end
 
-    context "with an existing patient matching first name, last name and date of birth" do
-      let(:data) { valid_data }
+    context "without an NHS number and an existing patient matching first name, last name and date of birth" do
+      let(:data) { valid_data.except("NHS_NUMBER") }
 
-      let(:patient) do
+      let(:other_patient) do
         create(
           :patient,
           given_name:,
           family_name:,
+          nhs_number:,
           date_of_birth: Date.parse(date_of_birth)
         )
       end
 
-      it { should eq(patient) }
+      it { should eq(other_patient) }
     end
 
-    context "with an existing patient matching first name, last name and postcode" do
-      let(:data) { valid_data }
+    context "without an NHS number and an existing patient matching first name, last name and postcode" do
+      let(:data) { valid_data.except("NHS_NUMBER") }
 
-      let(:patient) do
-        create(:patient, given_name:, family_name:, address_postcode:)
+      let(:other_patient) do
+        create(
+          :patient,
+          given_name:,
+          family_name:,
+          address_postcode:,
+          nhs_number:
+        )
       end
 
-      it { should eq(patient) }
+      it { should eq(other_patient) }
     end
 
-    context "with an existing patient matching first name, date of birth and postcode" do
-      let(:data) { valid_data }
+    context "without an NHS number and an existing patient matching first name, date of birth and postcode" do
+      let(:data) { valid_data.except("NHS_NUMBER") }
 
-      let(:patient) do
+      let(:other_patient) do
         create(
           :patient,
           given_name:,
           date_of_birth: Date.parse(date_of_birth),
-          address_postcode:
+          address_postcode:,
+          nhs_number:
         )
       end
 
-      it { should eq(patient) }
+      it { should eq(other_patient) }
     end
 
-    context "with an existing patient matching last name, date of birth and postcode" do
-      let(:data) { valid_data }
+    context "without an NHS number and an existing patient matching last name, date of birth and postcode" do
+      let(:data) { valid_data.except("NHS_NUMBER") }
 
-      let(:patient) do
+      let(:other_patient) do
         create(
           :patient,
           family_name:,
           date_of_birth: Date.parse(date_of_birth),
-          address_postcode:
+          address_postcode:,
+          nhs_number:
         )
       end
 
-      it { should eq(patient) }
+      it { should eq(other_patient) }
     end
 
     describe "#cohort" do

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -333,14 +333,9 @@ describe ImmunisationImport do
         )
       end
 
-      it "identifies potential changes in the patient record" do
+      it "ignores changes in the patient record" do
         expect { record! }.not_to change(Patient, :count)
-
-        expect(existing_patient.reload.pending_changes).to eq(
-          "address_postcode" => "LE3 2DB",
-          "date_of_birth" => "2011-09-13",
-          "gender_code" => "female"
-        )
+        expect(existing_patient.reload.pending_changes).to be_empty
       end
     end
 


### PR DESCRIPTION
To prevent obsolete details (like the child's old address if they've moved) from being flagged as import issues, don't stage any patient changes from vaccination uploads that have been matched to an existing patient in the cohort.

This change is part of a broader strategy around what updates happen when something is imported against an existing cohort patient:

<img width="617" alt="image" src="https://github.com/user-attachments/assets/e5d59b13-f0fa-4821-a319-e8056fedbad5">

This PR also includes some technical work:

- Fix `ImmunisationImportRow` specs - they were not testing anything
- Improve spec coverage around the "Immunisation import duplicate resolution" spec

Best reviewed commit-by-commit.