### PR TITLE
Consolidate school and home_educated values

### DIFF
--- a/app/components/app_compare_consent_form_and_patient_component.rb
+++ b/app/components/app_compare_consent_form_and_patient_component.rb
@@ -29,7 +29,7 @@ class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
 
   def school_match?
     if consent_form.education_setting_school?
-      (consent_form.school || consent_form.location) == patient.school
+      consent_form.school == patient.school
     elsif consent_form.education_setting_home?
       patient.home_educated
     else
@@ -38,13 +38,10 @@ class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
   end
 
   def consent_form_patient
-    if consent_form.education_setting_school?
-      Patient.new(school: consent_form.school || consent_form.location)
-    elsif consent_form.education_setting_home?
-      Patient.new(school: nil, home_educated: true)
-    else
-      Patient.new(school: nil, home_educated: false)
-    end
+    Patient.new(
+      school: consent_form.school,
+      home_educated: consent_form.home_educated
+    )
   end
 
   def consent_form_parent

--- a/app/components/app_compare_consent_form_and_patient_component.rb
+++ b/app/components/app_compare_consent_form_and_patient_component.rb
@@ -28,13 +28,8 @@ class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
   end
 
   def school_match?
-    if consent_form.education_setting_school?
+    consent_form.home_educated == patient.home_educated &&
       consent_form.school == patient.school
-    elsif consent_form.education_setting_home?
-      patient.home_educated
-    else
-      patient.school.nil? && !patient.home_educated
-    end
   end
 
   def consent_form_patient

--- a/app/models/class_import_row.rb
+++ b/app/models/class_import_row.rb
@@ -21,6 +21,6 @@ class ClassImportRow < PatientImportRow
   end
 
   def home_educated
-    false
+    nil # false is used when school is unknown
   end
 end

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -30,10 +30,10 @@ class CohortImportRow < PatientImportRow
   end
 
   def home_educated
-    if school_urn == SCHOOL_URN_UNKNOWN
-      nil
-    else
-      school_urn == SCHOOL_URN_HOME_EDUCATED
+    if school_urn == SCHOOL_URN_HOME_EDUCATED
+      true
+    elsif school_urn == SCHOOL_URN_UNKNOWN
+      false
     end
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -417,7 +417,7 @@ class ConsentForm < ApplicationRecord
       notify_log_entries.update_all(patient_id: patient.id)
 
       if education_setting_school?
-        patient.school = school_confirmed ? location : school
+        patient.school = school
         patient.home_educated = false
       elsif education_setting_home?
         patient.school = nil
@@ -535,9 +535,15 @@ class ConsentForm < ApplicationRecord
 
     self.gp_name = nil unless gp_response_yes?
 
-    self.education_setting = "school" if !school.nil? || school_confirmed
-    self.school = nil if school_confirmed || education_setting_home? ||
-      education_setting_none?
+    if school_confirmed
+      self.education_setting = "school"
+      self.school = location
+    elsif education_setting_home? || education_setting_none?
+      self.school = nil
+      self.school_confirmed = false
+    elsif school
+      self.education_setting = "school"
+    end
   end
 
   def seed_health_questions

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -416,16 +416,8 @@ class ConsentForm < ApplicationRecord
     ActiveRecord::Base.transaction do
       notify_log_entries.update_all(patient_id: patient.id)
 
-      if education_setting_school?
-        patient.school = school
-        patient.home_educated = false
-      elsif education_setting_home?
-        patient.school = nil
-        patient.home_educated = true
-      elsif education_setting_none?
-        patient.school = nil
-        patient.home_educated = false
-      end
+      patient.school = school
+      patient.home_educated = home_educated
 
       if patient.changed?
         patient.save!
@@ -443,6 +435,12 @@ class ConsentForm < ApplicationRecord
 
       Consent.from_consent_form!(self, patient:)
     end
+  end
+
+  def home_educated
+    return nil if education_setting_school?
+
+    education_setting_home?
   end
 
   private

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -158,7 +158,8 @@ class ImmunisationImportRow
   def patient
     return unless valid?
 
-    @patient ||= existing_patients.first || Patient.create!(patient_attributes)
+    @patient ||=
+      existing_patients.first || Patient.create!(new_patient_attributes)
   end
 
   def session
@@ -545,14 +546,16 @@ class ImmunisationImportRow
     )
   end
 
-  def patient_attributes
+  def new_patient_attributes
     {
       address_postcode: patient_postcode,
       date_of_birth: patient_date_of_birth,
       family_name: patient_last_name,
       given_name: patient_first_name,
       gender_code: patient_gender_code,
-      nhs_number: patient_nhs_number
+      nhs_number: patient_nhs_number,
+      school: nil,
+      home_educated: false
     }.compact
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -162,7 +162,16 @@ class Patient < ApplicationRecord
               with: /\A(?:\d\s*){10}\z/
             },
             allow_nil: true
-  validates :school, absence: true, if: :home_educated
+
+  validates :school,
+            presence: {
+              if: -> { home_educated.nil? }
+            },
+            absence: {
+              unless: -> { home_educated.nil? }
+            }
+
+  validates :home_educated, inclusion: { in: :valid_home_educated_values }
   validate :school_is_correct_type
 
   validates :address_postcode, postcode: { allow_nil: true }
@@ -367,6 +376,10 @@ class Patient < ApplicationRecord
   end
 
   private
+
+  def valid_home_educated_values
+    school.nil? ? [true, false] : [nil]
+  end
 
   def school_is_correct_type
     location = school

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -131,9 +131,12 @@ class PatientSession < ApplicationRecord
     PatientSession.transaction do
       PatientSession.find_or_create_by!(patient:, session: proposed_session)
 
