### PR TITLE
Use '0' instead of 'None' on session table

### DIFF
--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -20,7 +20,7 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   attr_reader :sessions
 
   def cohort_count(session:)
-    (count = session.patient_sessions.length).zero? ? "None" : count
+    session.patient_sessions.length.to_s
   end
 
   def number_stat(session:, key:)


### PR DESCRIPTION
We show "None" in a few other places, but in a table with numerical values we should show "0" instead.