### PR TITLE
Download offline spreadsheet

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -40,7 +40,24 @@ class SessionsController < ApplicationController
 
     @stats = PatientSessionStats.new(patient_sessions)
 
-    render layout: "full"
+    respond_to do |format|
+      format.html { render layout: "full" }
+      format.csv do
+        filename =
+          if @session.location.urn.present?
+            "#{@session.location.name} (#{@session.location.urn})"
+          else
+            @session.location.name
+          end
+
+        send_data(
+          SessionCSVExporter.call(@session),
+          filename:
+            "#{filename} - exported on #{Date.current.to_fs(:long)}.csv",
+          disposition: "attachment"
+        )
+      end
+    end
   end
 
   def edit

--- a/app/lib/session_csv_exporter.rb
+++ b/app/lib/session_csv_exporter.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+class SessionCSVExporter
+  def initialize(session)
+    @session = session
+  end
+
+  def call
+    CSV.generate(headers:, write_headers: true) do |csv|
+      patient_sessions.each do |patient_session|
+        rows(patient_session:).each { |row| csv << row }
+      end
+    end
+  end
+
+  def self.call(*args, **kwargs)
+    new(*args, **kwargs).call
+  end
+
+  private_class_method :new
+
+  private
+
+  attr_reader :session
+
+  delegate :location, :organisation, to: :session
+
+  def headers
+    %w[
+      ORGANISATION_CODE
+      SCHOOL_URN
+      SCHOOL_NAME
+      CARE_SETTING
+      NHS_NUMBER
+      PERSON_FORENAME
+      PERSON_SURNAME
+      PERSON_GENDER_CODE
+      PERSON_DOB
+      PERSON_POSTCODE
+      DATE_OF_VACCINATION
+      TIME_OF_VACCINATION
+      VACCINATED
+      VACCINE_GIVEN
+      BATCH_NUMBER
+      BATCH_EXPIRY_DATE
+      ANATOMICAL_SITE
+      DOSE_SEQUENCE
+      PERFORMING_PROFESSIONAL_EMAIL
+    ].tap { |values| values << "CLINIC_NAME" if location.generic_clinic? }
+  end
+
+  def patient_sessions
+    session
+      .patient_sessions
+      .includes(:patient, :vaccination_records)
+      .strict_loading
+  end
+
+  def care_setting
+    location.school? ? "1" : "2"
+  end
+
+  def school_urn(patient:)
+    if location.school?
+      location.urn
+    elsif patient.home_educated?
+      "999999"
+    else
+      patient.school&.urn || "888888"
+    end
+  end
+
+  def school_name(patient:)
+    location.school? ? location.name : patient.school&.name || ""
+  end
+
+  def rows(patient_session:)
+    vaccination_records =
+      patient_session.vaccination_records.order(:administered_at)
+
+    if vaccination_records.any?
+      vaccination_records.map do |vaccination_record|
+        existing_row(vaccination_record:)
+      end
+    else
+      [new_row(patient: patient_session.patient)]
+    end
+  end
+
+  def new_row(patient:)
+    [
+      organisation.ods_code,
+      school_urn(patient:),
+      school_name(patient:),
+      care_setting,
+      patient.nhs_number,
+      patient.given_name,
+      patient.family_name,
+      patient.gender_code.humanize,
+      patient.date_of_birth.strftime("%Y%m%d"),
+      patient.address_postcode,
+      "", # DATE_OF_VACCINATION left blank for recording
+      "", # TIME_OF_VACCINATION left blank for recording
+      "", # VACCINATED left blank for recording
+      "", # VACCINE_GIVEN left blank for recording
+      "", # BATCH_NUMBER left blank for recording
+      "", # BATCH_EXPIRY_DATE left blank for recording
+      "", # ANATOMICAL_SITE left blank for recording
+      1, # DOSE_SEQUENCE is 1 by default TODO: revisit this for other programmes
+      "" # PERFORMING_PROFESSIONAL_EMAIL left blank for recording
+    ].tap do |values|
+      values << "" if location.generic_clinic? # CLINIC_NAME left blank for recording
+    end
+  end
+
+  def existing_row(vaccination_record:)
+    patient = vaccination_record.patient
+
+    delivery_site =
+      if vaccination_record.delivery_site
+        ImmunisationImportRow::DELIVERY_SITES.key(
+          vaccination_record.delivery_site
+        )
+      end
+
+    [
+      organisation.ods_code,
+      school_urn(patient:),
+      school_name(patient:),
+      care_setting,
+      patient.nhs_number,
+      patient.given_name,
+      patient.family_name,
+      patient.gender_code.humanize,
+      patient.date_of_birth.strftime("%Y%m%d"),
+      patient.address_postcode,
+      vaccination_record.administered_at&.strftime("%Y%m%d"),
+      vaccination_record.administered_at&.strftime("%H:%M:%S"),
+      vaccination_record.administered? ? "Y" : "N",
+      (
+        if vaccination_record.administered?
+          vaccination_record.vaccine.nivs_name
+        else
+          ""
+        end
+      ),
+      vaccination_record.administered? ? vaccination_record.batch&.name : "",
+      (
+        if vaccination_record.administered?
+          vaccination_record.batch&.expiry&.strftime("%Y%m%d")
+        else
+          ""
+        end
+      ),
+      delivery_site,
+      vaccination_record.administered? ? vaccination_record.dose_sequence : "",
+      (
+        if vaccination_record.administered?
+          vaccination_record.performed_by_user&.email
+        else
+          ""
+        end
+      )
+    ].tap do |values|
+      values << vaccination_record.location_name if location.generic_clinic?
+    end
+  end
+end

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -22,6 +22,10 @@
     <li class="app-action-list__item">
       <%= govuk_link_to "Download consent form (PDF)", consent_form_session_path(@session) %>
     </li>
