### PR TITLE
Don't create patient sessions in UnscheduledSessionsFactory

### DIFF
--- a/app/lib/unscheduled_sessions_factory.rb
+++ b/app/lib/unscheduled_sessions_factory.rb
@@ -28,12 +28,7 @@ class UnscheduledSessionsFactory
 
           next if programmes.empty?
 
-          Session.create!(
-            academic_year:,
-            location:,
-            programmes:,
-            organisation:
-          ).tap(&:create_patient_sessions!)
+          Session.create!(academic_year:, location:, programmes:, organisation:)
         end
 
         location_ids = organisation.locations.map(&:id)


### PR DESCRIPTION
This is unnecessary as we want to create the sessions well before an organisation has any patients, as part of onboarding. This also helps us in preparation for the removal of the `create_patient_sessions!` method as we decouple school moves with session moves.