### PR TITLE
Imms import: allow all Mavis reasons within REASON_NOT_VACCINATED

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -143,14 +143,9 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
         notes:
           "Optional, must be #{tag.i("Y")} or #{tag.i("N")}. If omitted, " \
             "#{tag.i("Y")} is assumed."
-      },
-      {
-        name: "REASON_NOT_VACCINATED",
-        notes:
-          "Required if #{tag.code("VACCINATED")} is #{tag.i("N")}, must be #{tag.i("did not attend")}, " \
-            "#{tag.i("vaccination contraindicated")} or #{tag.i("unwell")}"
       }
-    ] + dose_sequence + care_setting + performing_professional
+    ] + reason_not_vaccinated + dose_sequence + care_setting +
+      performing_professional
   end
 
   def child_columns
@@ -204,6 +199,23 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
         }
       ]
     end
+  end
+
+  def reason_not_vaccinated
+    reasons = ImmunisationImportRow::REASONS.keys.sort.map { tag.i(_1) }
+    reasons_sentence =
+      reasons.to_sentence(
+        last_word_connector: " or ",
+        two_words_connector: " or "
+      )
+
+    [
+      {
+        name: "REASON_NOT_VACCINATED",
+        notes:
+          "Required if #{tag.code("VACCINATED")} is #{tag.i("N")}, must be #{reasons_sentence}"
+      }
+    ]
   end
 
   def dose_sequence

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -202,9 +202,12 @@ class ImmunisationImportRow
   end
 
   REASONS = {
-    "did not attend" => :absent_from_session,
+    "refused" => :refused,
+    "unwell" => :not_well,
     "vaccination contraindicated" => :contraindications,
-    "unwell" => :not_well
+    "already had elsewhere" => :already_had,
+    "did not attend" => :absent_from_session,
+    "absent from school" => :absent_from_school
   }.freeze
 
   def reason

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -818,31 +818,21 @@ describe ImmunisationImportRow do
       it { expect(immunisation_import_row).to be_invalid }
     end
 
-    context "with a did not attend reason" do
-      let(:data) do
-        { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => "Did Not Attend" }
+    {
+      "refused" => :refused,
+      "unwell" => :not_well,
+      "vaccination contraindicated" => :contraindications,
+      "already had elsewhere" => :already_had,
+      "did not attend" => :absent_from_session,
+      "absent from school" => :absent_from_school
+    }.each do |input_reason, expected_enum|
+      context "with reason '#{input_reason}'" do
+        let(:data) do
+          { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => input_reason }
+        end
+
+        it { should eq(expected_enum) }
       end
-
-      it { should eq(:absent_from_session) }
-    end
-
-    context "with a vaccination contraindicated reason" do
-      let(:data) do
-        {
-          "VACCINATED" => "N",
-          "REASON_NOT_VACCINATED" => "Vaccination contraindicated"
-        }
-      end
-
-      it { should eq(:contraindications) }
-    end
-
-    context "with an unwell reason" do
-      let(:data) do
-        { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => "unwell" }
-      end
-
-      it { should eq(:not_well) }
     end
   end
 


### PR DESCRIPTION
Without this, the offline export is incomplete and offline recording wouldn't allow the same reasons for refusal as online recording.