### PR TITLE
Don't move patient if sessions are the same

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -305,6 +305,8 @@ class Patient < ApplicationRecord
 
     old_session = from
 
+    return if new_session == old_session
+
     existing_patient_sessions = patient_sessions.where(session: old_session)
 
     if existing_patient_sessions.exists?

--- a/spec/features/parent_consent_school_session_completed_spec.rb
+++ b/spec/features/parent_consent_school_session_completed_spec.rb
@@ -5,8 +5,9 @@ describe "Parental consent" do
   after { Flipper.disable(:release_1b) }
 
   scenario "Move to a completed session" do
+    stub_pds_search_to_return_no_patients
+
     given_an_hpv_programme_is_underway
-    and_requests_can_be_made_to_pds
 
     when_i_go_to_the_consent_form
     when_i_fill_in_my_childs_name_and_birthday
@@ -48,13 +49,6 @@ describe "Parental consent" do
       )
 
     @child = create(:patient, session: @scheduled_session)
-  end
-
-  def and_requests_can_be_made_to_pds
-    stub_request(
-      :get,
-      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
-    ).with(query: hash_including({})).to_return_json(body: { total: 0 })
   end
 
   def when_a_nurse_checks_consent_responses

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -5,8 +5,9 @@ describe "Parental consent school" do
   after { Flipper.disable(:release_1b) }
 
   scenario "Child attending a clinic goes to a school" do
+    stub_pds_search_to_return_no_patients
+
     given_an_hpv_programme_is_underway
-    and_requests_can_be_made_to_pds
 
     when_i_go_to_the_consent_form
     and_i_fill_in_my_childs_name_and_birthday
@@ -36,8 +37,9 @@ describe "Parental consent school" do
   end
 
   scenario "Child attending a clinic is home-schooled" do
+    stub_pds_search_to_return_no_patients
+
     given_an_hpv_programme_is_underway
-    and_requests_can_be_made_to_pds
 
     when_i_go_to_the_consent_form
     and_i_fill_in_my_childs_name_and_birthday
@@ -64,8 +66,9 @@ describe "Parental consent school" do
   end
 
   scenario "Child attending a clinic is not in education" do
+    stub_pds_search_to_return_no_patients
+
     given_an_hpv_programme_is_underway
-    and_requests_can_be_made_to_pds
 
     when_i_go_to_the_consent_form
     and_i_fill_in_my_childs_name_and_birthday
@@ -110,13 +113,6 @@ describe "Parental consent school" do
     @child = create(:patient, session: @session)
 
     create(:school, organisation: @organisation, name: "Pilot School")
-  end
-
-  def and_requests_can_be_made_to_pds
-    stub_request(
-      :get,
-      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
-    ).with(query: hash_including({})).to_return_json(body: { total: 0 })
   end
 
   def when_i_go_to_the_consent_form


### PR DESCRIPTION
If we're trying to move a patient between the same session we don't need to propose a change since there's no move to take place. This also fixes a bug where confirming the move would remove the patient from the session because we end up with a single patient session that ends up being deleted by `confirm!` rather than two patient sessions.

I've also improved our clinic parental consent feature test to ensure this scenario is fully tested, including the nurse logging in and checking for any moves and the patient school details.