### PR TITLE
Discard vaccination records

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -109,8 +109,11 @@ class VaccinationsController < ApplicationController
   def destroy
     authorize @vaccination_record
 
-    # TODO: soft delete if session was on a different day
-    @vaccination_record.destroy!
+    if @vaccination_record.session.today?
+      @vaccination_record.destroy!
+    else
+      @vaccination_record.discard!
+    end
 
     redirect_to session_patient_path(id: @patient.id),
                 flash: {

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -195,6 +195,29 @@ describe AppActivityLogComponent do
                      by: "Nurse Joy"
   end
 
+  describe "discarded vaccination" do
+    before do
+      create(
+        :vaccination_record,
+        :discarded,
+        programme:,
+        patient_session:,
+        administered_at: Time.zone.local(2024, 5, 31, 13),
+        discarded_at: Time.zone.local(2024, 5, 31, 14),
+        performed_by: user
+      )
+    end
+
+    include_examples "card",
+                     title: "Vaccinated with Gardasil 9 (HPV)",
+                     date: "31 May 2024 at 1:00pm",
+                     by: "Nurse Joy"
+
+    include_examples "card",
+                     title: "HPV vaccination record deleted",
+                     date: "31 May 2024 at 2:00pm"
+  end
+
   describe "self-consent" do
     before do
       create(


### PR DESCRIPTION
Instead of destroying vaccination records, if it's a different day to when the session is being held, we should keep a record of what the vaccination record used to be and display it in the activity log.