### PR TITLE
UI to download vaccination reports

### DIFF
--- a/app/controllers/concerns/wizard_controller_concern.rb
+++ b/app/controllers/concerns/wizard_controller_concern.rb
@@ -6,8 +6,10 @@ module WizardControllerConcern
   include Wicked::Wizard::Translated
 
   included do
-    before_action :set_steps
-    before_action :setup_wizard_translated
+    with_options only: %i[show update] do
+      before_action :set_steps
+      before_action :setup_wizard_translated
+    end
   end
 
   def current_step

--- a/app/controllers/vaccination_reports_controller.rb
+++ b/app/controllers/vaccination_reports_controller.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class VaccinationReportsController < ApplicationController
+  before_action :set_vaccination_report
+  before_action :set_programme, only: %i[show update]
+
+  include WizardControllerConcern
+
+  skip_after_action :verify_policy_scoped, only: %i[show update download]
+
+  def create
+    @programme = policy_scope(Programme).find_by(type: params[:programme_type])
+
+    @vaccination_report.reset!
+    @vaccination_report.update!(programme: @programme)
+
+    redirect_to vaccination_report_path(Wicked::FIRST_STEP)
+  end
+
+  def download
+    # TODO: download the real data
+    send_data("", filename: @vaccination_report.filename)
+  end
+
+  def show
+    render_wizard
+  end
+
+  def update
+    @vaccination_report.assign_attributes(update_params)
+
+    render_wizard @vaccination_report
+  end
+
+  private
+
+  def set_vaccination_report
+    @vaccination_report =
+      VaccinationReport.new(request_session: session, current_user:)
+  end
+
+  def set_programme
+    @programme = @vaccination_report.programme
+  end
+
+  def set_steps
+    self.steps = @vaccination_report.wizard_steps
+  end
+
+  def finish_wizard_path
+    download_vaccination_report_path
+  end
+
+  def update_params
+    params
+      .require(:vaccination_report)
+      .permit(:date_from, :date_to, :file_format)
+      .merge(wizard_step: current_step)
+  end
+end

--- a/app/models/concerns/request_session_persistable.rb
+++ b/app/models/concerns/request_session_persistable.rb
@@ -35,6 +35,11 @@ module RequestSessionPersistable
     save(context: :update) # rubocop:disable Rails/SaveBang
   end
 
+  def update!(...)
+    assign_attributes(...)
+    save!(context: :update)
+  end
+
   def [](attr)
     public_send(attr)
   end

--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class VaccinationReport
+  include RequestSessionPersistable
+  include WizardStepConcern
+
+  FILE_FORMATS = %w[careplus mavis].freeze
+
+  def self.request_session_key
+    "vaccination_report"
+  end
+
+  attribute :date_from, :datetime
+  attribute :date_to, :integer
+  attribute :file_format, :string
+  attribute :programme_id, :integer
+
+  def wizard_steps
+    %i[dates file_format]
+  end
+
+  on_wizard_step :file_format, exact: true do
+    validates :file_format, inclusion: { in: FILE_FORMATS }
+  end
+
+  def programme
+    ProgrammePolicy::Scope
+      .new(@current_user, Programme)
+      .resolve
+      .find_by(id: programme_id)
+  end
+
+  def programme=(value)
+    self.programme_id = value.id
+  end
+
+  def filename
+    return nil if invalid?
+
+    from_str = date_from&.to_fs(:long) || "earliest"
+    to_str = date_to&.to_fs(:long) || "latest"
+
+    "#{programme.name} - #{file_format} - #{from_str} - #{to_str}.csv"
+  end
+
+  private
+
+  def reset_unused_fields
+  end
+end

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -10,6 +10,10 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :overview) %>
 
+<% if Flipper.enabled?(:release_1b) %>
+  <%= govuk_button_to "Download vaccination report", programme_vaccination_reports_path(@programme), class: "app-button--secondary" %>
+<% end %>
+
 <div class="nhsuk-grid-row nhsuk-card-group">
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: programme_cohorts_path(@programme), colour: "reversed", data: true) do |card| %>

--- a/app/views/vaccination_reports/dates.html.erb
+++ b/app/views/vaccination_reports/dates.html.erb
@@ -1,0 +1,23 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: programme_path(@programme),
+        name: "programme page",
+      ) %>
+<% end %>
+
+<%= form_with model: @vaccination_report, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="nhsuk-caption-l"><%= @programme.name %></span>
+  <%= h1 "Select a vaccination date range" %>
+
+  <%= f.govuk_date_field :date_from,
+                         legend: { text: "From" },
+                         hint: { text: "For example, 27 3 2017" } %>
+
+  <%= f.govuk_date_field :date_to,
+                         legend: { text: "Until" },
+                         hint: { text: "For example, 27 3 2017" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/vaccination_reports/file_format.html.erb
+++ b/app/views/vaccination_reports/file_format.html.erb
@@ -1,0 +1,17 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: previous_wizard_path,
+        name: "previous step",
+      ) %>
+<% end %>
+
+<% title = "Select file format" %>
+<% content_for :page_title, title %>
+
+<%= form_with model: @vaccination_report, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons :file_format, VaccinationReport::FILE_FORMATS, :itself, legend: { text: title, size: "l", tag: "h1" }, caption: { text: @programme.name } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,6 +267,10 @@ en:
             relationship_other_name:
               blank: Enter a relationship
               too_long: Enter a relationship that is less than 300 characters long
