### PR TITLE
Refactor how organisations are onboarded

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -56,16 +56,20 @@ class Location < ApplicationRecord
 
   validates :name, presence: true
   validates :url, url: true, allow_nil: true
+  validates :urn, uniqueness: true, allow_nil: true
 
-  validates :ods_code, presence: true, if: :clinic?
-
-  with_options if: :generic_clinic? do
+  with_options if: :clinic? do
+    validates :ods_code, presence: true
     validates :team, presence: true
-    validates :ods_code, comparison: { equal_to: :organisation_ods_code }
   end
 
+  validates :ods_code,
+            comparison: {
+              equal_to: :organisation_ods_code
+            },
+            if: :generic_clinic?
+
   validates :urn, presence: true, if: :school?
-  validates :urn, uniqueness: true, allow_nil: true
 
   normalizes :urn, with: -> { _1.blank? ? nil : _1.strip }
 

--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+class Onboarding
+  include ActiveModel::Model
+
+  validates :organisation, presence: true
+  validates :programmes, presence: true
+  validates :teams, presence: true
+  validates :schools, presence: true
+  validates :clinics, presence: true
+
+  def initialize(hash)
+    config = hash.deep_symbolize_keys
+
+    @organisation = Organisation.new(config.fetch(:organisation, {}))
+
+    @programmes =
+      config
+        .fetch(:programmes, [])
+        .map do |type|
+          ExistingProgramme.new(type:, organisation: @organisation)
+        end
+
+    teams_by_name =
+      config
+        .fetch(:teams, {})
+        .transform_values do |team_config|
+          Team.new(**team_config, organisation:)
+        end
+
+    @teams = teams_by_name.values
+
+    @users =
+      config
+        .fetch(:users, [])
+        .map do |user_config|
+          User.new(**user_config, organisations: [organisation])
+        end
+
+    @schools =
+      config
+        .fetch(:schools, {})
+        .flat_map do |team_name, school_urns|
+          team = teams_by_name[team_name]
+          school_urns.map { |urn| ExistingSchool.new(urn:, team:) }
+        end
+
+    @clinics =
+      config
+        .fetch(:clinics, {})
+        .flat_map do |team_name, clinic_configs|
+          team = teams_by_name[team_name]
+          clinic_configs.map do |clinic_config|
+            Location.new(**clinic_config, type: :community_clinic, team:)
+          end
+        end
+  end
+
+  def valid?(context = nil)
+    ([super] + models.map(&:valid?)).all?
+  end
+
+  def invalid?(context = nil)
+    ([super] + models.map(&:invalid?)).any?
+  end
+
+  def errors
+    super.tap do |errors|
+      merge_errors_from([organisation], errors:, name: "organisation")
+      merge_errors_from(programmes, errors:, name: "programme")
+      merge_errors_from(teams, errors:, name: "team")
+      merge_errors_from(users, errors:, name: "user")
+      merge_errors_from(schools, errors:, name: "school")
+      merge_errors_from(clinics, errors:, name: "clinic")
+    end
+  end
+
+  def save!
+    ActiveRecord::Base.transaction do
+      models.each(&:save!)
+      organisation.generic_clinic
+      UnscheduledSessionsFactory.new.call
+    end
+  end
+
+  private
+
+  attr_reader :organisation, :programmes, :teams, :users, :schools, :clinics
+
+  def models
+    [organisation] + programmes + teams + users + schools + clinics
+  end
+
+  def merge_errors_from(objects, errors:, name:)
+    objects.each_with_index do |obj, index|
+      obj.errors.each do |error|
+        prefix =
+          if objects.count == 1
+            name
+          else
+            "#{name}.#{index}"
+          end
+
+        errors.import(error, attribute: "#{prefix}.#{error.attribute}")
+      end
+    end
+  end
+
+  class ExistingProgramme
+    include ActiveModel::Model
+
+    attr_accessor :type, :organisation
+
+    validates :programme, presence: true
+
+    def programme
+      @programme ||= Programme.find_by(type:)
+    end
+
+    def save!
+      OrganisationProgramme.create!(organisation:, programme:)
+    end
+  end
+
+  class ExistingSchool
+    include ActiveModel::Model
+
+    attr_accessor :urn, :team
+
+    validates :existing_team, absence: true
+    validates :location, presence: true
+    validates :team, presence: true
+
+    def location
+      @location ||= Location.school.find_by(urn:)
+    end
+
+    def existing_team
+      location&.team
+    end
+
+    def save!
+      location.update!(team:)
+    end
+  end
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -46,7 +46,7 @@ class Organisation < ApplicationRecord
 
   validates :email, notify_safe_email: true
   validates :name, presence: true, uniqueness: true
