### PR TITLE
Add Register attendance functionality

### DIFF
--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -52,7 +52,8 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       postcode: "Postcode",
       reason: "Reason for refusal",
       select_for_matching: "Action",
-      year_group: "Year group"
+      year_group: "Year group",
+      attendance: "Today’s attendance"
     }.fetch(column)
   end
 
@@ -80,6 +81,8 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       patient.restricted? ? "" : patient.address_postcode
     when :select_for_matching
       matching_link(patient)
+    when :attendance
+      attendance_cell(patient)
     else
       raise ArgumentError, "Unknown column: #{column}"
     end
@@ -125,8 +128,41 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     )
   end
 
+  def attendance_cell(patient)
+    tag.div(
+      safe_join([attending_button(patient), absent_button(patient)]),
+      class: "app-button-group app-button-group--table"
+    )
+  end
+
+  def attending_button(patient)
+    govuk_button_to(
+      "Attending",
+      session_register_attendance_path(
+        session_slug: params[:session_slug],
+        tab: :unregistered,
+        patient_id: patient.id,
+        state: :attending
+      ),
+      class: "app-button--secondary app-button--small"
+    )
+  end
+
+  def absent_button(patient)
+    govuk_button_to(
+      "Absent",
+      session_register_attendance_path(
+        session_slug: params[:session_slug],
+        tab: :unregistered,
+        patient_id: patient.id,
+        state: :absent
+      ),
+      class: "app-button--secondary-warning app-button--small"
+    )
+  end
+
   def header_link(column)
-    return column_name(column) if column == :select_for_matching
+    return column_name(column) if column.in? %i[attendance select_for_matching]
 
     direction =
       if params[:sort] == column.to_s && params[:direction] == "asc"

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class RegisterAttendancesController < ApplicationController
+  include PatientSortingConcern
+
+  before_action :set_session, only: %i[index create]
+  before_action :set_patient_sessions, only: %i[index]
+  before_action :set_patient, only: %i[create]
+  before_action :set_session_date, only: %i[create]
+  before_action :set_patient_session, only: %i[create]
+
+  layout "full"
+
+  def index
+    sort_and_filter_patients!(@patient_sessions)
+  end
+
+  def create
+    session_attendance =
+      @patient_session.session_attendances.create!(
+        session_date: @session_date,
+        attending: params[:state] == "attending"
+      )
+
+    name = @patient.full_name
+    flash[:info] = if session_attendance.attending?
+      "#{name} is attending today’s session. They are ready for the nurse."
+    else
+      "#{name} is absent from today’s session."
+    end
+    redirect_to session_attendances_path(@session)
+  end
+
+  private
+
+  def set_session
+    @session = policy_scope(Session).find_by!(slug: params[:session_slug])
+  end
+
+  def set_patient_sessions
+    @patient_sessions =
+      @session.patient_sessions.select { _1.current_attendance.nil? }
+  end
+
+  def set_patient
+    @patient = @session.patients.find_by(id: params[:patient_id])
+  end
+
+  def set_session_date
+    @session_date = @session.session_dates.find_by!(value: Date.current)
+  end
+
+  def set_patient_session
+    @patient_session = @patient.patient_sessions.find_by(session: @session)
+  end
+end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -76,7 +76,8 @@ class PatientSession < ApplicationRecord
             :consents,
             :gillick_assessment,
             :triages,
-            :vaccination_records
+            :vaccination_records,
+            :session_attendances
           )
         end
 

--- a/app/models/patient_session_stats.rb
+++ b/app/models/patient_session_stats.rb
@@ -15,6 +15,7 @@ class PatientSessionStats
           vaccinated
           could_not_vaccinate
           with_conflicting_consent
+          not_registered
         ]
   end
 
@@ -56,6 +57,8 @@ class PatientSessionStats
         patient_session.consent_conflicts? ||
         patient_session.triaged_do_not_vaccinate? ||
         patient_session.unable_to_vaccinate?
+    when :not_registered
+      patient_session.current_attendance.nil?
     end
   end
 end

