### PR TITLE
Ensure triage notes are saved correctly

### DIFF
--- a/app/views/draft_consents/triage.html.erb
+++ b/app/views/draft_consents/triage.html.erb
@@ -39,7 +39,7 @@
   <% end %>
 
   <%= f.govuk_text_area(
-        :notes,
+        :triage_notes,
         label: { text: "Triage notes (optional)" },
         rows: 5,
       ) %>

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -53,6 +53,7 @@ describe "Verbal consent" do
     click_button "Continue"
 
     choose "No, keep in triage"
+    fill_in "Triage notes (optional)", with: "Some notes."
     click_button "Continue"
 
     # Confirm
@@ -65,6 +66,7 @@ describe "Verbal consent" do
   def and_the_patient_status_is_needing_triage
     click_link @patient.full_name
     expect(page).to have_content("Needs triage")
+    expect(page).to have_content("Some notes.")
   end
 
   def then_an_email_is_sent_to_the_parent_about_triage


### PR DESCRIPTION
This is a bug that was introduced when we switched to creating consents in the browser session.