### PR TITLE
Patient page: show the right date on vaccination outcome

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -108,7 +108,10 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def last_action_time
-    @last_action_time ||= vaccination_record&.created_at || triage&.created_at
+    # if vaccination record is not administered, use created_at
+    @last_action_time ||=
+      vaccination_record&.administered_at || vaccination_record&.created_at ||
+        triage&.created_at
   end
 
   def heading

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -29,6 +29,24 @@ describe AppOutcomeBannerComponent do
     end
   end
 
+  context "triaged, not possible to vaccinate" do
+    let(:patient_session) { create(:patient_session, :unable_to_vaccinate) }
+
+    it { should have_css(".app-card--red") }
+    it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
+    it { should have_text("Reason\nAlya Merton has already had the vaccine") }
+  end
+
+  context "not triaged, not possible to vaccinate" do
+    let(:patient_session) do
+      create(:patient_session, :unable_to_vaccinate_and_had_no_triage)
+    end
+
+    it { should have_css(".app-card--red") }
+    it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
+    it { should have_text("Reason\nAlya Merton has already had the vaccine") }
+  end
+
   context "state is vaccinated" do
     let(:programme) { create(:programme, :hpv) }
     let(:patient_session) { create(:patient_session, :vaccinated, programme:) }
@@ -36,8 +54,8 @@ describe AppOutcomeBannerComponent do
     let(:vaccine) { programme.vaccines.first }
     let(:location) { patient_session.session.location }
     let(:batch) { vaccine.batches.first }
-    let(:date) { vaccination_record.created_at.to_date.to_fs(:long) }
-    let(:time) { vaccination_record.created_at.to_fs(:time) }
+    let(:date) { vaccination_record.administered_at.to_date.to_fs(:long) }
+    let(:time) { vaccination_record.administered_at.to_fs(:time) }
 
     it { should have_css(".app-card--green") }
     it { should have_css(".nhsuk-card__heading", text: "Vaccinated") }
@@ -47,11 +65,11 @@ describe AppOutcomeBannerComponent do
     it { should have_text("Time\n#{time}") }
     it { should have_text("Location\n#{location.name}") }
 
-    context "created_at is not today" do
+    context "vaccination was not administered today" do
       let(:date) { Time.zone.now - 2.days }
       let(:patient_session) do
         create(:patient_session, :vaccinated).tap do |ps|
-          ps.vaccination_records.first.update(created_at: date)
+          ps.vaccination_records.first.update(administered_at: date)
         end
       end
 
@@ -86,7 +104,7 @@ describe AppOutcomeBannerComponent do
       )
     end
 
-    context "created_at is not today" do
+    context "triage decision was not recorded today" do
       let(:date) { Time.zone.now - 2.days }
       let(:patient_session) do
         create(:patient_session, :triaged_do_not_vaccinate).tap do |ps|

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -193,6 +193,28 @@ FactoryBot.define do
       end
     end
 
+    trait :unable_to_vaccinate_and_had_no_triage do
+      patient do
+        association :patient,
+                    :consent_given_triage_not_needed,
+                    performed_by: user,
+                    programme:,
+                    organisation:,
+                    school: session.location
+      end
+
+      after(:create) do |patient_session, evaluator|
+        create(
+          :vaccination_record,
+          :not_administered,
+          patient_session:,
+          programme: evaluator.programme,
+          performed_by: evaluator.user,
+          reason: :already_had
+        )
+      end
+    end
+
     trait :vaccinated do
       patient do
         association :patient,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4fb14748-9d06-4347-95a7-610413c695b9)

Before this fix, the outcome banner was showing the time of creation of the record, not when the vaccination was administered. This is an issue if vaccs records are back-dated due to delays in recording.