### PR TITLE
Add CLINIC_NAME column

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -221,12 +221,17 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
 
   def care_setting
     return [] unless @programme.hpv?
+
     [
       {
         name: "CARE_SETTING",
         notes:
           "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}, must be " \
-            "#{tag.i("1")} (school) or #{tag.i("2")} (care setting)"
+            "#{tag.i("1")} (school) or #{tag.i("2")} (clinic)"
+      },
+      {
+        name: "CLINIC_NAME",
+        notes: "Optional, if #{tag.code("CARE_SETTING")} is #{tag.i("2")}"
       }
     ]
   end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -153,10 +153,13 @@ class ImmunisationImportRow
     return unless location&.generic_clinic?
 
     if school_urn == SCHOOL_URN_UNKNOWN &&
-         (care_setting.nil? || care_setting == CARE_SETTING_SCHOOL)
+         (
+           (care_setting.nil? && clinic_name.blank?) ||
+             care_setting == CARE_SETTING_SCHOOL
+         )
       school_name
     else
-      "Unknown"
+      clinic_name.presence || "Unknown"
     end
   end
 
@@ -267,6 +270,10 @@ class ImmunisationImportRow
     @data["SCHOOL_NAME"]&.strip
   end
 
+  def clinic_name
+    @data["CLINIC_NAME"]&.strip
+  end
+
   def school_urn
     @data["SCHOOL_URN"]&.strip
   end
@@ -325,7 +332,11 @@ class ImmunisationImportRow
 
   def location
     @location ||=
-      if school && (care_setting.nil? || care_setting == CARE_SETTING_SCHOOL)
+      if school &&
+           (
+             (care_setting.nil? && clinic_name.blank?) ||
+               care_setting == CARE_SETTING_SCHOOL
+           )
         school
       else
         organisation.generic_clinic

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -569,6 +569,19 @@ describe ImmunisationImportRow do
       it { should eq("Unknown") }
     end
 
+    context "when home educated and community care setting and a named clinic" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "999999",
+          "SCHOOL_NAME" => "",
+          "CARE_SETTING" => "2",
+          "CLINIC_NAME" => "A Clinic"
+        )
+      end
+
+      it { should eq("A Clinic") }
+    end
+
     context "when home educated and unknown care setting" do
       let(:data) do
         valid_data.merge("SCHOOL_URN" => "999999", "SCHOOL_NAME" => "")
@@ -577,12 +590,37 @@ describe ImmunisationImportRow do
       it { should eq("Unknown") }
     end
 
+    context "when home educated and unknown care setting and a named clinic" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "999999",
+          "SCHOOL_NAME" => "",
+          "CLINIC_NAME" => "A Clinic"
+        )
+      end
+
+      it { should eq("A Clinic") }
+    end
+
     context "with an unknown school and school care setting" do
       let(:data) do
         valid_data.merge(
           "SCHOOL_URN" => "888888",
           "SCHOOL_NAME" => "Waterloo Road",
           "CARE_SETTING" => "1"
+        )
+      end
+
+      it { should eq("Waterloo Road") }
+    end
+
+    context "with an unknown school and school care setting and a clinic name" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "888888",
+          "SCHOOL_NAME" => "Waterloo Road",
+          "CARE_SETTING" => "1",
+          "CLINIC_NAME" => "A Clinic"
         )
       end
 
@@ -601,7 +639,20 @@ describe ImmunisationImportRow do
       it { should eq("Unknown") }
     end
 
-    context "with an unknown school and unknown case setting" do
+    context "with an unknown school and community care setting and a clinic name" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "888888",
+          "SCHOOL_NAME" => "Waterloo Road",
+          "CARE_SETTING" => "2",
+          "CLINIC_NAME" => "A Clinic"
+        )
+      end
+
+      it { should eq("A Clinic") }
+    end
+
+    context "with an unknown school and unknown care setting" do
       let(:data) do
         valid_data.merge(
           "SCHOOL_URN" => "888888",
@@ -610,6 +661,18 @@ describe ImmunisationImportRow do
       end
 
       it { should eq("Waterloo Road") }
+    end
+
+    context "with an unknown school and unknown care setting and a clinic name" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "888888",
+          "SCHOOL_NAME" => "Waterloo Road",
+          "CLINIC_NAME" => "A Clinic"
+        )
+      end
+
+      it { should eq("A Clinic") }
     end
   end
 


### PR DESCRIPTION
This adds a new column which we parse when when importing immunisations for clinics which currently doesn't allow for a way of specifying the name of the clinic, unlike when using the app directly record vaccinations. This helps us to support offline recording of vaccinations but is unlikely to be used for historical imports.