### PR TITLE
Send email after deleting a vaccination record

### DIFF
--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -4,29 +4,10 @@ module VaccinationMailerConcern
   extend ActiveSupport::Concern
 
   def send_vaccination_confirmation(vaccination_record)
-    patient_session = vaccination_record.patient_session
-    patient = patient_session.patient
-
-    return unless patient.send_notifications?
-
-    consents = patient_session.latest_consents
-
-    parents =
-      if consents.any?(&:via_self_consent?)
-        if consents.any?(&:notify_parents)
-          patient.parents.select(&:contactable?)
-        else
-          []
-        end
-      else
-        consents
-          .select(&:response_given?)
-          .filter_map(&:parent)
-          .select(&:contactable?)
-      end
-
+    parents = parents_for_vaccination_mailer(vaccination_record)
     return if parents.empty?
 
+    patient = vaccination_record.patient_session.patient
     sent_by = current_user
 
     mailer_action =
@@ -46,6 +27,44 @@ module VaccinationMailerConcern
       end
 
       TextDeliveryJob.perform_later(text_template_name, **params)
+    end
+  end
+
+  def send_vaccination_deletion(vaccination_record)
+    parents = parents_for_vaccination_mailer(vaccination_record)
+    return if parents.empty?
+
+    patient = vaccination_record.patient_session.patient
+    sent_by = current_user
+
+    parents.each do |parent|
+      params = { parent:, patient:, vaccination_record:, sent_by: }
+
+      if parent.email.present?
+        VaccinationMailer.with(params).deleted.deliver_later
+      end
+    end
+  end
+
+  def parents_for_vaccination_mailer(vaccination_record)
+    patient_session = vaccination_record.patient_session
+    patient = patient_session.patient
+
+    return [] unless patient.send_notifications?
+
+    consents = patient_session.latest_consents
+
+    if consents.any?(&:via_self_consent?)
+      if consents.any?(&:notify_parents)
+        patient.parents.select(&:contactable?)
+      else
+        []
+      end
+    else
+      consents
+        .select(&:response_given?)
+        .filter_map(&:parent)
+        .select(&:contactable?)
     end
   end
 end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -114,6 +114,8 @@ class VaccinationsController < ApplicationController
 
     @vaccination_record.discard!
 
+    send_vaccination_deletion(@vaccination_record)
+
     redirect_to session_patient_path(id: @patient.id),
                 flash: {
                   success: "Vaccination record deleted"

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -48,6 +48,8 @@ class GovukNotifyPersonalisation
       next_session_dates:,
       next_session_dates_or:,
       not_catch_up:,
+      outcome_administered:,
+      outcome_not_administered:,
       parent_full_name:,
       programme_name:,
       reason_did_not_vaccinate:,
@@ -154,6 +156,16 @@ class GovukNotifyPersonalisation
       .today_or_future_dates
       .map { _1.to_fs(:short_day_of_week) }
       .to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
+  end
+
+  def outcome_administered
+    return if vaccination_record.nil?
+    vaccination_record.administered? ? "yes" : "no"
+  end
+
+  def outcome_not_administered
+    return if vaccination_record.nil?
+    vaccination_record.not_administered? ? "yes" : "no"
   end
 
   def parent_full_name

--- a/app/mailers/vaccination_mailer.rb
+++ b/app/mailers/vaccination_mailer.rb
@@ -8,4 +8,8 @@ class VaccinationMailer < ApplicationMailer
   def confirmation_not_administered
     app_template_mail(:vaccination_confirmation_not_administered)
   end
+
+  def deleted
+    app_template_mail(:vaccination_deleted)
+  end
 end

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -18,7 +18,8 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f",
   vaccination_confirmation_administered: "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
   vaccination_confirmation_not_administered:
-    "130fe52a-014a-45dd-9f53-8e65c1b8bb79"
+    "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
+  vaccination_deleted: "1caf1459-abc9-4944-b8c0-deba906ea005"
 }.freeze
 
 GOVUK_NOTIFY_TEXT_TEMPLATES = {

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -26,6 +26,7 @@ describe "Delete vaccination record" do
 
     when_i_click_on_the_log
     then_i_see_the_delete_vaccination
+    and_the_parent_receives_an_email
   end
 
   scenario "User deletes a vaccination record on a closed session date" do
@@ -52,6 +53,7 @@ describe "Delete vaccination record" do
     @patient =
       create(
         :patient,
+        :consent_given_triage_needed,
         :triage_ready_to_vaccinate,
         given_name: "John",
         family_name: "Smith",
@@ -129,6 +131,10 @@ describe "Delete vaccination record" do
   def then_i_see_the_delete_vaccination
     expect(page).to have_content("Vaccinated with Gardasil 9")
     expect(page).to have_content("HPV vaccination record deleted")
+  end
+
+  def and_the_parent_receives_an_email
+    expect_email_to(@patient.parents.first.email, :vaccination_deleted)
   end
 
   def then_i_cant_click_on_delete_vaccination_record

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -189,7 +189,9 @@ describe GovukNotifyPersonalisation do
           day_month_year_of_vaccination: "01/01/2024",
           reason_did_not_vaccinate: "the nurse decided John was not well",
           show_additional_instructions: "yes",
-          today_or_date_of_vaccination: "1 January 2024"
+          today_or_date_of_vaccination: "1 January 2024",
+          outcome_administered: "no",
+          outcome_not_administered: "yes"
         )
       )
     end


### PR DESCRIPTION
This sends an email to the parents explaining that the email they would have received for the vaccination when it was recorded was incorrect and they can ignore it.