### PR TITLE
Treat already had vaccination records as administered

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -246,7 +246,7 @@ class Patient < ApplicationRecord
     # TODO: This logic doesn't work for vaccinations that require multiple doses.
 
     vaccination_records.any? do
-      _1.administered? && _1.programme_id == programme.id
+      (_1.administered? || _1.already_had?) && _1.programme_id == programme.id
     end
   end
 


### PR DESCRIPTION
This ensures that patients who have already had the vaccine are treated as administered, which means we don't move them to clinic when sessions are closed, for example.