### PR TITLE
Invalidate self-consent when closing a session

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -245,6 +245,15 @@ class Session < ApplicationRecord
         on_duplicate_key_ignore: true
       )
 
+      Consent
+        .via_self_consent
+        .where(
+          patient: unvaccinated_patients,
+          organisation:,
+          programme: programmes
+        )
+        .update_all(invalidated_at: Time.current)
+
       update!(closed_at: Time.current)
     end
   end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -487,6 +487,33 @@ describe Session do
             vaccinated_patient
           )
         end
+
+        context "with self-consent" do
+          let(:consent) do
+            create(
+              :consent,
+              :self_consent,
+              patient: unvaccinated_patient,
+              programme:
+            )
+          end
+
+          it "invalidates the consent" do
+            expect { close! }.to change { consent.reload.invalidated? }.from(
+              false
+            ).to(true)
+          end
+        end
+
+        context "with parental consent" do
+          let(:consent) do
+            create(:consent, patient: unvaccinated_patient, programme:)
+          end
+
+          it "doesn't invalidate the consent" do
+            expect { close! }.not_to(change { consent.reload.invalidated? })
+          end
+        end
       end
 
       context "when a patient has already had the vaccine" do


### PR DESCRIPTION
This ensures that the consent isn't available to be used in the clinic that the patient is moved to as self-consent can only be considered valid at a specific location.