### PR TITLE
Refactor locations factories

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,8 +20,8 @@ end
 
 def import_schools
   if Settings.fast_reset
-    FactoryBot.create_list(:location, 30, :primary)
-    FactoryBot.create_list(:location, 30, :secondary)
+    FactoryBot.create_list(:school, 30, :primary)
+    FactoryBot.create_list(:school, 30, :secondary)
   else
     Rake::Task["schools:import"].execute
   end
@@ -179,7 +179,7 @@ def setup_clinic(user, organisation)
   clinic_session = organisation.generic_clinic_session
 
   # set up clinic locations
-  FactoryBot.create_list(:location, 3, :community_clinic, organisation:)
+  FactoryBot.create_list(:community_clinic, 3, organisation:)
 
   # set up clinic dates
   clinic_session.session_dates.create!(value: Date.current)

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -18,7 +18,7 @@ describe AppActivityLogComponent do
   let(:user) do
     create(:user, organisation:, family_name: "Joy", given_name: "Nurse")
   end
-  let(:location) { create(:location, :school, name: "Hogwarts") }
+  let(:location) { create(:school, name: "Hogwarts") }
   let(:session) { create(:session, programme:, location:) }
   let(:patient) do
     create(:patient, school: location, given_name: "Sarah", family_name: "Doe")

--- a/spec/components/app_compare_consent_form_and_patient_component_spec.rb
+++ b/spec/components/app_compare_consent_form_and_patient_component_spec.rb
@@ -5,7 +5,7 @@ describe AppCompareConsentFormAndPatientComponent do
 
   let(:component) { described_class.new(heading: "", consent_form:, patient:) }
 
-  let(:location) { create(:location, :school, name: "Waterloo Road") }
+  let(:location) { create(:school, name: "Waterloo Road") }
   let(:consent_form) do
     create(
       :consent_form,
@@ -62,7 +62,7 @@ describe AppCompareConsentFormAndPatientComponent do
         address_line_2: consent_form.address_line_2,
         address_town: consent_form.address_town,
         address_postcode: consent_form.address_postcode,
-        school: create(:location, :school, name: "Hogwarts")
+        school: create(:school, name: "Hogwarts")
       )
     end
 

--- a/spec/components/app_consent_patient_summary_component_spec.rb
+++ b/spec/components/app_consent_patient_summary_component_spec.rb
@@ -11,9 +11,7 @@ describe AppConsentPatientSummaryComponent do
   let(:consent) do
     create(:consent, patient:, consent_form:, programme:, organisation:)
   end
-  let(:school) do
-    create(:location, :school, name: "Waterloo Road", organisation:)
-  end
+  let(:school) { create(:school, name: "Waterloo Road", organisation:) }
   let(:session) do
     create(:session, programme:, organisation:, location: school)
   end

--- a/spec/components/app_patient_session_table_component_spec.rb
+++ b/spec/components/app_patient_session_table_component_spec.rb
@@ -14,7 +14,7 @@ describe AppPatientSessionTableComponent do
   end
 
   context "with a session" do
-    let(:location) { create(:location, :school, name: "Waterloo Road") }
+    let(:location) { create(:school, name: "Waterloo Road") }
     let(:sessions) { create_list(:session, 1, location:, patients: [patient]) }
 
     it { should have_content("Location") }

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -4,8 +4,8 @@ describe AppPatientSummaryComponent do
   subject(:rendered) { render_inline(component) }
 
   let(:component) { described_class.new(patient) }
-  let(:school) { create(:location, :school, name: "Test School") }
-  let(:other_school) { create(:location, :school, name: "Other School") }
+  let(:school) { create(:school, name: "Test School") }
+  let(:other_school) { create(:school, name: "Other School") }
   let(:parent) { create(:parent, full_name: "Mark Doe") }
   let(:restricted) { false }
   let(:patient) do

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -24,7 +24,6 @@ describe AppPatientVaccinationTableComponent do
     let(:vaccine) { programme.vaccines.active.first }
     let(:location) do
       create(
-        :location,
         :school,
         name: "Test School",
         address_line_1: "Waterloo Road",

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -7,7 +7,7 @@ describe AppProgrammeSessionTableComponent do
 
   let(:programme) { create(:programme) }
 
-  let(:location) { create(:location, :school, name: "Waterloo Road") }
+  let(:location) { create(:school, name: "Waterloo Road") }
 
   let(:session) { create(:session, programme:, location:) }
 

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -6,7 +6,7 @@ describe AppSessionSummaryComponent do
   let(:component) { described_class.new(session) }
 
   let(:programme) { create(:programme, :hpv) }
-  let(:location) { create(:location, :school) }
+  let(:location) { create(:school) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:session) do
     create(
@@ -22,13 +22,13 @@ describe AppSessionSummaryComponent do
   it { should have_content("School session") }
 
   context "with a community clinic" do
-    let(:location) { create(:location, :community_clinic, organisation:) }
+    let(:location) { create(:community_clinic, organisation:) }
 
     it { should have_content("Community clinic") }
   end
 
   context "with a generic clinic" do
-    let(:location) { create(:location, :generic_clinic, organisation:) }
+    let(:location) { create(:generic_clinic, organisation:) }
 
     it { should have_content("Community clinic") }
   end

--- a/spec/components/app_session_table_component_spec.rb
+++ b/spec/components/app_session_table_component_spec.rb
@@ -12,7 +12,7 @@ describe AppSessionTableComponent do
         :session,
         academic_year: 2024,
         date: Date.new(2024, 10, 1),
-        location: create(:location, :school, name: "Waterloo Road"),
+        location: create(:school, name: "Waterloo Road"),
         programme:
       ),
       create(:session, programme:)

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -8,7 +8,7 @@ describe AppVaccinationRecordSummaryComponent do
   let(:current_user) { create(:user) }
   let(:performed_at) { Time.zone.local(2024, 9, 6, 12) }
   let(:outcome) { "administered" }
-  let(:location) { create(:location, :school, name: "Hogwarts") }
+  let(:location) { create(:school, name: "Hogwarts") }
   let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:session) { create(:session, programme:, location:, organisation:) }
