### PR TITLE
Align page container width to prototype

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,7 +28,7 @@ $mq-breakpoints: (
 @import "nhsuk-frontend/packages/nhsuk";
 
 // App options
-$app-page-width: 1160px;
+$app-page-width: 1100px;
 $color_app-dark-orange: darken(
   mix($color_nhsuk-red, $color_nhsuk-warm-yellow, 55%),
   10%


### PR DESCRIPTION
This was updated in the prototype a couple of weeks ago.