### PR TITLE
Show patients not in sessions

### DIFF
--- a/app/views/programme/patients/index.html.erb
+++ b/app/views/programme/patients/index.html.erb
@@ -23,6 +23,7 @@
       caption: t("children", count: @pagy.count),
       columns: %i[name dob year_group outcome],
       params:,
+      patients: @patients,
       patient_sessions: @patient_sessions,
       programme: @programme,
       section: :patients,

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -1,5 +1,7 @@
 en:
   patient_session_statuses:
+    not_in_session:
+      text: Not in a session
     added_to_session:
       colour: blue
       text: Get consent

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -113,6 +113,16 @@ describe AppSessionPatientTableComponent do
     end
   end
 
+  context "when passing in patients and patient sessions" do
+    let(:patients) { patient_sessions.map(&:patient) + [create(:patient)] }
+
+    let(:component) do
+      described_class.new(params:, patients:, patient_sessions:, section:)
+    end
+
+    it { should have_css(".nhsuk-table__body .nhsuk-table__row", count: 3) }
+  end
+
   describe "vaccinations section" do
     let(:section) { :vaccination }
     let(:tab) { :actions }


### PR DESCRIPTION
When using the `AppSessionPatientTableComponent` on the children overview page for a programme, we want to show all patients in the cohort, not just patients who also belong to a session.