### PR TITLE
Refactor how batches are unarchived

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -31,18 +31,19 @@ class BatchesController < ApplicationController
         vaccine:
       )
 
-    if @batch.persisted?
-      @batch.unarchive!
-    elsif !expiry_validator.date_params_valid? || !@batch.valid?
+    @batch.archived_at = nil if @batch.archived?
+
+    if !expiry_validator.date_params_valid? || @batch.invalid?
       @batch.expiry = expiry_validator.date_params_as_struct
       render :new, status: :unprocessable_entity
-      return
     else
       @batch.save!
-    end
 
-    flash[:success] = "Batch #{@batch.name} added"
-    redirect_to vaccines_path
+      redirect_to vaccines_path,
+                  flash: {
+                    success: "Batch #{@batch.name} added"
+                  }
+    end
   end
 
   def edit

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -68,8 +68,4 @@ class Batch < ApplicationRecord
   def archive!
     update!(archived_at: Time.current) unless archived?
   end
-
-  def unarchive!
-    update!(archived_at: nil) if archived?
-  end
 end


### PR DESCRIPTION
This checks that the batch is valid before performing the unarchive step to ensure we don't get any validation errors when trying to unarchive the batch.

https://good-machine.sentry.io/issues/6059349186/