### PR TITLE
Allow vaccination if child refused

### DIFF
--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -163,7 +163,7 @@ class VaccinationRecord < ApplicationRecord
 
   def retryable_reason?
     not_well? || contraindications? || absent_from_session? ||
-      absent_from_school?
+      absent_from_school? || refused?
   end
 
   def dose_volume_ml

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -51,7 +51,7 @@ describe "HPV Vaccination" do
   end
 
   def and_i_select_the_reason_why
-    choose "They refused it"
+    choose "They have already had the vaccine"
     click_button "Continue"
   end
 
@@ -59,7 +59,7 @@ describe "HPV Vaccination" do
     expect(page).to have_content("Check and confirm")
     expect(page).to have_content("Vaccination was not given")
     expect(page).to have_content("Child#{@patient.full_name}")
-    expect(page).to have_content("OutcomeRefused vaccine")
+    expect(page).to have_content("OutcomeAlready had")
   end
 
   def when_i_click_change_outcome
@@ -84,7 +84,9 @@ describe "HPV Vaccination" do
 
   def then_i_see_that_the_status_is_could_not_vaccinate
     expect(page).to have_content("Could not vaccinate")
-    expect(page).to have_content("Reason#{@patient.full_name} refused it")
+    expect(page).to have_content(
+      "Reason#{@patient.full_name} has already had the vaccine"
+    )
   end
 
   def and_an_email_is_sent_saying_the_vaccination_didnt_happen

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -6,6 +6,7 @@ describe "HPV Vaccination" do
 
   scenario "Delayed" do
     given_i_am_signed_in
+
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_record_that_the_patient_was_absent
     then_i_see_the_confirmation_page


### PR DESCRIPTION
This should be allowed in the case where the child refused the vaccine and then later on in the day decided they were happy to receive the vaccine, which we know can happen.

More context on this is available in the bug report: https://trello.com/c/tV9y34Qx/1511-nurse-is-not-allowed-to-record-a-vaccine-if-child-already-has-an-outcome-where-the-reason-not-given-is-they-refused-it-other-rea