### PR TITLE
Don't review cohort if not already set

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -62,9 +62,13 @@ class PatientImportRow
         existing_patient.registration = attributes.delete(:registration)
       end
 
-      if existing_patient.school_id.blank?
+      if existing_patient.school_id.nil?
         existing_patient.school_id = attributes.delete(:school_id)
         existing_patient.home_educated = attributes.delete(:home_educated)
+      end
+
+      if existing_patient.cohort_id.nil?
+        existing_patient.cohort_id = attributes.delete(:cohort_id)
       end
 
       existing_patient.stage_changes(attributes)

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -153,6 +153,15 @@ describe ClassImportRow do
           expect(patient.pending_changes).not_to include("home_educated")
         end
       end
+
+      context "when the patient has no cohort" do
+        before { existing_patient.update(cohort_id: nil) }
+
+        it "sets the cohort and doesn't stage it so admins don't have to review that change" do
+          expect(patient.cohort).not_to be_nil
+          expect(patient.pending_changes).not_to include("cohort_id")
+        end
+      end
     end
 
     describe "#cohort" do

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -190,6 +190,15 @@ describe CohortImportRow do
           expect(patient.pending_changes).not_to include("home_educated")
         end
       end
+
+      context "when the patient has no cohort" do
+        before { existing_patient.update(cohort_id: nil) }
+
+        it "sets the cohort and doesn't stage it so admins don't have to review that change" do
+          expect(patient.cohort).not_to be_nil
+          expect(patient.pending_changes).not_to include("cohort_id")
+        end
+      end
     end
 
     describe "#cohort" do


### PR DESCRIPTION
If we're importing a patient that doesn't already have a cohort we can set it without the user needing to review since there's been no change on the patient, their year group will be the same but internally the cohort will have been set.