-  validates :ods_code, presence: true
+  validates :ods_code, presence: true, uniqueness: true
   validates :phone, presence: true, phone: true
 
   def year_groups

--- a/config/onboarding/coventry-model-office.yaml
+++ b/config/onboarding/coventry-model-office.yaml
@@ -1,0 +1,151 @@
+organisation:
+  name: Coventry and Warwickshire Partnership NHS Trust
+  email: example@covwarkpt.nhs.uk
+  phone: 07700 900815
+  ods_code: RYG
+
+programmes: [hpv]
+
+teams:
+  generic:
+    name: Coventry and Warwickshire Partnership NHS Trust
+    email: example@covwarkpt.nhs.uk
+    phone: 07700 900815
+
+users:
+  - email: nurse.ryg@example.com
+    password: nurse.ryg@example.com
+    given_name: Nurse
+    family_name: RYG
+
+schools:
+  generic:
+    - 141939
+    - 103751
+    - 103760
+    - 139292
+    - 134269
+    - 150498
+    - 141376
+    - 140958
+    - 149424
+    - 131574
+    - 141992
+    - 146436
+    - 137209
+    - 136126
+    - 103747
+    - 142960
+    - 140366
+    - 135335
+    - 141104
+    - 137272
+    - 147346
+    - 103750
+    - 142339
+    - 137225
+    - 140248
+    - 138023
+    - 140961
+    - 134970
+    - 141008
+    - 125790
+    - 149577
+    - 137781
+    - 136587
+    - 140354
+    - 145575
+    - 125773
+    - 145200
+    - 140654
+    - 137771
+    - 125794
+    - 140371
+    - 138644
+    - 137767
+    - 143707
+    - 145019
+    - 149580
+    - 141277
+    - 148398
+    - 139936
+    - 139468
+    - 134464
+    - 144764
+    - 142881
+    - 136595
+    - 125777
+    - 141836
+    - 125764
+    - 136986
+    - 137079
+    - 148828
+    - 136158
+    - 136459
+    - 139937
+    - 148243
+    - 148554
+    - 137597
+    - 149916
+    - 145224
+    - 137172
+    - 136622
+    - 125774
+    - 137770
+    - 147345
+    - 145470
+    - 137766
+    - 125805
+    - 136963
+    - 136991
+    - 146697
+    - 147432
+    - 137302
+    - 125788
+    - 148429
+    - 136907
+    - 142202
+    - 136510
+    - 125787
+    - 138767
+    - 143905
+    - 143634
+    - 137235
+    - 137236
+    - 136786
+    - 125775
+    - 148362
+    - 144633
+    - 148032
+    - 125781
+    - 145486
+
+# !IMPORTANT! The ODS codes of these clinics are not correct.
+
+clinics:
+  generic:
+    - name: Jepson House
+      address_line_1: 4 Manor Court Avenue
+      address_town: Nuneaton
+      address_postcode: CV11 5HX
+      ods_code: CV115HX
+    - name: Locke House
+      address_line_1: The Railings Woodside Park
+      address_town: Rugby
+      address_postcode: CV21 2AW
+      ods_code: CV212AW
+    - name: Woodloes House
+      address_line_1: Woodloes Avenue South
+      address_town: Warwick
+      address_postcode: CV34 5XN
+      ods_code: CV345XN
+    - name: Alcester Clinic
+      address_line_1: Fields Park Drive
+      address_town: Warwickshire
+      address_postcode: B49 6QR
+      ods_code: B496QR
+    - name: City Of Coventry Health Centre
+      address_line_1: 2 Stoney Stanton Road
+      address_town: Coventry
+      address_postcode: CV1 4FS
+      ods_code: CV14FS

--- a/lib/tasks/onboard.rake
+++ b/lib/tasks/onboard.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+desc "Onboard an organisation from a configuration file."
+task :onboard, [:filename] => :environment do |_, args|
+  config = YAML.safe_load(File.read(args[:filename]))
+
+  onboarding = Onboarding.new(config)
+
+  if onboarding.valid?
+    onboarding.save!
+  else
+    onboarding.errors.full_messages.each { |message| puts message }
+  end
+end

