### PR TITLE
Prevent creation of session dates in current academic year

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -235,6 +235,7 @@ en:
               blank: Enter a date in the correct format.
               greater_than_or_equal_to: The vaccination date is outside the programme. Enter a date after the programme started.
               less_than_or_equal_to: The vaccination date is outside the programme. Enter a date before today.
+              inclusion: Enter a date for a current session
             time_of_vaccination:
               blank: Enter a time in the correct format.
             vaccine_given:

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "Immunisation imports" do
-  around { |example| travel_to(Date.new(2024, 5, 20)) { example.run } }
+  around { |example| travel_to(Date.new(2025, 5, 20)) { example.run } }
 
   scenario "User uploads a file, views cohort and vaccination records" do
     given_i_am_signed_in

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -132,6 +132,26 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "when date doesn't match an existing session" do
+      subject(:errors) { immunisation_import_row.errors[:date_of_vaccination] }
+
+      before { immunisation_import_row.valid? }
+
+      context "when importing for the current academic year" do
+        let(:data) do
+          { "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901" }
+        end
+
+        it { should include(/current session/) }
+      end
+
+      context "when importing for a different academic year" do
+        let(:data) { { "DATE_OF_VACCINATION" => "20220101" } }
+
+        it { should be_empty }
+      end
+    end
+
     context "with an invalid time of vaccination" do
       let(:data) { { "TIME_OF_VACCINATION" => "abc" } }
 
@@ -528,7 +548,7 @@ describe ImmunisationImportRow do
     context "without data" do
       let(:data) { {} }
 
-      it { should be_nil }
+      it { should eq("Unknown") }
     end
 
     context "with a school" do


### PR DESCRIPTION
When importing immunisations, we now validate that the date of vaccination matches an existing session date if we're importing records for the current academic year rather than creating new session dates.

To support this the `location` and `school` method can now be used even if the row doesn't validate (as they're used in this validation).