### PR TITLE
Show all vaccination deletions in activity log

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -109,11 +109,7 @@ class VaccinationsController < ApplicationController
   def destroy
     authorize @vaccination_record
 
-    if @vaccination_record.session.today?
-      @vaccination_record.destroy!
-    else
-      @vaccination_record.discard!
-    end
+    @vaccination_record.discard!
 
     redirect_to session_patient_path(id: @patient.id),
                 flash: {

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -3,38 +3,11 @@
 describe "Delete vaccination record" do
   before { Flipper.enable(:release_1b) }
 
-  after do
-    Flipper.disable(:release_1b)
-    travel_back
-  end
+  after { Flipper.disable(:release_1b) }
 
-  scenario "User deletes a vaccination record same day as session" do
+  scenario "User deletes a vaccination record" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
-
-    when_i_go_to_a_patient_that_is_vaccinated
-    and_i_click_on_delete_vaccination_record
-    then_i_see_the_delete_vaccination_page
-
-    when_i_dont_delete_the_vaccination_record
-    then_i_see_the_patient
-    and_they_are_already_vaccinated
-    and_i_click_on_delete_vaccination_record
-    then_i_see_the_delete_vaccination_page
-
-    when_i_delete_the_vaccination_record
-    then_i_see_the_patient
-    and_i_see_a_successful_message
-    and_they_can_be_vaccinated
-
-    when_i_click_on_the_log
-    then_i_see_no_vaccinations
-  end
-
-  scenario "User deletes a vaccination record different session date" do
-    given_an_hpv_programme_is_underway
-    and_an_administered_vaccination_record_exists
-    and_its_the_day_after_the_session
 
     when_i_go_to_a_patient_that_is_vaccinated
     and_i_click_on_delete_vaccination_record
@@ -58,7 +31,6 @@ describe "Delete vaccination record" do
   scenario "User deletes a vaccination record on a closed session date" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
-    and_its_the_day_after_the_session
     and_the_session_has_closed
 
     when_i_go_to_a_patient_that_is_vaccinated
@@ -70,7 +42,12 @@ describe "Delete vaccination record" do
     @programme = create(:programme, :hpv, organisations: [@organisation])
 
     @session =
-      create(:session, organisation: @organisation, programme: @programme)
+      create(
+        :session,
+        date: Date.yesterday,
+        organisation: @organisation,
+        programme: @programme
+      )
 
     @patient =
       create(
@@ -97,10 +74,6 @@ describe "Delete vaccination record" do
       patient_session: @patient_session,
       batch:
     )
-  end
-
-  def and_its_the_day_after_the_session
-    travel 1.day
   end
 
   def and_the_session_has_closed
@@ -151,10 +124,6 @@ describe "Delete vaccination record" do
 
   def when_i_click_on_the_log
     click_on "Activity log"
-  end
-
-  def then_i_see_no_vaccinations
-    expect(page).not_to have_content("Vaccinated")
   end
 
   def then_i_see_the_delete_vaccination


### PR DESCRIPTION
The current behaviour seems to be confusing for users, where we don't always show vaccination records as having been deleted in the activity log. This changes that to be consistent and always show the information in the log, as suggested by our designer.