### PR TITLE
Delete notifications when reseting organisation

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -47,6 +47,8 @@ class DevController < ApplicationController
       organisation_sessions = Session.where(organisation:)
 
       ClassImport.where(session: organisation_sessions).destroy_all
+      ConsentNotification.where(session: organisation_sessions).destroy_all
+      SessionNotification.where(session: organisation_sessions).destroy_all
 
       patient_sessions = PatientSession.where(session: organisation_sessions)
       patient_sessions.each do |patient_session|


### PR DESCRIPTION
Without this we get foreign key constraint errors when the organisation is reset.

https://good-machine.sentry.io/issues/6060092945/