### PR TITLE
Show archived or expired batches when editing records

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -18,11 +18,17 @@ class DraftConsentsController < ApplicationController
 
   before_action :set_parent_options, if: -> { current_step == :who }
 
+  after_action :verify_authorized
+
   def show
+    authorize Consent, :edit?
+
     render_wizard
   end
 
   def update
+    authorize Consent
+
     case current_step
     when :questions
       handle_questions

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -188,6 +188,7 @@ class VaccinationsController < ApplicationController
     @batches =
       policy_scope(Batch)
         .where(vaccine: @session.vaccines)
+        .not_archived
         .not_expired
         .order_by_name_and_expiration
   end

--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -8,6 +8,7 @@ class VaccinesController < ApplicationController
     @batches_by_vaccine_id =
       policy_scope(Batch)
         .where(vaccine: @vaccines)
+        .not_archived
         .order_by_name_and_expiration
         .group_by(&:vaccine_id)
     @todays_batch_id = todays_batch_id
@@ -15,6 +16,6 @@ class VaccinesController < ApplicationController
 
   def show
     @vaccine = policy_scope(Vaccine).active.find(params[:id])
-    @batches = policy_scope(Batch).where(vaccine: @vaccine)
+    @batches = policy_scope(Batch).not_archived.where(vaccine: @vaccine)
   end
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -33,7 +33,7 @@ class Batch < ApplicationRecord
   scope :order_by_name_and_expiration, -> { order(expiry: :asc, name: :asc) }
 
   scope :archived, -> { where.not(archived_at: nil) }
-  scope :unarchived, -> { where(archived_at: nil) }
+  scope :not_archived, -> { where(archived_at: nil) }
 
   scope :expired, -> { where("expiry <= ?", Time.current) }
   scope :not_expired, -> { where("expiry > ?", Time.current) }
@@ -59,10 +59,6 @@ class Batch < ApplicationRecord
 
   def archived?
     archived_at != nil
-  end
-
-  def unarchived?
-    archived_at.nil?
   end
 
   def archive!

--- a/app/policies/batch_policy.rb
+++ b/app/policies/batch_policy.rb
@@ -3,7 +3,7 @@
 class BatchPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.unarchived.where(organisation: user.selected_organisation)
+      scope.where(organisation: user.selected_organisation)
     end
   end
 end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -29,19 +29,19 @@ describe Batch do
 
   describe "scopes" do
     let(:archived_batch) { create(:batch, :archived) }
-    let(:unarchived_batch) { create(:batch) }
+    let(:not_archived_batch) { create(:batch) }
 
     describe "#archived" do
       subject(:scope) { described_class.archived }
 
       it { should include(archived_batch) }
-      it { should_not include(unarchived_batch) }
+      it { should_not include(not_archived_batch) }
     end
 
-    describe "#unarchived" do
-      subject(:scope) { described_class.unarchived }
+    describe "#not_archived" do
+      subject(:scope) { described_class.not_archived }
 
-      it { should include(unarchived_batch) }
+      it { should include(not_archived_batch) }
       it { should_not include(archived_batch) }
     end
   end
@@ -87,18 +87,6 @@ describe Batch do
       let(:batch) { build(:batch, archived_at: Date.new(2020, 1, 1)) }
 
       it { should be(true) }
-    end
-  end
-
-  describe "#unarchived?" do
-    subject(:unarchived?) { batch.unarchived? }
-
-    it { should be(true) }
-
-    context "when archived_at is set" do
-      let(:batch) { build(:batch, archived_at: Date.new(2020, 1, 1)) }
-
-      it { should be(false) }
     end
   end
 

--- a/spec/policies/batch_policy_spec.rb
+++ b/spec/policies/batch_policy_spec.rb
@@ -7,12 +7,12 @@ describe BatchPolicy do
     let(:organisation) { create(:organisation) }
     let(:user) { create(:user, organisation:) }
 
+    let(:batch) { create(:batch, organisation:) }
     let(:archived_batch) { create(:batch, :archived, organisation:) }
-    let(:unarchived_batch) { create(:batch, organisation:) }
     let(:non_organisation_batch) { create(:batch) }
 
-    it { should include(unarchived_batch) }
-    it { should_not include(archived_batch) }
+    it { should include(batch) }
+    it { should include(archived_batch) }
     it { should_not include(non_organisation_batch) }
   end
 end


### PR DESCRIPTION
When editing a vaccination record, it's possible that the batch has expired or been archived since the vaccination record was created. In that case we should still show this batch as an option if the user chooses to edit the record.

I've also refactored the policies and controllers to simplify the code slightly.