### PR TITLE
Improve programme vaccinations tests

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -123,7 +123,7 @@ class Reports::ProgrammeVaccinationsExporter
       health_question_answers(consents),
       triage&.status&.humanize || "",
       triage&.performed_by&.full_name || "",
-      triage&.created_at&.strftime("%Y%m%d") || "",
+      triage&.updated_at&.strftime("%Y%m%d") || "",
       triage&.notes || "",
       if gillick_assessment&.gillick_competent?
         "Gillick competent"
@@ -178,7 +178,7 @@ class Reports::ProgrammeVaccinationsExporter
   def consent_details(consents)
     values =
       consents.map do |consent|
-        "#{consent.response.humanize} by #{consent.name}  at #{consent.recorded_at}"
+        "#{consent.response.humanize} by #{consent.name} at #{consent.recorded_at}"
       end
 
     values.join(", ")

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -66,7 +66,7 @@ describe Reports::OfflineSessionExporter do
         worksheet_to_hashes(workbook.worksheets[0])
       end
 
-      let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 0o5, 20) }
+      let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
       let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
       let(:patient_session) { create(:patient_session, patient:, session:) }
       let(:patient) { create(:patient) }
@@ -282,7 +282,7 @@ describe Reports::OfflineSessionExporter do
         end
         let(:patient_session) { create(:patient_session, patient:, session:) }
         let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
-        let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 0o5, 20) }
+        let(:administered_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
 
         before do
           create(


### PR DESCRIPTION
This adds a number of tests to ensure we're exporting consents, triage and gillick assessments correctly.