### PR TITLE
Fix visibility of pending patients

### DIFF
--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -11,7 +11,7 @@ class PatientPolicy < ApplicationPolicy
         .or(Patient.where(school_id: school_ids))
         .or(
           Patient.where(
-            "pending_changes ->> 'cohort_id' != NULL AND pending_changes ->> 'cohort_id' IN (?)",
+            "pending_changes ->> 'cohort_id' IS NOT NULL AND pending_changes ->> 'cohort_id' IN (?)",
             cohort_ids
           )
         )

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -17,7 +17,7 @@ class PatientPolicy < ApplicationPolicy
         )
         .or(
           Patient.where(
-            "pending_changes ->> 'school_id' != NULL AND pending_changes ->> 'school_id' IN (?)",
+            "pending_changes ->> 'school_id' IS NOT NULL AND pending_changes ->> 'school_id' IN (?)",
             school_ids
           )
         )

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -5,13 +5,15 @@ describe PatientPolicy do
     subject { PatientPolicy::Scope.new(user, Patient).resolve }
 
     let(:organisation) { create(:organisation) }
+    let(:another_organisation) { create(:organisation) }
     let(:cohort) { create(:cohort, organisation:) }
-    let(:cohort_for_another_organisation) { create(:cohort) }
+    let(:cohort_for_another_organisation) do
+      create(:cohort, organisation: another_organisation)
+    end
+    let(:school) { create(:location, :school, organisation:) }
     let(:user) { create(:user, organisations: [organisation]) }
 
-    let(:patient_in_school) do
-      create(:patient, school: create(:location, :school, organisation:))
-    end
+    let(:patient_in_school) { create(:patient, school:) }
     let(:patient_in_cohort) { create(:patient, cohort:) }
     let(:patient_not_in_organisation) { create(:patient) }
 
@@ -38,6 +40,33 @@ describe PatientPolicy do
       it do
         expect(subject).not_to include(
           patient_with_pending_changes_to_enrol_in_another_cohort
+        )
+      end
+    end
+
+    context "when the patient not in the org but pending joining the school" do
+      let(:school_for_another_organisation) do
+        create(:location, :school, organisation: another_organisation)
+      end
+
+      let(:patient_with_pending_changes_to_enrol_in_school) do
+        create(:patient, pending_changes: { "school_id" => school.id })
+      end
+
+      let(:patient_with_pending_changes_to_enrol_in_another_school) do
+        create(
+          :patient,
+          pending_changes: {
+            "school_id" => school_for_another_organisation.id
+          }
+        )
+      end
+
+      it { should include(patient_with_pending_changes_to_enrol_in_school) }
+
+      it do
+        expect(subject).not_to include(
+          patient_with_pending_changes_to_enrol_in_another_school
         )
       end
     end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -5,18 +5,41 @@ describe PatientPolicy do
     subject { PatientPolicy::Scope.new(user, Patient).resolve }
 
     let(:organisation) { create(:organisation) }
+    let(:cohort) { create(:cohort, organisation:) }
+    let(:cohort_for_another_organisation) { create(:cohort) }
     let(:user) { create(:user, organisations: [organisation]) }
 
     let(:patient_in_school) do
       create(:patient, school: create(:location, :school, organisation:))
     end
-    let(:patient_in_cohort) do
-      create(:patient, cohort: create(:cohort, organisation:))
-    end
+    let(:patient_in_cohort) { create(:patient, cohort:) }
     let(:patient_not_in_organisation) { create(:patient) }
 
     it { should include(patient_in_school) }
     it { should include(patient_in_cohort) }
     it { should_not include(patient_not_in_organisation) }
+
+    context "when the patient not in the org but pending joining the cohort" do
+      let(:patient_with_pending_changes_to_enrol_in_cohort) do
+        create(:patient, pending_changes: { "cohort_id" => cohort.id })
+      end
+
+      let(:patient_with_pending_changes_to_enrol_in_another_cohort) do
+        create(
+          :patient,
+          pending_changes: {
+            "cohort_id" => cohort_for_another_organisation.id
+          }
+        )
+      end
+
+      it { should include(patient_with_pending_changes_to_enrol_in_cohort) }
+
+      it do
+        expect(subject).not_to include(
+          patient_with_pending_changes_to_enrol_in_another_cohort
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This code was introduced in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2293 but SQL had a subtle issue with it. This prevented all patients showing up in the children list and led to 404s when trying to review certain import issues.