### PR TITLE
Consent factory should generate more realistic health questions

### DIFF
--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -41,7 +41,14 @@
 FactoryBot.define do
   factory :consent do
     transient do
-      health_questions_list { ["Is there anything else we should know?"] }
+      health_questions_list do
+        questions = programme.vaccines.active.first&.health_questions
+        if questions&.any?
+          questions.in_order.pluck(:title)
+        else
+          ["Is there anything else we should know?"]
+        end
+      end
     end
 
     programme
@@ -110,7 +117,7 @@ FactoryBot.define do
     trait :health_question_notes do
       health_answers do
         health_questions_list.map do |question|
-          if question == "Is there anything else we should know?"
+          if question == health_questions_list.last
             HealthAnswer.new(
               question:,
               response: "yes",

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -227,8 +227,12 @@ describe Reports::ProgrammeVaccinationsExporter do
           "CONSENT_DETAILS" =>
             "Given by John Smith at 2024-01-01 12:05:20 +0000",
           "CONSENT_STATUS" => "Given",
-          "HEALTH_QUESTION_ANSWERS" =>
-            "Is there anything else we should know? No from Dad"
+          "HEALTH_QUESTION_ANSWERS" => [
+            "Does your child have any severe allergies? No from Dad",
+            "Does your child have any medical conditions for which they receive treatment? No from Dad",
+            "Has your child ever had a severe reaction to any medicines, including vaccines? No from Dad",
+            "Does your child need extra support during vaccination sessions? No from Dad"
+          ].join("\r\n")
         )
       end
     end


### PR DESCRIPTION
It should take the questions from the programme when that's set. This manifests itself in specs and in the seeded consent responses.

<img width="942" alt="image" src="https://github.com/user-attachments/assets/c1eaceea-cc11-4e98-a4ba-41dbc9c7254f">
