### PR TITLE
Correctly handle consent form notes being `nil`

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -217,7 +217,7 @@ class Consent < ApplicationRecord
         patient:,
         parent:,
         reason_for_refusal: consent_form.reason,
-        notes: consent_form.reason_notes,
+        notes: consent_form.reason_notes.presence || "",
         recorded_at: Time.zone.now,
         response: consent_form.response,
         route: "website",

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -100,7 +100,7 @@ describe Consent do
         described_class.from_consent_form!(consent_form, patient:)
       end
 
-      let(:consent_form) { create(:consent_form, :recorded) }
+      let(:consent_form) { create(:consent_form, :recorded, reason_notes: nil) }
       let(:patient) { create(:patient) }
 
       it "copies over attributes from consent_form" do


### PR DESCRIPTION
In the consent model these aren't allowed to be `nil`, instead we store them as a blank string.

https://good-machine.sentry.io/issues/6051539334/