### PR TITLE
Add script to delete old review apps

### DIFF
--- a/script/delete_old_review_apps.sh
+++ b/script/delete_old_review_apps.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+MAX=100
+DAYS_OLD=7
+REPO="nhsuk/manage-vaccinations-in-schools"
+PR_PREFIX="mavis-pr-"
+
+usage() {
+  echo "Usage: bash $0 [-h|--help]"
+  echo
+  echo "Delete GitHub review app environments older than $DAYS_OLD days."
+  echo "Requires GitHub CLI (gh) to be installed and authenticated."
+  echo
+  echo "Options:"
+  echo "  -h, --help    Show this help message"
+  exit 0
+}
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  usage
+fi
+
+fetch_old_review_apps() {
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$REPO/environments?per_page=$MAX" | \
+    jq -r --arg days "$DAYS_OLD" '
+      .environments[] |
+      select((now - (.updated_at | fromdateiso8601)) / 86400 > ($days | tonumber)) |
+      .name
+    ' | \
+    grep "$PR_PREFIX"
+}
+
+echo "Fetching review apps older than $DAYS_OLD days (max: $MAX)..."
+OLD_REVIEW_APPS=$(fetch_old_review_apps)
+
+if [ -z "$OLD_REVIEW_APPS" ]; then
+  echo "No old review apps found"
+  exit 0
+fi
+
+for env in $OLD_REVIEW_APPS; do
+  echo "Deleting review app: $env"
+  gh api \
+    --method DELETE \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$REPO/environments/$env"
+done


### PR DESCRIPTION
We had ~3k review app environments in GitHub which made the environment settings UI impossible to use in order to add deploy conditions to the production environment (28+ pages):

![Screenshot 2024-11-26 at 14 00 26](https://github.com/user-attachments/assets/ff7ca4b1-53b2-4576-8369-fb26d141838b)

This script facilitates deleting review apps 100 at a time.

We can later add a GitHub action to run this ~once a week.

```
$ bash script/delete_old_review_apps.sh --help
Usage: bash script/delete_old_review_apps.sh [-h|--help]

Delete GitHub review app environments older than 7 days.
Requires GitHub CLI (gh) to be installed and authenticated.

Options:
  -h, --help    Show this help message
$ bash script/delete_old_review_apps.sh
Fetching review apps older than 7 days (max: 100)...
Deleting review app: mavis-pr-1924
Deleting review app: mavis-pr-1925
Deleting review app: mavis-pr-1926
Deleting review app: mavis-pr-1927
Deleting review app: mavis-pr-1928
Deleting review app: mavis-pr-1929
...
```