### PR TITLE
Add "optional" to the vaccination export dates

### DIFF
--- a/app/views/vaccination_reports/dates.html.erb
+++ b/app/views/vaccination_reports/dates.html.erb
@@ -12,11 +12,11 @@
   <%= h1 "Select a vaccination date range" %>
 
   <%= f.govuk_date_field :date_from,
-                         legend: { text: "From" },
+                         legend: { text: "From (optional)" },
                          hint: { text: "For example, 27 3 2017" } %>
 
   <%= f.govuk_date_field :date_to,
-                         legend: { text: "Until" },
+                         legend: { text: "Until (optional)" },
                          hint: { text: "For example, 27 3 2017" } %>
 
   <%= f.govuk_submit %>


### PR DESCRIPTION
It looks like you can omit both fields, and it still works as you'd expect.

![Screenshot 2024-11-27 at 14 17 30](https://github.com/user-attachments/assets/80e5de86-fc3e-4f94-9855-3669459a6ac8)
