### PR TITLE
Add ability to delete vaccination records

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -109,9 +109,15 @@
       <%= render AppVaccinationRecordSummaryComponent.new(vaccination_record, current_user:) %>
 
       <% if Flipper.enabled?(:release_1b) %>
-        <%= govuk_button_to "Edit vaccination record",
-                            programme_vaccination_record_path(vaccination_record.programme, vaccination_record),
-                            method: :put, class: "app-button--secondary" %>
+        <div class="app-button-group">
+          <%= govuk_button_to "Edit vaccination record",
+                              programme_vaccination_record_path(vaccination_record.programme, vaccination_record),
+                              method: :put, class: "app-button--secondary" %>
+
+          <% if helpers.policy(vaccination_record).destroy? %>
+            <%= govuk_link_to "Delete vaccination record", destroy_vaccination_record_session_patient_vaccinations_path(patient_id: patient.id, vaccination_record_id: vaccination_record.id) %>
+          <% end %>
+        </div>
       <% end %>
     <% end %>
   <% end %>

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -17,6 +17,10 @@ class VaccinationRecordPolicy < ApplicationPolicy
     edit?
   end
 
+  def destroy?
+    user.is_nurse? && record.session.open?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.joins(:session).where(

--- a/app/views/vaccinations/destroy.html.erb
+++ b/app/views/vaccinations/destroy.html.erb
@@ -1,0 +1,22 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: session_patient_path(id: @patient.id),
+        name: "patient",
+      ) %>
+<% end %>
+
+<% page_title = "Are you sure you want to delete this vaccination record?" %>
+
+<%= h1 page_title do %>
+  <span class="nhsuk-caption-l">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<%= form_with url: vaccination_record_session_patient_vaccinations_path, method: :delete do |f| %>
+  <div class="app-button-group">
+    <%= f.govuk_submit "Yes, delete this vaccination record", warning: true %>
+    <%= govuk_link_to "No, return to patient", session_patient_path(id: @patient.id) %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,7 +308,16 @@ Rails.application.routes.draw do
                  path: "gillick",
                  only: %i[new create edit update]
         resource :triages, only: %i[new create]
-        resource :vaccinations, only: %i[create]
+        resource :vaccinations, only: %i[create] do
+          member do
+            delete ":vaccination_record_id",
+                   action: :destroy,
+                   as: :vaccination_record
+            get ":vaccination_record_id/destroy",
+                action: :confirm_destroy,
+                as: :destroy_vaccination_record
+          end
+        end
 
         resource :attendance,
                  controller: "session_attendances",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,7 +47,7 @@ def create_user(organisation:, email: nil, uid: nil, fallback_role: :nurse)
         given_name: "Nurse",
         email: "nurse.flo@example.nhs.uk",
         provider: "cis2",
-        organisations: [organisation],
+        organisation:,
         fallback_role:
         # password: Do not set this as they should not log in via password
       )
@@ -59,7 +59,7 @@ def create_user(organisation:, email: nil, uid: nil, fallback_role: :nurse)
         given_name: email.split("@").first.split(".").first.capitalize,
         email:,
         password: email,
-        organisations: [organisation],
+        organisation:,
         fallback_role:
       )
   else

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -16,12 +16,7 @@ describe AppActivityLogComponent do
     )
   end
   let(:user) do
-    create(
-      :user,
-      organisations: [organisation],
-      family_name: "Joy",
-      given_name: "Nurse"
-    )
+    create(:user, organisation:, family_name: "Joy", given_name: "Nurse")
   end
   let(:location) { create(:location, :school, name: "Hogwarts") }
   let(:session) { create(:session, programme:, location:) }

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -33,26 +33,11 @@ FactoryBot.define do
     privacy_policy_url { "https://example.com/privacy" }
 
     trait :with_one_nurse do
-      transient do
-        nurse_email { nil }
-        nurse_password { nil }
-      end
-
-      users do
-        create_list(
-          :user,
-          1,
-          **{ organisations: [instance], email: nurse_email }.compact
-        )
-      end
+      users { [create(:user, :nurse, organisation: instance)] }
     end
 
     trait :with_one_admin do
