### PR TITLE
Ensure consent refused can be given without notes

### DIFF
--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -116,6 +116,10 @@ class DraftConsent
     validates :triage_notes, length: { maximum: 1000 }
   end
 
+  on_wizard_step :notes, exact: true do
+    validates :notes, presence: true, length: { maximum: 1000 }
+  end
+
   on_wizard_step :confirm, exact: true do
     validates :outcome, presence: true
   end
@@ -257,10 +261,6 @@ class DraftConsent
     end
   end
 
-  def notes_required?
-    response_refused? && reason_for_refusal != "personal_choice"
-  end
-
   def via_self_consent?
     route == "self_consent"
   end
@@ -301,6 +301,10 @@ class DraftConsent
 
   private
 
+  def notes_required?
+    response_refused? && reason_for_refusal != "personal_choice"
+  end
+
   def triage_allowed?
     TriagePolicy.new(@current_user, Triage).new?
   end
@@ -319,10 +323,9 @@ class DraftConsent
 
   def reset_unused_fields
     self.reason_for_refusal = nil unless response_refused?
+    self.notes = "" unless notes_required?
 
     if response_given?
-      self.notes = ""
-
       if health_answers.empty?
         vaccine = programme.vaccines.first # assumes all vaccines in the programme have the same questions
         self.health_answers = vaccine.health_questions.to_health_answers

--- a/app/views/draft_consents/notes.html.erb
+++ b/app/views/draft_consents/notes.html.erb
@@ -10,10 +10,7 @@
 
   <%= h1 t(@draft_consent.reason_for_refusal, scope: %i[draft_consents notes title]) %>
 
-  <%= f.govuk_text_area :notes,
-                        label: { text: "Give details" + (@draft_consent.notes_required? ?
-                          "" :
-                          " (optional)") } %>
+  <%= f.govuk_text_area :notes, label: { text: "Give details" } %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/spec/features/verbal_consent_refused_personal_choice_spec.rb
+++ b/spec/features/verbal_consent_refused_personal_choice_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+describe "Verbal consent" do
+  before { Flipper.enable(:release_1b) }
+  after { Flipper.disable(:release_1b) }
+
+  scenario "Refused personal choice (no notes)" do
+    given_i_am_signed_in
+
+    when_i_record_the_consent_refusal_and_reason
+
+    then_an_email_is_sent_to_the_parent_confirming_the_refusal
+    and_a_text_is_sent_to_the_parent_confirming_the_refusal
+    and_the_patients_status_is_consent_refused
+    and_i_can_see_the_consent_response_details
+  end
+
+  def given_i_am_signed_in
+    programme = create(:programme, :hpv)
+    organisation =
+      create(:organisation, :with_one_nurse, programmes: [programme])
+    @session = create(:session, organisation:, programme:)
+    @patient = create(:patient, session: @session)
+
+    sign_in organisation.users.first
+  end
+
+  def when_i_record_the_consent_refusal_and_reason
+    visit session_consents_path(@session)
+    click_link @patient.full_name
+    click_button "Get consent"
+
+    # Who are you trying to get consent from?
+    choose @patient.parents.first.full_name
+    click_button "Continue"
+
+    # Details for parent or guardian: leave prepopulated details
+    click_button "Continue"
+
+    # How was the response given?
+    choose "By phone"
+    click_button "Continue"
+
+    # Do they agree?
+    choose "No, they do not agree"
+    click_button "Continue"
+
+    # Reason
+    choose "Personal choice"
+    click_button "Continue"
+
+    # No notes are asked for
+
+    # Confirm
+    expect(page).to have_content(["Decision", "Consent refused"].join)
+    expect(page).to have_content(
+      ["Name", @patient.parents.first.full_name].join
+    )
+    click_button "Confirm"
+
+    expect(page).to have_content("Check consent responses")
+    expect(page).to have_content("Consent recorded for #{@patient.full_name}")
+  end
+
+  def and_the_patients_status_is_consent_refused
+    click_link @patient.full_name
+
+    relation = @patient.parents.first.relationship_to(patient: @patient).label
+    expect(page).to have_content("Consent refused")
+    expect(page).to have_content("#{relation} refused to give consent.")
+  end
+
+  def and_i_can_see_the_consent_response_details
+    parent = @patient.parents.first
+    click_link parent.full_name
+
+    expect(page).to have_content(
+      ["Response date", Time.zone.today.to_fs(:long)].join
+    )
+    expect(page).to have_content(["Decision", "Consent refused"].join)
+    expect(page).to have_content(["Response method", "By phone"].join)
+    expect(page).to have_content(["Reason for refusal", "Personal choice"].join)
+    expect(page).not_to have_content("Notes")
+
+    expect(page).to have_content(["Full name", @patient.full_name].join)
+    expect(page).to have_content(
+      ["Date of birth", @patient.date_of_birth.to_fs(:long)].join
+    )
+    expect(page).to have_content(["School", @patient.school.name].join)
+
+    expect(page).to have_content(["Name", parent.full_name].join)
+    expect(page).to have_content(
+      ["Relationship", parent.relationship_to(patient: @patient).label].join
+    )
+    expect(page).to have_content(["Email address", parent.email].join)
+    expect(page).to have_content(["Phone number", parent.phone].join)
+
+    expect(page).not_to have_content("Answers to health questions")
+  end
+
+  def then_an_email_is_sent_to_the_parent_confirming_the_refusal
+    expect_email_to @patient.parents.first.email, :consent_confirmation_refused
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_the_refusal
+    expect_text_to @patient.parents.first.phone, :consent_confirmation_refused
+  end
+end

--- a/spec/models/draft_consent_spec.rb
+++ b/spec/models/draft_consent_spec.rb
@@ -79,5 +79,18 @@ describe DraftConsent do
         expect { save! }.to change(draft_consent, :health_answers).to([])
       end
     end
+
+    context "when notes not required" do
+      let(:attributes) do
+        valid_refused_attributes.merge(
+          reason_for_refusal: "personal_choice",
+          notes: "Some notes."
+        )
+      end
+
+      it "clears the notes" do
+        expect { save! }.to change(draft_consent, :notes).to("")
+      end
+    end
   end
 end


### PR DESCRIPTION
When refusing consent for personal reasons, we don't require notes to be provided, but this causes a validation error when trying to save the consent as we require this field to be `not null`. Instead we should save this as a blank string.