### PR TITLE
Show patient address when comparing duplicates

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -12,7 +12,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child details" } %>
-  <%= render AppPatientSummaryComponent.new(patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>
+  <%= render AppPatientSummaryComponent.new(patient, show_parent_or_guardians: true) %>
 <% end %>
 
 <% if display_gillick_assessment_card? %>

--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -3,8 +3,6 @@
 class AppPatientSummaryComponent < ViewComponent::Base
   def initialize(
     patient,
-    show_preferred_name: false,
-    show_address: false,
     show_parent_or_guardians: false,
     change_links: {},
     highlight: true
@@ -13,8 +11,6 @@ class AppPatientSummaryComponent < ViewComponent::Base
 
     @patient = patient
 
-    @show_preferred_name = show_preferred_name
-    @show_address = show_address
     @show_parent_or_guardians = show_parent_or_guardians
     @change_links = change_links
     @highlight = highlight
@@ -37,11 +33,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
         row.with_key { "Full name" }
         row.with_value { format_full_name }
       end
-      if @show_preferred_name &&
-           (
-             @patient.has_preferred_name? ||
-               @patient.preferred_full_name_changed?
-           )
+      if @patient.has_preferred_name? || @patient.preferred_full_name_changed?
         summary_list.with_row do |row|
           row.with_key { "Known as" }
           row.with_value { format_preferred_full_name }
@@ -62,16 +54,9 @@ class AppPatientSummaryComponent < ViewComponent::Base
         row.with_value { format_gender_code }
       end
       unless @patient.restricted?
-        if @show_address
-          summary_list.with_row do |row|
-            row.with_key { "Address" }
-            row.with_value { format_address }
-          end
-        else
-          summary_list.with_row do |row|
-            row.with_key { "Postcode" }
-            row.with_value { format_postcode }
-          end
+        summary_list.with_row do |row|
+          row.with_key { "Address" }
+          row.with_value { format_address }
         end
       end
       summary_list.with_row do |row|
@@ -143,10 +128,6 @@ class AppPatientSummaryComponent < ViewComponent::Base
       helpers.format_address_multi_line(@patient),
       @patient.address_changed?
     )
-  end
-
-  def format_postcode
-    highlight_if(@patient.address_postcode, @patient.address_postcode_changed?)
   end
 
   def format_school

--- a/app/views/consent_forms/new_patient.html.erb
+++ b/app/views/consent_forms/new_patient.html.erb
@@ -16,8 +16,6 @@
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child record" } %>
   <%= render AppPatientSummaryComponent.new(@patient,
-                                            show_preferred_name: true,
-                                            show_address: true,
                                             show_parent_or_guardians: true,
                                             highlight: false) %>
 <% end %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -16,8 +16,6 @@
   <% card.with_heading { "Record details" } %>
   <%= render AppPatientSummaryComponent.new(
         @patient,
-        show_preferred_name: true,
-        show_address: true,
         show_parent_or_guardians: true,
         change_links: { nhs_number: edit_nhs_number_patient_path(@patient) },
       ) %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -16,7 +16,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child record" } %>
-  <%= render AppPatientSummaryComponent.new(@patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>
+  <%= render AppPatientSummaryComponent.new(@patient, show_parent_or_guardians: true) %>
   <%= govuk_button_link_to "Edit child record", edit_patient_path(@patient), class: "app-button--secondary" %>
 <% end %>
 

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -10,7 +10,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Child record" } %>
-  <%= render AppPatientSummaryComponent.new(@patient, show_preferred_name: true, show_address: true, show_parent_or_guardians: true) %>
+  <%= render AppPatientSummaryComponent.new(@patient, show_parent_or_guardians: true) %>
 <% end %>
 
 <%= render AppCardComponent.new do |c| %>

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -13,6 +13,7 @@ describe AppPatientSummaryComponent do
       :patient,
       nhs_number: "1234567890",
       given_name: "John",
+      preferred_given_name: "Johnny",
       family_name: "Doe",
       date_of_birth: Date.new(2000, 1, 1),
       gender_code: "male",
@@ -37,14 +38,8 @@ describe AppPatientSummaryComponent do
   it { should have_content("Full name") }
   it { should have_content("John Doe") }
 
-  context "when showing the preferred name" do
-    let(:component) { described_class.new(patient, show_preferred_name: true) }
-
-    before { patient.update!(preferred_given_name: "Johnny") }
-
-    it { should have_content("Known as") }
-    it { should have_content("Johnny Doe") }
-  end
+  it { should have_content("Known as") }
+  it { should have_content("Johnny Doe") }
 
   it { should have_content("Date of birth") }
   it { should have_content("1 January 2000") }
@@ -52,29 +47,14 @@ describe AppPatientSummaryComponent do
   it { should have_content("Gender") }
   it { should have_content("Male") }
 
-  it { should have_content("Postcode") }
-  it { should have_content("SW1A 1AA") }
+  it { should have_content("Address") }
+  it { should have_content("10 Downing Street") }
 
   context "when the patient is restricted" do
     let(:restricted) { true }
 
-    it { should_not have_content("Postcode") }
-    it { should_not have_content("SW1A 1AA") }
-  end
-
-  context "when showing the address" do
-    let(:component) { described_class.new(patient, show_address: true) }
-
-    it { should_not have_content("Postcode") }
-    it { should have_content("Address") }
-    it { should have_content("10 Downing Street") }
-
-    context "when the patient is restricted" do
-      let(:restricted) { true }
-
-      it { should_not have_content("Address") }
-      it { should_not have_content("10 Downing Street") }
-    end
+    it { should_not have_content("Address") }
+    it { should_not have_content("10 Downing Street") }
   end
 
   it { should have_content("School") }

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -67,6 +67,9 @@ describe "Child record imports duplicates" do
         nhs_number: "1234567890", # First row of valid.csv
         date_of_birth: Date.new(2010, 1, 1),
         gender_code: :female,
+        address_line_1: "10 Downing Street",
+        address_line_2: "",
+        address_town: "London",
         address_postcode: "SW11 1AA",
         school: nil, # Unknown school, should be silently updated
         organisation: @organisation
@@ -80,6 +83,9 @@ describe "Child record imports duplicates" do
         nhs_number: "1234567891", # Second row of valid.csv
         date_of_birth: Date.new(2010, 1, 2),
         gender_code: :male,
+        address_line_1: "10 Downing Street",
+        address_line_2: "",
+        address_town: "London",
         address_postcode: "SW11 1AA",
         school: @location,
         organisation: @organisation
@@ -92,6 +98,9 @@ describe "Child record imports duplicates" do
         nhs_number: nil,
         date_of_birth: Date.new(2013, 3, 3), # different date of birth
         gender_code: :male,
+        address_line_1: "10 Downing Street",
+        address_line_2: "",
+        address_town: "London",
         address_postcode: "SW1A 1AA",
         school: @location,
         organisation: @organisation
@@ -148,16 +157,16 @@ describe "Child record imports duplicates" do
   def then_i_should_see_the_first_duplicate_record
     expect(page).to have_content("This record needs reviewing")
     expect(page).to have_content("Date of birth1 January 2010 (aged 14)")
-    expect(page).to have_content("PostcodeSW11 1AA")
-    expect(page).to have_content("PostcodeSW1A 1AA")
+    expect(page).to have_content("Address10 Downing StreetLondonSW11 1AA")
+    expect(page).to have_content("Address10 Downing StreetLondonSW1A 1AA")
   end
 
   def then_i_should_see_the_second_duplicate_record
     expect(page).to have_content("This record needs reviewing")
     expect(page).to have_content("Full nameJames Smith")
     expect(page).to have_content("Full nameJimmy Smith")
-    expect(page).to have_content("PostcodeSW11 1AA")
-    expect(page).to have_content("PostcodeSW1A 1AA")
+    expect(page).to have_content("Address10 Downing StreetLondonSW11 1AA")
+    expect(page).to have_content("Address10 Downing StreetLondonSW1A 1AA")
   end
 
   def then_i_should_see_a_validation_error

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -80,6 +80,9 @@ describe "Class list imports duplicates" do
         nhs_number: "9990000016",
         date_of_birth: Date.new(2010, 1, 1),
         gender_code: :male,
+        address_line_1: "10 Downing Street",
+        address_line_2: "",
+        address_town: "London",
         address_postcode: "SW1A 1AA",
         school: @location
       )
@@ -92,6 +95,9 @@ describe "Class list imports duplicates" do
         nhs_number: "9990000024",
         date_of_birth: Date.new(2010, 2, 2),
         gender_code: :female,
+        address_line_1: "10 Downing Street",
+        address_line_2: "",
+        address_town: "London",
         address_postcode: "SW1A 2BB",
         school: @location
       )
@@ -136,8 +142,8 @@ describe "Class list imports duplicates" do
 
   def then_i_should_see_the_first_duplicate_record
     expect(page).to have_content("This record needs reviewing")
-    expect(page).to have_content("PostcodeSW1A 1AA")
-    expect(page).to have_content("PostcodeSW1A 1BB")
+    expect(page).to have_content("Address10 Downing StreetLondonSW1A 1AA")
+    expect(page).to have_content("Address10 Downing StreetLondonSW1A 1BB")
   end
 
   def when_i_submit_the_form_without_choosing_anything


### PR DESCRIPTION
Various parts of the patient's address can change when importing from class lists and cohort lists so we should ensure this is all visible to the user rather than just showing the postcode.

In all cases where the patient summary component is used we are now showing the full address and preferred name, so these options can be removed and we can show it in all cases.