### PR TITLE
Allow editing vaccination outcome

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -121,7 +121,7 @@ class DraftVaccinationRecordsController < ApplicationController
       date_and_time: %i[administered_at],
       delivery: %i[delivery_site delivery_method],
       location: %i[location_name],
-      reason: %i[reason],
+      outcome: %i[outcome],
       vaccine: %i[vaccine_id]
     }.fetch(current_step)
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -60,6 +60,7 @@ class VaccinationsController < ApplicationController
     if @draft_vaccination_record.save
       steps = @draft_vaccination_record.wizard_steps
 
+      steps.delete(:outcome) if @draft_vaccination_record.administered?
       steps.delete(:date_and_time)
       if @draft_vaccination_record.delivery_method.present? &&
            @draft_vaccination_record.delivery_site.present?

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -17,26 +17,23 @@
   <%= h1 "Check and confirm" %>
 <% end %>
 
+<% change_links = {
+     administered_at: wizard_path("date-and-time"),
+     batch: wizard_path("batch"),
+     delivery_method: wizard_path("delivery"),
+     delivery_site: wizard_path("delivery"),
+     location: @draft_vaccination_record.wizard_steps.include?(:location) ? wizard_path("location") : nil,
+     outcome: wizard_path("outcome"),
+     vaccine: wizard_path("vaccine"),
+   } %>
+
 <% if @draft_vaccination_record.administered? %>
   <%= render AppCardComponent.new do |card| %>
     <% card.with_heading { "Vaccination details" } %>
     <%= render AppVaccinationRecordSummaryComponent.new(
           @draft_vaccination_record,
           current_user:,
-          change_links: {
-            administered_at: wizard_path("date-and-time"),
-            batch: wizard_path("batch"),
-            delivery_method: wizard_path("delivery"),
-            delivery_site: wizard_path("delivery"),
-            location: @draft_vaccination_record.wizard_steps.include?(:location) ? wizard_path(:location) : nil,
-            outcome: @draft_vaccination_record.editing? ? nil : session_patient_path(
-              @session,
-              @patient,
-              section: "vaccinations",
-              tab: "vaccinate",
-            ),
-            vaccine: wizard_path("vaccine"),
-          },
+          change_links:,
           show_notes: false,
         ) %>
   <% end %>
@@ -45,26 +42,18 @@
     <%= render AppVaccinationRecordSummaryComponent.new(
           @draft_vaccination_record,
           current_user:,
-          change_links: {
-            administered_at: wizard_path("date-and-time"),
-            outcome: @draft_vaccination_record.editing? ? nil : session_patient_path(
-              @session,
-              @patient,
-              section: "vaccinations",
-              tab: "vaccinate",
-            ),
-          },
+          change_links:,
           show_notes: false,
         ) %>
   <% end %>
 <% end %>
 
-<% if @draft_vaccination_record.editing? %>
-  <%= govuk_button_to "Continue", wizard_path, method: :put, prevent_double_click: true %>
-<% else %>
-  <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
-    <% content_for(:before_content) { f.govuk_error_summary } %>
+<%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
 
+  <% if @draft_vaccination_record.editing? %>
+    <%= f.govuk_submit "Save changes" %>
+  <% else %>
     <div class="nhsuk-card">
       <div class="nhsuk-card__content">
         <%= f.govuk_text_area :notes,

--- a/app/views/draft_vaccination_records/outcome.html.erb
+++ b/app/views/draft_vaccination_records/outcome.html.erb
@@ -5,27 +5,35 @@
       ) %>
 <% end %>
 
