### PR TITLE
Remove pending school_id if session is proposed

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -215,6 +215,12 @@ class Session < ApplicationRecord
         .patient_sessions
         .where(session: other_sessions)
         .update_all(proposed_session_id: id)
+
+      # Since we've already proposed a transfer via the proposed_session
+      # mechanism, we can remove any `school_id` from the pending changes hash.
+      # If we don't, the user will see the school change as an import issue,
+      # as well as the proposed transfer in the session moves page.
+      patient.save! if patient.pending_changes.delete("school_id")
     end
 
     # Remove patients that have other upcoming sessions


### PR DESCRIPTION
We have two different mechanisms that are both handling similar functionality:

- The `patient.pending_changes` hash can contain a `school_id` which can be applied to:
  - update their location
- The `patient_session.proposed_session` id that can be applied to:
  - update a patient's session
  - update their location

The latter `proposed_session` mechanism is preferable in situations where the only thing that's changed as the result of a class list import is the patient's school. The patient shouldn't appear in the list of duplicate records to review, and instead appear in the session moves UI.

To prevent them from appearing in the duplicate records list, we can remove the `pending_changes["school_id"]` if a session is successfully proposed on their existing patient sessions.