+        vaccination_report:
+          attributes:
+            file_format:
+              inclusion: Choose a file format
   activerecord:
     attributes:
       consent:
@@ -828,8 +832,10 @@ en:
     contact_method: contact-method
     date_and_time: date-and-time
     date_of_birth: date-of-birth
+    dates: dates
     delivery: delivery
     education_setting: education-setting
+    file_format: file-format
     gp: gp
     health_question: health-question
     injection: injection

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -17,3 +17,7 @@ en:
           apply: Use duplicate record
           discard: Keep previously uploaded record
           keep_both: Keep both records
+      vaccination_report:
+        file_format_options:
+          careplus: CarePlus
+          mavis: CSV

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,11 @@ Rails.application.routes.draw do
   resource :draft_vaccination_record,
            only: %i[show update],
            path: "draft-vaccination-record/:id"
+  resource :vaccination_report,
+           only: %i[show update],
+           path: "draft-vaccination-report/:id" do
+    get "download", on: :member
+  end
 
   resources :notices, only: :index
 
@@ -150,6 +155,10 @@ Rails.application.routes.draw do
         post "reset-dps-export", on: :collection
       end
     end
+
+    resources :vaccination_reports,
+              path: "vaccination-reports",
+              only: %i[create]
   end
 
   resources :sessions, only: %i[edit index show], param: :slug do

--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+describe "Download vaccination reports" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
+  scenario "Download in CarePlus format" do
+    given_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_go_to_the_programme
+    and_i_click_on_download_vaccination_report
+    then_i_see_the_dates_page
+
+    when_i_enter_some_dates
+    then_i_see_the_file_format_page
+
+    when_i_choose_careplus
+    then_i_download_a_csv_file
+  end
+
+  scenario "Download in Mavis format" do
+    given_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_go_to_the_programme
+    and_i_click_on_download_vaccination_report
+    then_i_see_the_dates_page
+
+    when_i_enter_some_dates
+    then_i_see_the_file_format_page
+
+    when_i_choose_mavis
+    then_i_download_a_csv_file
+  end
+
+  def given_an_hpv_programme_is_underway
+    @organisation = create(:organisation, :with_one_nurse)
+    @programme = create(:programme, :hpv, organisations: [@organisation])
+
+    @session =
+      create(:session, organisation: @organisation, programme: @programme)
+
+    @patient =
+      create(
+        :patient,
+        :triage_ready_to_vaccinate,
+        given_name: "John",
+        family_name: "Smith",
+        programme: @programme,
+        organisation: @organisation
+      )
+
+    @patient_session =
+      create(:patient_session, patient: @patient, session: @session)
+  end
+
+  def and_an_administered_vaccination_record_exists
+    vaccine = @programme.vaccines.first
+
+    batch = create(:batch, organisation: @organisation, vaccine:)
+
+    create(
+      :vaccination_record,
+      programme: @programme,
+      patient_session: @patient_session,
+      batch:
+    )
+  end
+
+  def when_i_go_to_the_programme
+    sign_in @organisation.users.first
+    visit programme_path(@programme)
+  end
+
+  def and_i_click_on_download_vaccination_report
+    click_on "Download vaccination report"
+  end
+
+  def then_i_see_the_dates_page
+    expect(page).to have_content("Select a vaccination date range")
+  end
+
+  def when_i_enter_some_dates
+    within all(".nhsuk-fieldset")[0] do
+      fill_in "Day", with: "01"
+      fill_in "Month", with: "01"
+      fill_in "Year", with: "2024"
+    end
+
+    within all(".nhsuk-fieldset")[1] do
+      fill_in "Day", with: "31"
+      fill_in "Month", with: "12"
+      fill_in "Year", with: "2024"
+    end
+
+    click_on "Continue"
+  end
+
+  def then_i_see_the_file_format_page
+    expect(page).to have_content("Select file format")
+  end
+
+  def when_i_choose_careplus
+    choose "CarePlus"
+    click_on "Continue"
+  end
+
+  def when_i_choose_mavis
+    choose "CSV"
+    click_on "Continue"
+  end
+
+  def then_i_download_a_csv_file
+    expect(page.status_code).to eq(200)
+
+    # TODO: check contents looks right
+  end
+end


### PR DESCRIPTION
This adds a basic two question interface allowing the user to start downloading vaccination reports by choosing the date range and the file format they'd like the export to be in.

Currently the download step does nothing, but we expect this to link in to #2427 and another exporter for the Mavis format.

## Screenshots

![Screenshot 2024-11-13 at 16 14 59](https://github.com/user-attachments/assets/5f69a0f4-6246-4cbc-b5b2-c7f970d66eb5)
![Screenshot 2024-11-13 at 16 24 40](https://github.com/user-attachments/assets/adeeef3d-fe5d-428b-a5d1-7a65edd92ba3)
![Screenshot 2024-11-13 at 16 24 42](https://github.com/user-attachments/assets/521a06ca-25c3-45b9-b97e-6101c3624e9d)
![Screenshot 2024-11-13 at 16 24 44](https://github.com/user-attachments/assets/619c1755-bb3f-4159-9b83-8f7727f11a0d)
