### PR TITLE
Remove confusing and non-performant dashboard squares

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -15,36 +15,12 @@ class ProgrammesController < ApplicationController
         cohort: policy_scope(Cohort).for_year_groups(@programme.year_groups)
       )
 
-    sessions =
-      policy_scope(Session).has_programme(@programme).for_current_academic_year
-
-    patient_sessions =
-      PatientSession.where(patient: patients, session: sessions)
-
     @patients_count = patients.count
-    @sessions_count = sessions.count
-
     @vaccinations_count = policy_scope(VaccinationRecord).count
-
     @consent_notifications_count =
       @programme.consent_notifications.where(patient: patients).count
-
     @consents =
       policy_scope(Consent).where(patient: patients, programme: @programme)
-
-    stats =
-      PatientSessionStats.new(
-        patient_sessions.preload_for_state.strict_loading,
-        keys: %i[with_consent_given without_a_response needing_triage]
-      )
-
-    @consent_given_percentage =
-      percentage_of(stats[:with_consent_given], @consents.count)
-    @responses_received_and_triaged_percentage =
-      percentage_of(
-        @patients_count - (stats[:without_a_response] + stats[:needing_triage]),
-        @patients_count
-      )
   end
 
   def sessions

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -23,13 +23,6 @@
   </div>
 
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: sessions_programme_path(@programme), colour: "reversed", data: true) do |card| %>
-      <% card.with_heading { "Sessions" } %>
-      <% card.with_description { @sessions_count.to_s } %>
-    <% end %>
-  </div>
-
-  <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: programme_vaccination_records_path(@programme), colour: "reversed", data: true) do |card| %>
       <% card.with_heading { "Vaccinations" } %>
       <% card.with_description { @vaccinations_count.to_s } %>
@@ -37,23 +30,9 @@
   </div>
 
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(data: true) do |card| %>
+    <%= render AppCardComponent.new(data: true, colour: "reversed") do |card| %>
       <% card.with_heading { "Consent requests and reminders sent" } %>
       <% card.with_description { @consent_notifications_count.to_s } %>
-    <% end %>
-  </div>
-
-  <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(data: true) do |card| %>
-      <% card.with_heading { "Consent given (versus refused or no response)" } %>
-      <% card.with_description { number_to_percentage(@consent_given_percentage, precision: 0) } %>
-    <% end %>
-  </div>
-
-  <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(data: true) do |card| %>
-      <% card.with_heading { "Responses received and triaged" } %>
-      <% card.with_description { number_to_percentage(@responses_received_and_triaged_percentage, precision: 0) } %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This will be replaced with something more useful in future.

## Before

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/26731e29-3827-4ae1-b00f-9f30858051b7">


## After

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/ac3e5374-b945-43b4-80fc-dd36bea4bd73">
