### PR TITLE
Vaccination Record factory: don't set delivery method when not administered

### DIFF
--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -81,6 +81,7 @@ FactoryBot.define do
     trait :not_administered do
       administered_at { nil }
       delivery_site { nil }
+      delivery_method { nil }
       reason { "not_well" }
       vaccine { nil }
     end


### PR DESCRIPTION
This manifests itself when trying to download offline and re-upload a seeded session.