### PR TITLE
Don't fail fast when running deploy task

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   Deploy:
     strategy:
+      fail-fast: false
       matrix:
         environment: >-
           ${{ fromJSON(github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
The default is `true` which is causing 1 failed deploy to an environment to cancel deploying to all other environments.