### PR TITLE
Add smoke test onboarding yaml

### DIFF
--- a/config/onboarding/smoke-test.yml
+++ b/config/onboarding/smoke-test.yml
@@ -1,0 +1,25 @@
+organisation:
+  name: XXX SMOKE TEST XXX
+  email: england.mavis@nhs.net
+  phone: 07700900999
+  ods_code: Y90128
+
+programmes: [hpv]
+
+teams:
+  team1:
+    name: XXX SMOKE TEST XXX
+    email: xxx.smoke.test.xxx@example.nhs.net
+    phone: 07700900999
+
+schools:
+  team1:
+    - XXXXXX
+
+clinics:
+  team1:
+    - name: Test Clinic
+      address_line_1: 1 Clinic Test Street
+      address_town: Clinic Test Town
+      address_postcode: TE1 1ST
+      ods_code: XXXXX

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -314,3 +314,5 @@ create_patients(organisation)
 create_imports(user, organisation)
 
 UnscheduledSessionsFactory.new.call
+
+Rake::Task["schools:smoke_test"].execute

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -16,16 +16,16 @@ organisation:
 programmes: [] # A list of programmes, currently only hpv is valid
 
 teams:
-  team_name: # Name of the team referenced in schools and links
+  team1: # Identifier to link team with school and links below, not used in app
     name: # Name of the team
     email: # Contact email address
     phone: # Contact phone number
 
 schools:
-  team_name: [] # URNs managed by a particular team
+  team1: [] # URNs managed by a particular team
 
 clinics:
-  team_name:
+  team1:
     - name: # Name of the clinic
       address_line_1: # First line of the address
       address_town: # Town of the address

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -182,4 +182,17 @@ namespace :schools do
 
     UnscheduledSessionsFactory.new.call
   end
+
+  desc "Create smoke test school"
+  task smoke_test: :environment do
+    Location.create(
+      name: "XXX Smoke Test School XXX",
+      urn: "XXXXXX",
+      type: :school,
+      address_line_1: "1 Test Street",
+      address_town: "Test Town",
+      address_postcode: "TE1 1ST",
+      year_groups: [8, 9, 10, 11]
+    )
+  end
 end

--- a/script/set_up_coventry.sh
+++ b/script/set_up_coventry.sh
@@ -4,4 +4,5 @@ bin/rails db:schema:load
 
 bin/rails vaccines:seed[hpv]
 bin/rails schools:import
+bin/rails schools:smoke_test
 bin/rails onboard[config/onboarding/coventry-model-office.yaml]


### PR DESCRIPTION
Once this is deployed to production the next steps are:

- Run the rake task to add the smoke-test school
- Run the rake task to onboard the smoke-test org
- Then login to org `Y90128` should work and sessions should be visible