### PR TITLE
Require selecting child for self-consent

### DIFF
--- a/app/controllers/consents/edit_controller.rb
+++ b/app/controllers/consents/edit_controller.rb
@@ -99,7 +99,7 @@ class Consents::EditController < ApplicationController
       @consent.save!
     end
 
-    session.delete(:manage_consents_new_or_existing_parent_id)
+    session.delete(:consents_new_or_existing_contact)
   end
 
   def handle_questions
@@ -112,8 +112,8 @@ class Consents::EditController < ApplicationController
   end
 
   def handle_who
-    session[:manage_consents_new_or_existing_parent_id] = update_params[
-      :new_or_existing_parent
+    session[:consents_new_or_existing_contact] = update_params[
+      :new_or_existing_contact
     ]
     @consent.assign_attributes(update_params)
   end
@@ -160,11 +160,11 @@ class Consents::EditController < ApplicationController
   end
 
   def set_parent
-    new_or_existing_parent = session[:manage_consents_new_or_existing_parent_id]
+    new_or_existing_contact = session[:consents_new_or_existing_contact]
     @parent =
-      if new_or_existing_parent == "new"
+      if new_or_existing_contact == "new"
         @consent.draft_parent || Parent.new
-      elsif new_or_existing_parent.present?
+      elsif new_or_existing_contact.present?
         @consent.parent
       end
   end
@@ -189,8 +189,8 @@ class Consents::EditController < ApplicationController
 
   def set_consent
     @consent = policy_scope(Consent).find(params[:consent_id])
-    @consent.new_or_existing_parent =
-      session[:manage_consents_new_or_existing_parent_id]
+    @consent.new_or_existing_contact =
+      session[:consents_new_or_existing_contact]
   end
 
   def set_patient_session
@@ -219,7 +219,7 @@ class Consents::EditController < ApplicationController
       questions: questions_params,
       reason: %i[reason_for_refusal],
       route: %i[route],
-      who: %i[new_or_existing_parent]
+      who: %i[new_or_existing_contact]
     }.fetch(current_step)
 
     params

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -142,8 +142,7 @@ class ConsentsController < ApplicationController
       patient: @patient,
       programme: @session.programmes.first, # TODO: handle multiple programmes
       organisation: @session.organisation,
-      recorded_by: current_user,
-      route: @patient_session.gillick_competent? ? :self_consent : nil
+      recorded_by: current_user
     }
   end
 

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -138,7 +138,7 @@ class Consent < ApplicationRecord
 
   def wizard_steps
     [
-      (:who unless via_self_consent?),
+      :who,
       (:parent_details unless via_self_consent?),
       (:route unless via_self_consent?),
       :agree,
@@ -238,9 +238,16 @@ class Consent < ApplicationRecord
 
   def new_or_existing_contact=(value)
     @new_or_existing_contact = value
-    self.parent_id = value if value.to_i.in?(
-      patient.consents.pluck(:parent_id) + patient.parents.pluck(:id)
-    )
+
+    return if value == "new"
+
+    if value == "patient"
+      self.route = "self_consent"
+    elsif value.to_i.in?(
+          patient.consents.pluck(:parent_id) + patient.parents.pluck(:id)
+        )
+      self.parent_id = value
+    end
   end
 
   private

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -47,7 +47,7 @@ class Consent < ApplicationRecord
 
   before_save :reset_unused_fields
 
-  attr_reader :new_or_existing_parent
+  attr_reader :new_or_existing_contact
   attr_accessor :triage, :triage_allowed
 
   belongs_to :patient
@@ -110,7 +110,7 @@ class Consent < ApplicationRecord
   end
 
   on_wizard_step :who, exact: true do
-    validates :new_or_existing_parent, presence: true
+    validates :new_or_existing_contact, presence: true
   end
 
   on_wizard_step :parent_details do
@@ -236,8 +236,8 @@ class Consent < ApplicationRecord
       )
   end
 
