### PR TITLE
Speed up copilot deploys

### DIFF
--- a/.github/workflows/_deploy-template.yml
+++ b/.github/workflows/_deploy-template.yml
@@ -20,7 +20,6 @@ jobs:
 
     environment:
       name: ${{ inputs.environment }}
-      url: https://${{ steps.host-name.outputs.value }}
 
     concurrency:
       group: ${{ inputs.environment }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ run-name: >-
 
 on:
   push:
-    branches: [main]
+    branches: [fast]
   workflow_dispatch:
     inputs:
       environment:

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -1,25 +1,17 @@
-# The manifest for the "webapp" service.
-# Read the full specification for the "Load Balanced Web Service" type at:
-#  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
-
-# Your service name will be used in naming your resources like log groups, ECS services, etc.
 name: webapp
 type: Load Balanced Web Service
 
-# Distribute traffic to your service.
 http:
-  # Requests to this path will be forwarded to your service.
-  # To match all requests you can use the "/" path.
   path: "/"
-  # You can specify a custom health check path. The default is "/".
-  healthcheck: "/ping"
+  healthcheck:
+    path: "/ping"
+    interval: 5s
 
-# Configuration for your containers and service.
 image:
-  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
   build: Dockerfile
-  # Port exposed through your container to route traffic to it.
   port: 4000
+  healthcheck:
+    interval: 5s
 
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.
@@ -32,14 +24,6 @@ network:
     security_groups:
       groups:
         - from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-dbSecurityGroup
-
-# storage:
-# readonly_fs: true       # Limit to read-only access to mounted root filesystems.
-
-# Optional fields for more advanced use-cases.
-#
-#variables:                    # Pass environment variables as key value pairs.
-#  LOG_LEVEL: info
 
 secrets:
   RAILS_MASTER_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RAILS_MASTER_KEY

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -6,12 +6,14 @@ http:
   healthcheck:
     path: "/ping"
     interval: 5s
+    timeout: 3s
 
 image:
   build: Dockerfile
   port: 4000
   healthcheck:
     interval: 5s
+    timeout: 3s
 
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -5,11 +5,17 @@ http:
   path: "/"
   healthcheck:
     path: "/ping"
-    interval: 5s
+    healthy_threshold: 1 # Number of checks before target is healthy
+    unhealthy_threshold: 10 # Number of checks before giving up; max is 10
+    interval: 5s # Time between checks; minimum is 5s, default is 30s
+    grace_period: 0s # Start healthchecks immediately, default is 60s
 
 image:
   build: Dockerfile
   port: 4000
+  healthcheck:
+    interval: 5s # Default is 10s
+    timeout: 1s # Default is 5s
 
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -13,10 +13,10 @@ http:
 image:
   build: Dockerfile
   port: 4000
-  healthcheck:
-    interval: 5s # Default is 10s
-    timeout: 4s # Default is 5s
-    retries: 4 # Default is 2
+  # healthcheck:
+  #   interval: 5s # Default is 10s
+  #   timeout: 4s # Default is 5s
+  #   retries: 4 # Default is 2
 
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -5,17 +5,18 @@ http:
   path: "/"
   healthcheck:
     path: "/ping"
-    healthy_threshold: 1 # Number of checks before target is healthy
+    healthy_threshold: 2 # Number of checks before target is healthy; min is 2
     unhealthy_threshold: 10 # Number of checks before giving up; max is 10
-    interval: 5s # Time between checks; minimum is 5s, default is 30s
-    grace_period: 0s # Start healthchecks immediately, default is 60s
+    interval: 5s # Time between checks; minimum is 5s; default is 30s
+    grace_period: 0s # Start healthchecks immediately; default is 60s
 
 image:
   build: Dockerfile
   port: 4000
   healthcheck:
     interval: 5s # Default is 10s
-    timeout: 1s # Default is 5s
+    timeout: 4s # Default is 5s
+    retries: 4 # Default is 2
 
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -6,14 +6,10 @@ http:
   healthcheck:
     path: "/ping"
     interval: 5s
-    timeout: 3s
 
 image:
   build: Dockerfile
   port: 4000
-  healthcheck:
-    interval: 5s
-    timeout: 3s
 
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.


### PR DESCRIPTION
Apparently, Copilot only attempts to hit `/ping` every 180s by default. Reducing this to 5s might make deploying much faster.