### PR TITLE
Prevent vaccination and triages on closed sessions

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -86,7 +86,7 @@
     <% end %>
   <% end %>
 
-  <% if helpers.policy(Triage).create? && @patient_session.next_step == :triage %>
+  <% if helpers.policy(Triage).create? && @patient_session.next_step == :triage && @patient_session.session.open? %>
     <%= render AppCardComponent.new do %>
       <%= render AppTriageFormComponent.new(
             patient_session: @patient_session,

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -21,10 +21,14 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def render?
-    @patient_session.next_step == :vaccinate && @patient_session.session.today?
+    @patient_session.next_step == :vaccinate && session.open? && session.today?
   end
 
   private
+
+  def session
+    @patient_session.session
+  end
 
   # TODO: this code will need to be revisited in future as it only really
   # works for HPV, where we only have one vaccine. It is likely to fail for

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -43,14 +43,14 @@ describe AppPatientPageComponent do
     it { should_not have_css(".nhsuk-card__heading", text: "Triage notes") }
 
     it "shows the triage form" do
-      expect(subject).to have_selector(
+      expect(rendered).to have_selector(
         :heading,
         text: "Is it safe to vaccinate"
       )
     end
 
     it "does not show the vaccination form" do
-      expect(subject).not_to have_css(
+      expect(rendered).not_to have_css(
         ".nhsuk-card",
         text: "Did they get the HPV vaccine?"
       )
@@ -62,11 +62,39 @@ describe AppPatientPageComponent do
       before { stub_authorization(allowed: false) }
 
       it "does not show the triage form" do
-        expect(subject).not_to have_css(
+        expect(rendered).not_to have_css(
           ".nhsuk-card__heading",
           text: "Is it safe to vaccinate"
         )
       end
+    end
+  end
+
+  context "session closed, patient in triage" do
+    before { Flipper.enable(:release_1b) }
+    after { Flipper.disable(:release_1b) }
+
+    let(:patient_session) do
+      create(
+        :patient_session,
+        :consent_given_triage_needed,
+        :session_closed,
+        programme:
+      )
+    end
+
+    it "does not show the triage form" do
+      expect(rendered).not_to have_selector(
+        :heading,
+        text: "Is it safe to vaccinate"
+      )
+    end
+
+    it "does not show the vaccination form" do
+      expect(rendered).not_to have_css(
+        ".nhsuk-card",
+        text: "Did they get the HPV vaccine?"
+      )
     end
   end
 
@@ -88,14 +116,14 @@ describe AppPatientPageComponent do
     it { should have_css(".nhsuk-card__heading", text: "Triage notes") }
 
     it "does not show the triage form" do
-      expect(subject).not_to have_css(
+      expect(rendered).not_to have_css(
         ".nhsuk-card__heading",
         text: "Is it safe to vaccinate"
       )
     end
 
     it "shows the vaccination form" do
-      expect(subject).to have_css(
+      expect(rendered).to have_css(
         ".nhsuk-card__heading",
         text: "Did they get the HPV vaccine?"
       )
@@ -105,7 +133,7 @@ describe AppPatientPageComponent do
       before { stub_authorization(allowed: false) }
 
       it "does not show the vaccination form" do
-        expect(subject).not_to have_css(
+        expect(rendered).not_to have_css(
           ".nhsuk-card__heading",
           text: "Did they get the HPV vaccine?"
         )
@@ -150,7 +178,7 @@ describe AppPatientPageComponent do
       it { should have_css("a", text: "Edit Gillick competence") }
 
       it "shows the Gillick assessment" do
-        expect(subject).to have_css(
+        expect(rendered).to have_css(
           ".nhsuk-card__heading",
           text: "Gillick assessment"
         )

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -295,6 +295,10 @@ FactoryBot.define do
       session { association :session, :today, programme: }
     end
 
+    trait :session_closed do
+      session { association :session, :closed, programme: }
+    end
+
     trait :not_gillick_competent do
       after(:create) do |patient_session, _evaluator|
         create(:gillick_assessment, :not_competent, patient_session:)

--- a/spec/features/hpv_vaccination_cannot_record_closed_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_closed_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe "HPV vaccination" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
+
+  scenario "Cannot be recorded in a closed session" do
+    given_i_am_signed_in_as_an_admin
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    then_i_cannot_record_that_the_patient_has_been_vaccinated
+  end
+
+  def given_i_am_signed_in_as_an_admin
+    programme = create(:programme, :hpv)
+    organisation =
+      create(:organisation, :with_one_nurse, programmes: [programme])
+    location = create(:location, :school)
+    @session =
+      create(:session, :today, :closed, organisation:, programme:, location:)
+    @patient =
+      create(:patient, :consent_given_triage_not_needed, session: @session)
+
+    sign_in organisation.users.first
+  end
+
+  def when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    visit session_triage_path(@session)
+    click_link "No triage needed"
+    click_link @patient.full_name
+  end
+
+  def then_i_cannot_record_that_the_patient_has_been_vaccinated
+    expect(page).not_to have_content("Did they get the HPV vaccine?")
+  end
+end


### PR DESCRIPTION
This shouldn't be allowed if the session has been closed, so this prevents the users from being able to.