--- a/app/views/register_attendances/index.html.erb
+++ b/app/views/register_attendances/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(
+        items: [
+          { text: "Home", href: dashboard_path },
+          { text: t("sessions.index.title"), href: sessions_path },
+          { text: @session.location.name, href: session_path(@session) },
+        ],
+      ) %>
+<% end %>
+
+<%= h1 "Register attendance" %>
+
+<%= render AppSessionPatientTableComponent.new(
+      caption: t("patients_table.register_attendance.caption", children: t("children", count: @patient_sessions.count)),
+      columns: %i[name year_group outcome attendance],
+      params:,
+      patient_sessions: @patient_sessions,
+      section: :attendance,
+      year_groups: @session.year_groups,
+    ) %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -83,6 +83,17 @@
           <% end %>
         </li>
 
+        <% if Flipper.enabled?(:record_attendance) && @session.today? %>
+          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+            <%= render AppCardComponent.new(link_to: session_attendances_path(@session)) do |c| %>
+              <% c.with_heading { "Register attendance" } %>
+              <% c.with_description do %>
+                <%= t("children", count: @stats[:not_registered]) %> still to register
+              <% end %>
+            <% end %>
+          </li>
+        <% end %>
+
         <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
             <% c.with_heading { "Record vaccinations" } %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -74,27 +74,25 @@
           <% end %>
         </li>
 
-        <% if Flipper.enabled?(:release_1b) %>
-          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-            <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
-              <% c.with_heading { "Triage health questions" } %>
-              <% c.with_description do %>
-                <%= t("children", count: @stats[:needing_triage]) %> needing triage
-              <% end %>
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
+            <% c.with_heading { "Triage health questions" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @stats[:needing_triage]) %> needing triage
             <% end %>
-          </li>
+          <% end %>
+        </li>
 
-          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-            <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
-              <% c.with_heading { "Record vaccinations" } %>
-              <% c.with_description do %>
-                <%= t("children", count: @stats[:vaccinate]) %> to vaccinate<br>
-                <%= t("children", count: @stats[:vaccinated]) %> vaccinated<br>
-                <%= t("children", count: @stats[:could_not_vaccinate]) %> could not be vaccinated
-              <% end %>
+        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+          <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
+            <% c.with_heading { "Record vaccinations" } %>
+            <% c.with_description do %>
+              <%= t("children", count: @stats[:vaccinate]) %> to vaccinate<br>
+              <%= t("children", count: @stats[:vaccinated]) %> vaccinated<br>
+              <%= t("children", count: @stats[:could_not_vaccinate]) %> could not be vaccinated
             <% end %>
-          </li>
-        <% end %>
+          <% end %>
+        </li>
       <% end %>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -743,6 +743,9 @@ en:
     no_triage_needed:
       caption: "%{children} with no triage needed"
       label: No triage needed
+    register_attendance:
+      caption: "%{children} still to register"
+      label: Register attendance
     triage_complete:
       caption: "%{children} with triage completed"
       label: Triage completed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,27 @@ Rails.application.routes.draw do
       end
     end
 
+    constraints section: "attendances" do
+      defaults section: "attendances" do
+        get "/",
+            as: "attendances",
+            to: redirect("/sessions/%{session_slug}/attendances/unregistered")
+
+        get ":tab",
+            controller: "register_attendances",
+            action: :index,
+            as: :attendances_tab,
+            tab: :unregistered
+
+        post ":tab/patients/:patient_id/register/:state",
+             controller: "register_attendances",
+             action: :create,
+             as: :register_attendance,
+             tab: :unregistered,
+             state: %i[attending absent]
+      end
+    end
+
     scope ":tab" do
       resources :patient_sessions,
                 path: "patients",

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -17,7 +17,19 @@ describe "Manage attendance" do
     given_my_organisation_is_running_an_hpv_vaccination_programme
     and_there_is_a_vaccination_session_today_with_a_patient_ready_to_vaccinate
 