@@ -240,7 +240,7 @@ describe AppVaccinationRecordSummaryComponent do
     end
 
     context "when the location is a generic clinic" do
-      let(:location) { create(:location, :generic_clinic, organisation:) }
+      let(:location) { create(:generic_clinic, organisation:) }
       let(:location_name) { "Hogwarts" }
 
       it do

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -72,11 +72,7 @@ describe ConsentFormMailerConcern do
 
     context "when there are no upcoming sessions" do
       let(:consent_form) do
-        create(
-          :consent_form,
-          school_confirmed: false,
-          school: create(:location, :school)
-        )
+        create(:consent_form, school_confirmed: false, school: create(:school))
       end
 
       it "sends an confirmation needs triage email" do

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -44,41 +44,39 @@ FactoryBot.define do
 
     team { organisation ? association(:team, organisation:) : nil }
 
-    trait :clinic do
+    factory :generic_clinic do
+      type { :generic_clinic }
+      name { "Community clinics" }
+
+      ods_code { team.organisation.ods_code }
       urn { nil }
     end
 
-    trait :generic_clinic do
-      clinic
-      type { :generic_clinic }
-      name { "Community clinics" }
-      ods_code { team.organisation.ods_code }
-    end
-
-    trait :community_clinic do
-      clinic
+    factory :community_clinic do
       type { :community_clinic }
       name { "#{Faker::University.name} Clinic" }
+
       sequence(:ods_code, 10_000, &:to_s)
+      urn { nil }
+
+      organisation
     end
 
-    trait :school do
+    factory :school do
       type { :school }
       name { Faker::Educator.primary_school }
+
       sequence(:urn, 100_000, &:to_s)
       ods_code { nil }
-    end
 
-    trait :primary do
-      school
-      name { Faker::Educator.primary_school }
-      year_groups { (0..6).to_a }
-    end
+      trait :primary do
+        year_groups { (0..6).to_a }
+      end
 
-    trait :secondary do
-      school
-      name { Faker::Educator.secondary_school }
-      year_groups { (7..11).to_a }
+      trait :secondary do
+        name { Faker::Educator.secondary_school }
+        year_groups { (7..11).to_a }
+      end
     end
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -42,7 +42,7 @@ FactoryBot.define do
 
     trait :with_generic_clinic do
       after(:create) do |organisation, _evaluator|
-        create(:location, :generic_clinic, team: organisation.generic_team)
+        create(:generic_clinic, team: organisation.generic_team)
       end
     end
   end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
     academic_year { (date || Date.current).academic_year }
     programmes { [programme] }
     organisation { association(:organisation, programmes:) }
-    location { association :location, :school, team: }
+    location { association :school, team: }
 
     days_before_consent_reminders do
       if date && !location.generic_clinic?

--- a/spec/features/cis2_backchannel_logout_spec.rb
+++ b/spec/features/cis2_backchannel_logout_spec.rb
@@ -23,7 +23,7 @@ describe "CIS2 backchannel logout", :cis2 do
 
   def given_the_app_is_setup
     @organisation = create(:organisation, :with_one_nurse)
-    create(:location, :school, urn: "123456")
+    create(:school, urn: "123456")
     @user = @organisation.users.first
   end
 

--- a/spec/features/dev_reset_organisation_spec.rb
+++ b/spec/features/dev_reset_organisation_spec.rb
@@ -24,8 +24,8 @@ describe "Dev endpoint to reset a organisation" do
     end
 
     @organisation.update!(ods_code: "R1L") # to match valid_hpv.csv