-      transient { admin_email { "admin.hope@example.com" } }
-
-      users do
-        create_list(:user, 1, organisations: [instance], email: admin_email)
-      end
+      users { [create(:user, :admin, organisation: instance)] }
     end
 
     trait :with_generic_clinic do

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -26,7 +26,7 @@ FactoryBot.define do
     transient do
       programme { association :programme }
       organisation { session.organisation }
-      user { association :user, organisations: [organisation] }
+      user { association :user, organisation: }
     end
 
     session { association :session, programme: }

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe "Delete vaccination record" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
+  scenario "User deletes a vaccination record" do
+    given_i_am_signed_in
+    and_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_go_to_a_patient_that_is_vaccinated
+    and_i_click_on_delete_vaccination_record
+    then_i_see_the_delete_vaccination_page
+
+    when_i_dont_delete_the_vaccination_record
+    then_i_see_the_patient
+    and_they_are_already_vaccinated
+    and_i_click_on_delete_vaccination_record
+    then_i_see_the_delete_vaccination_page
+
+    when_i_delete_the_vaccination_record
+    then_i_see_the_patient
+    and_i_see_a_successful_message
+    and_they_can_be_vaccinated
+  end
+
+  def given_i_am_signed_in
+    @organisation = create(:organisation, :with_one_nurse)
+    sign_in @organisation.users.first
+  end
+
+  def and_an_hpv_programme_is_underway
+    @programme = create(:programme, :hpv, organisations: [@organisation])
+
+    @session =
+      create(:session, organisation: @organisation, programme: @programme)
+
+    @patient =
+      create(
+        :patient,
+        :triage_ready_to_vaccinate,
+        given_name: "John",
+        family_name: "Smith",
+        programme: @programme,
+        organisation: @organisation
+      )
+
+    @patient_session =
+      create(:patient_session, patient: @patient, session: @session)
+  end
+
+  def and_an_administered_vaccination_record_exists
+    vaccine = @programme.vaccines.first
+
+    batch = create(:batch, organisation: @organisation, vaccine:)
+
+    create(
+      :vaccination_record,
+      programme: @programme,
+      patient_session: @patient_session,
+      batch:
+    )
+  end
+
+  def when_i_go_to_a_patient_that_is_vaccinated
+    visit session_vaccinations_path(@session)
+    click_link "Vaccinated"
+    click_link @patient.full_name
+  end
+
+  def and_i_click_on_delete_vaccination_record
+    click_on "Delete vaccination record"
+  end
+
+  def then_i_see_the_delete_vaccination_page
+    expect(page).to have_content(
+      "Are you sure you want to delete this vaccination record?"
+    )
+  end
+
+  def when_i_dont_delete_the_vaccination_record
+    click_on "No, return to patient"
+  end
+
+  def then_i_see_the_patient
+    expect(page).to have_content(@patient.full_name)
+  end
+
+  def and_they_are_already_vaccinated
+    expect(page).to have_content("Vaccinated")
+  end
+
+  def when_i_delete_the_vaccination_record
+    click_on "Yes, delete this vaccination record"
+  end
+
+  def and_i_see_a_successful_message
+    expect(page).to have_content("Vaccination record deleted")
+  end
+
+  def and_they_can_be_vaccinated
+    expect(page).to have_content("Safe to vaccinate")
+    expect(page).not_to have_content("Vaccinated")
+  end
+end

--- a/spec/lib/session_xlsx_exporter_spec.rb
+++ b/spec/lib/session_xlsx_exporter_spec.rb
@@ -16,9 +16,7 @@ describe SessionXlsxExporter do
 
   let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:user) do
-    create(:user, email: "nurse@example.com", organisations: [organisation])
-  end
+  let(:user) { create(:user, email: "nurse@example.com", organisation:) }
   let(:team) { create(:team, organisation:) }
   let(:session) { create(:session, location:, organisation:, programme:) }
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -57,7 +57,7 @@ describe ImmunisationImport do
 
   let(:file) { "valid_flu.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/immunisation_import/#{file}") }
-  let(:uploaded_by) { create(:user, organisations: [organisation]) }
+  let(:uploaded_by) { create(:user, organisation:) }
 
   it_behaves_like "a CSVImportable model"
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,20 +39,20 @@ describe User do
   end
 
   describe "#selected_organisation" do
-    subject { user.selected_organisation }
+    subject(:selected_organisation) { user.selected_organisation }
 
     context "cis2 is disabled", cis2: :disabled do
       let(:organisation) { build(:organisation) }