--- a/script/set_up_coventry.sh
+++ b/script/set_up_coventry.sh
@@ -4,16 +4,4 @@ bin/rails db:schema:load
 
 bin/rails vaccines:seed[hpv]
 bin/rails schools:import
-
-bin/rails "organisations:create_hpv[example@covwarkpt.nhs.uk,Coventry and Warwickshire Partnership NHS Trust,07700 900815,RYG,,]"
-bin/rails users:create[nurse.ryg@example.com,nurse.ryg@example.com,Nurse,RYG,RYG]
-
-bin/rails "schools:add_to_organisation[RYG,Coventry and Warwickshire Partnership NHS Trust,141939,103751,103760,139292,134269,150498,141376,140958,149424,131574,141992,146436,137209,136126,103747,142960,140366,135335,141104,137272,147346,103750,142339,137225,140248,138023,140961,134970,141008,125790,149577,137781,136587,140354,145575,125773,145200,140654,137771,125794,140371,138644,137767,143707,145019,149580,141277,148398,139936,139468,134464,144764,142881,136595,125777,141836,125764,136986,137079,148828,136158,136459,139937,148243,148554,137597,149916,145224,137172,136622,125774,137770,147345,145470,137766,125805,136963,136991,146697,147432,137302,125788,148429,136907,142202,136510,125787,138767,143905,143634,137235,137236,136786,125775,148362,144633,148032,125781,145486]"
-
-# !IMPORTANT! The ODS codes of these clinics are not correct.
-
-bin/rails "clinics:create[Jepson House,4 Manor Court Avenue,Nuneaton,CV11 5HX,CV115HX,RYG]"
-bin/rails "clinics:create[Locke House,The Railings Woodside Park,Rugby,CV21 2AW,CV212AW,RYG]"
-bin/rails "clinics:create[Woodloes House,Woodloes Avenue South,Warwick,CV34 5XN,CV345XN,RYG]"
-bin/rails "clinics:create[Alcester Clinic,Fields Park Drive,Warwickshire,B49 6QR,B496QR,RYG]"
-bin/rails "clinics:create[City Of Coventry Health Centre,2 Stoney Stanton Road,Coventry,CV1 4FS,CV14FS,RYG]"
+bin/rails onboard[config/onboarding/coventry-model-office.yaml]

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -22,7 +22,7 @@ describe AppSessionSummaryComponent do
   it { should have_content("School session") }
 
   context "with a community clinic" do
-    let(:location) { create(:location, :community_clinic) }
+    let(:location) { create(:location, :community_clinic, organisation:) }
 
     it { should have_content("Community clinic") }
   end

--- a/spec/fixtures/files/onboarding/invalid.yaml
+++ b/spec/fixtures/files/onboarding/invalid.yaml
@@ -1,0 +1,9 @@
+organisation:
+  email: example@trust.nhs.uk
+
+teams:
+  team_1:
+    phone: 07700 900816
+
+schools:
+  unknown_team: [123456, 234567]

--- a/spec/fixtures/files/onboarding/valid.yaml
+++ b/spec/fixtures/files/onboarding/valid.yaml
@@ -1,0 +1,31 @@
+organisation:
+  name: NHS Trust
+  email: example@trust.nhs.uk
+  phone: 07700 900815
+  ods_code: EXAMPLE
+
+programmes: [hpv]
+
+teams:
+  team_1:
+    name: Team 1
+    email: team-1@trust.nhs.uk
+    phone: 07700 900816
+  team_2:
+    name: Team 2
+    email: team-2@trust.nhs.uk
+    phone: 07700 900817
+
+schools:
+  team_1: [123456, 234567]
+  team_2: [345678, 456789]
+
+clinics:
+  team_1:
+    - name: 10 Downing Street
+      address_postcode: SW1A 1AA
+      ods_code: SW1A10
+  team_2:
+    - name: 11 Downing Street
+      address_postcode: SW1A 1AA
+      ods_code: SW1A11

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -253,7 +253,7 @@ describe DPSExportRow do
 
       context "when the session has a location with an ODS code" do
         let(:location) do
-          create(:location, :community_clinic, ods_code: "12345")
+          create(:location, :community_clinic, ods_code: "12345", organisation:)
         end
 
         it { should eq("12345") }
@@ -282,7 +282,7 @@ describe DPSExportRow do
       end
 
       context "when the session has a location without a URN" do
