### PR TITLE
Add documentation for onboarding process

### DIFF
--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,48 @@
+# Onboarding
+
+Onboarding a new organisation involves creating a YAML file containing all the information about the organisation and using the `onboard` Rake task to add everything in to the service.
+
+## Configuration file
+
+```yaml
+organisation:
+  name: # Unique name of the organisation
+  email: # Contact email address
+  phone: # Contact phone number
+  ods_code: # Unique ODS code
+  privacy_policy_url: # Optional privacy policy URL
+  reply_to_id: # Optional GOV.UK Notify Reply-To UUID
+
+programmes: [] # A list of programmes, currently only hpv is valid
+
+teams:
+  team_name: # Name of the team referenced in schools and links
+    name: # Name of the team
+    email: # Contact email address
+    phone: # Contact phone number
+
+schools:
+  team_name: [] # URNs managed by a particular team
+
+clinics:
+  team_name:
+    - name: # Name of the clinic
+      address_line_1: # First line of the address
+      address_town: # Town of the address
+      address_postcode: # Postcode of the address
+      ods_code: # Unique ODS code
+```
+
+An example configuration file used for [the Coventry model office can be found in the repo][coventry-model-office].
+
+[coventry-model-office]: /config/onboarding/coventry-model-office.yaml
+
+## Rake task
+
+Once the file has been written you can use the `onboard` Rake task to set everything up in the service.
+
+```sh
+$ bundle exec rails onboard[path/to/configuration.yaml]
+```
+
+If any validation errors are detected in the file they will be output and nothing will be processed, only if the file is completely valid will anything be processed.


### PR DESCRIPTION
This adds some documentation explaining how to onboard a new organisation and the format of the configuration YAML file.