### PR TITLE
Send clinic confirmation email when no session dates exist

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -16,6 +16,10 @@ module ConsentFormMailerConcern
       )
     elsif consent_form.needs_triage?
       mailer.confirmation_triage.deliver_later
+    elsif consent_form.actual_upcoming_session.nil? ||
+          consent_form.actual_upcoming_session.completed? ||
+          consent_form.actual_upcoming_session.closed?
+      mailer.confirmation_clinic.deliver_later
     else
       mailer.confirmation_given.deliver_later
       TextDeliveryJob.perform_later(:consent_confirmation_given, consent_form:)

--- a/app/mailers/consent_mailer.rb
+++ b/app/mailers/consent_mailer.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ConsentMailer < ApplicationMailer
+  def confirmation_clinic
+    app_template_mail(:consent_confirmation_clinic)
+  end
+
   def confirmation_given
     app_template_mail(:consent_confirmation_given)
   end

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -2,6 +2,7 @@
 
 GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   consent_clinic_request: "14e88a09-4281-4257-9574-6afeaeb42715",
+  consent_confirmation_clinic: "f2921e23-4b73-4e44-abbb-38b0e235db8e",
   consent_confirmation_given: "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
   consent_confirmation_injection: "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
   consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -69,5 +69,26 @@ describe ConsentFormMailerConcern do
         expect { send_consent_form_confirmation }.not_to have_enqueued_text
       end
     end
+
+    context "when there are no upcoming sessions" do
+      let(:consent_form) do
+        create(
+          :consent_form,
+          school_confirmed: false,
+          school: create(:location, :school)
+        )
+      end
+
+      it "sends an confirmation needs triage email" do
+        expect { send_consent_form_confirmation }.to have_enqueued_mail(
+          ConsentMailer,
+          :confirmation_clinic
+        ).with(params: { consent_form: }, args: [])
+      end
+
+      it "doesn't send a text" do
+        expect { send_consent_form_confirmation }.not_to have_enqueued_text
+      end
+    end
   end
 end

--- a/spec/mailers/consent_mailer_spec.rb
+++ b/spec/mailers/consent_mailer_spec.rb
@@ -1,6 +1,40 @@
 # frozen_string_literal: true
 
 describe ConsentMailer do
+  describe "#confirmation_clinic" do
+    subject(:mail) { described_class.with(consent_form:).confirmation_clinic }
+
+    let(:programme) { create(:programme, :flu) }
+    let(:consent_form) do
+      create(
+        :consent_form,
+        :recorded,
+        :given,
+        programme:,
+        session: create(:session, programme:)
+      )
+    end
+
+    it { should have_attributes(to: [consent_form.parent_email]) }
+
+    describe "personalisation" do
+      subject(:personalisation) do
+        mail.message.header["personalisation"].unparsed_value
+      end
+
+      it "sets the personalisation" do
+        expect(personalisation.keys).to include(
+          :full_and_preferred_patient_name,
+          :short_patient_name_apos,
+          :team_email,
+          :team_name,
+          :team_phone,
+          :vaccination
+        )
+      end
+    end
+  end
+
   describe "#confirmation_injection" do
     subject(:mail) do
       described_class.with(consent_form:).confirmation_injection


### PR DESCRIPTION
If the parent fills out a consent form and tells us that their child is in a different school, and that school has no more session dates coming up we need to tell the parent that either new dates will be added or they need to book in to a clinic.