### PR TITLE
Redirect user to import page if file is small

### DIFF
--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -28,13 +28,14 @@ class ClassImportsController < ApplicationController
 
     if @class_import.slow?
       ProcessImportJob.perform_later(@class_import)
-      flash = { success: "Import processing started" }
+      redirect_to programme_imports_path(@session.programmes.first),
+                  flash: {
+                    success: "Import processing started"
+                  }
     else
       ProcessImportJob.perform_now(@class_import)
-      flash = { success: "Import completed" }
+      redirect_to session_class_import_path(@session, @class_import)
     end
-
-    redirect_to programme_imports_path(@session.programmes.first), flash:
   end
 
   def show

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -28,13 +28,14 @@ class CohortImportsController < ApplicationController
 
     if @cohort_import.slow?
       ProcessImportJob.perform_later(@cohort_import)
-      flash = { success: "Import processing started" }
+      redirect_to programme_imports_path(@programme),
+                  flash: {
+                    success: "Import processing started"
+                  }
     else
       ProcessImportJob.perform_now(@cohort_import)
-      flash = { success: "Import completed" }
+      redirect_to programme_cohort_import_path(@programme, @cohort_import)
     end
-
-    redirect_to programme_imports_path(@programme), flash:
   end
 
   def show

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -28,13 +28,17 @@ class ImmunisationImportsController < ApplicationController
 
     if @immunisation_import.slow?
       ProcessImportJob.perform_later(@immunisation_import)
-      flash = { success: "Import processing started" }
+      redirect_to programme_imports_path(@programme),
+                  flash: {
+                    success: "Import processing started"
+                  }
     else
       ProcessImportJob.perform_now(@immunisation_import)
-      flash = { success: "Import completed" }
+      redirect_to programme_immunisation_import_path(
+                    @programme,
+                    @immunisation_import
+                  )
     end
-
-    redirect_to programme_imports_path(@programme), flash:
   end
 
   def show

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -226,8 +226,6 @@ describe "HPV Vaccination" do
     attach_file("immunisation_import[csv]", "tmp/modified.csv")
     click_on "Continue"
 
-    click_on "1 February 2024 at 12:00pm"
-
     expect(page).to have_content("Completed")
     expect(page).not_to have_content("Invalid")
     expect(page).to have_content("2 previously imported records were omitted")

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -33,9 +33,6 @@ describe "Import child records" do
     when_it_is_a_litte_bit_later
     and_i_go_back_to_the_upload_page
     and_i_upload_a_valid_file
-    then_i_should_see_the_imports_page_with_the_completed_flash
-
-    when_i_go_to_the_import_page
     then_i_should_see_the_upload
     and_i_should_see_the_patients
 
@@ -52,8 +49,8 @@ describe "Import child records" do
     travel_to 1.minute.from_now # to ensure the created_at is different for the import jobs
 
     when_i_upload_a_valid_file_with_changes
-    then_i_should_see_the_imports_page_with_the_completed_flash
-    and_i_should_see_import_issues_with_the_count
+    and_i_go_to_the_imports_page
+    then_i_should_see_import_issues_with_the_count
   end
 
   def given_the_app_is_setup
@@ -198,10 +195,6 @@ describe "Import child records" do
     expect(page).to have_content("Import processing started")
   end
 
-  def then_i_should_see_the_imports_page_with_the_completed_flash
-    expect(page).to have_content("Import completed")
-  end
-
   def when_i_wait_for_the_background_job_to_complete
     perform_enqueued_jobs
   end
@@ -226,7 +219,11 @@ describe "Import child records" do
     click_on "Continue"
   end
 
-  def and_i_should_see_import_issues_with_the_count
+  def and_i_go_to_the_imports_page
+    click_on "Imports"
+  end
+
+  def then_i_should_see_import_issues_with_the_count
     expect(page).to have_link("Import issues")
     expect(page).to have_selector(".app-count", text: "( 1 )")
   end

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -121,7 +121,6 @@ describe "Child record imports duplicates" do
   def and_i_upload_a_file_with_duplicate_records
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
-    click_link CohortImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -11,12 +11,12 @@ describe "Import class lists - Moving patients" do
     then_i_should_see_the_import_page
 
     when_i_upload_a_valid_file
-    then_i_should_see_the_imports_page_with_the_completed_flash
+    then_i_should_see_the_import_complete_page
 
     when_i_visit_a_different_session_page_for_the_hpv_programme
     and_i_start_adding_children_to_the_session
     and_i_upload_a_valid_file
-    then_i_should_see_the_imports_page_with_the_completed_flash
+    then_i_should_see_the_import_complete_page
 
     when_i_visit_a_session_page_for_the_hpv_programme
     then_i_should_see_pending_moves_out
@@ -101,8 +101,10 @@ describe "Import class lists - Moving patients" do
     click_on "Import class list"
   end
 
-  def then_i_should_see_the_imports_page_with_the_completed_flash
-    expect(page).to have_content("Import completed")
+  def then_i_should_see_the_import_complete_page
+    expect(page).to have_content("Completed")
+    expect(page).to have_content("Imported on")
+    expect(page).to have_content("Imported by")
   end
 
   def then_i_should_see_pending_moves_out

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -31,9 +31,6 @@ describe "Import class lists" do
 
     when_i_go_back_to_the_upload_page
     and_i_upload_a_valid_file
-    then_i_should_see_the_imports_page_with_the_completed_flash
-
-    when_i_go_to_the_import_page
     then_i_should_see_the_upload
     and_i_should_see_the_patients
 
@@ -168,10 +165,6 @@ describe "Import class lists" do
 
   def then_i_should_see_the_imports_page_with_the_processing_flash
     expect(page).to have_content("Import processing started")
-  end
-
-  def then_i_should_see_the_imports_page_with_the_completed_flash
-    expect(page).to have_content("Import completed")
   end
 
   def when_i_wait_for_the_background_job_to_complete

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -129,7 +129,6 @@ describe "Class list imports duplicates" do
       "spec/fixtures/class_import/duplicates.csv"
     )
     click_on "Continue"
-    click_link ClassImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -18,18 +18,12 @@ describe "Immunisation imports" do
     then_i_should_see_an_error
 
     when_i_upload_an_invalid_file
-    then_i_should_see_the_imports_page
-
-    when_i_go_to_the_import_page
     then_i_should_see_the_errors_page
 
     travel_to 1.minute.from_now # to ensure the created_at is different for the import jobs
 
     when_i_go_back_to_the_upload_page
     and_i_upload_a_valid_file
-    then_i_should_see_the_imports_page
-
-    when_i_go_to_the_import_page
     then_i_should_see_the_upload
     and_i_should_see_the_vaccination_records
 
@@ -205,12 +199,4 @@ describe "Immunisation imports" do
   end
 
   alias_method :and_i_click_on_the_upload_link, :when_i_click_on_the_upload_link
-
-  def then_i_should_see_the_imports_page
-    expect(page).to have_content("Import completed")
-  end
-
-  def when_i_go_to_the_import_page
-    click_link ImmunisationImport.last.created_at.to_fs(:long), match: :first
-  end
 end

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -154,7 +154,6 @@ describe "Immunisation imports duplicates" do
       "spec/fixtures/immunisation_import/valid_hpv.csv"
     )
     click_on "Continue"
-    click_link ImmunisationImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records


### PR DESCRIPTION
If the file is small and can be processed immediately, we can take the user directly to the page showing the results of the import, and avoid showing a potentially confusing message of "Import completed" when there could actually be validation errors.