### PR TITLE
Remove FLIPPER_INITIALIZERS for basic_auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,8 +24,6 @@ class ApplicationController < ActionController::Base
     rescue_from UnprocessableEntity, with: :handle_unprocessable_entity
   end
 
-  FLIPPER_INITIALIZERS[:basic_auth].call unless Flipper.exist? :basic_auth
-
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
   layout "two_thirds"

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -10,15 +10,3 @@ if Rails.env.test?
     end
   end
 end
-
-# Flipper doesn't give us a way to set default values for features, no less
-# using a proc.
-FLIPPER_INITIALIZERS = {
-  basic_auth: -> do
-    if Rails.env.staging? || Rails.env.production?
-      Flipper.enable(:basic_auth)
-    else
-      Flipper.disable(:basic_auth)
-    end
-  end
-}.freeze


### PR DESCRIPTION
This ensures that the first time an environment is deployed, it's behind basic auth.

We then override this on some of our environments, like training.

However, if you then:

- Clear the database
- Redeploy at some point

The flag will get re-initialised to `true` and users will lose access.

Since this has happened twice on the training environment, this initializer is doing more harm than good.