### PR TITLE
Look up NHS numbers for invalidated patients

### DIFF
--- a/app/jobs/patient_nhs_number_lookup_job.rb
+++ b/app/jobs/patient_nhs_number_lookup_job.rb
@@ -18,15 +18,7 @@ class PatientNHSNumberLookupJob < ApplicationJob
 
     return if pds_patient.nil?
 
-    if (
-         existing_patient =
-           Patient.includes(
-             :class_imports,
-             :cohort_imports,
-             :immunisation_imports,
-             :patient_sessions
-           ).find_by(nhs_number: pds_patient.nhs_number)
-       )
+    if (existing_patient = Patient.find_by(nhs_number: pds_patient.nhs_number))
       PatientMerger.call(to_keep: existing_patient, to_destroy: patient)
       existing_patient.update_from_pds!(pds_patient)
     else

--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -30,6 +30,7 @@ class PatientUpdateFromPDSJob < ApplicationJob
     end
   rescue NHS::PDS::InvalidatedResource, NHS::PDS::InvalidNHSNumber
     patient.invalidate!
+    PatientNHSNumberLookupJob.perform_later(patient)
   end
 
   class MissingNHSNumber < StandardError

--- a/app/jobs/patient_update_from_pds_job.rb
+++ b/app/jobs/patient_update_from_pds_job.rb
@@ -17,12 +17,7 @@ class PatientUpdateFromPDSJob < ApplicationJob
     if pds_patient.nhs_number != patient.nhs_number
       if (
            existing_patient =
-             Patient.includes(
-               :class_imports,
-               :cohort_imports,
-               :immunisation_imports,
-               :patient_sessions
-             ).find_by(nhs_number: pds_patient.nhs_number)
+             Patient.find_by(nhs_number: pds_patient.nhs_number)
          )
         PatientMerger.call(to_keep: existing_patient, to_destroy: patient)
         existing_patient.update_from_pds!(pds_patient)

--- a/spec/jobs/patient_update_from_pds_job_spec.rb
+++ b/spec/jobs/patient_update_from_pds_job_spec.rb
@@ -53,6 +53,12 @@ describe PatientUpdateFromPDSJob do
         expect { perform_now }.not_to change(Patient, :count)
       end
 
+      it "doesn't queue a job to look up NHS number" do
+        expect { perform_now }.not_to have_enqueued_job(
+          PatientNHSNumberLookupJob
+        )
+      end
+
       context "when the NHS number for the patient has changed" do
         let!(:patient) { create(:patient, nhs_number: "0123456789") }
 
@@ -95,6 +101,12 @@ describe PatientUpdateFromPDSJob do
         expect(patient).to receive(:invalidate!)
         perform_now
       end
+
+      it "queues a job to look up NHS number" do
+        expect { perform_now }.to have_enqueued_job(
+          PatientNHSNumberLookupJob
+        ).with(patient)
+      end
     end
 
     context "when the NHS number is invalid" do
@@ -116,6 +128,12 @@ describe PatientUpdateFromPDSJob do
       it "marks the patient as invalid" do
         expect(patient).to receive(:invalidate!)
         perform_now
+      end
+
+      it "queues a job to look up NHS number" do
+        expect { perform_now }.to have_enqueued_job(
+          PatientNHSNumberLookupJob
+        ).with(patient)
       end
     end
   end


### PR DESCRIPTION
If we look up a patient from their NHS number and we get a response from PDS saying either the NHS number is invalid or the patient is invalidated, we should try once to look up their new NHS number from their demographic data (names, postcode, date of birth). This could help to handle the case where the nurse has entered an NHS number incorrectly.