### PR TITLE
Imms import: extra validations on anatomical site

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -223,7 +223,9 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
       {
         name: "ANATOMICAL_SITE",
         notes:
-          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}, must be #{site_sentence}"
+          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}. It must be " \
+            "appropriate for the vaccine delivery method and be one of: " \
+            "#{site_sentence}"
       }
     ]
   end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -14,6 +14,8 @@ class ImmunisationImportRow
   validates :batch_number, presence: true, if: :administered
   validates :reason, presence: true, if: -> { administered == false }
   validates :delivery_site, presence: true, if: :administered
+  validate :delivery_site_appropriate_for_vaccine,
+           if: -> { administered && delivery_site.present? && vaccine.present? }
   validates :dose_sequence,
             comparison: {
               greater_than_or_equal_to: 1,
@@ -451,6 +453,18 @@ class ImmunisationImportRow
 
     unless @programme.year_groups.include?(patient_date_of_birth.year_group)
       errors.add(:patient_date_of_birth, :inclusion)
+    end
+  end
+
+  def delivery_site_appropriate_for_vaccine
+    return if vaccine.nil? || delivery_site.nil?
+    if date_of_vaccination.present? &&
+         academic_year != Date.current.academic_year
+      return
+    end
+
+    unless vaccine.available_delivery_sites.include?(delivery_site)
+      errors.add(:delivery_site, :inclusion)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -204,6 +204,7 @@ en:
               inclusion: Enter a date for a current session
             delivery_site:
               blank: Enter an anatomical site.
+              inclusion: Enter a anatomical site that is appropriate for the vaccine.
             dose_sequence:
               blank: The dose sequence number cannot be greater than 3. Enter a dose sequence number, for example, 1, 2 or 3.
             existing_patients:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -271,6 +271,63 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "vaccination in this academic year, with a delivery site that is not appropriate for HPV" do
+      let(:programme) { create(:programme, :hpv) }
+
+      let(:data) do
+        {
+          "ANATOMICAL_SITE" => "nasal",
+          "VACCINATED" => "Y",
+          "VACCINE_GIVEN" => "Gardasil9",
+          "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901"
+        }
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:delivery_site]).to eq(
+          ["Enter a anatomical site that is appropriate for the vaccine."]
+        )
+      end
+    end
+
+    context "vaccination in a previous academic year, with a delivery site that's typically not appropriate for HPV" do
+      let(:programme) { create(:programme, :hpv) }
+
+      let(:data) do
+        {
+          "ANATOMICAL_SITE" => "left buttock",
+          "VACCINATED" => "Y",
+          "VACCINE_GIVEN" => "Gardasil9",
+          "DATE_OF_VACCINATION" => "20220101"
+        }
+      end
+
+      it "raises no errors on delivery site to be more permissive of legacy records" do
+        immunisation_import_row.valid?
+        expect(immunisation_import_row.errors[:delivery_site]).to be_empty
+      end
+    end
+
+    context "vaccination in this academic year, with a delivery site that is not appropriate for flu" do
+      let(:programme) { create(:programme, :flu) }
+
+      let(:data) do
+        {
+          "ANATOMICAL_SITE" => "left buttock",
+          "VACCINATED" => "Y",
+          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
+        }
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:delivery_site]).to eq(
+          ["Enter a anatomical site that is appropriate for the vaccine."]
+        )
+      end
+    end
+
     context "with valid fields for Flu" do
       let(:programme) { create(:programme, :flu) }
 


### PR DESCRIPTION
For current academic year:
* make sure the site is appropriate for the administered vaccine (e.g. disallow importing HPV injections into the buttocks or nose, nasal flu into the thigh)
* skip that validation for previous academic years to be more permissive of past data quality issues.