-        let(:location) { create(:location, :community_clinic) }
+        let(:location) { create(:location, :community_clinic, organisation:) }
 
         it { should eq("https://fhir.nhs.uk/Id/ods-organization-code") }
       end

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+describe Onboarding do
+  subject(:onboarding) { described_class.new(config) }
+
+  let(:config) { YAML.safe_load(file_fixture(filename).read) }
+
+  let!(:programme) { create(:programme, :hpv) }
+  # rubocop:disable RSpec/IndexedLet
+  let!(:school1) { create(:location, :secondary, urn: "123456") }
+  let!(:school2) { create(:location, :secondary, urn: "234567") }
+  let!(:school3) { create(:location, :secondary, urn: "345678") }
+  let!(:school4) { create(:location, :secondary, urn: "456789") }
+  # rubocop:enable RSpec/IndexedLet
+
+  context "with a valid configuration file" do
+    let(:filename) { "onboarding/valid.yaml" }
+
+    it { should be_valid }
+
+    it "set up the models" do
+      expect { onboarding.save! }.not_to raise_error
+
+      organisation = Organisation.find_by!(ods_code: "EXAMPLE")
+      expect(organisation.name).to eq("NHS Trust")
+      expect(organisation.email).to eq("example@trust.nhs.uk")
+      expect(organisation.phone).to eq("07700 900815")
+      expect(organisation.programmes).to contain_exactly(programme)
+
+      team1 = organisation.teams.find_by!(name: "Team 1")
+      expect(team1.email).to eq("team-1@trust.nhs.uk")
+      expect(team1.phone).to eq("07700 900816")
+
+      team2 = organisation.teams.find_by!(name: "Team 2")
+      expect(team2.email).to eq("team-2@trust.nhs.uk")
+      expect(team2.phone).to eq("07700 900817")
+
+      expect(team1.schools).to contain_exactly(school1, school2)
+      expect(team2.schools).to contain_exactly(school3, school4)
+
+      clinic1 = team1.clinics.find_by!(ods_code: "SW1A10")
+      expect(clinic1.name).to eq("10 Downing Street")
+      expect(clinic1.address_postcode).to eq("SW1A 1AA")
+
+      clinic2 = team2.clinics.find_by!(ods_code: "SW1A11")
+      expect(clinic2.name).to eq("11 Downing Street")
+      expect(clinic2.address_postcode).to eq("SW1A 1AA")
+
+      expect(organisation.sessions.count).to eq(5)
+    end
+  end
+
+  context "with an invalid configuration file" do
+    let(:filename) { "onboarding/invalid.yaml" }
+
+    it { should be_invalid }
+
+    it "has errors" do
+      onboarding.invalid?
+
+      expect(onboarding.errors.messages).to eq(
+        {
+          "organisation.name": ["can't be blank"],
+          "organisation.ods_code": ["can't be blank"],
+          "organisation.phone": ["can't be blank", "is invalid"],
+          "school.0.team": ["can't be blank"],
+          "school.1.team": ["can't be blank"],
+          "team.email": ["can't be blank"],
+          "team.name": ["can't be blank"],
+          clinics: ["can't be blank"],
+          programmes: ["can't be blank"]
+        }
+      )
+    end
+  end
+end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -71,7 +71,15 @@ describe Patient do
 
     context "with an invalid school" do
       subject(:patient) do
-        build(:patient, school: create(:location, :community_clinic))
+        build(
+          :patient,
+          school:
+            create(
+              :location,
+              :community_clinic,
+              organisation: create(:organisation)
+            )
+        )
       end
 
       it "is invalid" do


### PR DESCRIPTION
This introduces a new Rake task `onboard` and a YAML configuration file that needs to contain all the information required to onboard an organisation (teams, schools, clinics, programmes, etc) and only if it is all valid does it create the database records.

This helps to avoid situations where the organisations can be partially created, which in the case of missing clinics can be clinically unsafe.

I'm raising this to get a review on the approach taken, but I think there are a number of follow tasks required:

- Document this onboarding process
- Set up our test environments using this process rather than seeds
- Remove Rake tasks which should no longer be used

## Example invalid output

```
❯ bundle exec rails onboard[spec/fixtures/files/onboarding/invalid.yaml]
Programmes can't be blank
Clinics can't be blank
Organisation name can't be blank
Organisation ODS code can't be blank
Organisation phone can't be blank
Organisation phone is invalid
Team name can't be blank
Team email can't be blank
School 0 team can't be blank
School 1 location can't be blank
School 1 team can't be blank
```