### PR TITLE
Add support for parsing ISO 8601 dates

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -393,17 +393,20 @@ class ImmunisationImportRow
     administered && @programme.flu?
   end
 
+  DATE_FORMATS = %w[%Y%m%d %Y-%m-%d %d/%m/%Y].freeze
+
   def parse_date(key)
     value = @data[key]&.strip
     return nil if value.nil?
 
-    Date.strptime(value, "%Y%m%d")
-  rescue ArgumentError, TypeError
-    begin
-      Date.strptime(value, "%d/%m/%Y")
-    rescue ArgumentError, TypeError
-      nil
-    end
+    parsed_dates =
+      DATE_FORMATS.lazy.filter_map do |format|
+        Date.strptime(value, format)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+    parsed_dates.first
   end
 
   TIME_FORMATS = %w[%H:%M:%S %H:%M %H%M%S %H%M %H].freeze

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1252,6 +1252,16 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "with an ISO 8601 date format" do
+      let(:data) { valid_data.merge("DATE_OF_VACCINATION" => "2023-09-01") }
+
+      it "parses the date and sets the administered at time" do
+        expect(vaccination_record.administered_at).to eq(
+          Time.new(2023, 9, 1, 12, 0, 0, "+01:00")
+        )
+      end
+    end
+
     context "with a time of vaccination" do
       let(:data) { valid_data.merge("TIME_OF_VACCINATION" => "10:30:25") }
 


### PR DESCRIPTION
This extends our date parsing to handle another common date format that we might sometimes see in the files provided by our users.