### PR TITLE
Allow editing historical vaccination records

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -113,7 +113,11 @@ class VaccinationsController < ApplicationController
         :programme_id,
         :vaccine_id
       )
-      .merge(patient_session: @patient_session, wizard_step: :date_and_time)
+      .merge(
+        patient_session: @patient_session,
+        performed_by_user: current_user,
+        wizard_step: :date_and_time
+      )
   end
 
   def create_params

--- a/app/models/concerns/vaccination_record_performed_by_concern.rb
+++ b/app/models/concerns/vaccination_record_performed_by_concern.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module VaccinationRecordPerformedByConcern
+  extend ActiveSupport::Concern
+
+  included do
+    validates :performed_by_family_name,
+              :performed_by_given_name,
+              absence: {
+                if: :performed_by_user
+              }
+  end
+
+  def performed_by
+    return performed_by_user if performed_by_user
+
+    if performed_by_given_name.present? || performed_by_family_name.present?
+      OpenStruct.new(
+        given_name: performed_by_given_name,
+        family_name: performed_by_family_name,
+        full_name: [
+          performed_by_given_name,
+          performed_by_family_name
+        ].compact_blank.join(" ")
+      )
+    end
+  end
+
+  def performed_by=(user)
+    self.performed_by_user = user
+  end
+end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -43,6 +43,7 @@
 class VaccinationRecord < ApplicationRecord
   include LocationNameConcern
   include PendingChangesConcern
+  include VaccinationRecordPerformedByConcern
 
   audited associated_with: :patient_session
 
@@ -143,12 +144,6 @@ class VaccinationRecord < ApplicationRecord
               less_than_or_equal_to: :maximum_dose_sequence
             }
 
-  validates :performed_by_family_name,
-            :performed_by_given_name,
-            absence: {
-              if: :performed_by_user
-            }
-
   validates :administered_at,
             comparison: {
               less_than_or_equal_to: -> { Time.current },
@@ -172,25 +167,6 @@ class VaccinationRecord < ApplicationRecord
     # TODO: this will need to be revisited once it's possible to record half-doses
     # e.g. for the flu programme where a child refuses the second half of the dose
     vaccine.dose_volume_ml * 1 if vaccine.present?
-  end
-
-  def performed_by
-    return performed_by_user if performed_by_user
-
-    if performed_by_given_name.present? || performed_by_family_name.present?
-      OpenStruct.new(
-        given_name: performed_by_given_name,
-        family_name: performed_by_family_name,
-        full_name: [
-          performed_by_given_name,
-          performed_by_family_name
-        ].compact_blank.join(" ")
-      )
-    end
-  end
-
-  def performed_by=(user)
-    self.performed_by_user = user
   end
 
   private

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -4,7 +4,7 @@ describe "Edit vaccination record" do
   before { Flipper.enable(:release_1b) }
   after { Flipper.disable(:release_1b) }
 
-  scenario "User edits the vaccination record" do
+  scenario "User edits a current vaccination record" do
     given_i_am_signed_in
     and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
@@ -31,6 +31,37 @@ describe "Edit vaccination record" do
 
     when_i_fill_in_an_invalid_time
     then_i_see_the_date_time_form_with_errors
+
+    when_i_fill_in_a_valid_date_and_time
+    then_i_see_the_edit_vaccination_record_page
+    and_i_should_see_the_updated_date_time
+
+    when_i_click_change_vaccine
+    and_i_choose_a_vaccine
+    then_i_see_the_edit_vaccination_record_page
+
+    when_i_click_on_change_batch
+    and_i_choose_a_batch
+    then_i_see_the_edit_vaccination_record_page
+    and_i_should_see_the_updated_batch
+  end
+
+  scenario "User edits an historical vaccination record" do
+    given_i_am_signed_in
+    and_an_hpv_programme_is_underway
+    and_an_historical_administered_vaccination_record_exists
+
+    when_i_go_to_the_vaccination_records_page
+    then_i_should_see_the_vaccination_records
+
+    when_i_click_on_the_vaccination_record
+    then_i_should_see_the_vaccination_record
+
+    when_i_click_on_edit_vaccination_record
+    then_i_see_the_edit_vaccination_record_page
+
+    when_i_click_on_change_date
+    then_i_should_see_the_date_time_form
 
     when_i_fill_in_a_valid_date_and_time
     then_i_see_the_edit_vaccination_record_page
@@ -147,6 +178,18 @@ describe "Edit vaccination record" do
       programme: @programme,
       patient_session: @patient_session,
       batch: @original_batch
+    )
+  end
+
+  def and_an_historical_administered_vaccination_record_exists
+    create(
+      :vaccination_record,
+      programme: @programme,
+      patient_session: @patient_session,
+      batch: @original_batch,
+      performed_by_user: nil,
+      performed_by_given_name: "Nurse",
+      performed_by_family_name: "Joy"
     )
   end
 


### PR DESCRIPTION
Historical vaccination records don't have a performed by user, so we need to handle this by mapping the same fields we have on vaccination records across to the draft vaccination record. To avoid duplicating code I've introduced a `VaccinationRecordPerformedByConcern` that handles the common logic across the two models.

https://good-machine.sentry.io/issues/6060365840/