### PR TITLE
Avoid showing nil parents

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -157,7 +157,7 @@ class DraftConsentsController < ApplicationController
 
   def set_parent_options
     @parent_options =
-      (@patient.parents + @patient_session.consents.map(&:parent))
+      (@patient.parents + @patient_session.consents.filter_map(&:parent))
         .compact
         .uniq
         .sort_by(&:full_name)


### PR DESCRIPTION
The consent column can also include self-consents, where the parent will be `nil`, so we should filter those out.