### PR TITLE
Update programme vaccination export to match spec

### DIFF
--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -123,7 +123,7 @@ describe "Download vaccination reports" do
     expect(page.status_code).to eq(200)
 
     expect(page).to have_content(
-      "ORGANISATION_CODE,SCHOOL_URN,SCHOOL_NAME,CLINIC_NAME,CARE_SETTING,NHS_NUMBER"
+      "ORGANISATION_CODE,SCHOOL_URN,SCHOOL_NAME,CARE_SETTING,CLINIC_NAME,PERSON_FORENAME,PERSON_SURNAME"
     )
   end
 end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -33,26 +33,39 @@ describe Reports::ProgrammeVaccinationsExporter do
           ORGANISATION_CODE
           SCHOOL_URN
           SCHOOL_NAME
-          CLINIC_NAME
           CARE_SETTING
-          NHS_NUMBER
+          CLINIC_NAME
           PERSON_FORENAME
           PERSON_SURNAME
-          PERSON_GENDER_CODE
           PERSON_DOB
+          YEAR_GROUP
+          PERSON_GENDER_CODE
           PERSON_POSTCODE
+          NHS_NUMBER
+          CONSENT_STATUS
+          CONSENT_DETAILS
+          HEALTH_QUESTION_ANSWERS
+          TRIAGE_STATUS
+          TRIAGED_BY
+          TRIAGE_DATE
+          TRIAGE_NOTES
+          GILLICK_STATUS
+          GILLICK_ASSESSMENT_DATE
+          GILLICK_ASSESSED_BY
+          GILLICK_ASSESSMENT_NOTES
+          VACCINATED
           DATE_OF_VACCINATION
           TIME_OF_VACCINATION
-          VACCINATED
           VACCINE_GIVEN
-          REASON_NOT_VACCINATED
-          BATCH_NUMBER
-          BATCH_EXPIRY_DATE
-          ANATOMICAL_SITE
-          DOSE_SEQUENCE
           PERFORMING_PROFESSIONAL_EMAIL
           PERFORMING_PROFESSIONAL_FORENAME
           PERFORMING_PROFESSIONAL_SURNAME
+          BATCH_NUMBER
+          BATCH_EXPIRY_DATE
+          ANATOMICAL_SITE
+          ROUTE_OF_VACCINATION
+          DOSE_SEQUENCE
+          REASON_NOT_GIVEN
         ]
       )
     end
@@ -67,7 +80,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       it { should be_empty }
 
       context "with a vaccinated patient" do
-        let(:patient) { create(:patient) }
+        let(:patient) { create(:patient, year_group: 8) }
         let(:patient_session) { create(:patient_session, patient:, session:) }
         let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
         let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 0o5, 20) }
@@ -87,13 +100,20 @@ describe Reports::ProgrammeVaccinationsExporter do
           expect(rows.count).to eq(1)
           expect(rows.first.to_hash).to eq(
             {
-              "ANATOMICAL_SITE" => "left upper arm",
+              "ANATOMICAL_SITE" => "Left arm upper position",
               "BATCH_EXPIRY_DATE" => batch.expiry.strftime("%Y%m%d"),
               "BATCH_NUMBER" => batch.name,
               "CARE_SETTING" => "1",
               "CLINIC_NAME" => "",
+              "CONSENT_DETAILS" => "",
+              "CONSENT_STATUS" => "",
               "DATE_OF_VACCINATION" => "20240101",
               "DOSE_SEQUENCE" => "1",
+              "GILLICK_ASSESSED_BY" => "",
+              "GILLICK_ASSESSMENT_DATE" => "",
+              "GILLICK_ASSESSMENT_NOTES" => "",
+              "GILLICK_STATUS" => "",
+              "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
@@ -104,12 +124,18 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
-              "REASON_NOT_VACCINATED" => "",
+              "REASON_NOT_GIVEN" => "",
+              "ROUTE_OF_VACCINATION" => "Intramuscular",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
               "TIME_OF_VACCINATION" => "12:05:20",
+              "TRIAGED_BY" => "",
+              "TRIAGE_DATE" => "",
+              "TRIAGE_NOTES" => "",
+              "TRIAGE_STATUS" => "",
               "VACCINATED" => "Y",
-              "VACCINE_GIVEN" => "Gardasil9"
+              "VACCINE_GIVEN" => "Gardasil9",
+              "YEAR_GROUP" => "8"
             }
           )
         end
@@ -122,7 +148,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       it { should be_empty }
 
       context "with a vaccinated patient" do
-        let(:patient) { create(:patient) }
+        let(:patient) { create(:patient, year_group: 8) }
         let(:patient_session) { create(:patient_session, patient:, session:) }
         let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
         let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 0o5, 20) }
@@ -143,13 +169,20 @@ describe Reports::ProgrammeVaccinationsExporter do
           expect(rows.count).to eq(1)
           expect(rows.first.to_hash).to eq(
             {
-              "ANATOMICAL_SITE" => "left upper arm",
+              "ANATOMICAL_SITE" => "Left arm upper position",
               "BATCH_EXPIRY_DATE" => batch.expiry.strftime("%Y%m%d"),
               "BATCH_NUMBER" => batch.name,
               "CARE_SETTING" => "2",
               "CLINIC_NAME" => "A Clinic",
+              "CONSENT_DETAILS" => "",
+              "CONSENT_STATUS" => "",
               "DATE_OF_VACCINATION" => "20240101",
               "DOSE_SEQUENCE" => "1",
+              "GILLICK_ASSESSED_BY" => "",
+              "GILLICK_ASSESSMENT_DATE" => "",
+              "GILLICK_ASSESSMENT_NOTES" => "",
+              "GILLICK_STATUS" => "",
+              "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
@@ -160,12 +193,18 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
-              "REASON_NOT_VACCINATED" => "",
+              "REASON_NOT_GIVEN" => "",
+              "ROUTE_OF_VACCINATION" => "Intramuscular",
               "SCHOOL_NAME" => "",
               "SCHOOL_URN" => "888888",
               "TIME_OF_VACCINATION" => "12:05:20",
+              "TRIAGED_BY" => "",
+              "TRIAGE_DATE" => "",
+              "TRIAGE_NOTES" => "",
+              "TRIAGE_STATUS" => "",
               "VACCINATED" => "Y",
-              "VACCINE_GIVEN" => "Gardasil9"
+              "VACCINE_GIVEN" => "Gardasil9",
+              "YEAR_GROUP" => "8"
             }
           )
         end


### PR DESCRIPTION
This adds a number of missing fields to match the spec. A lot of these fields are untested at the moment, but I thought it would make sense to get this in and improve the tests later.