### PR TITLE
Vaccines page layout

### DIFF
--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -3,6 +3,8 @@
 class VaccinesController < ApplicationController
   include TodaysBatchConcern
 
+  layout "full"
+
   def index
     @vaccines = policy_scope(Vaccine).active.order(:brand)
     @batches_by_vaccine_id =

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -7,9 +7,7 @@
       <%= vaccine.manufacturer %>
     </p>
 
-    <p>
-      <%= link_to "Add a batch", new_vaccine_batch_path(vaccine) %>
-    </p>
+    <%= govuk_button_link_to "Add a new batch", new_vaccine_batch_path(vaccine), class: "app-button--secondary" %>
 
     <% if (batches = @batches_by_vaccine_id[vaccine.id]).present? %>
       <%= govuk_table do |table| %>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -3,7 +3,7 @@
 <% @vaccines.each do |vaccine| %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { link_to(vaccine_heading(vaccine), vaccine_path(vaccine)) } %>
-    <p class="nhsuk-body-s nhsuk-secondary-text-color">
+    <p>
       <%= vaccine.manufacturer %>
     </p>
 

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -64,7 +64,7 @@ describe "Manage batches" do
   end
 
   def when_i_try_to_add_a_batch_with_an_invalid_expiry_date
-    click_on "Add a batch", match: :first
+    click_on "Add a new batch", match: :first
 
     fill_in "Batch", with: "AB1234"
 
@@ -122,7 +122,7 @@ describe "Manage batches" do
   end
 
   def when_i_add_the_archived_batch_again
-    click_on "Add a batch", match: :first
+    click_on "Add a new batch", match: :first
 
     fill_in "Batch", with: "AB1234"
 


### PR DESCRIPTION
Brings pages a little closer to design used in prototype:

- Make pages full width within this controller
- Use secondary button style for ‘Add a new batch’ (adding ‘new’ to this text)
- Use normal paragraph style for manufacture

I haven’t update the card header to the design used in the prototype, as the prototype doesn’t currently provide for a link to vaccine details, and I don’t want to change the scope of what’s shown/not shown here.

| Before | After |
|-|-|
| <img width="1160" alt="Screenshot before" src="https://github.com/user-attachments/assets/871e2f7b-bc2d-4ed0-a42c-88577e575568"> | <img width="1190" alt="Screenshot after" src="https://github.com/user-attachments/assets/2d41d986-776e-4dc3-8534-86ab1383e169"> |