-<% title = t(@programme.type, scope: "vaccinations.reason.title") %>
+<% editing = @draft_vaccination_record.editing? || @draft_vaccination_record.outcome.present? %>
+
+<% title = editing ? "Vaccination outcome" : t(@programme.type, scope: "vaccinations.reason.title") %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset(:reason,
+  <%= f.govuk_radio_buttons_fieldset(:outcome,
                                      caption: { text: @patient.full_name, size: "l" },
                                      legend: { size: "l", tag: "h1",
                                                text: title }) do %>
-    <%= f.govuk_radio_button :reason, "refused",
+
+    <% if editing %>
+      <%= f.govuk_radio_button :outcome, "vaccinated",
+                               label: { text: "Vaccinated" } %>
+    <% end %>
+
+    <%= f.govuk_radio_button :outcome, "refused",
                              label: { text: "They refused it" } %>
-    <%= f.govuk_radio_button :reason, "not_well",
+    <%= f.govuk_radio_button :outcome, "not_well",
                              label: { text: "They were not well enough" } %>
-    <%= f.govuk_radio_button :reason, "contraindications",
+    <%= f.govuk_radio_button :outcome, "contraindications",
                              label: { text: "They had contraindications" } %>
-    <%= f.govuk_radio_button :reason, "already_had",
+    <%= f.govuk_radio_button :outcome, "already_had",
                              label: { text: "They have already had the vaccine" } %>
-    <%= f.govuk_radio_button :reason, "absent_from_school",
+    <%= f.govuk_radio_button :outcome, "absent_from_school",
                              label: { text: "They were absent from school" } %>
-    <%= f.govuk_radio_button :reason, "absent_from_session",
+    <%= f.govuk_radio_button :outcome, "absent_from_session",
                              label: { text: "They were absent from the session" } %>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,17 +160,19 @@ en:
               blank: Choose a batch
               incorrect_vaccine: Choose a batch of the %{vaccine_brand} vaccine
             delivery_method:
+              blank: Choose a method of delivery
               inclusion: Choose a method of delivery
             delivery_site:
+              blank: Choose a delivery site
               inclusion: Choose a delivery site
             location_name:
               blank: Enter where the vaccination was given
             notes:
               too_long: Enter notes that are less than 1000 characters long
-            reason:
-              inclusion: Choose a reason
-            site:
-              blank: Choose a site
+            outcome:
+              inclusion: Choose an outcome
+            vaccine_id:
+              blank: Choose a vaccine
         health_answer:
           attributes:
             notes:
@@ -808,6 +810,7 @@ en:
     location: location
     name: name
     notes: notes
+    outcome: outcome
     parent: parent
     parent_details: parent-details
     questions: questions

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -16,7 +16,10 @@ describe "HPV Vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_click_change_outcome
-    and_i_record_that_the_patient_has_been_vaccinated
+    and_i_choose_vaccinated
+    and_i_select_the_date
+    and_i_select_the_delivery
+    and_i_select_the_vaccine
     and_i_select_the_batch
     then_i_see_the_confirmation_page
 
@@ -119,6 +122,11 @@ describe "HPV Vaccination" do
 
   def when_i_click_change_outcome
     click_on "Change outcome"
+  end
+
+  def and_i_choose_vaccinated
+    choose "Vaccinated"
+    click_on "Continue"
   end
 
   def when_i_click_change_batch

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -13,7 +13,6 @@ describe "HPV Vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_click_change_outcome
-    and_i_record_that_the_patient_wasnt_vaccinated
     and_i_select_the_reason_why
     then_i_see_the_confirmation_page
 


### PR DESCRIPTION
This makes it possible to change the outcome of a vaccination, specifically from not administered to administered and the reverse.

## Screenshots

<img width="840" alt="Screenshot 2024-11-08 at 14 48 13" src="https://github.com/user-attachments/assets/b90950c7-c084-46ba-b6b9-9d74a6edc378">
<img width="318" alt="Screenshot 2024-11-08 at 14 46 51" src="https://github.com/user-attachments/assets/600db033-20e5-4870-a686-cc8d0a134ff1">
<img width="826" alt="Screenshot 2024-11-08 at 14 44 04" src="https://github.com/user-attachments/assets/ed89aa37-69fe-4092-83dd-cd127dbf5d66">
<img width="544" alt="Screenshot 2024-11-08 at 14 43 55" src="https://github.com/user-attachments/assets/4e12b090-510a-4219-985e-69562b385ba3">
<img width="833" alt="Screenshot 2024-11-08 at 14 43 49" src="https://github.com/user-attachments/assets/d6f7478e-dcde-426c-81a4-5e0064a71adb">
