### PR TITLE
Add link to create patients from consent forms

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -6,7 +6,8 @@ class AppPatientSummaryComponent < ViewComponent::Base
     show_preferred_name: false,
     show_address: false,
     show_parent_or_guardians: false,
-    change_links: {}
+    change_links: {},
+    highlight: true
   )
     super
 
@@ -16,6 +17,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
     @show_address = show_address
     @show_parent_or_guardians = show_parent_or_guardians
     @change_links = change_links
+    @highlight = highlight
   end
 
   def call
@@ -182,6 +184,8 @@ class AppPatientSummaryComponent < ViewComponent::Base
   end
 
   def highlight_if(value, condition)
-    condition ? tag.span(value, class: "app-highlight") : value
+    return value unless @highlight && condition
+
+    tag.span value, class: "app-highlight"
   end
 end

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -45,6 +45,30 @@ class ConsentFormsController < ApplicationController
     redirect_to action: :index
   end
 
+  def new_patient
+    @patient = Patient.from_consent_form(@consent_form)
+
+    render layout: "two_thirds"
+  end
+
+  def create_patient
+    @patient = Patient.from_consent_form(@consent_form)
+
+    ActiveRecord::Base.transaction do
+      @patient.save!
+
+      # This should now match because the patient with the same NHS number
+      # exists. We need to perform_now to make sure the record is matched and
+      # the consent form disappears from the index page
+      ConsentFormMatchingJob.perform_now(@consent_form)
+    end
+
+    flash[:success] = "#{@patient.full_name}’s record created from a consent \
+                       response from #{@consent_form.parent_full_name}"
+
+    redirect_to action: :index
+  end
+
   private
 
   def consent_form_scope

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -314,6 +314,22 @@ class Patient < ApplicationRecord
     end
   end
 
+  def self.from_consent_form(consent_form)
+    new(
+      address_line_1: consent_form.address_line_1,
+      address_line_2: consent_form.address_line_2,
+      address_postcode: consent_form.address_postcode,
+      address_town: consent_form.address_town,
+      date_of_birth: consent_form.date_of_birth,
+      family_name: consent_form.family_name,
+      given_name: consent_form.given_name,
+      nhs_number: consent_form.nhs_number,
+      preferred_family_name: consent_form.preferred_family_name,
+      preferred_given_name: consent_form.preferred_given_name,
+      school: consent_form.school
+    )
+  end
+
   class NHSNumberMismatch < StandardError
   end
 

--- a/app/views/consent_forms/index.html.erb
+++ b/app/views/consent_forms/index.html.erb
@@ -19,7 +19,20 @@
               row.with_cell(text: consent_form.recorded_at.to_date.to_fs(:long))
               row.with_cell(text: consent_form.full_name)
               row.with_cell(text: consent_form.parent_full_name)
-              row.with_cell(text: govuk_link_to("Find match", consent_form))
+              row.with_cell do
+                tag.ul(class: "app-action-list") do
+                  match_link = link_to("Match with record", consent_form)
+                  create_link = link_to("Create record", patient_consent_form_path(consent_form))
+    
+                  links = [tag.li(class: "app-action-list__item") { match_link }]
+    
+                  if consent_form.nhs_number.present?
+                    links << tag.li(class: "app-action-list__item") { create_link }
+                  end
+    
+                  safe_join(links)
+                end
+              end
             end
           end
         end

