### PR TITLE
Show administration time of vaccinations on the activity log

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -120,7 +120,8 @@ class AppActivityLogComponent < ViewComponent::Base
 
       {
         title:,
-        time: vaccination_record.created_at,
+        time:
+          vaccination_record.administered_at || vaccination_record.created_at,
         notes: vaccination_record.notes,
         by: vaccination_record.performed_by&.full_name
       }

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -93,7 +93,7 @@ describe AppActivityLogComponent do
         :vaccination_record,
         programme:,
         patient_session:,
-        created_at: Time.zone.parse("2024-05-31 12:00"),
+        administered_at: Time.zone.parse("2024-05-31 12:00"),
         performed_by: user,
         notes: "Some notes"
       )
@@ -102,7 +102,7 @@ describe AppActivityLogComponent do
         :vaccination_record,
         programme:,
         patient_session:,
-        created_at: Time.zone.parse("2024-05-31 13:00"),
+        administered_at: Time.zone.parse("2024-05-31 13:00"),
         performed_by: nil,
         notes: "Some notes",
         vaccine: create(:vaccine, :gardasil, programme:)


### PR DESCRIPTION
Not the creation time of the record, that can potentially be years afterwards.