### PR TITLE
Use SessionPolicy for session actions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -99,7 +99,7 @@ class SessionsController < ApplicationController
   delegate :organisation, to: :current_user
 
   def set_session
-    @session = sessions_scope.find_by!(slug: params[:slug])
+    @session = authorize sessions_scope.find_by!(slug: params[:slug])
   end
 
   def sessions_scope

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -155,10 +155,6 @@ class Session < ApplicationRecord
     closed_at != nil
   end
 
-  def closable?
-    open? && completed?
-  end
-
   def year_groups
     programmes.flat_map(&:year_groups).uniq.sort
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -12,24 +12,24 @@ class ApplicationPolicy
     user.is_nurse? || user.is_admin?
   end
 
-  def show?
-    user.is_nurse? || user.is_admin?
+  def new?
+    create?
   end
 
   def create?
     user.is_nurse? || user.is_admin?
   end
 
-  def new?
-    create?
-  end
-
-  def update?
+  def show?
     user.is_nurse? || user.is_admin?
   end
 
   def edit?
     update?
+  end
+
+  def update?
+    user.is_nurse? || user.is_admin?
   end
 
   def destroy?

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -5,6 +5,14 @@ class SessionPolicy < ApplicationPolicy
     super && record.open?
   end
 
+  def edit_close?
+    update_close?
+  end
+
+  def update_close?
+    (user.is_nurse? || user.is_admin?) && record.open? && record.completed?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.where(organisation: user.selected_organisation)

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -13,6 +13,14 @@ class SessionPolicy < ApplicationPolicy
     (user.is_nurse? || user.is_admin?) && record.open? && record.completed?
   end
 
+  def consent_form?
+    user.is_nurse? || user.is_admin?
+  end
+
+  def make_in_progress?
+    user.is_nurse? || user.is_admin?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.where(organisation: user.selected_organisation)

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class SessionPolicy < ApplicationPolicy
+  def update?
+    super && record.open?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.where(organisation: user.selected_organisation)

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -111,11 +111,11 @@
   <div class="nhsuk-grid-column-one-third">
     <%= render AppSessionSummaryComponent.new(@session) %>
 
-    <% unless @session.unscheduled? %>
+    <% if policy(@session).edit? %>
       <%= govuk_button_link_to "Edit session", edit_session_path(@session), class: "app-button--secondary" %>
     <% end %>
 
-    <% if @session.closable? %>
+    <% if policy(@session).edit_close? %>
       <%= govuk_button_link_to "Close session", close_session_path(@session), class: "app-button--secondary" %>
     <% end %>
   </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "d2aea4e63ad176c5c13a741d740fb246456dac7830c6747b59c4b57a616ae174",
+      "fingerprint": "7c210a4df45dc0a10b88e8ec76404ebc8013d239bf5bcaa70d750268e0e91980",
       "check_name": "SendFile",
       "message": "Parameter value used in file name",
       "file": "app/controllers/sessions_controller.rb",
-      "line": 73,
+      "line": 85,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "send_file(\"public/consent_forms/#{sessions_scope.find_by!(:slug => params[:slug]).programmes.first.type}.pdf\", :filename => (\"#{sessions_scope.find_by!(:slug => params[:slug]).programmes.first.name} Consent Form.pdf\"), :disposition => \"attachment\")",
+      "code": "send_file(\"public/consent_forms/#{authorize(sessions_scope.find_by!(:slug => params[:slug])).programmes.first.type}.pdf\", :filename => (\"#{authorize(sessions_scope.find_by!(:slug => params[:slug])).programmes.first.name} Consent Form.pdf\"), :disposition => \"attachment\")",
       "render_path": null,
       "location": {
         "type": "method",
@@ -24,6 +24,6 @@
       "note": "Programme names/types come from a limited set of enums."
     }
   ],
