### PR TITLE
Preload more for patient activity log

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -134,7 +134,7 @@ class AppActivityLogComponent < ViewComponent::Base
       .flat_map(&:session_attendances)
       .map do
         title = (_1.attending? ? "Attended session" : "Absent from session")
-        title += " at #{_1.patient_session.session.location.name}"
+        title += " at #{_1.patient_session.location.name}"
 
         { title:, time: _1.created_at }
       end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -77,10 +77,11 @@ class PatientsController < ApplicationController
         .includes(
           :school,
           :cohort,
-          :triages,
+          consents: :parent,
           notify_log_entries: :sent_by,
           parents: :parent_relationships,
           patient_sessions: %i[location session_attendances],
+          triages: :performed_by_user,
           vaccination_records: [:performed_by_user, { vaccine: :programme }]
         )
         .strict_loading


### PR DESCRIPTION
This fixes a different issue that has come up regarding the patient activity log, follows up from 60a5a57896b05aed796e00b49b105dc39e145acf.