### PR TITLE
Render offline health questions on individual lines

### DIFF
--- a/app/lib/reports/export_formatters.rb
+++ b/app/lib/reports/export_formatters.rb
@@ -49,7 +49,7 @@ module Reports::ExportFormatters
         "#{question} #{formatted_responses.join(", ")}"
       end
 
-    values.join("\n")
+    values.join("\r\n")
   end
 
   def gillick_status(gillick_assessment:)

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -27,12 +27,22 @@ class Reports::OfflineSessionExporter
   delegate :location, :organisation, to: :session
 
   def add_vaccinations_sheet(package)
+    package.use_shared_strings = true
+
     workbook = package.workbook
 
     date_style = workbook.styles.add_style(format_code: "dd/mm/yyyy")
+    wrap_style = workbook.styles.add_style(alignment: { wrap_text: true })
 
     types = headers_and_types.values
-    style = types.map { _1 == :date ? date_style : nil }
+    style =
+      headers_and_types.map do |header, type|
+        if type == :date
+          date_style
+        elsif header == "HEALTH_QUESTION_ANSWERS"
+          wrap_style
+        end
+      end
 
     workbook.add_worksheet(name: "Vaccinations") do |sheet|
       sheet.add_row(headers_and_types.keys)

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -191,6 +191,25 @@ describe Reports::OfflineSessionExporter do
             performed_at.to_date
           )
         end
+
+        context "with lots of health answers" do
+          before do
+            create(
+              :consent,
+              :from_dad,
+              :recorded,
+              patient:,
+              programme:,
+              health_questions_list: ["First question?", "Second question?"]
+            )
+          end
+
+          it "separates the answers by new lines" do
+            expect(rows.first["HEALTH_QUESTION_ANSWERS"]).to eq(
+              "First question? No from Dad\nSecond question? No from Dad"
+            )
+          end
+        end
       end
 
       context "with a patient who couldn't be vaccinated" do


### PR DESCRIPTION
It seems like Excel is not interpreting the new line character correctly, so we need to add some styles to the cells to ensure the content is word wrapped.

I don't have Excel to test this works correctly, but it's based on reading through: https://stackoverflow.com/questions/25770025/rails-axlsx-new-line-in-cell