### PR TITLE
Refactor PDS background jobs to improve performance and possible race conditions

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -10,17 +10,19 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
   def perform
     patients = Patient.with_nhs_number.not_invalidated.not_deceased
 
-    patients
-      .where(updated_from_pds_at: nil)
-      .find_each do |patient|
-        PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
-      end
+    GoodJob::Bulk.enqueue do
+      patients
+        .where(updated_from_pds_at: nil)
+        .find_each do |patient|
+          PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
+        end
 
-    patients
-      .where("updated_from_pds_at < ?", 6.hours.ago)
-      .order(:updated_from_pds_at)
-      .find_each do |patient|
-        PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
-      end
+      patients
+        .where("updated_from_pds_at < ?", 6.hours.ago)
+        .order(:updated_from_pds_at)
+        .find_each do |patient|
+          PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
+        end
+    end
   end
 end

--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -12,11 +12,15 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
 
     patients
       .where(updated_from_pds_at: nil)
-      .find_each { |patient| PatientUpdateFromPDSJob.perform_later(patient) }
+      .find_each do |patient|
+        PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
+      end
 
     patients
       .where("updated_from_pds_at < ?", 6.hours.ago)
       .order(:updated_from_pds_at)
-      .find_each { |patient| PatientUpdateFromPDSJob.perform_later(patient) }
+      .find_each do |patient|
+        PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
+      end
   end
 end

--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -13,15 +13,18 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
     GoodJob::Bulk.enqueue do
       patients
         .where(updated_from_pds_at: nil)
-        .find_each do |patient|
-          PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
-        end
+        .or(patients.where("updated_from_pds_at < ?", 6.hours.ago))
+        .order("updated_from_pds_at ASC NULLS FIRST")
+        .each_with_index do |patient, index|
+          # Schedule with a delay to preemptively handle rate limit issues.
+          # This shouldn't be necessary, but we're finding that Good Job
+          # has occasional race condition issues, and spreading out the jobs
+          # should reduce the risk of this.
 
-      patients
-        .where("updated_from_pds_at < ?", 6.hours.ago)
-        .order(:updated_from_pds_at)
-        .find_each do |patient|
-          PatientUpdateFromPDSJob.set(priority: 50).perform_later(patient)
+          PatientUpdateFromPDSJob.set(
+            priority: 50,
+            wait: 0.21 * index
+          ).perform_later(patient)
         end
     end
   end

--- a/app/jobs/concerns/nhs_api_concurrency_concern.rb
+++ b/app/jobs/concerns/nhs_api_concurrency_concern.rb
@@ -7,8 +7,7 @@ module NHSAPIConcurrencyConcern
 
   included do
     # NHS API imposes a limit of 5 requests per second
-    good_job_control_concurrency_with perform_limit: 5,
-                                      perform_throttle: [5, 1.second],
+    good_job_control_concurrency_with perform_throttle: [5, 1.second],
                                       key: :nhs_api
 
     # Because the NHS API imposes a limit of 5 requests per second, we're almost

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -164,11 +164,13 @@ module CSVImportable
   def update_from_pds
     return unless Settings.pds.perform_jobs
 
-    patients.find_each do |patient|
-      if patient.nhs_number.nil?
-        PatientNHSNumberLookupJob.perform_later(patient)
-      else
-        PatientUpdateFromPDSJob.set(queue: :imports).perform_later(patient)
+    GoodJob::Bulk.enqueue do
+      patients.find_each do |patient|
+        if patient.nhs_number.nil?
+          PatientNHSNumberLookupJob.perform_later(patient)
+        else
+          PatientUpdateFromPDSJob.set(queue: :imports).perform_later(patient)
+        end
       end
     end
   end


### PR DESCRIPTION
This changes how the jobs to update patient information in PDS are scheduled to introduce gaps between the jobs as part of the enqueue process rather than relying only on Good Job to handle the concurrency throttling.

Due to the way Good Jobs concurrency throttling works, we end up with lots of job failures from `ThrottleExceeded` exceptions, where the jobs are then enqueued at a later date. This approach works but is very resource intensive, given our rate of 5 requests per second and the fact that the majority of our jobs will fail.

I'm also seeing race condition issues when we have lots of jobs they don't seem to be able to succeed, and I reckon this is down to the fact that by the time the jobs are ready to run, they're no longer part of the active jobs.

These jobs are run on a regular schedule so should be lower priority than any other jobs that might have been run intentionally. In Active Job, jobs with smaller numbers have the highest priority and the default is 0.

I've also removed the `perform_limit` concurrent argument as we don't need to limit the number of concurrent jobs, only the number of jobs performed per second.