-      school = proposed_session.location
-      school = nil if school.generic_clinic?
-      patient.update!(school:)
+      location = proposed_session.location
+      if location.school?
+        patient.update!(school: location, home_educated: nil)
+      else
+        patient.update!(school: nil, home_educated: false)
+      end
 
       safe_to_destroy? ? destroy! : update!(proposed_session: nil)
     end

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -104,7 +104,7 @@
         end
       
         school = if @consent_form.education_setting_school?
-            (@consent_form.school || @consent_form.location).name
+            @consent_form.school.name
           elsif @consent_form.education_setting_home?
             "Home-schooled"
           else

--- a/db/migrate/20241128081013_consolidate_patient_school_home_educated.rb
+++ b/db/migrate/20241128081013_consolidate_patient_school_home_educated.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ConsolidatePatientSchoolHomeEducated < ActiveRecord::Migration[7.2]
+  def change
+    # school present and home_educated_nil => known school
+    # school nil and home_educated true => home schooled
+    # school nil and home_educated false => unknown school
+
+    Patient.where.not(school_id: nil).update_all(home_educated: nil)
+    Patient.where(home_educated: true).update_all(school_id: nil)
+    Patient.where(home_educated: false).update_all(school_id: nil)
+
+    if Patient.any?(&:invalid?)
+      raise "Patients are not all valid. Aborting to rollback transaction."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_20_140814) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_28_081013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
   enable_extension "plpgsql"

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -28,17 +28,16 @@ FactoryBot.define do
       organisation { session.organisation }
       user { association :user, organisation: }
       year_group { nil }
-      in_school { session.location.school? }
-      home_educated { !in_school }
+      school { session.location.school? ? session.location : nil }
+      home_educated { school.present? ? nil : false }
+      location_name do
+        organisation.community_clinics.sample.name if session.location.clinic?
+      end
     end
 
     session { association :session, programme: }
     patient do
-      association :patient,
-                  organisation:,
-                  school: in_school ? session.location : nil,
-                  home_educated:,
-                  year_group:
+      association :patient, organisation:, school:, home_educated:, year_group:
     end
 
     trait :added_to_session
@@ -50,7 +49,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -63,7 +62,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -76,7 +75,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -89,7 +88,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -102,7 +101,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -115,7 +114,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -129,7 +128,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -143,7 +142,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -157,7 +156,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -171,7 +170,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -183,12 +182,7 @@ FactoryBot.define do
           patient_session:,
           programme: evaluator.programme,
           performed_by: evaluator.user,
-          location_name:
-            (
-              if evaluator.home_educated
-                evaluator.organisation.community_clinics.sample.name
-              end
-            ),
+          location_name: evaluator.location_name,
           outcome: :absent_from_school
         )
       end
@@ -201,7 +195,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -215,7 +209,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -227,12 +221,7 @@ FactoryBot.define do
           patient_session:,
           programme: evaluator.programme,
           performed_by: evaluator.user,
-          location_name:
-            (
-              if evaluator.home_educated
-                evaluator.organisation.community_clinics.sample.name
-              end
-            ),
+          location_name: evaluator.location_name,
           outcome: :already_had
         )
       end
@@ -245,7 +234,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -270,7 +259,7 @@ FactoryBot.define do
                     performed_by: user,
                     programme:,
                     organisation:,
-                    school: in_school ? session.location : nil,
+                    school:,
                     home_educated:,
                     year_group:
       end
@@ -281,12 +270,7 @@ FactoryBot.define do
           patient_session:,
           programme: evaluator.programme,
           performed_by: evaluator.user,
-          location_name:
-            (
-              if evaluator.home_educated
-                evaluator.organisation.community_clinics.sample.name
-              end
-            )
+          location_name: evaluator.location_name
         )
       end
     end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -92,7 +92,10 @@ FactoryBot.define do
         Faker::Date.birthday(min_age: 7, max_age: 16)
       end
     end
+
     school { session.location if session&.location&.school? }
+    home_educated { school.present? ? nil : false }
+
     registration do
       "#{date_of_birth.year_group}#{Faker::Alphanumeric.alpha(number: 2)}"
     end

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -116,7 +116,7 @@ describe ClassImportRow do
 
     it do
       expect(patient).to have_attributes(
-        home_educated: false,
+        home_educated: nil,
         gender_code: "not_known",
         registration: "8AB"
       )

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -139,9 +139,7 @@ describe CohortImportRow do
 
     it { should_not be_nil }
 
-    it { should have_attributes(registration: "8AB") }
-
-    it { should have_attributes(home_educated: false) }
+    it { should have_attributes(registration: "8AB", home_educated: nil) }
 
     context "when home educated" do
       let(:school_urn) { "999999" }

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -805,10 +805,8 @@ describe ConsentForm do
         ).to(new_school)
       end
 
-      it "changes the patient's home educated status" do
-        expect { match_with_patient! }.to change(patient, :home_educated).to(
-          false
-        )
+      it "doesn't change the patient's home educated status" do
+        expect { match_with_patient! }.not_to change(patient, :home_educated)
       end
 
       it "marks the patient with a proposed move" do


### PR DESCRIPTION
This consolidates the values of `school` and `home_educated` to use them in a consistent way across the service. This means that there will be three possible combinations of these values:

- `school` present and `home_educated` `nil`
- `school` `nil` and `home_educated` `true`
- `school` `nil` and `home_educated` `false`

I've also fixed a bug where a school move for a home-schooled patient wouldn't update their home-schooled status, which would lead to them staying in the community clinic when they should instead be added to the school.