### PR TITLE
Invalidate triage after consent

### DIFF
--- a/app/models/concerns/invalidatable.rb
+++ b/app/models/concerns/invalidatable.rb
@@ -6,6 +6,9 @@ module Invalidatable
   included do
     scope :not_invalidated, -> { where(invalidated_at: nil) }
     scope :invalidated, -> { where.not(invalidated_at: nil) }
+
+    scope :invalidate_all,
+          -> { not_invalidated.update_all(invalidated_at: Time.current) }
   end
 
   def invalidated?

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -252,7 +252,7 @@ class Session < ApplicationRecord
           organisation:,
           programme: programmes
         )
-        .update_all(invalidated_at: Time.current)
+        .invalidate_all
 
       update!(closed_at: Time.current)
     end

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -11,7 +11,32 @@ describe "Invalidate consent" do
     when_i_go_to_the_patient
     then_i_see_the_patient
     and_i_see_the_consent
-    and_i_am_able_to_record_a_vaccination
+    and_the_patient_is_ready_for_the_nurse
+
+    when_i_click_on_the_consent
+    then_i_see_the_consent
+    and_i_click_invalidate_consent
+
+    when_i_fill_in_the_notes
+    and_i_click_invalidate_consent
+    then_i_see_the_consent_has_been_invalidated
+    and_i_cant_mark_as_invalid
+
+    when_i_click_back
+    then_i_see_the_patient
+    and_i_see_the_consent
+    and_i_am_not_able_to_record_a_vaccination
+  end
+
+  scenario "Already given and triaged" do
+    given_i_am_signed_in
+    and_consent_has_been_given
+    and_triaged_as_safe_to_vaccinate
+
+    when_i_go_to_the_patient
+    then_i_see_the_patient
+    and_i_see_the_consent
+    and_the_patient_is_safe_to_vaccinate
 
     when_i_click_on_the_consent
     then_i_see_the_consent
@@ -51,6 +76,10 @@ describe "Invalidate consent" do
       )
   end
 
+  def and_triaged_as_safe_to_vaccinate
+    create(:triage, patient: @patient, programme: @programme)
+  end
+
   def when_i_go_to_the_patient
     visit session_consents_path(@session)
     click_on "Consent given"
@@ -67,8 +96,13 @@ describe "Invalidate consent" do
 
   alias_method :and_i_see_the_consent, :then_i_see_the_consent
 
-  def and_i_am_able_to_record_a_vaccination
+  def and_the_patient_is_ready_for_the_nurse
     expect(page).to have_content("Ready for nurse")
+    expect(page).to have_content("Did they get the HPV vaccine?")
+  end
+
+  def and_the_patient_is_safe_to_vaccinate
+    expect(page).to have_content("Safe to vaccinate")
     expect(page).to have_content("Did they get the HPV vaccine?")
   end
 

--- a/spec/features/withdraw_consent_spec.rb
+++ b/spec/features/withdraw_consent_spec.rb
@@ -11,7 +11,33 @@ describe "Withdraw consent" do
     when_i_go_to_the_patient
     then_i_see_the_patient
     and_i_see_the_consent
-    and_i_am_able_to_record_a_vaccination
+    and_the_patient_is_ready_for_the_nurse
+
+    when_i_click_on_the_consent
+    then_i_see_the_consent
+    and_i_click_withdraw_consent
+
+    when_i_choose_a_reason
+    and_i_fill_in_the_notes
+    and_i_click_withdraw_consent
+    then_i_see_the_consent_has_been_withdrawn
+    and_i_cant_withdraw
+
+    when_i_click_back
+    then_i_see_the_patient
+    and_i_see_the_consent
+    and_i_am_not_able_to_record_a_vaccination
+  end
+
+  scenario "Already given and triaged" do
+    given_i_am_signed_in
+    and_consent_has_been_given
+    and_triaged_as_safe_to_vaccinate
+
+    when_i_go_to_the_patient
+    then_i_see_the_patient
+    and_i_see_the_consent
+    and_the_patient_is_safe_to_vaccinate
 
     when_i_click_on_the_consent
     then_i_see_the_consent
@@ -53,8 +79,17 @@ describe "Withdraw consent" do
       )
   end
 
-  def and_i_am_able_to_record_a_vaccination
+  def and_triaged_as_safe_to_vaccinate
+    create(:triage, patient: @patient, programme: @programme)
+  end
+
+  def and_the_patient_is_ready_for_the_nurse
     expect(page).to have_content("Ready for nurse")
+    expect(page).to have_content("Did they get the HPV vaccine?")
+  end
+
+  def and_the_patient_is_safe_to_vaccinate
+    expect(page).to have_content("Safe to vaccinate")
     expect(page).to have_content("Did they get the HPV vaccine?")
   end
 


### PR DESCRIPTION
If consent is withdrawn or invalidated, we need to invalidate any triages that were performed on the patient using the old consent responses. Currently this invalidates all triages, which works in most situations, however could be unnecessary if, for example, both parents consent and then one parent withdraws their consent, in that case you'd still expect the patient to be safe to vaccinate. However this seemed like a simpler solution for now, especially while we don't surface the invalidated triages, and we can iterate on this in the future.