### PR TITLE
Pre-fetch consent recorded_by

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -88,7 +88,7 @@ class PatientsController < ApplicationController
         .includes(
           :school,
           cohort: :organisation,
-          consents: %i[parent patient],
+          consents: %i[parent patient recorded_by],
           notify_log_entries: :sent_by,
           parents: :parent_relationships,
           patient_sessions: %i[location session_attendances],


### PR DESCRIPTION
The patient is marked as strict loading and this is shown in the activity log so we need to ensure this is available.

https://good-machine.sentry.io/issues/6082397978/