### PR TITLE
Handle sending texts from a consent correctly

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -49,6 +49,7 @@ class DraftConsentsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       @triage&.save! if @draft_consent.response_given?
+      @consent.parent&.save!
       @consent.save!
     end
 
@@ -86,13 +87,13 @@ class DraftConsentsController < ApplicationController
       notes: %i[notes],
       notify_parents: %i[notify_parents],
       parent_details: %i[
-        parent_full_name
         parent_email
-        parent_responsibility
+        parent_full_name
         parent_phone
         parent_phone_receive_updates
-        parent_relationship_type
         parent_relationship_other_name
+        parent_relationship_type
+        parent_responsibility
       ],
       questions: questions_params,
       reason: %i[reason_for_refusal],

--- a/app/jobs/text_delivery_job.rb
+++ b/app/jobs/text_delivery_job.rb
@@ -22,7 +22,8 @@ class TextDeliveryJob < ApplicationJob
       consent_form&.parent_phone || consent&.parent&.phone || parent&.phone
     return if phone_number.nil?
 
-    unless consent_form&.parent_phone_receive_updates || consent&.parent ||
+    unless consent_form&.parent_phone_receive_updates ||
+             consent&.parent&.phone_receive_updates ||
              parent&.phone_receive_updates
       return
     end

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -63,6 +63,7 @@ class DraftConsent
               phone: {
                 allow_blank: true
               }
+    validates :parent_phone_receive_updates, inclusion: { in: [true, false] }
   end
 
   with_options if: -> do

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -91,6 +91,22 @@ describe TextDeliveryJob do
       end
     end
 
+    context "when the consent's parent doesn't want to receive updates" do
+      let(:parent) { nil }
+      let(:consent) do
+        create(
+          :consent,
+          parent: create(:parent, phone_receive_updates: false),
+          programme:
+        )
+      end
+
+      it "doesn't send a text" do
+        expect(notifications_client).not_to receive(:send_sms)
+        perform_now
+      end
+    end
+
     context "when the parent doesn't have a phone number" do
       let(:parent) { create(:parent, phone: nil) }
 


### PR DESCRIPTION
Currently when queuing a `TextDeliveryJob` the details of the parent can come from three places, the `consent_form`, the `consent` or a `parent` directly. When passing it only a `consent`, we weren't correctly checking the value of `phone_receive_updates` on the parent meaning that the parent would receive a text even if they didn't request one.