-  "updated": "2024-10-28 17:13:18 +0000",
-  "brakeman_version": "6.2.1"
+  "updated": "2024-11-17 09:23:51 +0000",
+  "brakeman_version": "6.2.2"
 }

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -66,6 +66,7 @@ describe "Manage school sessions" do
 
     when_i_close_the_session
     then_i_see_the_close_confirmation
+    and_i_cant_edit_the_session
     and_i_go_back_to_sessions
 
     when_i_go_to_unscheduled_sessions
@@ -266,6 +267,10 @@ describe "Manage school sessions" do
 
   def then_i_see_the_close_confirmation
     expect(page).to have_content("Session closed.")
+  end
+
+  def and_i_cant_edit_the_session
+    expect(page).not_to have_content("Edit session")
   end
 
   def and_i_go_back_to_sessions

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -1,6 +1,66 @@
 # frozen_string_literal: true
 
 describe SessionPolicy do
+  subject(:policy) { described_class.new(user, session) }
+
+  shared_examples "edit/update session" do
+    context "with an admin" do
+      let(:user) { create(:admin) }
+
+      context "with a scheduled session" do
+        let(:session) { create(:session, :scheduled) }
+
+        it { should be(true) }
+      end
+
+      context "with an unscheduled session" do
+        let(:session) { create(:session, :unscheduled) }
+
+        it { should be(true) }
+      end
+
+      context "with a closed session" do
+        let(:session) { create(:session, :closed) }
+
+        it { should be(false) }
+      end
+    end
+
+    context "with a nurse" do
+      let(:user) { create(:nurse) }
+
+      context "with a scheduled session" do
+        let(:session) { create(:session, :scheduled) }
+
+        it { should be(true) }
+      end
+
+      context "with an unscheduled session" do
+        let(:session) { create(:session, :unscheduled) }
+
+        it { should be(true) }
+      end
+
+      context "with a closed session" do
+        let(:session) { create(:session, :closed) }
+
+        it { should be(false) }
+      end
+    end
+  end
+
+  describe "#edit?" do
+    subject(:edit?) { policy.edit? }
+
+    include_examples "edit/update session"
+  end
+
+  describe "#update?" do
+    subject(:update?) { policy.update? }
+
+    include_examples "edit/update session"
+  end
+
   describe "Scope#resolve" do
     subject { SessionPolicy::Scope.new(user, Session).resolve }
 

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -61,6 +61,64 @@ describe SessionPolicy do
     include_examples "edit/update session"
   end
 
+  shared_examples "close session" do
+    context "with an admin" do
+      let(:user) { create(:admin) }
+
+      context "with a scheduled session" do
+        let(:session) { create(:session, :scheduled) }
+
+        it { should be(false) }
+      end
+
+      context "with a closed session" do
+        let(:session) { create(:session, :closed) }
+
+        it { should be(false) }
+      end
+
+      context "with a completed session" do
+        let(:session) { create(:session, :completed) }
+
+        it { should be(true) }
+      end
+    end
+
+    context "with a nurse" do
+      let(:user) { create(:nurse) }
+
+      context "with a scheduled session" do
+        let(:session) { create(:session, :scheduled) }
+
+        it { should be(false) }
+      end
+
+      context "with a closed session" do
+        let(:session) { create(:session, :closed) }
+
+        it { should be(false) }
+      end
+
+      context "with a completed session" do
+        let(:session) { create(:session, :completed) }
+
+        it { should be(true) }
+      end
+    end
+  end
+
+  describe "#edit_close?" do
+    subject(:edit_close?) { policy.edit_close? }
+
+    include_examples "close session"
+  end
+
+  describe "#update_close?" do
+    subject(:update_close?) { policy.update_close? }
+
+    include_examples "close session"
+  end
+
   describe "Scope#resolve" do
     subject { SessionPolicy::Scope.new(user, Session).resolve }
 


### PR DESCRIPTION
This refactors the session actions to use a policy class, and ensures we're not allowing users to edit or close sessions when that action shouldn't be available.