### PR TITLE
Validate vaccinator email address if provided

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -421,14 +421,13 @@ class ImmunisationImportRow
   def performed_by_details_present_where_required
     if outcome_in_this_academic_year?
       errors.add(:performed_by_user, :blank) if performed_by_user.nil?
-    elsif @programme.hpv? # previous academic years from here on
-      nil
-      # no validation required
-    elsif @programme.flu?
+    else # previous academic years from here on
       email_field_populated =
         @data["PERFORMING_PROFESSIONAL_EMAIL"]&.strip.present?
-      if !email_field_populated &&
-           (performed_by_given_name.blank? || performed_by_family_name.blank?)
+
+      if email_field_populated
+        errors.add(:performed_by_user, :blank) if performed_by_user.nil?
+      elsif @programme.flu? # no validation required for HPV
         if performed_by_given_name.blank?
           errors.add(:performed_by_given_name, :blank)
         end
@@ -436,8 +435,6 @@ class ImmunisationImportRow
           errors.add(:performed_by_family_name, :blank)
         end
       end
-    else
-      raise "Unexpected programme"
     end
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -343,6 +343,22 @@ describe ImmunisationImportRow do
       it { should be_valid }
     end
 
+    context "HPV vaccination in previous academic year, vaccinator email provided but doesn't exist" do
+      let(:data) do
+        valid_hpv_data.merge(
+          "PERFORMING_PROFESSIONAL_EMAIL" => "non-existent@example.com",
+          "DATE_OF_VACCINATION" => "20220101"
+        )
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:performed_by_user]).to include(
+          "Enter a valid email address"
+        )
+      end
+    end
+
     context "Flu vaccination in previous academic year, no vaccinator details provided" do
       let(:data) do
         valid_flu_data.except(


### PR DESCRIPTION
If a vaccinator email address has been provided, even if it's for historical records, we should validate that the email address exists otherwise we currently silently ignore these errors.