### PR TITLE
Sort parent options by label rather than name

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -160,7 +160,7 @@ class DraftConsentsController < ApplicationController
       (@patient.parents + @patient_session.consents.filter_map(&:parent))
         .compact
         .uniq
-        .sort_by(&:full_name)
+        .sort_by(&:label)
   end
 
   # Returns:

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -21,6 +21,12 @@ describe "Verbal consent" do
     @session = create(:session, organisation:, programme:)
     @patient = create(:patient, session: @session)
 
+    create(
+      :parent_relationship,
+      patient: @patient,
+      parent: build(:parent, full_name: nil)
+    )
+
     sign_in organisation.users.first
   end
 


### PR DESCRIPTION
We won't always have the name for a parent so we should be sorting on the label instead which handles the case when the name isn't there.

https://good-machine.sentry.io/issues/6078125818/