+
+    <li class="app-action-list__item">
+      <%= govuk_link_to "Record offline (CSV)", session_path(@session, format: :csv) %>
+    </li>
   <% end %>
 
   <% if @session.open? && @session.location.school? %>

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe "HPV Vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
+  scenario "Download spreadsheet" do
+    given_an_hpv_programme_is_underway
+    and_i_am_signed_in
+
+    when_i_go_to_a_session
+    and_i_click_record_offline
+    then_i_see_a_csv_file
+
+    # TODO: modify the file to add a vaccination
+    # TODO: upload the file
+    # TODO: check the vaccination appears
+  end
+
+  def given_an_hpv_programme_is_underway
+    programme = create(:programme, :hpv)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [programme])
+    location = create(:location, :school)
+
+    vaccine = programme.vaccines.active.first
+    @batch = create(:batch, organisation: @organisation, vaccine:)
+
+    @session =
+      create(:session, organisation: @organisation, programme:, location:)
+    @patient =
+      create(:patient, :consent_given_triage_not_needed, session: @session)
+  end
+
+  def and_i_am_signed_in
+    sign_in @organisation.users.first
+  end
+
+  def when_i_go_to_a_session
+    visit session_path(@session)
+  end
+
+  def and_i_click_record_offline
+    click_link "Record offline (CSV)"
+  end
+
+  def then_i_see_a_csv_file
+    expect(page.status_code).to eq(200)
+
+    # check headers look right
+    expect(page).to have_content("ORGANISATION_CODE")
+  end
+end

