### PR TITLE
Remove batchs when reseting organisations

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -52,6 +52,7 @@ class DevController < ApplicationController
       patients.destroy_all
 
       Cohort.where(organisation:).destroy_all
+      Batch.where(organisation:).destroy_all
 
       UnscheduledSessionsFactory.new.call
     end


### PR DESCRIPTION
This avoids the list of batches growing and growing, as they belong to each organisation.