### PR TITLE
Remove triage objects on reset

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -66,6 +66,8 @@ class DevController < ApplicationController
       ConsentForm.where(organisation:).delete_all
       Consent.where(organisation:).delete_all
 
+      Triage.where(organisation:).delete_all
+
       Patient
         .joins(:cohort)
         .where(cohorts: { organisation: })


### PR DESCRIPTION
Leaving these behind will raise foreign key constraint errors when deleting patients.