### PR TITLE
Validate that either parent phone or email is present

### DIFF
--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -55,16 +55,29 @@ class DraftConsent
   end
 
   on_wizard_step :parent_details, exact: true do
-    validates :parent_email, notify_safe_email: true
-    validates :parent_phone,
-              presence: {
-                if: :parent_phone_receive_updates
-              },
-              phone: {
-                allow_blank: true
-              }
     validates :parent_phone_receive_updates, inclusion: { in: [true, false] }
   end
+
+  validates :parent_email,
+            notify_safe_email: {
+              allow_blank: true
+            },
+            presence: {
+              if: -> do
+                required_for_step?(:parent_details, exact: true) &&
+                  parent_phone.blank?
+              end
+            }
+  validates :parent_phone,
+            phone: {
+              allow_blank: true
+            },
+            presence: {
+              if: -> do
+                required_for_step?(:parent_details, exact: true) &&
+                  (parent_email.blank? || parent_phone_receive_updates)
+              end
+            }
 
   with_options if: -> do
                  parent_id.nil? &&

--- a/spec/models/draft_consent_spec.rb
+++ b/spec/models/draft_consent_spec.rb
@@ -19,6 +19,7 @@ describe DraftConsent do
     {
       notes: "Some notes.",
       response: "given",
+      parent_email: "test@example.com",
       patient_session_id: patient_session.id,
       programme_id: programme.id
     }
@@ -28,6 +29,7 @@ describe DraftConsent do
     {
       response: "refused",
       notes: "Some notes.",
+      parent_email: "test@example.com",
       patient_session_id: patient_session.id,
       programme_id: programme.id
     }


### PR DESCRIPTION
When the parent fills out a consent form, we allow the email address to be optional, so we should do the same when a nurse fills in verbal consent. However, if a nurse doens't provide an email address we need to ensure that a phone number is provided instead.