### PR TITLE
Conditionally show links in footer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
   before_action :set_header_path
   before_action :set_service_name
+  before_action :set_service_guide_url
   before_action :set_secondary_navigation
   before_action :set_privacy_policy_url
   before_action :authenticate_basic
@@ -59,8 +60,11 @@ class ApplicationController < ActionController::Base
     redirect_to(request.referer || root_path, status: :forbidden)
   end
 
+  def set_service_guide_url
+    @service_guide_url = "https://guide.manage-vaccinations-in-schools.nhs.uk"
+  end
+
   def set_privacy_policy_url
-    @privacy_policy_url =
-      current_user&.selected_organisation&.privacy_policy_url
+    @privacy_policy_url = nil
   end
 end

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -38,6 +38,10 @@ module ParentInterface
       @show_secondary_navigation = false
     end
 
+    def set_service_guide_url
+      @service_guide_url = nil
+    end
+
     def set_privacy_policy_url
       @privacy_policy_url = @organisation.privacy_policy_url
     end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -70,8 +70,8 @@
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: t("service.guide"), secondary: true) do |card| %>
-      <% card.with_heading { t("guide.show.title") } %>
+    <%= render AppCardComponent.new(link_to: @service_guide_url, secondary: true) do |card| %>
+      <% card.with_heading { t("service.guide.title") } %>
       <% card.with_description { "How to use this service" } %>
     <% end %>
   </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,14 +51,16 @@
               <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item">
                 <%= link_to "Accessibility statement", :accessibility_statement, classes: "nhsuk-footer__list-item-link" %>
               </li>
-              <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item">
-                <% if @privacy_policy_url %>
+              <% if @privacy_policy_url %>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item">
                   <%= link_to "Privacy policy", @privacy_policy_url, classes: "nhsuk-footer__list-item-link" %>
-                <% end %>
-              </li>
-              <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item">
-                <%= link_to "#{t("guide.show.title")} (opens in a new tab)", t("service.guide"), classes: "nhsuk-footer__list-item-link", target: "_blank" %>
-              </li>
+                </li>
+              <% end %>
+              <% if @service_guide_url %>
+                <li class="nhsuk-footer__list-item nhsuk-footer-default__list-item">
+                  <%= link_to "#{t("service.guide.title")} (opens in a new tab)", @service_guide_url, classes: "nhsuk-footer__list-item-link", target: "_blank" %>
+                </li>
+              <% end %>
             </ul>
             <p class="nhsuk-footer__copyright">&copy; NHS England</p>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -688,9 +688,6 @@ en:
         other: Why are they refusing to give consent?
         personal_choice: Why are they refusing to give consent?
         will_be_vaccinated_elsewhere: Where will their child get their vaccination?
-  guide:
-    show:
-      title: Service guidance
   imports:
     index:
       title: Imports
@@ -782,7 +779,8 @@ en:
         unscheduled: No sessions scheduled
   service:
     email: england.mavis@nhs.net
-    guide: https://guide.manage-vaccinations-in-schools.nhs.uk
+    guide:
+      title: Service guidance
   sessions:
     index:
       title: Sessions


### PR DESCRIPTION
- Service guidance should only be shown to users of ‘Manage vaccinations in schools’
- The privacy policy should only be shown to users of ‘Give or refuse consent for vaccinations’ (if a privacy policy URL has been set for the organisation)

This PR makes the existence of values for `@service_guide_url` and `@privacy_policy_url` determine whether links to these resources are shown in the footer, with controllers setting either the appropriate values for these resources, or `false`.

This also fixes an issue with an empty `li` being shown if no `@privacy_policy_url` is set.

Also renames the remaining `guide.show.title` locale string, moving it alongside the other `service` locale key to `service.guide.title`.