-    create(:location, :school, urn: "123456", organisation: @organisation) # to match cohort_import/valid.csv
-    create(:location, :school, urn: "110158", organisation: @organisation) # to match valid_hpv.csv
+    create(:school, urn: "123456", organisation: @organisation) # to match cohort_import/valid.csv
+    create(:school, urn: "110158", organisation: @organisation) # to match valid_hpv.csv
     @user = @organisation.users.first
   end
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -48,7 +48,7 @@ describe "End-to-end journey" do
       create(:organisation, :with_one_nurse, programmes: [@programme])
     @school =
       create(
-        :location,
+        :school,
         :secondary,
         organisation: @organisation,
         name: "Pilot School"

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -185,7 +185,7 @@ describe "Edit vaccination record" do
     @replacement_batch =
       create(:batch, organisation: @organisation, vaccine: @vaccine)
 
-    location = create(:location, :school)
+    location = create(:school)
 
     @session =
       create(

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -62,7 +62,7 @@ describe "HPV Vaccination" do
     programme = create(:programme, :hpv_all_vaccines)
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
-    location = create(:location, :school)
+    location = create(:school)
 
     programme.vaccines.discontinued.each do |vaccine|
       create(:batch, organisation:, vaccine:)

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -32,7 +32,7 @@ describe "HPV Vaccination" do
     programme = create(:programme, :hpv)
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
-    location = create(:location, :school)
+    location = create(:school)
     @batch = create(:batch, organisation:, vaccine: programme.vaccines.first)
     @session = create(:session, organisation:, programme:, location:)
     @patient =

--- a/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
@@ -16,7 +16,7 @@ describe "HPV vaccination" do
     programme = create(:programme, :hpv_all_vaccines)
     organisation =
       create(:organisation, :with_one_admin, programmes: [programme])
-    location = create(:location, :school)
+    location = create(:school)
     @session = create(:session, organisation:, programme:, location:)
     @patient =
       create(:patient, :consent_given_triage_not_needed, session: @session)

--- a/spec/features/hpv_vaccination_cannot_record_closed_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_closed_spec.rb
@@ -16,7 +16,7 @@ describe "HPV vaccination" do
     programme = create(:programme, :hpv)
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
-    location = create(:location, :school)
+    location = create(:school)
     @session =
       create(:session, :today, :closed, organisation:, programme:, location:)
     @patient =

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -35,9 +35,9 @@ describe "HPV Vaccination" do
     programme = create(:programme, :hpv_all_vaccines)
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
-    location = create(:location, :generic_clinic, organisation:)
+    location = create(:generic_clinic, organisation:)
 
-    @community_clinic = create(:location, :community_clinic, organisation:)
+    @community_clinic = create(:community_clinic, organisation:)
 
     programme.vaccines.discontinued.each do |vaccine|
       create(:batch, organisation:, vaccine:)

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -27,7 +27,7 @@ describe "HPV Vaccination" do
     programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
-    location = create(:location, :school)
+    location = create(:school)
     @batch =
       create(
         :batch,

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -52,7 +52,7 @@ describe "HPV Vaccination" do
         :with_generic_clinic,
         programmes: [programme]
       )
-    school = create(:location, :school)
+    school = create(:school)
     previous_date = 1.month.ago
 
     if clinic
@@ -62,7 +62,6 @@ describe "HPV Vaccination" do
 
       @physical_clinic_location =
         create(
-          :location,
           :community_clinic,
           name: "Westfield Shopping Centre",
           organisation: @organisation

--- a/spec/features/import_child_records_slow_spec.rb
+++ b/spec/features/import_child_records_slow_spec.rb
@@ -27,7 +27,7 @@ describe "Import child records" do
 
   def given_the_app_is_setup
     @organisation = create(:organisation, :with_one_nurse)
-    create(:location, :school, urn: "141939")
+    create(:school, urn: "141939")
     @user = @organisation.users.first
   end
 

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -58,7 +58,7 @@ describe "Import child records" do
 
   def given_the_app_is_setup
     @organisation = create(:organisation, :with_one_nurse)
-    create(:location, :school, urn: "123456")
+    create(:school, urn: "123456")
     @user = @organisation.users.first
   end
 

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -55,7 +55,7 @@ describe "Child record imports duplicates" do
       organisation: @organisation,
       programme: @programme
     )
-    @location = create(:location, :school, urn: "123456")
+    @location = create(:school, urn: "123456")
   end
 
   def and_an_existing_patient_record_exists

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -38,14 +38,14 @@ describe "Import class lists - Moving patients" do
     @organisation = create(:organisation, :with_one_nurse)
     location =
       create(
-        :location,
+        :school,
         :secondary,
         name: "Waterloo Road",
         organisation: @organisation
       )
     other_location =
       create(
-        :location,
+        :school,
         :secondary,
         name: "Different Road",
         organisation: @organisation

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -45,7 +45,7 @@ describe "Import class lists" do
     @organisation = create(:organisation, :with_one_nurse)
     location =
       create(
-        :location,
+        :school,
         :secondary,
         name: "Waterloo Road",
         organisation: @organisation

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -56,7 +56,7 @@ describe "Class list imports duplicates" do
     )
     @location =
       create(
-        :location,
+        :school,
         :secondary,
         name: "Waterloo Road",
         organisation: @organisation

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -51,15 +51,15 @@ describe "Immunisation imports" do
   def and_an_hpv_programme_is_underway
     programme =
       create(:programme, :hpv_all_vaccines, organisations: [@organisation])
-    location = create(:location, :school)
+    location = create(:school)
     @session =
       create(:session, programme:, location:, organisation: @organisation)
   end
 
   def and_school_locations_exist
-    create(:location, :school, urn: "110158")
-    create(:location, :school, urn: "120026")
-    create(:location, :school, urn: "144012")
+    create(:school, urn: "110158")
+    create(:school, urn: "120026")
+    create(:school, urn: "144012")
   end
 
   def when_i_go_to_the_vaccinations_page

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -47,7 +47,7 @@ describe "Immunisation imports duplicates" do
       organisation: @organisation,
       programme: @programme
     )
-    @location = create(:location, :school, urn: "110158")
+    @location = create(:school, urn: "110158")
     @session =
       create(
         :session,

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -57,7 +57,7 @@ describe "Manage attendance" do
   end
 
   def and_there_is_a_vaccination_session_today_with_a_patient_ready_to_vaccinate
-    location = create(:location, :school)
+    location = create(:school)
     @session =
       create(
         :session,

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -37,7 +37,7 @@ describe "Manage batches" do
   end
 
   def and_there_is_a_vaccination_session_today_with_one_patient_ready_to_vaccinate
-    location = create(:location, :school)
+    location = create(:school)
     session = create(:session, :today, programme: @programme, location:)
 
     create(

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -81,7 +81,7 @@ describe "Manage children" do
   end
 
   def given_patients_exist
-    school = create(:location, :school, organisation: @organisation)
+    school = create(:school, organisation: @organisation)
     @patient =
       create(
         :patient,

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -85,7 +85,7 @@ describe "Manage school sessions" do
         :with_generic_clinic,
         programmes: [@programme]
       )
-    @location = create(:location, :secondary, organisation: @organisation)
+    @location = create(:school, :secondary, organisation: @organisation)
     session =
       create(
         :session,

--- a/spec/features/parent_consent_school_session_completed_spec.rb
+++ b/spec/features/parent_consent_school_session_completed_spec.rb
@@ -26,8 +26,8 @@ describe "Parental consent" do
 
     team = create(:team, organisation: @organisation)
 
-    @scheduled_school = create(:location, :secondary, team:)
-    @completed_school = create(:location, :secondary, team:)
+    @scheduled_school = create(:school, :secondary, team:)
+    @completed_school = create(:school, :secondary, team:)
 
     @scheduled_session =
       create(

--- a/spec/features/parental_consent_authentication_spec.rb
+++ b/spec/features/parental_consent_authentication_spec.rb
@@ -23,7 +23,7 @@ describe "Parental consent" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session = create(:session, :scheduled, programme: @programme, location:)
     @child = create(:patient, session: @session)
   end

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -76,12 +76,7 @@ RSpec.feature "Parental consent change answers" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
     location =
-      create(
-        :location,
-        :school,
-        name: "Pilot School",
-        organisation: @organisation
-      )
+      create(:school, name: "Pilot School", organisation: @organisation)
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -51,7 +51,7 @@ describe "Parental consent school" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
 
-    location = create(:location, :generic_clinic, organisation: @organisation)
+    location = create(:generic_clinic, organisation: @organisation)
 
     @session =
       create(
@@ -64,12 +64,7 @@ describe "Parental consent school" do
 
     @child = create(:patient, session: @session)
 
-    create(
-      :location,
-      :school,
-      organisation: @organisation,
-      name: "Pilot School"
-    )
+    create(:school, organisation: @organisation, name: "Pilot School")
   end
 
   def when_i_go_to_the_consent_form

--- a/spec/features/parental_consent_closed_spec.rb
+++ b/spec/features/parental_consent_closed_spec.rb
@@ -12,12 +12,7 @@ describe "Parental consent closed" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
     location =
-      create(
-        :location,
-        :school,
-        name: "Pilot School",
-        organisation: @organisation
-      )
+      create(:school, name: "Pilot School", organisation: @organisation)
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -36,7 +36,7 @@ describe "Parental consent create patient" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -23,7 +23,7 @@ describe "Parental consent" do
     @programme = create(:programme, :flu)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session = create(:session, :scheduled, programme: @programme, location:)
     @child = create(:patient, session: @session)
   end

--- a/spec/features/parental_consent_home_educated_spec.rb
+++ b/spec/features/parental_consent_home_educated_spec.rb
@@ -25,12 +25,7 @@ describe "Parental consent school" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
     location =
-      create(
-        :location,
-        :school,
-        organisation: @organisation,
-        name: "Pilot School"
-      )
+      create(:school, organisation: @organisation, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_inexact_auto_match_spec.rb
+++ b/spec/features/parental_consent_inexact_auto_match_spec.rb
@@ -19,7 +19,7 @@ describe "Parental consent given with an inexact automatic match" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -24,7 +24,7 @@ describe "Parental consent manual matching" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
     @user = @organisation.users.first
-    @school = create(:location, :school, name: "Pilot School")
+    @school = create(:school, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -31,7 +31,7 @@ describe "Parental consent" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_school_spec.rb
+++ b/spec/features/parental_consent_school_spec.rb
@@ -21,12 +21,7 @@ describe "Parental consent school" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
     location =
-      create(
-        :location,
-        :school,
-        organisation: @organisation,
-        name: "Pilot School"
-      )
+      create(:school, organisation: @organisation, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -25,7 +25,7 @@ describe "Parental consent" do
       create(:organisation, :with_one_nurse, programmes: [programme])
     @user = @organisation.users.first
 
-    location = create(:location, :generic_clinic, organisation: @organisation)
+    location = create(:generic_clinic, organisation: @organisation)
 
     @session =
       create(

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -34,7 +34,7 @@ describe "Parental consent" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -54,7 +54,7 @@ describe "Patient sorting and filtering" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school)
+    location = create(:school)
     @user = @organisation.users.first
     @session =
       create(

--- a/spec/features/scheduled_consent_requests_spec.rb
+++ b/spec/features/scheduled_consent_requests_spec.rb
@@ -28,7 +28,7 @@ describe "Scheduled consent requests" do
         :with_generic_clinic,
         programmes: [@programme]
       )
-    @location = create(:location, :secondary, organisation: @organisation)
+    @location = create(:school, :secondary, organisation: @organisation)
     @session =
       create(
         :session,

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -34,7 +34,7 @@ describe "Self-consent" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
 
-    @school = create(:location, :school)
+    @school = create(:school)
 
     @session =
       create(

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -32,7 +32,7 @@ describe "Triage" do
     programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
-    @school = create(:location, :school)
+    @school = create(:school)
     session =
       create(
         :session,

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -39,7 +39,7 @@ describe "Triage" do
         organisation: @organisation,
         vaccine: @programme.vaccines.first
       )
-    location = create(:location, :school)
+    location = create(:school)
     @session =
       create(
         :session,

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -31,8 +31,8 @@ describe "User authorisation" do
     @other_organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
 
-    location = create(:location, :school, name: "Pilot School")
-    other_location = create(:location, :school, name: "Other School")
+    location = create(:school, name: "Pilot School")
+    other_location = create(:school, name: "Other School")
     @session =
       create(
         :session,

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -19,7 +19,7 @@ feature "Verbal consent" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:location, :school, name: "Pilot School")
+    location = create(:school, name: "Pilot School")
     @session =
       create(
         :session,

--- a/spec/helpers/address_helper_spec.rb
+++ b/spec/helpers/address_helper_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe AddressHelper do
+describe AddressHelper do
   let(:location) do
     create(
-      :location,
       :school,
       address_line_1: "10 Downing Street",
       address_town: "London",

--- a/spec/helpers/cohorts_helper_spec.rb
+++ b/spec/helpers/cohorts_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe CohortsHelper do
+describe CohortsHelper do
   describe "#format_year_group" do
     subject(:formatted_year_group) { helper.format_year_group(year_group) }
 

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -67,7 +67,7 @@ describe PatientsHelper do
     end
 
     context "with a school" do
-      let(:school) { create(:location, :school, name: "Waterloo Road") }
+      let(:school) { create(:school, name: "Waterloo Road") }
       let(:patient) { create(:patient, school:) }
 
       it { should eq("Waterloo Road") }

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -2,7 +2,7 @@
 
 describe SessionsHelper do
   let(:programme) { create(:programme, :flu) }
-  let(:location) { create(:location, :school, name: "Waterloo Road") }
+  let(:location) { create(:school, name: "Waterloo Road") }
   let(:date) { nil }
   let(:session) { create(:session, programme:, date:, location:) }
 

--- a/spec/helpers/vaccines_helper_spec.rb
+++ b/spec/helpers/vaccines_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe VaccinesHelper, type: :helper do
+describe VaccinesHelper do
   let(:vaccine) { create(:vaccine, :fluenz_tetra) }
 
   describe "#vaccine_heading" do

--- a/spec/jobs/clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/clinic_session_invitations_job_spec.rb
@@ -7,7 +7,7 @@ describe ClinicSessionInvitationsJob do
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:parents) { create_list(:parent, 2) }
   let(:patient) { create(:patient, parents:) }
-  let(:location) { create(:location, :generic_clinic, organisation:) }
+  let(:location) { create(:generic_clinic, organisation:) }
 
   context "for a scheduled clinic session in 3 weeks" do
     let(:date) { 3.weeks.from_now.to_date }
@@ -142,7 +142,7 @@ describe ClinicSessionInvitationsJob do
   end
 
   context "for a school session in 3 weeks time" do
-    let(:location) { create(:location, :school, organisation:) }
+    let(:location) { create(:school, organisation:) }
 
     before do
       create(

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -41,7 +41,7 @@ describe SchoolConsentRemindersJob do
   let(:dates) { [Date.new(2024, 1, 12), Date.new(2024, 1, 15)] }
 
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:location) { create(:location, :school, organisation:) }
+  let(:location) { create(:school, organisation:) }
 
   let!(:session) do
     create(
@@ -85,7 +85,7 @@ describe SchoolConsentRemindersJob do
     end
 
     context "when location is a generic clinic" do
-      let(:location) { create(:location, :generic_clinic, organisation:) }
+      let(:location) { create(:generic_clinic, organisation:) }
 
       it "doesn't send any notifications" do
         expect(ConsentNotification).not_to receive(:create_and_send!)

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -77,7 +77,7 @@ describe SchoolConsentRequestsJob do
 
     context "when location is a generic clinic" do
       let(:organisation) { create(:organisation, programmes: [programme]) }
-      let(:location) { create(:location, :generic_clinic, organisation:) }
+      let(:location) { create(:generic_clinic, organisation:) }
       let(:session) do
         create(
           :session,

--- a/spec/jobs/school_session_reminders_job_spec.rb
+++ b/spec/jobs/school_session_reminders_job_spec.rb
@@ -96,7 +96,7 @@ describe SchoolSessionRemindersJob do
 
   context "for a generic clinic session tomorrow" do
     let(:organisation) { create(:organisation, programmes: [programme]) }
-    let(:location) { create(:location, :generic_clinic, organisation:) }
+    let(:location) { create(:generic_clinic, organisation:) }
 
     before do
       create(

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -32,7 +32,7 @@ describe GovukNotifyPersonalisation do
       date_of_birth: Date.current - 13.years
     )
   end
-  let(:location) { create(:location, :school, name: "Hogwarts") }
+  let(:location) { create(:school, name: "Hogwarts") }
   let(:session) do
     create(
       :session,
@@ -146,7 +146,7 @@ describe GovukNotifyPersonalisation do
 
     context "where the school is different" do
       let(:session) { nil }
-      let(:school) { create(:location, :school, name: "Waterloo Road") }
+      let(:school) { create(:school, name: "Waterloo Road") }
 
       let(:consent_form) do
         create(

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -21,7 +21,7 @@ describe Reports::OfflineSessionExporter do
   let(:session) { create(:session, location:, organisation:, programme:) }
 
   context "a school session" do
-    let(:location) { create(:location, :school, team:) }
+    let(:location) { create(:school, team:) }
 
     it { should_not be_blank }
 
@@ -279,7 +279,7 @@ describe Reports::OfflineSessionExporter do
   end
 
   context "a clinic session" do
-    let(:location) { create(:location, :generic_clinic, team:) }
+    let(:location) { create(:generic_clinic, team:) }
 
     it { should_not be_blank }
 
@@ -390,8 +390,7 @@ describe Reports::OfflineSessionExporter do
         let(:patient) do
           create(
             :patient,
-            school:
-              create(:location, :school, urn: "123456", name: "Waterloo Road")
+            school: create(:school, urn: "123456", name: "Waterloo Road")
           )
         end
         let(:patient_session) { create(:patient_session, patient:, session:) }

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -75,7 +75,7 @@ describe Reports::ProgrammeVaccinationsExporter do
     subject(:rows) { CSV.parse(call, headers: true) }
 
     context "a school session" do
-      let(:location) { create(:location, :school, team:) }
+      let(:location) { create(:school, team:) }
 
       it { should be_empty }
 
@@ -143,7 +143,7 @@ describe Reports::ProgrammeVaccinationsExporter do
     end
 
     context "a clinic session" do
-      let(:location) { create(:location, :generic_clinic, team:) }
+      let(:location) { create(:generic_clinic, team:) }
 
       it { should be_empty }
 

--- a/spec/lib/unscheduled_sessions_factory_spec.rb
+++ b/spec/lib/unscheduled_sessions_factory_spec.rb
@@ -8,7 +8,7 @@ describe UnscheduledSessionsFactory do
     let(:organisation) { create(:organisation, programmes: [programme]) }
 
     context "with a school that's eligible for the programme" do
-      let!(:location) { create(:location, :secondary, organisation:) }
+      let!(:location) { create(:school, :secondary, organisation:) }
 
       it "creates missing unscheduled sessions" do
         expect { call }.to change(organisation.sessions, :count).by(1)
@@ -20,7 +20,7 @@ describe UnscheduledSessionsFactory do
     end
 
     context "with a generic clinic" do
-      let!(:location) { create(:location, :generic_clinic, organisation:) }
+      let!(:location) { create(:generic_clinic, organisation:) }
 
       it "creates missing unscheduled sessions" do
         expect { call }.to change(organisation.sessions, :count).by(1)
@@ -32,7 +32,7 @@ describe UnscheduledSessionsFactory do
     end
 
     context "with a community clinic" do
-      before { create(:location, :community_clinic, organisation:) }
+      before { create(:community_clinic, organisation:) }
 
       it "doesn't create any unscheduled sessions" do
         expect { call }.not_to change(organisation.sessions, :count)
@@ -40,7 +40,7 @@ describe UnscheduledSessionsFactory do
     end
 
     context "with a school that's not eligible for the programme" do
-      before { create(:location, :primary, organisation:) }
+      before { create(:school, :primary, organisation:) }
 
       it "doesn't create any sessions" do
         expect { call }.not_to change(Session, :count)
@@ -49,7 +49,7 @@ describe UnscheduledSessionsFactory do
 
     context "when a session already exists" do
       before do
-        location = create(:location, :secondary, organisation:)
+        location = create(:school, :secondary, organisation:)
         create(:session, organisation:, location:, programme:)
       end
 
@@ -60,7 +60,7 @@ describe UnscheduledSessionsFactory do
 
     context "when a session exists for a different academic year" do
       before do
-        location = create(:location, :secondary, organisation:)
+        location = create(:school, :secondary, organisation:)
         create(
           :session,
           organisation:,
@@ -76,7 +76,7 @@ describe UnscheduledSessionsFactory do
     end
 
     context "with an unscheduled session for a location no longer managed by the organisation" do
-      let(:location) { create(:location, :secondary) }
+      let(:location) { create(:school, :secondary) }
       let!(:session) do
         create(:session, :unscheduled, organisation:, location:, programme:)
       end
@@ -88,7 +88,7 @@ describe UnscheduledSessionsFactory do
     end
 
     context "with a scheduled session for a location no longer managed by the organisation" do
-      let(:location) { create(:location, :secondary) }
+      let(:location) { create(:school, :secondary) }
 
       before do
         create(:session, :scheduled, organisation:, location:, programme:)

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -5,7 +5,7 @@ describe ClassImportRow do
 
   let(:programme) { create(:programme) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:school) { create(:location, :school, organisation:) }
+  let(:school) { create(:school, organisation:) }
   let(:session) do
     create(:session, organisation:, programme:, location: school)
   end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -40,7 +40,7 @@ describe ClassImport do
 
   let(:programme) { create(:programme) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:location) { create(:location, :school, organisation:) }
+  let(:location) { create(:school, organisation:) }
   let(:session) { create(:session, location:, programme:, organisation:) }
 
   let(:file) { "valid.csv" }
@@ -395,7 +395,7 @@ describe ClassImport do
       let!(:existing_patient) { create(:patient, session:) }
 
       it "proposes moving the existing patient to the generic clinic" do
-        location = create(:location, :generic_clinic, organisation:)
+        location = create(:generic_clinic, organisation:)
         generic_clinic_session =
           create(:session, location:, organisation:, programme:)
 

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -45,7 +45,7 @@ describe CohortImportRow do
     }
   end
 
-  before { create(:location, :school, urn: "123456") }
+  before { create(:school, urn: "123456") }
 
   describe "validations" do
     let(:data) { valid_data }

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -46,7 +46,7 @@ describe CohortImport do
 
   # Ensure location URN matches the URN in our fixture files
   let!(:location) do
-    Location.find_by(urn: "123456") || create(:location, :school, urn: "123456")
+    Location.find_by(urn: "123456") || create(:school, urn: "123456")
   end
 
   it_behaves_like "a CSVImportable model"
@@ -145,8 +145,7 @@ describe CohortImport do
       let(:file) { "valid_iso_8859_1_encoding.csv" }
 
       let(:location) do
-        Location.find_by(urn: "120026") ||
-          create(:location, :school, urn: "120026")
+        Location.find_by(urn: "120026") || create(:school, urn: "120026")
       end
 
       it "is valid" do

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -750,7 +750,7 @@ describe ConsentForm do
     let(:programme) { create(:programme) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
 
-    let(:school) { create(:location, :school) }
+    let(:school) { create(:school) }
     let(:location) { school }
     let(:session) { create(:session, organisation:, programme:, location:) }
     let(:patient) { create(:patient, school:, session:) }
@@ -790,7 +790,7 @@ describe ConsentForm do
         )
       end
 
-      let(:new_school) { create(:location, :school) }
+      let(:new_school) { create(:school) }
       let!(:new_session) do
         create(:session, programme:, organisation:, location: new_school)
       end
@@ -822,7 +822,7 @@ describe ConsentForm do
       end
 
       context "if the session is a clinic" do
-        let(:location) { create(:location, :generic_clinic, organisation:) }
+        let(:location) { create(:generic_clinic, organisation:) }
 
         it "changes the patient's school" do
           expect { match_with_patient! }.to change(patient, :school).from(
@@ -849,7 +849,7 @@ describe ConsentForm do
         )
       end
 
-      let(:new_location) { create(:location, :generic_clinic, organisation:) }
+      let(:new_location) { create(:generic_clinic, organisation:) }
       let!(:new_session) do
         create(:session, programme:, organisation:, location: new_location)
       end

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -47,7 +47,7 @@ describe ConsentNotification do
     let(:patient) { create(:patient, parents:) }
     let(:programme) { create(:programme) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
-    let(:location) { create(:location, :school, organisation:) }
+    let(:location) { create(:school, organisation:) }
     let(:session) do
       create(
         :session,
@@ -118,7 +118,7 @@ describe ConsentNotification do
 
     context "with a request and a clinic location" do
       let(:type) { :request }
-      let(:location) { create(:location, :generic_clinic, organisation:) }
+      let(:location) { create(:generic_clinic, organisation:) }
 
       it "creates a record" do
         expect { create_and_send! }.to change(described_class, :count).by(1)

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -8,8 +8,8 @@ describe DPSExportRow do
   let(:vaccine) do
     create(:vaccine, :gardasil_9, programme:, dose_volume_ml: 0.5)
   end
-  let(:location) { create(:location, :school) }
-  let(:school) { create(:location, :school) }
+  let(:location) { create(:school) }
+  let(:school) { create(:school) }
   let(:patient) do
     create(:patient, date_of_birth: Date.new(2012, 12, 29), school:)
   end
@@ -246,14 +246,14 @@ describe DPSExportRow do
       it { should_not be_nil }
 
       context "when the session has a location with a URN" do
-        let(:location) { create(:location, :school, urn: "12345") }
+        let(:location) { create(:school, urn: "12345") }
 
         it { should eq("12345") }
       end
 
       context "when the session has a location with an ODS code" do
         let(:location) do
-          create(:location, :community_clinic, ods_code: "12345", organisation:)
+          create(:community_clinic, ods_code: "12345", organisation:)
         end
 
         it { should eq("12345") }
@@ -263,7 +263,7 @@ describe DPSExportRow do
         let(:organisation) do
           create(:organisation, ods_code: "ABC", programmes: [programme])
         end
-        let(:location) { create(:location, :generic_clinic, organisation:) }
+        let(:location) { create(:generic_clinic, organisation:) }
         let(:location_name) { "Unknown" }
 
         it { should eq("ABC") }
@@ -276,13 +276,13 @@ describe DPSExportRow do
       it { should_not be_nil }
 
       context "when the session has a location with a URN" do
-        let(:location) { create(:location, :school) }
+        let(:location) { create(:school) }
 
         it { should eq("https://fhir.hl7.org.uk/Id/urn-school-number") }
       end
 
       context "when the session has a location without a URN" do
-        let(:location) { create(:location, :community_clinic, organisation:) }
+        let(:location) { create(:community_clinic, organisation:) }
 
         it { should eq("https://fhir.nhs.uk/Id/ods-organization-code") }
       end
@@ -291,7 +291,7 @@ describe DPSExportRow do
         let(:organisation) do
           create(:organisation, ods_code: "ABC", programmes: [programme])
         end
-        let(:location) { create(:location, :generic_clinic, organisation:) }
+        let(:location) { create(:generic_clinic, organisation:) }
         let(:location_name) { "Unknown" }
 
         it { should eq("https://fhir.nhs.uk/Id/ods-organization-code") }

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -51,7 +51,7 @@ describe ImmunisationImportRow do
   end
   let(:valid_data) { valid_flu_data }
 
-  before { create(:location, :school, urn: "123456") }
+  before { create(:school, urn: "123456") }
 
   describe "validations" do
     context "with an empty row" do
@@ -650,7 +650,7 @@ describe ImmunisationImportRow do
 
     context "current academic year, home educated and community care setting" do
       let(:clinic) do
-        create(:location, :community_clinic, name: "A Clinic", organisation:)
+        create(:community_clinic, name: "A Clinic", organisation:)
       end
       let(:session_date) do
         create(

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -40,9 +40,9 @@ describe ImmunisationImport do
   end
 
   before do
-    create(:location, :school, urn: "110158")
-    create(:location, :school, urn: "120026")
-    create(:location, :school, urn: "144012")
+    create(:school, urn: "110158")
+    create(:school, urn: "120026")
+    create(:school, urn: "144012")
   end
 
   let(:programme) { create(:programme, :flu_all_vaccines) }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -37,8 +37,8 @@ describe Location do
 
       let(:year_groups) { [8, 9, 10, 11] }
 
-      let(:matching) { create(:location, :secondary) } # 7-11
-      let(:mismatch) { create(:location, :primary) } # 0-6
+      let(:matching) { create(:school, :secondary) } # 7-11
+      let(:mismatch) { create(:school, :primary) } # 0-6
 
       it { should include(matching) }
       it { should_not include(mismatch) }
@@ -49,9 +49,7 @@ describe Location do
     it { should validate_presence_of(:name) }
 
     context "with a community clinic" do
-      subject(:location) do
-        build(:location, :community_clinic, ods_code: "abc")
-      end
+      subject(:location) { build(:community_clinic, ods_code: "abc") }
 
       it { should validate_presence_of(:ods_code) }
       it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
@@ -61,7 +59,7 @@ describe Location do
     end
 
     context "with a generic clinic" do
-      subject(:location) { build(:location, :generic_clinic, organisation:) }
+      subject(:location) { build(:generic_clinic, organisation:) }
 
       let(:organisation) { create(:organisation) }
 
@@ -79,7 +77,7 @@ describe Location do
     end
 
     context "with a school" do
-      subject(:location) { build(:location, :school, urn: "abc") }
+      subject(:location) { build(:school, urn: "abc") }
 
       it { should_not validate_presence_of(:ods_code) }
       it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
@@ -97,21 +95,21 @@ describe Location do
     subject(:clinic?) { location.clinic? }
 
     context "with a community clinic" do
-      let(:location) { build(:location, :community_clinic) }
+      let(:location) { build(:community_clinic) }
 
       it { should be(true) }
     end
 
     context "with a generic clinic" do
       let(:location) do
-        build(:location, :generic_clinic, organisation: create(:organisation))
+        build(:generic_clinic, organisation: create(:organisation))
       end
 
       it { should be(true) }
     end
 
     context "with a school" do
-      let(:location) { build(:location, :school) }
+      let(:location) { build(:school) }
 
       it { should be(false) }
     end

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -7,10 +7,10 @@ describe Onboarding do
 
   let!(:programme) { create(:programme, :hpv) }
   # rubocop:disable RSpec/IndexedLet
-  let!(:school1) { create(:location, :secondary, urn: "123456") }
-  let!(:school2) { create(:location, :secondary, urn: "234567") }
-  let!(:school3) { create(:location, :secondary, urn: "345678") }
-  let!(:school4) { create(:location, :secondary, urn: "456789") }
+  let!(:school1) { create(:school, :secondary, urn: "123456") }
+  let!(:school2) { create(:school, :secondary, urn: "234567") }
+  let!(:school3) { create(:school, :secondary, urn: "345678") }
+  let!(:school4) { create(:school, :secondary, urn: "456789") }
   # rubocop:enable RSpec/IndexedLet
 
   context "with a valid configuration file" do

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -39,9 +39,7 @@ describe Organisation do
   it { should normalize(:ods_code).from(" r1a ").to("R1A") }
 
   describe "#community_clinics" do
-    let(:clinic_locations) do
-      create_list(:location, 3, :community_clinic, organisation:)
-    end
+    let(:clinic_locations) { create_list(:community_clinic, 3, organisation:) }
 
     it "returns the clinic locations" do
       expect(organisation.community_clinics).to eq(clinic_locations)

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -213,7 +213,7 @@ describe PatientSession do
 
     context "when the patient session is for the generic clinic" do
       let(:organisation) { original_session.organisation }
-      let(:location) { create(:location, :generic_clinic, organisation:) }
+      let(:location) { create(:generic_clinic, organisation:) }
       let(:proposed_session) do
         create(:session, location:, organisation:, programme:)
       end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -70,17 +70,7 @@ describe Patient do
     end
 
     context "with an invalid school" do
-      subject(:patient) do
-        build(
-          :patient,
-          school:
-            create(
-              :location,
-              :community_clinic,
-              organisation: create(:organisation)
-            )
-        )
-      end
+      subject(:patient) { build(:patient, school: create(:community_clinic)) }
 
       it "is invalid" do
         expect(patient.valid?).to be(false)

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -44,7 +44,7 @@ describe SessionNotification do
     let(:patient) { create(:patient, parents:) }
     let(:programme) { create(:programme) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
-    let(:location) { create(:location, :school, organisation:) }
+    let(:location) { create(:school, organisation:) }
     let(:session) { create(:session, location:, programme:, organisation:) }
     let(:session_date) { session.dates.min }
     let(:patient_session) { create(:patient_session, patient:, session:) }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -240,7 +240,7 @@ describe Session do
     let(:organisation) { create(:organisation, programmes:) }
     let(:session) { create(:session, organisation:, location:, programmes:) }
 
-    let(:school) { create(:location, :primary) }
+    let(:school) { create(:school, :primary) }
 
     let!(:unvaccinated_child) do
       create(:patient, year_group: 6, organisation:, school:)
@@ -338,7 +338,7 @@ describe Session do
       end
 
       context "in a generic clinic" do
-        let(:location) { create(:location, :generic_clinic, organisation:) }
+        let(:location) { create(:generic_clinic, organisation:) }
 
         it "adds the unvaccinated patients" do
           create_patient_sessions!
@@ -381,7 +381,7 @@ describe Session do
       end
 
       context "in a generic clinic" do
-        let(:location) { create(:location, :generic_clinic, organisation:) }
+        let(:location) { create(:generic_clinic, organisation:) }
 
         it "adds the unvaccinated patients" do
           create_patient_sessions!
@@ -427,7 +427,7 @@ describe Session do
       end
 
       context "in a generic clinic" do
-        let(:location) { create(:location, :generic_clinic, organisation:) }
+        let(:location) { create(:generic_clinic, organisation:) }
 
         it "adds the unvaccinated patients" do
           create_patient_sessions!
@@ -467,7 +467,7 @@ describe Session do
         create(:patient, :vaccinated, session:, programme:)
       end
 
-      let(:generic_clinic) { create(:location, :generic_clinic, organisation:) }
+      let(:generic_clinic) { create(:generic_clinic, organisation:) }
       let(:generic_clinic_session) do
         create(:session, location: generic_clinic, organisation:, programme:)
       end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -10,7 +10,7 @@ describe PatientPolicy do
     let(:cohort_for_another_organisation) do
       create(:cohort, organisation: another_organisation)
     end
-    let(:school) { create(:location, :school, organisation:) }
+    let(:school) { create(:school, organisation:) }
     let(:user) { create(:user, organisation:) }
 
     let(:patient_in_school) { create(:patient, school:) }
@@ -46,7 +46,7 @@ describe PatientPolicy do
 
     context "when the patient not in the org but pending joining the school" do
       let(:school_for_another_organisation) do
-        create(:location, :school, organisation: another_organisation)
+        create(:school, organisation: another_organisation)
       end
 
       let(:patient_with_pending_changes_to_enrol_in_school) do


### PR DESCRIPTION
This changes the factories for locations to use separate factories for the three types of locations, schools, community clinics and generic clinics. This makes it impossible to use the school traits in clinics and vice-versa, by introducing a clear separation between the types of locations.

I also think this helps to make the code that uses these factories clearer and easier to read.