### PR TITLE
Allow downloading and uploading vaccinations without postcodes

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -180,7 +180,7 @@ class Reports::OfflineSessionExporter
       patient.date_of_birth,
       patient.year_group,
       patient.gender_code.humanize,
-      patient.address_postcode,
+      patient.restricted? ? "" : patient.address_postcode,
       patient.nhs_number,
       consents.first&.response&.humanize,
       consent_details(consents:),

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -118,7 +118,7 @@ class Reports::ProgrammeVaccinationsExporter
       patient.date_of_birth.strftime("%Y%m%d"),
       patient.year_group || "",
       patient.gender_code.humanize,
-      patient.address_postcode,
+      patient.restricted? ? "" : patient.address_postcode,
       patient.nhs_number,
       consents.first&.response&.humanize || "",
       consent_details(consents:),

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -52,7 +52,16 @@ class ImmunisationImportRow
   validates :patient_last_name, presence: true
   validates :patient_date_of_birth, presence: true
   validates :patient_gender_code, inclusion: { in: Patient.gender_codes.keys }
-  validates :patient_postcode, postcode: true
+  validates :patient_postcode,
+            postcode: {
+              allow_nil: true
+            },
+            presence: {
+              if: -> do
+                @data["PERSON_POSTCODE"]&.strip.present? ||
+                  patient_nhs_number.blank?
+              end
+            }
   validate :date_of_birth_in_a_valid_year_group
 
   validates :date_of_vaccination,
@@ -523,7 +532,7 @@ class ImmunisationImportRow
 
   def existing_patients
     if patient_first_name.blank? || patient_last_name.blank? ||
-         patient_date_of_birth.nil? || patient_postcode.blank?
+         patient_date_of_birth.nil?
       return
     end
 

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -93,6 +93,17 @@ describe "HPV Vaccination" do
       performed_at: previous_date,
       performed_by: @organisation.users.first
     )
+
+    @restricted_vaccinated_patient =
+      create(
+        :patient,
+        :vaccinated,
+        :restricted,
+        session: clinic ? @organisation.generic_clinic_session : @session,
+        school:,
+        location_name: clinic ? @physical_clinic_location.name : nil,
+        year_group: 8
+      )
   end
 
   def when_i_choose_to_record_offline_from_a_school_session_page
@@ -207,7 +218,7 @@ describe "HPV Vaccination" do
 
     expect(page).to have_content("Completed")
     expect(page).not_to have_content("Invalid")
-    expect(page).to have_content("1 previously imported record was omitted")
+    expect(page).to have_content("2 previously imported records were omitted")
   end
 
   def and_i_navigate_to_the_session_page
@@ -237,13 +248,20 @@ describe "HPV Vaccination" do
     expect(page).to have_content("SiteLeft arm (upper position)")
 
     click_on "Back"
-
     click_on "Could not vaccinate"
 
     click_on @unvaccinated_patient.full_name
     expect(page).to have_content(@unvaccinated_patient.full_name)
     expect(page).to have_content("Could not vaccinate")
     expect(page).to have_content("OutcomeAbsent from session")
+
+    click_on "Back"
+    click_on "Vaccinated"
+
+    click_on @restricted_vaccinated_patient.full_name
+    expect(page).to have_content(@restricted_vaccinated_patient.full_name)
+    expect(page).to have_content("Vaccinated")
+    expect(page).not_to have_content("Address")
   end
 
   def and_the_clinic_location_is_displayed

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -131,6 +131,15 @@ describe Reports::OfflineSessionExporter do
         end
       end
 
+      context "with a restricted patient" do
+        before { create(:patient, :restricted, session:) }
+
+        it "doesn't include the postcode" do
+          expect(rows.count).to eq(1)
+          expect(rows.first["PERSON_POSTCODE"]).to be_blank
+        end
+      end
+
       context "with a vaccinated patient" do
         let!(:vaccination_record) do
           create(

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -92,6 +92,15 @@ describe ImmunisationImportRow do
           ["Enter a valid postcode, such as SW1A 1AA"]
         )
       end
+
+      context "with an NHS number and missing fields" do
+        let(:data) { { "VACCINATED" => "Y", "NHS_NUMBER" => nhs_number } }
+
+        it "doesn't require a postcode" do
+          expect(immunisation_import_row).to be_invalid
+          expect(immunisation_import_row.errors[:patient_postcode]).to be_empty
+        end
+      end
     end
 
     context "with an invalid organisation code" do
@@ -132,8 +141,8 @@ describe ImmunisationImportRow do
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
-        expect(immunisation_import_row.errors[:patient_postcode]).to eq(
-          ["Enter a valid postcode, such as SW1A 1AA"]
+        expect(immunisation_import_row.errors[:patient_gender_code]).to eq(
+          ["Enter a gender or gender code."]
         )
       end
     end


### PR DESCRIPTION
This is necessary to support restricted patients, ones where the postcode is not allowed to be seen by the nurse. We need to update the offline recording spreadsheet to not include the postcode for any restricted patients, and similarly, we need to make it possible to upload a vaccination file without a postcode.