### PR TITLE
Preload consent patient

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -17,7 +17,7 @@ class ConsentsController < ApplicationController
       @session
         .patient_sessions
         .preload_for_state
-        .preload(consents: :parent)
+        .preload(consents: %i[parent patient])
         .eager_load(patient: :cohort)
         .order_by_name
         .strict_loading

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -77,7 +77,7 @@ class PatientsController < ApplicationController
         .includes(
           :school,
           :cohort,
-          consents: :parent,
+          consents: %i[parent patient],
           notify_log_entries: :sent_by,
           parents: :parent_relationships,
           patient_sessions: %i[location session_attendances],

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -12,7 +12,7 @@ class SchoolSessionRemindersJob < ApplicationJob
           :gillick_assessment,
           :triages,
           :vaccination_records,
-          consents: :parent,
+          consents: %i[parent patient],
           patient: :parents
         )
         .eager_load(:session)


### PR DESCRIPTION
This follows on from 70c4b5c377a3eb46105ff7f7802e7449630e3f67 and extends all the locations where we preload the consent to also include the patient in the case of self-consent.