### PR TITLE
Automatically pick vaccine if one exists

### DIFF
--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -108,8 +108,14 @@ class DraftVaccinationRecord
   def outcome=(value)
     if value == "vaccinated"
       self.administered_at ||= Time.current
+      self.reason = nil
+
+      if programme && (vaccines = programme.vaccines.active).count == 1
+        self.vaccine_id = vaccines.first.id
+      end
     else
       self.reason = value
+      self.administered_at = nil
     end
   end
 

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -275,7 +275,8 @@ describe "Edit vaccination record" do
   end
 
   def when_i_click_on_add_vaccine
-    click_on "Add vaccine"
+    # vaccine is already populated for us as there is only one
+    click_on "Change vaccine"
   end
 
   def when_i_click_on_add_batch

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -62,6 +62,28 @@ describe DraftVaccinationRecord do
     end
   end
 
+  describe "#outcome=" do
+    let(:attributes) { valid_not_administered_attributes }
+
+    let(:vaccine) { programme.vaccines.active.first }
+
+    context "not vaccinated to vaccinated" do
+      it "marks as administered" do
+        expect { draft_vaccination_record.outcome = "vaccinated" }.to change(
+          draft_vaccination_record,
+          :administered?
+        ).from(false).to(true)
+      end
+
+      it "sets the vaccine" do
+        expect { draft_vaccination_record.outcome = "vaccinated" }.to change(
+          draft_vaccination_record,
+          :vaccine
+        ).from(nil).to(vaccine)
+      end
+    end
+  end
+
   describe "#reset_unused_fields" do
     subject(:save!) { draft_vaccination_record.save! }
 


### PR DESCRIPTION
When changing the outcome of a vaccination record, if changing to vaccinated, we can automatically choose the vaccine for the user if there's only one possible option which saves time.

It also fixes an issue we have for HPV where the batches and delivery site/methods are unavailable, however this problem will come again for Flu where there are multiple vaccines.

https://good-machine.sentry.io/issues/6057331062/