### PR TITLE
Validate TIME_OF_VACCINATION is not in the future

### DIFF
--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -60,8 +60,9 @@ class DraftVaccinationRecord
 
   on_wizard_step :date_and_time, exact: true do
     validates :administered_at,
+              presence: true,
               comparison: {
-                less_than_or_equal_to: -> { Time.zone.now }
+                less_than_or_equal_to: -> { Time.current }
               }
   end
 

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -50,8 +50,13 @@ class ImmunisationImportRow
               less_than_or_equal_to: -> { Date.current }
             }
   validates :time_of_vaccination,
-            presence: true,
-            if: -> { @data["TIME_OF_VACCINATION"]&.strip.present? }
+            presence: {
+              if: -> { @data["TIME_OF_VACCINATION"]&.strip.present? }
+            },
+            comparison: {
+              less_than_or_equal_to: -> { Time.current },
+              if: -> { date_of_vaccination == Date.current }
+            }
   validate :session_date_exists
 
   CARE_SETTING_SCHOOL = 1

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -151,9 +151,9 @@ class VaccinationRecord < ApplicationRecord
 
   validates :administered_at,
             comparison: {
-              less_than_or_equal_to: -> { Time.zone.now }
-            },
-            allow_blank: true
+              less_than_or_equal_to: -> { Time.current },
+              allow_nil: true
+            }
 
   def administered?
     administered_at != nil

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,7 @@ en:
         batch_expiry_date: <code>BATCH_EXPIRY_DATE</code>
         batch_number: <code>BATCH_NUMBER</code>
         care_setting: <code>CARE_SETTING</code>
+        date_of_vaccination: <code>DATE_OF_VACCINATION</code>
         delivery_site: <code>ANATOMICAL_SITE</code>
         dose_sequence: <code>DOSE_SEQUENCE</code>
         organisation_code: <code>ORGANISATION_CODE</code>
@@ -56,13 +57,12 @@ en:
         patient_last_name: <code>PERSON_SURNAME</code>
         patient_nhs_number: <code>NHS_NUMBER</code>
         patient_postcode: <code>PERSON_POSTCODE</code>
-        performed_by_user: <code>PERFORMING_PROFESSIONAL_EMAIL</code>
         performed_by_family_name: <code>PERFORMING_PROFESSIONAL_SURNAME</code>
         performed_by_given_name: <code>PERFORMING_PROFESSIONAL_FORENAME</code>
+        performed_by_user: <code>PERFORMING_PROFESSIONAL_EMAIL</code>
         reason: <code>REASON</code>
         school_name: <code>SCHOOL_NAME</code>
         school_urn: <code>SCHOOL_URN</code>
-        date_of_vaccination: <code>DATE_OF_VACCINATION</code>
         time_of_vaccination: <code>TIME_OF_VACCINATION</code>
         vaccine_given: <code>VACCINE_GIVEN</code>
     errors:
@@ -196,6 +196,11 @@ en:
             care_setting:
               blank: Enter a care setting.
               inclusion: Enter a valid care setting.
+            date_of_vaccination:
+              blank: Enter a date in the correct format
+              greater_than_or_equal_to: The vaccination date is outside the programme. Enter a date after the programme started.
+              less_than_or_equal_to: The vaccination date is outside the programme. Enter a date before today.
+              inclusion: Enter a date for a current session
             delivery_site:
               blank: Enter an anatomical site.
             dose_sequence:
@@ -232,13 +237,9 @@ en:
               blank: Enter a school name.
             school_urn:
               inclusion: The school URN is not recognised. If you’ve checked the URN, and you believe it’s valid, contact our support organisation.
-            date_of_vaccination:
-              blank: Enter a date in the correct format.
-              greater_than_or_equal_to: The vaccination date is outside the programme. Enter a date after the programme started.
-              less_than_or_equal_to: The vaccination date is outside the programme. Enter a date before today.
-              inclusion: Enter a date for a current session
             time_of_vaccination:
-              blank: Enter a time in the correct format.
+              blank: Enter a time in the correct format
+              less_than_or_equal_to: Enter a time in the past
             vaccine_given:
               inclusion: Enter a valid vaccine, eg Gardasil 9.
         import_duplicate_form:

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -66,12 +66,9 @@ describe DraftVaccinationRecord do
         valid_administered_attributes.merge(administered_at: 1.second.from_now)
       end
 
-      before do
-        draft_vaccination_record.wizard_step = :date_and_time
-        travel_to Time.zone.local(2024, 11, 1, 12, 0, 1)
-      end
+      around { |example| freeze_time { example.run } }
 
-      after { travel_back }
+      before { draft_vaccination_record.wizard_step = :date_and_time }
 
       it "has an error" do
         expect(draft_vaccination_record.save(context: :update)).to be(false)

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -132,6 +132,24 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "with a date and time of vaccination in the future" do
+      around { |example| freeze_time { example.run } }
+
+      let(:data) do
+        {
+          "DATE_OF_VACCINATION" => Date.current.strftime("%Y%m%d"),
+          "TIME_OF_VACCINATION" => 1.second.from_now.strftime("%H:%M:%S")
+        }
+      end
+
+      it "has an error" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:time_of_vaccination]).to include(
+          "Enter a time in the past"
+        )
+      end
+    end
+
     context "when date doesn't match an existing session" do
       subject(:errors) { immunisation_import_row.errors[:date_of_vaccination] }
 
@@ -158,7 +176,7 @@ describe ImmunisationImportRow do
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:time_of_vaccination]).to eq(
-          ["Enter a time in the correct format."]
+          ["Enter a time in the correct format"]
         )
       end
     end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -98,9 +98,7 @@ describe VaccinationRecord do
     end
 
     context "when administered_at is in the future" do
-      before { travel_to Time.zone.local(2024, 11, 1, 12, 0, 1) }
-
-      after { travel_back }
+      around { |example| freeze_time { example.run } }
 
       let(:vaccination_record) do
         build(:vaccination_record, administered_at: 1.second.from_now)


### PR DESCRIPTION
This extends the validation added in 337795f99291568bef9869f38a53cd8102121d2f to add the same validation to the immunisation import rows, meaning that import users will see a suitable validation error. Without this currently users see a broken import that never succeeds.

https://good-machine.sentry.io/issues/6059825084/