### PR TITLE
Preload consent patient

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -69,7 +69,11 @@ class Reports::CareplusExporter
     scope =
       session
         .patient_sessions
-        .includes(:vaccination_records, consents: :parent, patient: :school)
+        .includes(
+          :vaccination_records,
+          consents: %i[parent patient],
+          patient: :school
+        )
         .where.not(vaccination_records: { id: nil })
         .merge(VaccinationRecord.administered)
 


### PR DESCRIPTION
If the consent route is self-consent, there won't be a parent but instead a patient which we need to preload.

https://good-machine.sentry.io/issues/6064050500/