### PR TITLE
Allow navigating back to draft consent/vaccination record

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -83,7 +83,6 @@ class DraftConsentsController < ApplicationController
   end
 
   def finish_wizard_path
-    @draft_consent.reset!
     session_consents_path(@session)
   end
 

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -121,10 +121,7 @@ class DraftVaccinationRecordsController < ApplicationController
   end
 
   def finish_wizard_path
-    editing = @draft_vaccination_record.editing?
-    @draft_vaccination_record.reset!
-
-    if editing
+    if @draft_vaccination_record.editing?
       programme_vaccination_record_path(@programme, @vaccination_record)
     else
       session_vaccinations_path(@session)

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -218,6 +218,26 @@ describe "Edit vaccination record" do
     then_i_should_not_be_able_to_edit_the_vaccination_record
   end
 
+  scenario "Navigating back" do
+    given_i_am_signed_in
+    and_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_go_to_the_vaccination_records_page
+    and_i_click_on_the_vaccination_record
+    and_i_click_on_edit_vaccination_record
+    then_i_see_the_edit_vaccination_record_page
+
+    when_i_click_on_save_changes
+    then_i_should_see_the_vaccination_record
+
+    when_i_go_back_to_the_confirm_page
+    then_i_see_the_edit_vaccination_record_page
+
+    when_i_click_on_save_changes
+    then_i_should_see_the_vaccination_record
+  end
+
   def given_i_am_signed_in
     @organisation = create(:organisation, :with_one_nurse, ods_code: "R1L")
     sign_in @organisation.users.first
@@ -496,5 +516,9 @@ describe "Edit vaccination record" do
 
   def then_i_should_not_be_able_to_edit_the_vaccination_record
     expect(page).not_to have_content("Edit vaccination record")
+  end
+
+  def when_i_go_back_to_the_confirm_page
+    visit draft_vaccination_record_path(id: "confirm")
   end
 end


### PR DESCRIPTION
We previously used to reset the session after the user confirms changes, this was mostly to handle the limited size of the session when it was stored in cookies. However, now that we're storing these in the database we can leave the session and allow the user to go back without raising an error.

https://good-machine.sentry.io/issues/6072791861/