-    when_i_go_to_the_patient
+    when_i_go_to_the_session
+    then_i_see_the_register_attendance_card
+
+    when_i_click_on_the_register_attendance_card
+    then_i_see_the_register_attendance_page
+
+    when_i_register_a_patient_as_attending
+    then_i_see_the_attending_flash
+
+    when_i_register_a_patient_as_absent
+    then_i_see_the_absent_flash
+
+    when_i_go_to_a_patient
     then_the_patient_is_not_registered_yet
     and_i_am_not_able_to_vaccinate
 
@@ -55,23 +67,44 @@ describe "Manage attendance" do
         location:
       )
 
-    create(
+    create_list(
       :patient_session,
+      3,
       :consent_given_triage_not_needed,
       programme: @programme,
       session: @session
     )
-
-    @patient = @session.reload.patients.first
   end
 
-  def when_i_go_to_the_patient
+  def when_i_go_to_the_session
     sign_in @organisation.users.first
     visit dashboard_path
     click_link "Sessions", match: :first
     click_link @session.location.name
-    click_link "Record vaccinations"
-    click_link @patient.full_name
+  end
+
+  def then_i_see_the_register_attendance_card
+    expect(page).to have_link("Register attendance")
+  end
+
+  def when_i_click_on_the_register_attendance_card
+    click_link "Register attendance"
+  end
+
+  def then_i_see_the_register_attendance_page
+    expect(page).to have_heading("Register attendance")
+  end
+
+  def when_i_register_a_patient_as_attending
+    click_button "Attending", match: :first
+  end
+
+  def when_i_register_a_patient_as_absent
+    click_button "Absent", match: :first
+  end
+
+  def when_i_go_to_a_patient
+    click_link @session.reload.patients.last.full_name
   end
 
   def then_the_patient_is_not_registered_yet
@@ -89,7 +122,7 @@ describe "Manage attendance" do
   end
 
   def and_i_see_the_not_registered_flash
-    expect(page).to have_content("#{@patient.full_name} is not registered yet")
+    expect(page).to have_content("is not registered yet")
   end
 
   def when_i_choose_the_patient_is_absent
@@ -103,8 +136,9 @@ describe "Manage attendance" do
   end
 
   def and_i_see_the_absent_flash
-    expect(page).to have_content("#{@patient.full_name} is absent from today")
+    expect(page).to have_content("is absent from today")
   end
+  alias_method :then_i_see_the_absent_flash, :and_i_see_the_absent_flash
 
   def when_i_choose_the_patient_is_attending
     click_link "Update attendance"
@@ -117,8 +151,9 @@ describe "Manage attendance" do
   end
 
   def and_i_see_the_attending_flash
-    expect(page).to have_content("#{@patient.full_name} is attending today")
+    expect(page).to have_content("is attending today")
   end
+  alias_method :then_i_see_the_attending_flash, :and_i_see_the_attending_flash
 
   def and_i_can_vaccinate
     expect(page).to have_content("Did they get the HPV vaccine?")

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -11,6 +11,7 @@ describe PatientSessionStats do
       expect(to_h).to eq(
         could_not_vaccinate: 0,
         needing_triage: 0,
+        not_registered: 0,
         vaccinate: 0,
         vaccinated: 0,
         with_conflicting_consent: 0,
@@ -60,6 +61,7 @@ describe PatientSessionStats do
         expect(to_h).to eq(
           could_not_vaccinate: 1,
           needing_triage: 2,
+          not_registered: 6,
           vaccinate: 2,
           vaccinated: 0,
           with_conflicting_consent: 0,


### PR DESCRIPTION
This adds a "Register attendance" card to the sessions show page. It takes the user to a dev-designed table which allows nurses to register attendance for today for all the patients attending a session.

Review without whitespace.

### Screenshots

![Screenshot 2024-11-12 at 11 30 50](https://github.com/user-attachments/assets/fb686386-ad85-42a5-8467-ea26e1518734)
![Screenshot 2024-11-13 at 10 07 56](https://github.com/user-attachments/assets/6e6e0df8-3ab7-40b4-9f57-8977f6559edb)
![Screenshot 2024-11-13 at 10 08 26](https://github.com/user-attachments/assets/89597ecb-0eef-485d-9cbf-6833d8207a1d)


