### PR TITLE
Safe join page titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,6 +28,6 @@ or set it with content_for(:page_title)."
 
     title = "Error: #{title}" if response.status == 422
 
-    [title, service_name].join(" – ")
+    safe_join([title, service_name], " – ")
   end
 end


### PR DESCRIPTION
This ensures that we HTML escape the characters correctly so the titles render properly.

## Before

<img width="251" alt="Screenshot 2024-11-21 at 11 01 20" src="https://github.com/user-attachments/assets/f1d82822-8184-4fa4-9a55-bd3f7ca3b6ce">

## After

<img width="250" alt="Screenshot 2024-11-21 at 11 01 06" src="https://github.com/user-attachments/assets/281b140e-224a-4d41-b5f8-1cd79fc83a60">
