### PR TITLE
Imms import: tweaks to vaccinator validation and field logic

### DIFF
--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -177,6 +177,9 @@ describe "HPV Vaccination" do
     row_for_unvaccinated_patient["TIME_OF_VACCINATION"] = "10:01"
     row_for_unvaccinated_patient["VACCINATED"] = "N"
     row_for_unvaccinated_patient["REASON_NOT_VACCINATED"] = "did not attend"
+    row_for_unvaccinated_patient[
+      "PERFORMING_PROFESSIONAL_EMAIL"
+    ] = @organisation.users.first.email
     row_for_unvaccinated_patient["CLINIC_NAME"] = clinic_name if clinic_name
     File.write("tmp/modified.csv", csv_table.to_csv)
   end

--- a/spec/fixtures/immunisation_import/valid_flu.csv
+++ b/spec/fixtures/immunisation_import/valid_flu.csv
@@ -6,8 +6,8 @@ R1L,120026,shaftesbury junior school ,2675725722,Berry,Hamilton,20120915,Female,
 R1L,120026,shaftesbury junior school ,1108533868,Jordin,Mould,20120916,Male,LE2 2PX,Yes,20240514,Seqirus Flucelvax Tetra QIVC,123013325,20220730,Left Upper Arm,Vaccinator1,Name1,,Parental Consent,LocalPatient5,www.LocalPatient5
 R1L,120026,shaftesbury junior school ,8160442742,Oliver,Bowers,20120917,Male,LE5 2RP,Yes,20240514,Sanofi Pasteur QIVe,123013326,20220730,Right Upper Arm,Vaccinator1,Name1,,Parental Consent,LocalPatient6,www.LocalPatient6
 R1L,120026,shaftesbury junior school ,3314278071,Rosalind,Penn,20120918,Female,LE10 2DA,Yes,20240514,Sanofi Pasteur QIVe,123013326,20220730,Right Thigh,Vaccinator1,Name1,,Parental Consent,LocalPatient7,www.LocalPatient7
-R1L,120026,shaftesbury junior school ,3017356345,Trudie,Chadwick,20120919,Female,LE3 3DE,no,20240514,,,,,,,Did Not Attend,,LocalPatient8,www.LocalPatient8
-R1L,144012,Home Schooled,5404296666,Alecia,Ainsworth,20120920,Female,LE7 2DA,no,20240514,,,,,,,Vaccination Contraindicated,,LocalPatient9,www.LocalPatient9
-R1L,999999,Home Schooled,6401122986,Lily,Fletcher,20120921,Female,LE7 2PX,no,20240514,,,,,,,Unwell,,LocalPatient10,www.LocalPatient10
-R1L,888888,Unknown School,1234567890,Pete,Jones,20120922,Male,LE7 2FF,no,20240514,,,,,,,Unwell,,LocalPatient11,www.LocalPatient11
+R1L,120026,shaftesbury junior school ,3017356345,Trudie,Chadwick,20120919,Female,LE3 3DE,no,20240514,,,,,Vaccinator1,Name1,Did Not Attend,,LocalPatient8,www.LocalPatient8
+R1L,144012,Home Schooled,5404296666,Alecia,Ainsworth,20120920,Female,LE7 2DA,no,20240514,,,,,Vaccinator1,Name1,Vaccination Contraindicated,,LocalPatient9,www.LocalPatient9
+R1L,999999,Home Schooled,6401122986,Lily,Fletcher,20120921,Female,LE7 2PX,no,20240514,,,,,Vaccinator1,Name1,Unwell,,LocalPatient10,www.LocalPatient10
+R1L,888888,Unknown School,1234567890,Pete,Jones,20120922,Male,LE7 2FF,no,20240514,,,,,Vaccinator1,Name1,Unwell,,LocalPatient11,www.LocalPatient11
 ,,,,,,,,,,,,,,,,,,,,

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -15,11 +15,10 @@ describe ImmunisationImportRow do
   let(:family_name) { "Potter" }
   let(:date_of_birth) { "20120101" }
   let(:address_postcode) { "SW1A 1AA" }
-  let(:valid_data) do
+  let(:valid_common_data) do
     {
       "ORGANISATION_CODE" => "abc",
       "VACCINATED" => "Y",
-      "ANATOMICAL_SITE" => "nasal",
       "BATCH_EXPIRY_DATE" => "20210101",
       "BATCH_NUMBER" => "123",
       "SCHOOL_NAME" => "Hogwarts",
@@ -30,12 +29,26 @@ describe ImmunisationImportRow do
       "PERSON_POSTCODE" => address_postcode,
       "PERSON_GENDER_CODE" => "Male",
       "NHS_NUMBER" => nhs_number,
-      "DATE_OF_VACCINATION" => "20240101",
-      "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV",
-      "PERFORMING_PROFESSIONAL_FORENAME" => "John",
-      "PERFORMING_PROFESSIONAL_SURNAME" => "Smith"
+      "DATE_OF_VACCINATION" => "20240101"
     }
   end
+  let(:valid_flu_data) do
+    valid_common_data.deep_dup.merge(
+      "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV",
+      "ANATOMICAL_SITE" => "nasal",
+      "PERFORMING_PROFESSIONAL_FORENAME" => "John",
+      "PERFORMING_PROFESSIONAL_SURNAME" => "Smith"
+    )
+  end
+  let(:valid_hpv_data) do
+    valid_common_data.deep_dup.merge(
+      "VACCINE_GIVEN" => "Gardasil9",
+      "ANATOMICAL_SITE" => "Left Upper Arm",
+      "DOSE_SEQUENCE" => "1",
+      "CARE_SETTING" => "1"
+    )
+  end
+  let(:valid_data) { valid_flu_data }
 
   before { create(:location, :school, urn: "123456") }
 
@@ -275,12 +288,12 @@ describe ImmunisationImportRow do
       let(:programme) { create(:programme, :hpv) }
 
       let(:data) do
-        {
+        valid_hpv_data.merge(
           "ANATOMICAL_SITE" => "nasal",
           "VACCINATED" => "Y",
           "VACCINE_GIVEN" => "Gardasil9",
           "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901"
-        }
+        )
       end
 
       it "has errors" do
@@ -316,7 +329,8 @@ describe ImmunisationImportRow do
         {
           "ANATOMICAL_SITE" => "left buttock",
           "VACCINATED" => "Y",
-          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
+          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV",
+          "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901"
         }
       end
 


### PR DESCRIPTION
* For this academic year:
  * email address is mandatory
  * first and last name will be ignored if provided
* For previous years:
  * for HPV, don't validate the presence of a vaccinator as it's unnecessary
  * for flu, validate that either email or both first name and last name are present
* 'Administered' and 'not administered' outcomes are treated the same

I've separated out a couple of pre-factor commits.