### PR TITLE
Tweak Careplus exporter

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -125,7 +125,7 @@ class Reports::CareplusExporter
       "School Nurse", # Staff Code
       "Y", # Attended; Did not attends do not get recorded on GP systems
       "", # Reason Not Attended; Always blank
-      "", # Suspension End Date; Not sure what this is, leaving blank
+      "", # Suspension End Date; Doesn't need to be used
       *vaccine_fields(vaccination_records, 0),
       *vaccine_fields(vaccination_records, 1),
       *vaccine_fields(vaccination_records, 2),
@@ -144,11 +144,31 @@ class Reports::CareplusExporter
 
     [
       record.vaccine.snomed_product_code, # Vaccine X
-      "", # Dose X field; Not sure, documentation says this is derived later?
+      "#{record.dose_sequence}P", # Dose X field
       VaccinationRecord.human_enum_name(:reason, record.reason), # Reason Not Given X
-      record.delivery_site, # Site X; Coded value, but we don't know the codes yet
+      coded_site(record.delivery_site), # Site X; Coded value
       record.vaccine.manufacturer, # Manufacturer X
       record.batch.name # Batch No X
+    ]
+  end
+
+  def coded_site(site)
+    {
+      # These are confirmed
+      left_arm: "LA",
+      right_arm: "RA",
+      # These are made up/guessed
+      left_arm_upper_position: "LUP",
+      left_arm_lower_position: "LLP",
+      right_arm_upper_position: "RUP",
+      right_arm_lower_position: "RLP",
+      left_thigh: "LT",
+      right_thigh: "RT",
+      left_buttock: "LB",
+      right_buttock: "RB",
+      nose: "N"
+    }[
+      site
     ]
   end
 end

--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -4,7 +4,7 @@ class VaccinationReport
   include RequestSessionPersistable
   include WizardStepConcern
 
-  FILE_FORMATS = %w[careplus mavis].freeze
+  FILE_FORMATS = Settings.export.formats.freeze
 
   def self.request_session_key
     "vaccination_report"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,11 @@ disallow_database_seeding: true
 fast_reset: false
 web_concurrency: 2
 
+export:
+  formats:
+    # - careplus
+    - mavis
+
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via
 # Devise.
 cis2:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,6 +3,11 @@ disallow_database_seeding: false
 fast_reset: true
 web_concurrency: 0
 
+export:
+  formats:
+    - careplus
+    - mavis
+
 cis2:
   enabled: false
   authentication_assurance_level: 1

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,6 +3,11 @@ disallow_database_seeding: false
 fast_reset: true
 web_concurrency: 0
 
+export:
+  formats:
+    - careplus
+    - mavis
+
 cis2:
   issuer: "http://localhost:4000/test/oidc"
   client_id: "31337.apps.national"


### PR DESCRIPTION
We've confirmed that the Suspension end date field isn't used. We also found out some more information about the Dose and Site fields that help us get them closer to correct, but they still need some more tweaking.