### PR TITLE
Include who recorded consent in activity log

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -47,7 +47,8 @@ class AppActivityLogComponent < ViewComponent::Base
           {
             title:
               "Consent #{consent.response} by #{consent.name} (#{consent.who_responded})",
-            time: consent.recorded_at
+            time: consent.recorded_at,
+            by: consent.recorded_by&.full_name
           },
           {
             title: "Consent from #{consent.name} invalidated",
@@ -59,7 +60,8 @@ class AppActivityLogComponent < ViewComponent::Base
           {
             title:
               "Consent given by #{consent.name} (#{consent.who_responded})",
-            time: consent.recorded_at
+            time: consent.recorded_at,
+            by: consent.recorded_by&.full_name
           },
           {
             title: "Consent from #{consent.name} withdrawn",
@@ -71,7 +73,8 @@ class AppActivityLogComponent < ViewComponent::Base
           {
             title:
               "Consent #{consent.response} by #{consent.name} (#{consent.who_responded})",
-            time: consent.recorded_at
+            time: consent.recorded_at,
+            by: consent.recorded_by&.full_name
           }
         ]
       end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -52,7 +52,8 @@ describe AppActivityLogComponent do
         programme:,
         patient:,
         parent: mum,
-        recorded_at: Time.zone.parse("2024-05-30 12:00")
+        recorded_at: Time.zone.parse("2024-05-30 12:00"),
+        recorded_by: user
       )
       create(
         :consent,
@@ -161,7 +162,8 @@ describe AppActivityLogComponent do
 
     include_examples "card",
                      title: "Consent given by Jane Doe (Mum)",
-                     date: "30 May 2024 at 12:00pm"
+                     date: "30 May 2024 at 12:00pm",
+                     by: "Nurse Joy"
 
     include_examples "card",
                      title: "Added to session at Hogwarts",


### PR DESCRIPTION
This is particularly useful if a nurse is recording verbal or paper consent, if the parent gives consent via online then this won't be shown.