### PR TITLE
Don't try to show patient's unadministered vaccination records

### DIFF
--- a/app/components/app_patient_vaccination_table_component.rb
+++ b/app/components/app_patient_vaccination_table_component.rb
@@ -12,6 +12,6 @@ class AppPatientVaccinationTableComponent < ViewComponent::Base
   attr_reader :patient
 
   def vaccination_records
-    patient.vaccination_records.order(administered_at: :desc)
+    patient.vaccination_records.administered.order(administered_at: :desc)
   end
 end

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -13,6 +13,12 @@ describe AppPatientVaccinationTableComponent do
     it { should have_content("No vaccinations") }
   end
 
+  context "with a not administered vaccination record" do
+    before { create(:vaccination_record, :not_administered, patient:) }
+
+    it { should have_content("No vaccinations") }
+  end
+
   context "with a vaccination record" do
     let(:programme) { create(:programme, :hpv) }
     let(:vaccine) { programme.vaccines.active.first }


### PR DESCRIPTION
This currently breaks as we try and show the administered at date and vaccine on a record that won't have that information. Perhaps we might want to improve this component to show details about unadministered vaccinations in the future.

https://good-machine.sentry.io/issues/6059157719/