### PR TITLE
Show invalidated triage notes with a strikethrough

### DIFF
--- a/app/components/app_triage_notes_component.html.erb
+++ b/app/components/app_triage_notes_component.html.erb
@@ -1,16 +1,22 @@
 <% entries.each_with_index do |triage, index| %>
   <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
+    <% if triage.invalidated? %><s><% end %>
     Triaged decision: <%= triage.human_enum_name(:status) %>
+    <% if triage.invalidated? %></s><% end %>
   </h3>
 
   <% if (notes = triage.notes).present? %>
-    <blockquote><p><%= notes %></p></blockquote>
+    <blockquote><p>
+      <%= triage.invalidated? ? tag.s(notes) : notes %>
+    </p></blockquote>
   <% end %>
 
   <p class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">
-    <%= triage.created_at.to_fs(:long) %>
-    &middot;
-    <%= triage.performed_by.full_name %>
+    <% if triage.invalidated? %><s><% end %>
+      <%= triage.created_at.to_fs(:long) %>
+      &middot;
+      <%= triage.performed_by.full_name %>
+    <% if triage.invalidated? %></s><% end %>
   </p>
 
   <% if index < entries.size - 1 %>

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -42,7 +42,7 @@ class PatientSession < ApplicationRecord
 
   # TODO: Only fetch consents and triages for the relevant programme.
   has_many :consents, -> { recorded.includes(:parent) }, through: :patient
-  has_many :triages, -> { not_invalidated }, through: :patient
+  has_many :triages, through: :patient
 
   has_many :session_notifications,
            -> { where(session_id: _1.session_id) },
@@ -110,7 +110,7 @@ class PatientSession < ApplicationRecord
   end
 
   def latest_triage
-    @latest_triage ||= triages.max_by(&:updated_at)
+    @latest_triage ||= triages.not_invalidated.max_by(&:updated_at)
   end
 
   def latest_vaccination_record

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -38,10 +38,19 @@ describe AppTriageNotesComponent do
     end
 
     it { should have_css("h3", text: "Triaged decision: Safe to vaccinate") }
-    it { should have_css("p", text: patient_session.triages.first.notes) }
+    it { should have_css("p", text: "Some notes") }
     it { should have_css("p", text: "4 December 2023 at 10:04am") }
     it { should have_css("p", text: "Joe Gear") }
     it { should_not have_css("hr") }
+  end
+
+  context "with an invalidated triage" do
+    before do
+      create(:triage, :invalidated, programme:, notes: "Some notes", patient:)
+    end
+
+    it { should have_css("s", text: "Triaged decision: Safe to vaccinate") }
+    it { should have_css("s", text: "Some notes") }
   end
 
   context "multiple triage notes are present" do

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -48,12 +48,8 @@ describe PatientSession do
     let(:earlier_triage) do
       create(:triage, programme:, patient:, updated_at: 1.day.ago)
     end
-    let(:invalidated_triage) do
-      create(:triage, :invalidated, programme:, patient:)
-    end
 
     it { should eq([earlier_triage, later_triage]) }
-    it { should_not include(invalidated_triage) }
   end
 
   describe "#latest_triage" do
@@ -61,7 +57,13 @@ describe PatientSession do
 
     let(:patient) { patient_session.patient }
     let(:later_triage) do
-      create(:triage, programme:, status: :ready_to_vaccinate, patient:)
+      create(
+        :triage,
+        created_at: 1.day.ago,
+        programme:,
+        status: :ready_to_vaccinate,
+        patient:
+      )
     end
 
     before do
@@ -69,7 +71,16 @@ describe PatientSession do
         :triage,
         programme:,
         status: :needs_follow_up,
-        created_at: 1.day.ago,
+        created_at: 2.days.ago,
+        patient:
+      )
+
+      # should not be returned as invalidated even if more recent
+      create(
+        :triage,
+        :invalidated,
+        programme:,
+        status: :ready_to_vaccinate,
         patient:
       )
     end


### PR DESCRIPTION
This allows users to see invalidated triage notes if a consent is withdrawn or invalidated, while showing that they're no longer accurate with the strikethrough formatting.