### PR TITLE
Ensure self-consent triages are invalidated

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -245,14 +245,20 @@ class Session < ApplicationRecord
         on_duplicate_key_ignore: true
       )
 
-      Consent
-        .via_self_consent
-        .where(
+      self_consents =
+        Consent.via_self_consent.where(
           patient: unvaccinated_patients,
           organisation:,
           programme: programmes
         )
-        .invalidate_all
+
+      self_consents.invalidate_all
+
+      Triage.where(
+        patient: self_consents.map(&:patient),
+        organisation:,
+        programme: programmes
+      ).invalidate_all
 
       update!(closed_at: Time.current)
     end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -498,8 +498,23 @@ describe Session do
             )
           end
 
+          let(:triage) do
+            create(
+              :triage,
+              patient: consent.patient,
+              programme: consent.programme,
+              organisation: consent.organisation
+            )
+          end
+
           it "invalidates the consent" do
             expect { close! }.to change { consent.reload.invalidated? }.from(
+              false
+            ).to(true)
+          end
+
+          it "invalidates the triage" do
+            expect { close! }.to change { triage.reload.invalidated? }.from(
               false
             ).to(true)
           end
@@ -510,8 +525,21 @@ describe Session do
             create(:consent, patient: unvaccinated_patient, programme:)
           end
 
+          let(:triage) do
+            create(
+              :triage,
+              patient: consent.patient,
+              programme: consent.programme,
+              organisation: consent.organisation
+            )
+          end
+
           it "doesn't invalidate the consent" do
             expect { close! }.not_to(change { consent.reload.invalidated? })
+          end
+
+          it "doesn't invalidate the triage" do
+            expect { close! }.not_to(change { triage.reload.invalidated? })
           end
         end
       end


### PR DESCRIPTION
This was missed in d62ed3d278f3224f1fe43cfce2c88d5ab5bcb04e to cover the situation where a session has been closed, self-consents have been invalidated and therefore any associated triages must be invalidated too.

If we encounter a similar bug it might be worth refactoring this code to handle the invalidation in the consent model rather than in the controllers.

I also think it's worth adding a feature test for this in the future.