-      let(:user) { build(:user, organisations: [organisation]) }
+      let(:user) { build(:user, organisation:) }
 
-      it { should eq user.organisations.first }
+      it { should eq(organisation) }
     end
 
     context "cis2 is enabled", cis2: :enabled do
       let(:organisation) { create(:organisation) }
-      let(:user) { create(:user, selected_organisation: organisation) }
+      let(:user) { create(:user, organisation:) }
 
-      it { should eq organisation }
+      it { should eq(organisation) }
     end
   end
 

--- a/spec/policies/batch_policy_spec.rb
+++ b/spec/policies/batch_policy_spec.rb
@@ -5,7 +5,7 @@ describe BatchPolicy do
     subject { BatchPolicy::Scope.new(user, Batch).resolve }
 
     let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, organisations: [organisation]) }
+    let(:user) { create(:user, organisation:) }
 
     let(:archived_batch) { create(:batch, :archived, organisation:) }
     let(:unarchived_batch) { create(:batch, organisation:) }

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -11,7 +11,7 @@ describe PatientPolicy do
       create(:cohort, organisation: another_organisation)
     end
     let(:school) { create(:location, :school, organisation:) }
-    let(:user) { create(:user, organisations: [organisation]) }
+    let(:user) { create(:user, organisation:) }
 
     let(:patient_in_school) { create(:patient, school:) }
     let(:patient_in_cohort) { create(:patient, cohort:) }

--- a/spec/policies/patient_session_policy_spec.rb
+++ b/spec/policies/patient_session_policy_spec.rb
@@ -4,7 +4,7 @@ describe PatientSessionPolicy do
   let(:programme) { create(:programme) }
 
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:user) { create(:user, organisations: [organisation]) }
+  let(:user) { create(:user, organisation:) }
 
   let(:patient_session) do
     create(

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -6,7 +6,7 @@ describe SessionPolicy do
 
     let(:programme) { create(:programme) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
-    let(:user) { create(:user, organisations: [organisation]) }
+    let(:user) { create(:user, organisation:) }
 
     let(:users_organisations_session) do
       create(:session, organisation:, programme:)

--- a/spec/policies/triage_policy_spec.rb
+++ b/spec/policies/triage_policy_spec.rb
@@ -5,7 +5,7 @@ describe TriagePolicy do
     subject { TriagePolicy::Scope.new(user, Triage).resolve }
 
     let(:organisation) { create(:organisation) }
-    let(:user) { create(:user, organisations: [organisation]) }
+    let(:user) { create(:user, organisation:) }
 
     let(:organisation_batch) { create(:triage, organisation:) }
     let(:non_organisation_batch) { create(:triage) }

--- a/spec/policies/vaccination_record_policy_spec.rb
+++ b/spec/policies/vaccination_record_policy_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+describe VaccinationRecordPolicy do
+  subject(:policy) { described_class.new(user, vaccination_record) }
+
+  describe "destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    let(:programme) { create(:programme) }
+    let(:vaccination_record) do
+      create(:vaccination_record, session:, programme:)
+    end
+
+    context "when session is open" do
+      let(:session) { create(:session, :scheduled, programme:) }
+
+      context "with an admin" do
+        let(:user) { create(:admin) }
+
+        it { should be(false) }
+      end
+
+      context "with a nurse" do
+        let(:user) { create(:nurse) }
+
+        it { should be(true) }
+      end
+    end
+
+    context "when session is not open" do
+      let(:session) { create(:session, :closed, programme:) }
+
+      context "with an admin" do
+        let(:user) { create(:admin) }
+
+        it { should be(false) }
+      end
+
+      context "with a nurse" do
+        let(:user) { create(:nurse) }
+
+        it { should be(false) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the basic functionality that allows users to delete vaccination records for sessions that are still open. There's no design for this in the prototype so the interface might need changing in the future.

Some further improvements required include soft-deletion so old vaccination records can be shown in the activity log and a feature test to ensure the records can only be deleted for open sessions. I'll add those in a separate PR.

## Screenshot

![Screenshot 2024-11-13 at 10 50 42](https://github.com/user-attachments/assets/f85a208e-e9ac-4ed8-abf2-7d9c7c7cedec)