-  def new_or_existing_parent=(value)
-    @new_or_existing_parent = value
+  def new_or_existing_contact=(value)
+    @new_or_existing_contact = value
     self.parent_id = value if value.to_i.in?(
       patient.consents.pluck(:parent_id) + patient.parents.pluck(:id)
     )

--- a/app/views/consents/edit/who.html.erb
+++ b/app/views/consents/edit/who.html.erb
@@ -18,12 +18,18 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:new_or_existing_contact, legend: nil) do %>
+    <% if @patient_session.gillick_competent? %>
+      <%= f.govuk_radio_button :new_or_existing_contact, "patient",
+                               label: { text: "Child (Gillick competent)" },
+                               link_errors: true %>
+    <% end %>
+
     <% if @parent_options.present? %>
       <% @parent_options.each.with_index do |parent, i| %>
         <%= f.govuk_radio_button :new_or_existing_contact, parent.id,
                                  label: { text: parent.label_to(patient: @patient) },
                                  hint: { text: parent.contact_label },
-                                 link_errors: i == 0 %>
+                                 link_errors: !@patient_session.gillick_competent? && i == 0 %>
       <% end %>
 
       <%= f.govuk_radio_divider %>
@@ -31,7 +37,7 @@
 
     <%= f.govuk_radio_button :new_or_existing_contact, "new",
                              label: { text: "Add a new parental contact" },
-                             link_errors: @parent_options.empty? %>
+                             link_errors: !@patient_session.gillick_competent? && @parent_options.empty? %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/consents/edit/who.html.erb
+++ b/app/views/consents/edit/who.html.erb
@@ -17,10 +17,10 @@
 <%= form_with model: @consent, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_radio_buttons_fieldset(:new_or_existing_parent, legend: nil) do %>
+  <%= f.govuk_radio_buttons_fieldset(:new_or_existing_contact, legend: nil) do %>
     <% if @parent_options.present? %>
       <% @parent_options.each.with_index do |parent, i| %>
-        <%= f.govuk_radio_button :new_or_existing_parent, parent.id,
+        <%= f.govuk_radio_button :new_or_existing_contact, parent.id,
                                  label: { text: parent.label_to(patient: @patient) },
                                  hint: { text: parent.contact_label },
                                  link_errors: i == 0 %>
@@ -29,7 +29,7 @@
       <%= f.govuk_radio_divider %>
     <% end %>
 
-    <%= f.govuk_radio_button :new_or_existing_parent, "new",
+    <%= f.govuk_radio_button :new_or_existing_contact, "new",
                              label: { text: "Add a new parental contact" },
                              link_errors: @parent_options.empty? %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,7 +365,7 @@ en:
               missing_headers: "The file is missing the following headers: %{missing_headers}"
         consent:
           attributes:
-            new_or_existing_parent:
+            new_or_existing_contact:
               blank: Choose who you are trying to get consent from
             reason_for_refusal:
               inclusion: Choose a reason

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -154,6 +154,10 @@ describe "Self-consent" do
   def then_the_child_can_give_their_own_consent_that_the_nurse_records
     click_on "Get consent"
 
+    # who
+    choose "Child (Gillick competent)"
+    click_on "Continue"
+
     # record consent
     choose "Yes, they agree"
     click_on "Continue"
@@ -203,10 +207,9 @@ describe "Self-consent" do
 
   def then_the_child_cannot_give_their_own_consent
     click_on "Get consent"
-    expect(page).to have_content("Who are you trying to get consent from?")
-    expect(page).not_to have_content(
-      "Do they agree to them having the HPV vaccination?"
-    )
+
+    expect(page).not_to have_content("Child (Gillick competent)")
+
     click_on "Back"
   end
 


### PR DESCRIPTION
Currently for self-consent, if the child is Gillick competent then we assume that's who will be providing consent and don't allow the nurse to choose a parental contact.

## Screenshot

<img width="793" alt="Screenshot 2024-11-10 at 15 35 43" src="https://github.com/user-attachments/assets/20a325e4-84ee-441c-8793-2fe3bb56b382">
