### PR TITLE
Add PERFORMING_PROFESSIONAL_EMAIL immunisation import column

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -234,12 +234,23 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
   def performing_professional
     [
       {
+        name: "PERFORMING_PROFESSIONAL_EMAIL",
+        notes:
+          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")} unless " \
+            "#{tag.code("PERFORMING_PROFESSIONAL_FORENAME")} and " \
+            "#{tag.code("PERFORMING_PROFESSIONAL_SURNAME")} is provided"
+      },
+      {
         name: "PERFORMING_PROFESSIONAL_FORENAME",
-        notes: "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}"
+        notes:
+          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")} unless " \
+            "#{tag.code("PERFORMING_PROFESSIONAL_EMAIL")} is provided"
       },
       {
         name: "PERFORMING_PROFESSIONAL_SURNAME",
-        notes: "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}"
+        notes:
+          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")} unless " \
+            "#{tag.code("PERFORMING_PROFESSIONAL_EMAIL")} is provided"
       }
     ]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,19 +65,6 @@ class User < ApplicationRecord
 
   enum :fallback_role, { nurse: 0, admin: 1 }, prefix: true
 
-  def selected_organisation
-    @selected_organisation ||=
-      if Settings.cis2.enabled
-        Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
-      else
-        organisations.first
-      end
-  end
-
-  def requires_email_and_password?
-    provider.blank? || uid.blank?
-  end
-
   def self.find_or_create_from_cis2_oidc(userinfo)
     user =
       User.find_or_initialize_by(
@@ -92,6 +79,19 @@ class User < ApplicationRecord
       userinfo[:extra][:raw_info][:sid].presence || Devise.friendly_token
 
     user.tap(&:save!)
+  end
+
+  def selected_organisation
+    @selected_organisation ||=
+      if Settings.cis2.enabled
+        Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
+      else
+        organisations.first
+      end
+  end
+
+  def requires_email_and_password?
+    provider.blank? || uid.blank?
   end
 
   def is_admin?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
         patient_last_name: <code>PERSON_SURNAME</code>
         patient_nhs_number: <code>NHS_NUMBER</code>
         patient_postcode: <code>PERSON_POSTCODE</code>
+        performed_by_user: <code>PERFORMING_PROFESSIONAL_EMAIL</code>
         performed_by_family_name: <code>PERFORMING_PROFESSIONAL_SURNAME</code>
         performed_by_given_name: <code>PERFORMING_PROFESSIONAL_FORENAME</code>
         reason: <code>REASON</code>
@@ -218,6 +219,12 @@ en:
               wrong_length: Enter an NHS number with 10 characters.
             patient_postcode:
               blank: Enter a valid postcode, such as SW1A 1AA
+            performed_by_user:
+              blank: Enter a valid email address
+            performed_by_given_name:
+              blank: Enter a first name
+            performed_by_family_name:
+              blank: Enter a last name
             reason:
               blank: Enter a reason
             school_name:

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -117,7 +117,8 @@ describe "Immunisation imports duplicates" do
         delivery_site: :nose,
         dose_sequence: 1,
         patient_session: @patient_session,
-        vaccine: @vaccine
+        vaccine: @vaccine,
+        performed_by_user: nil
       )
     @another_previous_vaccination_record =
       create(
@@ -131,7 +132,8 @@ describe "Immunisation imports duplicates" do
         delivery_site: :left_arm_upper_position,
         dose_sequence: 1,
         patient_session: @third_patient_session,
-        vaccine: @other_vaccine
+        vaccine: @other_vaccine,
+        performed_by_user: nil
       )
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -241,6 +241,22 @@ describe ImmunisationImportRow do
       end
 
       it { should be_valid }
+
+      context "with a performing profession email provided as well" do
+        before { data["PERFORMING_PROFESSIONAL_EMAIL"] = create(:user).email }
+
+        it { should be_invalid }
+
+        it "has errors" do
+          expect(immunisation_import_row).to be_invalid
+          expect(
+            immunisation_import_row.errors[:performed_by_given_name]
+          ).to include(/blank/)
+          expect(
+            immunisation_import_row.errors[:performed_by_family_name]
+          ).to include(/blank/)
+        end
+      end
     end
 
     context "with valid fields for HPV" do
@@ -1004,6 +1020,30 @@ describe ImmunisationImportRow do
       let(:data) { { "CARE_SETTING" => "School" } }
 
       it { should be_nil }
+    end
+  end
+
+  describe "#performed_by_user" do
+    subject(:performed_by_user) { immunisation_import_row.performed_by_user }
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with a value" do
+      let(:data) { { "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com" } }
+
+      context "and a user that doesn't exist" do
+        it { should be_nil }
+      end
+
+      context "and a user that does exist" do
+        let!(:user) { create(:user, email: "nurse@example.com") }
+
+        it { should eq(user) }
+      end
     end
   end
 


### PR DESCRIPTION
This adds a new optional column that can be parsed allowing the uploader to specify the email address of the user who performed the vaccination. This allows us to create a direct link in our database between vaccinations and users rather than filling in the free text family/given name fields.