--- a/app/views/consent_forms/new_patient.html.erb
+++ b/app/views/consent_forms/new_patient.html.erb
@@ -1,0 +1,46 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+        href: consent_forms_path,
+        name: "unmatched consent responses",
+      ) %>
+<% end %>
+
+<% page_title = "Create a new child record from this consent response?" %>
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l">
+    Consent response from <%= @consent_form.parent_full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<%= render AppCardComponent.new do |c| %>
+  <% c.with_heading { "Child record" } %>
+  <%= render AppPatientSummaryComponent.new(@patient,
+                                            show_preferred_name: true,
+                                            show_address: true,
+                                            show_parent_or_guardians: true,
+                                            highlight: false) %>
+<% end %>
+
+<%= render AppCardComponent.new do |c|
+      c.with_heading { "Consent response" }
+      render AppConsentFormSummaryComponent.new(
+        name: @consent_form.parent_full_name,
+        relationship: @consent_form.parent_relationship_label,
+        contact: {
+          phone: @consent_form.parent_phone,
+          email: @consent_form.parent_email,
+        },
+        response: {
+          text: @consent_form.summary_with_route,
+          timestamp: @consent_form.recorded_at,
+        },
+        refusal_reason: {
+          reason: @consent_form.human_enum_name(:reason).presence,
+          notes: @consent_form.reason_notes,
+        },
+      )
+    end %>
+
+<%= govuk_button_to "Create a new record from response",
+                    patient_consent_form_path(@consent_form) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,9 @@ Rails.application.routes.draw do
     member do
       get "match/:patient_id", action: :edit_match, as: :match
       post "match/:patient_id", action: :update_match
+
+      get "patient", action: :new_patient
+      post "patient", action: :create_patient
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -138,6 +138,20 @@ def create_session(user, organisation, completed:)
     )
   end
 
+  # Add extra consent forms with a successful NHS number lookup
+  2.times do
+    temporary_patient = FactoryBot.build(:patient)
+    FactoryBot.create(
+      :consent_form,
+      :recorded,
+      programme:,
+      given_name: temporary_patient.given_name,
+      family_name: temporary_patient.family_name,
+      nhs_number: temporary_patient.nhs_number,
+      session:
+    )
+  end
+
   %i[
     consent_given_triage_not_needed
     consent_given_triage_needed

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+describe "Parental consent create patient" do
+  scenario "Nurse creates a patient from a consent response" do
+    stub_pds_search_to_return_a_patient
+
+    given_the_app_is_setup
+
+    when_i_go_to_the_consent_form
+    when_i_fill_in_my_childs_name_and_birthday
+
+    when_i_give_consent
+    and_i_answer_no_to_all_the_medical_questions
+    and_i_submit_the_consent_form
+    then_i_see_the_consent_confirmation_page
+
+    when_i_wait_for_background_jobs_to_complete
+    and_the_nurse_checks_the_unmatched_consent_responses
+    then_they_see_the_consent_form
+
+    when_the_nurse_clicks_create_record
+    then_they_see_the_new_patient_page
+
+    when_the_nurse_submits_the_new_patient
+    then_the_patient_and_associated_records_are_created
+    and_the_unmatched_consent_responses_page_is_empty
+  end
+
+  def given_the_app_is_setup
+    @programme = create(:programme, :hpv)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [@programme])
+    location = create(:location, :school, name: "Pilot School")
+    @session =
+      create(
+        :session,
+        :scheduled,
+        organisation: @organisation,
+        programme: @programme,
+        location:
+      )
+    @child = build(:patient) # NB: Build, not create, so we don't persist to DB
+  end
+
+  def when_i_go_to_the_consent_form
+    visit start_parent_interface_consent_forms_path(@session, @programme)
+  end
+
+  def when_i_give_consent
+    choose "Yes, they go to this school"
+    click_on "Continue"
+
+    expect(page).to have_content("About you")
+    fill_in "Your name", with: "Jane #{@child.family_name}"
+    choose "Mum" # Your relationship to the child
+    fill_in "Email address", with: "jane@example.com"
+    fill_in "Phone number", with: "07123456789"
+    check "Tick this box if you’d like to get updates by text message"
+    click_on "Continue"
+
+    expect(page).to have_content("Phone contact method")
+    choose "I do not have specific needs"
+    click_on "Continue"
+
+    expect(page).to have_content("Do you agree")
+    choose "Yes, I agree"
+    click_on "Continue"
+
+    expect(page).to have_content("Is your child registered with a GP?")
+    choose "Yes, they are registered with a GP"
+    fill_in "Name of GP surgery", with: "GP Surgery"
+    click_on "Continue"
+
+    expect(page).to have_content("Home address")
+    fill_in "Address line 1", with: "1 Test Street"
+    fill_in "Address line 2 (optional)", with: "2nd Floor"
+    fill_in "Town or city", with: "Testville"
+    fill_in "Postcode", with: "TE1 1ST"
+    click_on "Continue"
+  end
+
+  def when_i_fill_in_my_childs_name_and_birthday
+    click_on "Start now"
+
+    expect(page).to have_content("What is your child’s name?")
+    fill_in "First name", with: @child.given_name
+    fill_in "Last name", with: @child.family_name
+    choose "No" # Do they use a different name in school?
+    click_on "Continue"
+
+    expect(page).to have_content("What is your child’s date of birth?")
+    fill_in "Day", with: @child.date_of_birth.day
+    fill_in "Month", with: @child.date_of_birth.month
+    fill_in "Year", with: @child.date_of_birth.year
+    click_on "Continue"
+  end
+
+  def and_i_answer_no_to_all_the_medical_questions
+    until page.has_content?("Check your answers and confirm")
+      choose "No"
+      click_on "Continue"
+    end
+  end
+
+  def and_i_submit_the_consent_form
+    click_on "Confirm"
+  end
+
+  def then_i_see_the_consent_confirmation_page
+    expect(page).to have_content(
+      "#{@child.full_name} will get their HPV vaccination at school"
+    )
+  end
+
+  def when_i_wait_for_background_jobs_to_complete
+    perform_enqueued_jobs
+  end
+
+  def and_the_nurse_checks_the_unmatched_consent_responses
+    sign_in @organisation.users.first
+    visit "/dashboard"
+
+    click_on "Responses", match: :first
+  end
+
+  def then_they_see_the_consent_form
+    expect(page).to have_content(@child.full_name)
+    expect(page).to have_link("Match with record")
+    expect(page).to have_link("Create record")
+  end
+
+  def when_the_nurse_clicks_create_record
+    click_link "Create record"
+  end
+
+  def then_they_see_the_new_patient_page
+    expect(page).to have_heading("Create a new child record")
+    expect(page).to have_content("Full name#{@child.full_name}")
+  end
+
+  def when_the_nurse_submits_the_new_patient
+    click_button "Create"
+  end
+
+  def then_the_patient_and_associated_records_are_created
+    expect(Patient.count).to eq(1)
+    expect(Patient.last.consents.count).to eq(1)
+    expect(Patient.last.parents.count).to eq(1)
+  end
+
+  def and_the_unmatched_consent_responses_page_is_empty
+    expect(page).to have_content("0 consent responses")
+  end
+end

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -52,7 +52,7 @@ describe "Parental consent manual matching" do
   end
 
   def when_i_choose_a_consent_response
