### PR TITLE
Add autocomplete values to relevant consent form fields

### DIFF
--- a/app/views/parent_interface/consent_forms/edit/address.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/address.html.erb
@@ -11,16 +11,20 @@
   <%= h1 "Home address" %>
 
   <%= f.govuk_text_field :address_line_1,
-                         label: { text: "Address line 1" } %>
+                         label: { text: "Address line 1" },
+                         autocomplete: "address-line1" %>
 
   <%= f.govuk_text_field :address_line_2,
-                         label: { text: "Address line 2 (optional)" } %>
+                         label: { text: "Address line 2 (optional)" },
+                         autocomplete: "address-line2" %>
 
   <%= f.govuk_text_field :address_town,
-                         label: { text: "Town or city" } %>
+                         label: { text: "Town or city" },
+                         autocomplete: "address-level2" %>
 
   <%= f.govuk_text_field :address_postcode,
                          label: { text: "Postcode" },
+                         autocomplete: "postal-code",
                          class: "nhsuk-input--width-10" %>
 
   <div class="nhsuk-u-margin-top-6">

--- a/app/views/parent_interface/consent_forms/edit/parent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/parent.html.erb
@@ -11,7 +11,9 @@
 
   <%= h1 "About you" %>
 
-  <%= f.govuk_text_field :parent_full_name, label: { text: "Your name" } %>
+  <%= f.govuk_text_field :parent_full_name,
+                         label: { text: "Your name" },
+                         autocomplete: "name" %>
 
   <%= f.govuk_radio_buttons_fieldset(:parent_relationship_type,
                                      legend: { size: "s",
@@ -39,11 +41,14 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_email_field :parent_email, label: { text: "Email address" } %>
+  <%= f.govuk_email_field :parent_email,
+                          label: { text: "Email address" },
+                          autocomplete: "email" %>
 
   <%= f.govuk_phone_field :parent_phone,
                           label: { text: "Phone number (optional)" },
-                          hint: { text: "Someone might call you about your child’s vaccination" } %>
+                          hint: { text: "Someone might call you about your child’s vaccination" },
+                          autocomplete: "tel" %>
 
   <%= f.govuk_check_boxes_fieldset :parent_phone_receive_updates, multiple: false, legend: nil do %>
     <%= f.govuk_check_box :parent_phone_receive_updates, 1, 0, multiple: false, link_errors: true, label: { text: "Tick this box if you’d like to get updates by text message" } %>


### PR DESCRIPTION
Add relevant `autocomplete` values to the following fields in the consent journey:

- Parent name
- Parent email
- Parent telephone
- Parent address