### PR TITLE
Add www. to hostnames

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -106,5 +106,5 @@ environments:
     variables:
       RAILS_ENV: production
       SENTRY_ENVIRONMENT: production
-      MAVIS__HOST: "manage-vaccinations-in-schools.nhs.uk"
-      MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "give-or-refuse-consent-for-vaccinations.nhs.uk"
+      MAVIS__HOST: "www.manage-vaccinations-in-schools.nhs.uk"
+      MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "www.give-or-refuse-consent-for-vaccinations.nhs.uk"


### PR DESCRIPTION
Previously we had the root domain, 'manage-vaccinations-in-schools.nhs.uk', CNAMEd to our app so that users can hit it and be redirected to the 'www.'. This is not RFC compliant, and we've been told by NHS's DNS team that we can't do that. Apparently there are ways to do this, but it can depend on the provider and in our case, they simply setup A records to point to the IPs of our LBs at the time, which can go (and have gone) stale.

Until we find a way to properly CNAME the root domain we need to change our settings to use the 'www' hostname.