-    click_on "Find match"
+    click_on "Match with record"
   end
 
   def then_i_am_on_the_consent_matching_page

--- a/spec/support/pds_helper.rb
+++ b/spec/support/pds_helper.rb
@@ -7,4 +7,16 @@ module PDSHelper
       "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
     ).with(query: hash_including({})).to_return_json(body: { total: 0 })
   end
+
+  def stub_pds_search_to_return_a_patient
+    stub_request(
+      :get,
+      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
+    ).with(query: hash_including({})).to_return(
+      body: file_fixture("pds/search-patients-response.json"),
+      headers: {
+        "Content-Type" => "application/fhir+json"
+      }
+    )
+  end
 end


### PR DESCRIPTION
When an unmatched consent form doesn't map to any existing patient, we want to allow users to create a new patient record. This record should use an NHS number that's looked up via PDS, have a consent attached to it that matches the consent from the parent form, and a parent that also uses the details from the form.

We don't display the option to create patient records for consent forms without an NHS number (e.g. where the PDS lookup didn't find any records).

TODO:

- [x] Add PDS lookup
- [x] `create` action (create: patient, parent, consent)
- [x] Don't highlight patient attributes
- [x] Feature spec

Prerequisites:

- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2473
- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2475

### Screenshots

![Screenshot 2024-11-17 at 22 31 30](https://github.com/user-attachments/assets/85fcc6f7-8569-4932-bf80-bc1b7c7cab33)

![Screenshot 2024-11-17 at 22 31 02](https://github.com/user-attachments/assets/16b23e69-33d1-48a1-8f20-e326c408a068)
