### PR TITLE
Hide "Edit vaccination record" button for admins

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -110,9 +110,11 @@
 
       <% if Flipper.enabled?(:release_1b) %>
         <div class="app-button-group">
-          <%= govuk_button_to "Edit vaccination record",
-                              programme_vaccination_record_path(vaccination_record.programme, vaccination_record),
-                              method: :put, class: "app-button--secondary" %>
+          <% if helpers.policy(vaccination_record).edit? %>
+            <%= govuk_button_to "Edit vaccination record",
+                                programme_vaccination_record_path(vaccination_record.programme, vaccination_record),
+                                method: :put, class: "app-button--secondary" %>
+          <% end %>
 
           <% if helpers.policy(vaccination_record).destroy? %>
             <%= govuk_link_to "Delete vaccination record", destroy_vaccination_record_session_patient_vaccinations_path(patient_id: patient.id, vaccination_record_id: vaccination_record.id) %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -17,7 +17,7 @@
   <% c.with_heading { "Vaccination details" } %>
   <%= render AppVaccinationRecordSummaryComponent.new(@vaccination_record, current_user:) %>
 
-  <% if Flipper.enabled?(:release_1b) %>
+  <% if Flipper.enabled?(:release_1b) && policy(@vaccination_record).edit? %>
     <%= govuk_button_to "Edit vaccination record",
                         programme_vaccination_record_path(@programme, @vaccination_record),
                         method: :put, class: "app-button--secondary" %>

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -208,9 +208,24 @@ describe "Edit vaccination record" do
     then_i_should_see_the_vaccination_record
   end
 
+  scenario "Cannot as an admin" do
+    given_i_am_signed_in_as_an_admin
+    and_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_go_to_the_vaccination_records_page
+    and_i_click_on_the_vaccination_record
+    then_i_should_not_be_able_to_edit_the_vaccination_record
+  end
+
   def given_i_am_signed_in
     @organisation = create(:organisation, :with_one_nurse, ods_code: "R1L")
     sign_in @organisation.users.first
+  end
+
+  def given_i_am_signed_in_as_an_admin
+    @organisation = create(:organisation, :with_one_admin, ods_code: "R1L")
+    sign_in @organisation.users.first, role: :admin_staff
   end
 
   def and_an_hpv_programme_is_underway
@@ -478,4 +493,8 @@ describe "Edit vaccination record" do
 
   alias_method :and_the_parent_receives_an_administered_email,
                :then_the_parent_receives_an_administered_email
+
+  def then_i_should_not_be_able_to_edit_the_vaccination_record
+    expect(page).not_to have_content("Edit vaccination record")
+  end
 end


### PR DESCRIPTION
An admin doesn't have permission to edit vaccination records, so we shouldn't show this button if permission is not allowed.