--- a/spec/lib/session_csv_exporter_spec.rb
+++ b/spec/lib/session_csv_exporter_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+describe SessionCSVExporter do
+  subject(:call) { described_class.call(session) }
+
+  let(:programme) { create(:programme, :hpv) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:user) do
+    create(:user, email: "nurse@example.com", organisations: [organisation])
+  end
+  let(:team) { create(:team, organisation:) }
+  let(:session) { create(:session, location:, organisation:, programme:) }
+
+  context "a school session" do
+    let(:location) { create(:location, :school, team:) }
+
+    it { should_not be_blank }
+
+    describe "headers" do
+      subject(:headers) { CSV.parse(call).first }
+
+      it do
+        expect(headers).to eq(
+          %w[
+            ORGANISATION_CODE
+            SCHOOL_URN
+            SCHOOL_NAME
+            CARE_SETTING
+            NHS_NUMBER
+            PERSON_FORENAME
+            PERSON_SURNAME
+            PERSON_GENDER_CODE
+            PERSON_DOB
+            PERSON_POSTCODE
+            DATE_OF_VACCINATION
+            TIME_OF_VACCINATION
+            VACCINATED
+            VACCINE_GIVEN
+            BATCH_NUMBER
+            BATCH_EXPIRY_DATE
+            ANATOMICAL_SITE
+            DOSE_SEQUENCE
+            PERFORMING_PROFESSIONAL_EMAIL
+          ]
+        )
+      end
+    end
+
+    describe "rows" do
+      subject(:rows) { CSV.parse(call, headers: true) }
+
+      it { should be_empty }
+
+      context "with a patient" do
+        let!(:patient) { create(:patient, session:) }
+
+        it "adds a row to fill in" do
+          expect(rows.count).to eq(1)
+          expect(rows.first.to_hash).to eq(
+            {
+              "ANATOMICAL_SITE" => "",
+              "BATCH_EXPIRY_DATE" => "",
+              "BATCH_NUMBER" => "",
+              "CARE_SETTING" => "1",
+              "DATE_OF_VACCINATION" => "",
+              "DOSE_SEQUENCE" => "1",
+              "NHS_NUMBER" => patient.nhs_number,
+              "ORGANISATION_CODE" => organisation.ods_code,
+              "PERFORMING_PROFESSIONAL_EMAIL" => "",
+              "PERSON_DOB" => patient.date_of_birth.strftime("%Y%m%d"),
+              "PERSON_FORENAME" => patient.given_name,
+              "PERSON_GENDER_CODE" => "Not known",
+              "PERSON_POSTCODE" => patient.address_postcode,
+              "PERSON_SURNAME" => patient.family_name,
+              "SCHOOL_NAME" => location.name,
+              "SCHOOL_URN" => location.urn,
+              "TIME_OF_VACCINATION" => "",
+              "VACCINATED" => "",
+              "VACCINE_GIVEN" => ""
+            }
+          )
+        end
+      end
+
+      context "with a vaccinated patient" do
+        let(:patient) { create(:patient) }
+        let(:patient_session) { create(:patient_session, patient:, session:) }
+        let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
+        let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 0o5, 20) }
+
+        before do
+          create(
+            :vaccination_record,
+            administered_at:,
+            batch:,
+            patient_session:,
+            programme:,
+            performed_by: user
+          )
+        end
+
+        it "adds a row to fill in" do
+          expect(rows.count).to eq(1)
+          expect(rows.first.to_hash).to eq(
+            {
+              "ANATOMICAL_SITE" => "left upper arm",
+              "BATCH_EXPIRY_DATE" => batch.expiry.strftime("%Y%m%d"),
+              "BATCH_NUMBER" => batch.name,
+              "CARE_SETTING" => "1",
+              "DATE_OF_VACCINATION" => "20240101",
+              "DOSE_SEQUENCE" => "1",
+              "NHS_NUMBER" => patient.nhs_number,
+              "ORGANISATION_CODE" => organisation.ods_code,
+              "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+              "PERSON_DOB" => patient.date_of_birth.strftime("%Y%m%d"),
+              "PERSON_FORENAME" => patient.given_name,
+              "PERSON_GENDER_CODE" => "Not known",
+              "PERSON_POSTCODE" => patient.address_postcode,
+              "PERSON_SURNAME" => patient.family_name,
+              "SCHOOL_NAME" => location.name,
+              "SCHOOL_URN" => location.urn,
+              "TIME_OF_VACCINATION" => "12:05:20",
+              "VACCINATED" => "Y",
+              "VACCINE_GIVEN" => "Gardasil9"
+            }
+          )
+        end
+      end
+    end
+  end
+
+  context "a clinic session" do
+    let(:location) { create(:location, :generic_clinic, team:) }
+
+    it { should_not be_blank }
+
+    describe "headers" do
+      subject(:headers) { CSV.parse(call).first }
+
+      it do
+        expect(headers).to eq(
+          %w[
+            ORGANISATION_CODE
+            SCHOOL_URN
+            SCHOOL_NAME
+            CARE_SETTING
+            NHS_NUMBER
+            PERSON_FORENAME
+            PERSON_SURNAME
+            PERSON_GENDER_CODE
+            PERSON_DOB
+            PERSON_POSTCODE
+            DATE_OF_VACCINATION
+            TIME_OF_VACCINATION
+            VACCINATED
+            VACCINE_GIVEN
+            BATCH_NUMBER
+            BATCH_EXPIRY_DATE
+            ANATOMICAL_SITE
+            DOSE_SEQUENCE
+            PERFORMING_PROFESSIONAL_EMAIL
+            CLINIC_NAME
+          ]
+        )
+      end
+    end
+
+    describe "rows" do
+      subject(:rows) { CSV.parse(call, headers: true) }
+
+      it { should be_empty }
+
+      context "with a patient" do
+        let!(:patient) { create(:patient, session:) }
+
+        it "adds a row to fill in" do
+          expect(rows.count).to eq(1)
+          expect(rows.first.to_hash).to eq(
+            {
+              "ANATOMICAL_SITE" => "",
+              "BATCH_EXPIRY_DATE" => "",
+              "BATCH_NUMBER" => "",
+              "CARE_SETTING" => "2",
+              "CLINIC_NAME" => "",
+              "DATE_OF_VACCINATION" => "",
+              "DOSE_SEQUENCE" => "1",
+              "NHS_NUMBER" => patient.nhs_number,
+              "ORGANISATION_CODE" => organisation.ods_code,
+              "PERFORMING_PROFESSIONAL_EMAIL" => "",
+              "PERSON_DOB" => patient.date_of_birth.strftime("%Y%m%d"),
+              "PERSON_FORENAME" => patient.given_name,
+              "PERSON_GENDER_CODE" => "Not known",
+              "PERSON_POSTCODE" => patient.address_postcode,
+              "PERSON_SURNAME" => patient.family_name,
+              "SCHOOL_NAME" => "",
+              "SCHOOL_URN" => "888888",
+              "TIME_OF_VACCINATION" => "",
+              "VACCINATED" => "",
+              "VACCINE_GIVEN" => ""
+            }
+          )
+        end
+      end
+
+      context "with a vaccinated patient" do
+        let(:patient) { create(:patient) }
+        let(:patient_session) { create(:patient_session, patient:, session:) }
+        let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
+        let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 0o5, 20) }
+
+        before do
+          create(
+            :vaccination_record,
+            administered_at:,
+            batch:,
+            patient_session:,
+            programme:,
+            location_name: "A Clinic",
+            performed_by: user
+          )
+        end
+
+        it "adds a row to fill in" do
+          expect(rows.count).to eq(1)
+          expect(rows.first.to_hash).to eq(
+            {
+              "ANATOMICAL_SITE" => "left upper arm",
+              "BATCH_EXPIRY_DATE" => batch.expiry.strftime("%Y%m%d"),
+              "BATCH_NUMBER" => batch.name,
+              "CARE_SETTING" => "2",
+              "CLINIC_NAME" => "A Clinic",
+              "DATE_OF_VACCINATION" => "20240101",
+              "DOSE_SEQUENCE" => "1",
+              "NHS_NUMBER" => patient.nhs_number,
+              "ORGANISATION_CODE" => organisation.ods_code,
+              "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+              "PERSON_DOB" => patient.date_of_birth.strftime("%Y%m%d"),
+              "PERSON_FORENAME" => patient.given_name,
+              "PERSON_GENDER_CODE" => "Not known",
+              "PERSON_POSTCODE" => patient.address_postcode,
+              "PERSON_SURNAME" => patient.family_name,
+              "SCHOOL_NAME" => "",
+              "SCHOOL_URN" => "888888",
+              "TIME_OF_VACCINATION" => "12:05:20",
+              "VACCINATED" => "Y",
+              "VACCINE_GIVEN" => "Gardasil9"
+            }
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the functionality to allow users to download an offline spreadsheet for a session containing empty rows that nurses can fill in with the missing information and then upload back in to the app.