### PR TITLE
Update unknown => known school automatically for patient imports

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -53,8 +53,18 @@ class PatientImportRow
     }.compact.merge(cohort_id: cohort&.id, school_id: school&.id)
 
     if (existing_patient = existing_patients.first)
+      # We want to automatically accept changes to
+      # - registration
+      # - when an unknown school is updated to a known school
+      # without staging, so admins don't have to review those changes
+
       unless stage_registration?
         existing_patient.registration = attributes.delete(:registration)
+      end
+
+      if existing_patient.school_id.blank?
+        existing_patient.school_id = attributes.delete(:school_id)
+        existing_patient.home_educated = attributes.delete(:home_educated)
       end
 
       existing_patient.stage_changes(attributes)

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -142,6 +142,17 @@ describe ClassImportRow do
         expect(patient.registration).to eq("8AB")
         expect(patient.pending_changes).not_to have_key("registration")
       end
+
+      context "when the patient has no school" do
+        before { existing_patient.update(school_id: nil) }
+
+        it "sets the school/home-educated status and doesn't stage it so admins don't have to review that change" do
+          expect(patient.school).to eq(school)
+          expect(patient.home_educated).to be_falsey
+          expect(patient.pending_changes).not_to include("school_id")
+          expect(patient.pending_changes).not_to include("home_educated")
+        end
+      end
     end
 
     describe "#cohort" do

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -179,6 +179,17 @@ describe CohortImportRow do
         expect(patient.registration).not_to eq("8AB")
         expect(patient.pending_changes).to include("registration" => "8AB")
       end
+
+      context "when the patient has no school" do
+        before { existing_patient.update(school_id: nil) }
+
+        it "sets the school/home-educated status and doesn't stage it so admins don't have to review that change" do
+          expect(patient.school).to eq(Location.find_by(urn: school_urn))
+          expect(patient.home_educated).to be_falsey
+          expect(patient.pending_changes).not_to include("school_id")
+          expect(patient.pending_changes).not_to include("home_educated")
+        end
+      end
     end
 
     describe "#cohort" do


### PR DESCRIPTION
This prevents admins from having to review and accept every one of those changes if vaccs history was uploaded first (which creates the patients with unknown schools) and then the cohort was added later (which sets the school)

The change also covers the home-educated status as well, as it's inextricably linked to school.

This change is part of a broader strategy around what updates happen when something is imported against an existing cohort patient:

<img width="620" alt="image" src="https://github.com/user-attachments/assets/83b029bc-f14a-452b-b616-ea729c7d186e">
