### PR TITLE
Specify an Excel date format

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -27,17 +27,20 @@ class Reports::OfflineSessionExporter
   delegate :location, :organisation, to: :session
 
   def add_vaccinations_sheet(package)
-    package
-      .workbook
-      .add_worksheet(name: "Vaccinations") do |sheet|
-        sheet.add_row(headers_and_types.keys)
+    workbook = package.workbook
 
-        patient_sessions.each do |patient_session|
-          rows(patient_session:).each do |row|
-            sheet.add_row(row, types: headers_and_types.values)
-          end
-        end
+    date_style = workbook.styles.add_style(format_code: "dd/mm/yyyy")
+
+    types = headers_and_types.values
+    style = types.map { _1 == :date ? date_style : nil }
+
+    workbook.add_worksheet(name: "Vaccinations") do |sheet|
+      sheet.add_row(headers_and_types.keys)
+
+      patient_sessions.each do |patient_session|
+        rows(patient_session:).each { |row| sheet.add_row(row, types:, style:) }
       end
+    end
   end
 
   def headers_and_types


### PR DESCRIPTION
When including dates in an Excel file format, we can specify a format code for the dates. I can't test this locally, but I'm hoping this ensures that when the file is exported, it uses the format specified here rather than the user's system date formatting preferences.