### PR TITLE
Strikethrough invalid NHS numbers

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -98,7 +98,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
 
   def format_nhs_number
     highlight_if(
-      helpers.format_nhs_number(@patient.nhs_number),
+      helpers.patient_nhs_number(@patient),
       @patient.nhs_number_changed?
     )
   end

--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -23,7 +23,7 @@
 
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">NHS number</span>
-            <%= helpers.format_nhs_number(patient.nhs_number) %>
+            <%= helpers.patient_nhs_number(patient) %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/components/app_vaccination_record_table_component.html.erb
+++ b/app/components/app_vaccination_record_table_component.html.erb
@@ -20,7 +20,7 @@
 
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">NHS number</span>
-            <%= helpers.format_nhs_number(vaccination_record.patient.nhs_number) %>
+            <%= helpers.patient_nhs_number(vaccination_record.patient) %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -3,17 +3,21 @@
 module PatientsHelper
   # Replace each space in NHS number with a non-breaking space and
   # zero-width word joiner to prevent telephone format detection
-  def format_nhs_number(nhs_number)
-    if nhs_number.present?
-      tag.span(class: "app-u-monospace") do
-        nhs_number
-          .to_s
-          .gsub(/(\d{3})(\d{3})(\d{4})/, "\\1&nbsp;&zwj;\\2&nbsp;&zwj;\\3")
-          .html_safe
+  def patient_nhs_number(patient)
+    span =
+      if patient.nhs_number.blank?
+        "Not provided"
+      else
+        tag.span(class: "app-u-monospace") do
+          patient
+            .nhs_number
+            .to_s
+            .gsub(/(\d{3})(\d{3})(\d{4})/, "\\1&nbsp;&zwj;\\2&nbsp;&zwj;\\3")
+            .html_safe
+        end
       end
-    else
-      "Not provided"
-    end
+
+    patient.invalidated? ? tag.s(span) : span
   end
 
   def patient_date_of_birth(patient)

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -1,26 +1,48 @@
 # frozen_string_literal: true
 
-RSpec.describe PatientsHelper do
-  describe "#format_nhs_number" do
-    subject(:formatted_nhs_number) { helper.format_nhs_number(nhs_number) }
+describe PatientsHelper do
+  describe "#patient_nhs_number" do
+    subject(:patient_nhs_number) { helper.patient_nhs_number(patient) }
 
     context "when the NHS number is present" do
-      let(:nhs_number) { "0123456789" }
+      let(:patient) { build(:patient, nhs_number: "0123456789") }
 
       it { should be_html_safe }
 
       it do
-        expect(subject).to eq(
+        expect(patient_nhs_number).to eq(
           "<span class=\"app-u-monospace\">012&nbsp;&zwj;345&nbsp;&zwj;6789</span>"
         )
+      end
+
+      context "when the patient is invalidated" do
+        let(:patient) do
+          build(:patient, :invalidated, nhs_number: "0123456789")
+        end
+
+        it { should be_html_safe }
+
+        it do
+          expect(patient_nhs_number).to eq(
+            "<s><span class=\"app-u-monospace\">012&nbsp;&zwj;345&nbsp;&zwj;6789</span></s>"
+          )
+        end
       end
     end
 
     context "when the NHS number is not present" do
-      let(:nhs_number) { nil }
+      let(:patient) { build(:patient, nhs_number: nil) }
 
       it { should_not be_html_safe }
       it { should eq("Not provided") }
+
+      context "when the patient is invalidated" do
+        let(:patient) { build(:patient, :invalidated, nhs_number: nil) }
+
+        it { should be_html_safe }
+
+        it { expect(patient_nhs_number).to eq("<s>Not provided</s>") }
+      end
     end
   end
 


### PR DESCRIPTION
When rendering an NHS number for a patient, we should render it as striked through if the patient is marked as invalid so the nurses are able to see from the patient page that the patient is invalid.