### PR TITLE
Make immunisation row validation stricter

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,7 +275,7 @@ en:
             performed_by_family_name:
               blank: Enter a last name
             reason:
-              blank: Enter a reason
+              blank: Enter a valid reason
             school_name:
               blank: Enter a school name.
             school_urn:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -164,6 +164,17 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "when vaccinated and a reason not given" do
+      let(:data) do
+        { "VACCINATED" => "Y", "REASON_NOT_VACCINATED" => "unwell" }
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:reason]).to eq(["must be blank"])
+      end
+    end
+
     context "for a vaccination administered today, with no time provided" do
       around { |example| freeze_time { example.run } }
 


### PR DESCRIPTION
If the row is marked as not vaccinated, we should ensure that a batch, vaccine, delivery site is not provided. Similarly, if a row is marked as vaccinated, we should ensure that a reason not vaccinated is not provided.