### PR TITLE
Replace outcome column with status

### DIFF
--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -48,7 +48,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       action: "Action needed",
       dob: "Date of birth",
       name: "Full name",
-      outcome: "Outcome",
+      status: "Status",
       postcode: "Postcode",
       reason: "Reason for refusal",
       select_for_matching: "Action",
@@ -61,9 +61,12 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     patient_session = @patient_sessions[patient]
 
     case column
-    when :action, :outcome
+    when :action
       state = patient_session&.state || "not_in_session"
       t("patient_session_statuses.#{state}.text")
+    when :status
+      state = patient_session&.state || "not_in_session"
+      t("patient_session_statuses.#{state}.banner_title")
     when :dob
       patient.date_of_birth.to_fs(:long)
     when :name

--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -25,8 +25,8 @@ module PatientSortingConcern
       obj.try(:date_of_birth) || obj.patient.date_of_birth
     when "name"
       obj.try(:full_name) || obj.patient.full_name
-    when "outcome"
-      obj.state
+    when "status"
+      obj.try(:state) || "not_in_session"
     when "postcode"
       obj.try(:address_postcode) || obj.patient.address_postcode
     when "year_group"

--- a/app/views/programme/patients/index.html.erb
+++ b/app/views/programme/patients/index.html.erb
@@ -21,7 +21,7 @@
 
 <%= render AppSessionPatientTableComponent.new(
       caption: t("children", count: @pagy.count),
-      columns: %i[name dob year_group outcome],
+      columns: %i[name dob year_group status],
       params:,
       patients: @patients,
       patient_sessions: @patient_sessions,

--- a/app/views/register_attendances/index.html.erb
+++ b/app/views/register_attendances/index.html.erb
@@ -11,8 +11,9 @@
 <%= h1 "Register attendance" %>
 
 <%= render AppSessionPatientTableComponent.new(
-      caption: t("patients_table.register_attendance.caption", children: t("children", count: @patient_sessions.count)),
-      columns: %i[name year_group outcome attendance],
+      caption: t("patients_table.register_attendance.caption",
+                 children: t("children", count: @patient_sessions.count)),
+      columns: %i[name year_group status attendance],
       params:,
       patient_sessions: @patient_sessions,
       section: :attendance,

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -36,7 +36,9 @@
 
 <%= render AppSessionPatientTableComponent.new(
       caption: t("patients_table.#{@current_tab}.caption", children: t("children", count: @patient_sessions.count)),
-      columns: @current_tab == :vaccinate ? %i[name year_group action] : %i[name year_group outcome],
+      columns: @current_tab == :vaccinate ?
+        %i[name year_group action] :
+        %i[name year_group status],
       params:,
       patient_sessions: @patient_sessions,
       section: :vaccinations,

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -2,6 +2,7 @@ en:
   patient_session_statuses:
     not_in_session:
       text: Not in a session
+      banner_title: Not in session
     added_to_session:
       colour: blue
       text: Get consent

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -151,10 +151,10 @@ describe AppSessionPatientTableComponent do
       it { should have_column("Action needed") }
     end
 
-    context "includes outcome" do
-      let(:columns) { %i[name year_group outcome] }
+    context "includes status" do
+      let(:columns) { %i[name year_group status] }
 
-      it { should have_column("Outcome") }
+      it { should have_column("Status") }
     end
   end
 end


### PR DESCRIPTION
The outcome column isn't used in the patient's table anywhere in the prototype anymore.

![Screenshot 2024-11-19 at 19 16 15](https://github.com/user-attachments/assets/b3cb9cba-605d-47e8-ba72-1b39bff13a0e)
