### PR TITLE
Add prod deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,47 @@
+name: Deploy (production)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot:
+    name: AWS Copilot
+
+    permissions:
+      id-token: write
+      contents: read
+
+    environment:
+      name: production
+      url: https://${{ steps.host-name.outputs.value }}
+
+    concurrency:
+      group: production
+      cancel-in-progress: true
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::820242920762:role/GitHubActionsRole
+          aws-region: eu-west-2
+
+      - name: Install and Verify AWS Copilot
+        run: |
+          curl -Lo /tmp/copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+          chmod +x /tmp/copilot
+          mv /tmp/copilot /usr/local/bin/copilot
+          copilot --version
+
+      - name: Deploy the application using AWS Copilot
+        run: |
+          copilot svc deploy --name webapp --env production
+
+      - name: Get host name
+        id: host-name
+        run: |
+          echo "value=production" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Because our prod account is different from the non-prod ones, this is the quickest way to setup deploys to production via GitHub Actions.

Note that this will require that we setup the GitHubActionsRole in the production environment.