### PR TITLE
Design fixes

### DIFF
--- a/app/assets/stylesheets/_button-group.scss
+++ b/app/assets/stylesheets/_button-group.scss
@@ -8,7 +8,6 @@
   gap: nhsuk-spacing(3) nhsuk-spacing(4);
 
   @include mq($from: tablet) {
-    align-items: baseline;
     flex-direction: row;
     flex-wrap: wrap;
   }

--- a/app/assets/stylesheets/_button.scss
+++ b/app/assets/stylesheets/_button.scss
@@ -5,6 +5,7 @@ $app-cis2-button-shadow-color: #003087;
 $button-shadow-size: 4px;
 
 .nhsuk-button {
+  .button_to &,
   .nhsuk-table & {
     margin-bottom: 0;
   }

--- a/app/assets/stylesheets/_summary-list.scss
+++ b/app/assets/stylesheets/_summary-list.scss
@@ -1,9 +1,8 @@
-.app-summary-list--no-bottom-border {
-  .nhsuk-summary-list__row:last-child {
-    .nhsuk-summary-list__key,
-    .nhsuk-summary-list__value,
-    .nhsuk-summary-list__actions {
-      border-bottom: none;
+// Ensure width of value cell not affected by presence of actions cell
+.nhsuk-summary-list:where(:not(:has(.nhsuk-summary-list__actions))) {
+  .nhsuk-summary-list__value {
+    @include mq($from: tablet) {
+      width: 70%;
     }
   }
 }
@@ -36,6 +35,7 @@
   }
 }
 
+// Full width summary list
 .app-summary-list--full-width {
   .nhsuk-summary-list__row {
     border-bottom: 1px solid $nhsuk-border-color;
@@ -59,6 +59,7 @@
 
   .nhsuk-summary-list__key {
     margin-bottom: 0;
+    padding: 0;
   }
 
   .nhsuk-summary-list__value {

--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -22,6 +22,28 @@
   }
 }
 
+.app-table__cell-status {
+  &--aqua-green:first-of-type {
+    border-left: nhsuk-spacing(2) solid $color_nhsuk-aqua-green;
+    padding-left: nhsuk-spacing(3);
+  }
+
+  &--grey {
+    background-color: $color_nhsuk-grey-5;
+    color: $nhsuk-secondary-text-color;
+
+    &:first-of-type {
+      border-left: nhsuk-spacing(2) solid $color_nhsuk-grey-3;
+      padding-left: nhsuk-spacing(3);
+    }
+  }
+
+  &--red:first-of-type {
+    border-left: nhsuk-spacing(2) solid $color_nhsuk-red;
+    padding-left: nhsuk-spacing(3);
+  }
+}
+
 // Use same bottom margin for responsive table as non-responsive table
 .nhsuk-table-responsive {
   @include nhsuk-responsive-margin(7, "bottom");

--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -1,3 +1,13 @@
+.app-table--csv {
+  i {
+    color: shade($color_nhsuk-red, 50%);
+    font-family: ui-monospace, monospace;
+    font-style: normal;
+    font-weight: 500;
+    padding: 2px;
+  }
+}
+
 .app-table--small {
   th,
   td {
@@ -18,28 +28,6 @@
   .nhsuk-table__cell {
     padding-top: nhsuk-spacing(2);
     padding-bottom: nhsuk-spacing(2);
-  }
-}
-
-.app-table--csv {
-  th,
-  td {
-    @include nhsuk-typography-responsive(16);
-    @include nhsuk-responsive-padding(2, "bottom");
-    @include nhsuk-responsive-padding(3, "right");
-    @include nhsuk-responsive-padding(2, "top");
-  }
-
-  caption {
-    @include nhsuk-font($size: 19, $weight: bold);
-  }
-
-  i {
-    color: shade($color_nhsuk-red, 50%);
-    font-family: ui-monospace, monospace;
-    font-style: normal;
-    font-weight: 500;
-    padding: 2px;
   }
 }
 

--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -22,15 +22,6 @@
   }
 }
 
-.app-table--patients {
-  margin: 0;
-
-  .nhsuk-table__cell {
-    padding-top: nhsuk-spacing(2);
-    padding-bottom: nhsuk-spacing(2);
-  }
-}
-
 // Use same bottom margin for responsive table as non-responsive table
 .nhsuk-table-responsive {
   @include nhsuk-responsive-margin(7, "bottom");

--- a/app/assets/stylesheets/_table.scss
+++ b/app/assets/stylesheets/_table.scss
@@ -21,25 +21,6 @@
   }
 }
 
-.app-table--select-cohort {
-  .nhsuk-table__cell,
-  th {
-    padding-top: nhsuk-spacing(1);
-    padding-bottom: nhsuk-spacing(1);
-    vertical-align: middle;
-  }
-
-  .nhsuk-checkboxes {
-    padding: 0;
-    transform-origin: center left;
-    transform: scale(0.75);
-  }
-
-  .nhsuk-checkboxes__item {
-    padding: 0;
-  }
-}
-
 .app-table--csv {
   th,
   td {

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -29,13 +29,19 @@
     <%= table.with_body do |body| %>
       <% consents.each do |consent| %>
         <%= body.with_row do |row| %>
-          <%= row.with_cell do %>
+          <%= row.with_cell(classes: "app-table__cell-status--#{status_colour(consent)}") do %>
             <%= govuk_link_to consent&.parent&.full_name || consent.patient.full_name, session_patient_consent_path(session, patient, consent, section:, tab:) %>
             <br>
             <span class="nhsuk-u-font-size-16"><%= consent.who_responded %></span>
           <% end %>
-          <%= row.with_cell(text: consent.responded_at.to_fs(:long)) %>
-          <%= row.with_cell(text: helpers.consent_decision(consent)) %>
+          <%= row.with_cell(
+            classes: "app-table__cell-status--#{status_colour(consent)}",
+            text: consent.responded_at.to_fs(:long)
+          ) %>
+          <%= row.with_cell(
+            classes: "app-table__cell-status--#{status_colour(consent)}",
+            text: helpers.consent_decision(consent))
+          %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -35,13 +35,13 @@
             <span class="nhsuk-u-font-size-16"><%= consent.who_responded %></span>
           <% end %>
           <%= row.with_cell(
-            classes: "app-table__cell-status--#{status_colour(consent)}",
-            text: consent.responded_at.to_fs(:long)
-          ) %>
+                classes: "app-table__cell-status--#{status_colour(consent)}",
+                text: consent.responded_at.to_fs(:long),
+              ) %>
           <%= row.with_cell(
-            classes: "app-table__cell-status--#{status_colour(consent)}",
-            text: helpers.consent_decision(consent))
-          %>
+                classes: "app-table__cell-status--#{status_colour(consent)}",
+                text: helpers.consent_decision(consent),
+              ) %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -32,4 +32,16 @@ class AppConsentComponent < ViewComponent::Base
     patient_session.no_consent? && patient.send_notifications? &&
       session.open_for_consent? && patient.parents.any?
   end
+
+  def status_colour(consent)
+    if consent.invalidated? || consent.withdrawn?
+      "grey"
+    elsif consent.response_given?
+      "aqua-green"
+    elsif consent.response_refused?
+      "red"
+    else
+      "grey"
+    end
+  end
 end

--- a/app/components/app_consent_form_summary_component.rb
+++ b/app/components/app_consent_form_summary_component.rb
@@ -19,9 +19,7 @@ class AppConsentFormSummaryComponent < ViewComponent::Base
   end
 
   def call
-    govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border"
-    ) do |summary_list|
+    govuk_summary_list do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Name" }
         row.with_value { name }

--- a/app/components/app_consent_patient_summary_component.rb
+++ b/app/components/app_consent_patient_summary_component.rb
@@ -8,9 +8,7 @@ class AppConsentPatientSummaryComponent < ViewComponent::Base
   end
 
   def call
-    govuk_summary_list(
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
+    govuk_summary_list do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Full name" }
         row.with_value { patient.full_name }

--- a/app/components/app_consent_status_component.rb
+++ b/app/components/app_consent_status_component.rb
@@ -3,11 +3,11 @@
 class AppConsentStatusComponent < ViewComponent::Base
   def call
     if @patient_session.consent_given?
-      icon_tick "Given", "blue"
+      icon_tick "Consent given", "aqua-green"
     elsif @patient_session.consent_refused?
-      icon_cross "Refused", "red"
+      icon_cross "Consent refused", "red"
     elsif @patient_session.consent_conflicts?
-      icon_cross "Conflicts", "dark-orange"
+      icon_cross "Conflicting consent", "dark-orange"
     end
   end
 

--- a/app/components/app_consent_summary_component.rb
+++ b/app/components/app_consent_summary_component.rb
@@ -9,10 +9,7 @@ class AppConsentSummaryComponent < ViewComponent::Base
   end
 
   def call
-    govuk_summary_list(
-      actions: @change_links.present?,
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
+    govuk_summary_list(actions: @change_links.present?) do |summary_list|
       if @consent.responded_at.present?
         summary_list.with_row do |row|
           row.with_key { "Response date" }

--- a/app/components/app_health_questions_component.rb
+++ b/app/components/app_health_questions_component.rb
@@ -2,7 +2,7 @@
 
 class AppHealthQuestionsComponent < ViewComponent::Base
   erb_template <<-ERB
-    <dl class="nhsuk-summary-list app-summary-list--full-width nhsuk-u-margin-bottom-0">
+    <dl class="nhsuk-summary-list app-summary-list--full-width">
       <% health_answers.each do |question, answers| %>
         <div class="nhsuk-summary-list__row">
           <dt class="nhsuk-summary-list__key">

--- a/app/components/app_import_format_details_component.html.erb
+++ b/app/components/app_import_format_details_component.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_details(summary_text:) do %>
   <p class="nhsuk-body">Make sure the CSV you upload uses the following columns:</p>
 
-  <%= govuk_table(classes: "app-table--csv") do |table|
+  <%= govuk_table(classes: "app-table--csv app-table--small") do |table|
         table.with_head do |head|
           head.with_row do |row|
             row.with_cell(text: "Column name")

--- a/app/components/app_matching_criteria_component.html.erb
+++ b/app/components/app_matching_criteria_component.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+<%= govuk_summary_list do |summary_list|
      summary_list.with_row do |row|
        row.with_key { "Child" }
        row.with_value { child_full_name }

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -13,7 +13,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   def call
     render AppCardComponent.new(colour:) do |c|
       c.with_heading { heading }
-      govuk_summary_list(classes: "app-summary-list--no-bottom-border", rows:)
+      govuk_summary_list(rows:)
     end
   end
 

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -20,10 +20,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   end
 
   def call
-    govuk_summary_list(
-      actions: @change_links.present?,
-      classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0"
-    ) do |summary_list|
+    govuk_summary_list(actions: @change_links.present?) do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Child" }
         row.with_value { @patient.full_name }

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -49,7 +49,7 @@
 <% if @draft_consent.response_given? && @triage&.status.present? %>
   <%= render AppCardComponent.new do |card| %>
     <% card.with_heading { "Triage" } %>
-    <%= govuk_summary_list classes: "app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0" do |summary_list|
+    <%= govuk_summary_list do |summary_list|
           summary_list.with_row do |row|
             row.with_key { "Status" }
             row.with_value { @triage.status.humanize }

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -26,10 +26,7 @@
 <%= render AppCardComponent.new do |card| %>
   <% card.with_heading { "Details" } %>
 
-  <%= govuk_summary_list(
-        classes: %w[app-summary-list--no-bottom-border
-                    nhsuk-u-margin-bottom-0],
-      ) do |summary_list| %>
+  <%= govuk_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>
       <%= row.with_key { "Imported on" } %>
       <%= row.with_value { import.created_at.to_fs(:long) } %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -18,7 +18,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { t("consent_forms.confirm.consent_card_title.#{@consent_form.programme.type}") } %>
-  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Do you agree?" }
           row.with_value {
@@ -62,7 +62,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "About your child" } %>
-  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Child’s name" }
           row.with_value { @consent_form.full_name }
@@ -149,7 +149,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "About you" } %>
-  <%= govuk_summary_list classes: "app-summary-list--no-bottom-border" do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Your name" }
           row.with_value { @consent_form.parent_full_name }

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -13,7 +13,7 @@
 <%= render AppCardComponent.new do |card| %>
   <% card.with_heading { "Session details" } %>
 
-  <%= govuk_summary_list(classes: "app-summary-list--no-bottom-border") do |summary_list|
+  <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Programmes" }
           row.with_value { safe_join(@session.programmes.map(&:name), tag.br) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -740,7 +740,7 @@ en:
   patients_table:
     conflicting_consent:
       caption: "%{children} with conflicting consent responses"
-      label: Conflicts
+      label: Conflicting consent
     consent_given:
       caption: "%{children} with consent given"
       label: Consent given

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -41,7 +41,7 @@ describe AppConsentComponent, type: :component do
       "Consent refused by #{consent.parent.full_name} (#{relation})"
     end
 
-    it { should have_css("p.app-status", text: "Refused") }
+    it { should have_css("p.app-status--red", text: "Consent refused") }
 
     it { should have_css("table tr", text: /#{consent.parent.full_name}/) }
     it { should have_css("table tr", text: /#{relation}/) }
@@ -62,7 +62,7 @@ describe AppConsentComponent, type: :component do
       "Consent given by #{consent.parent.full_name} (#{relation})"
     end
 
-    it { should have_css("p.app-status", text: "Given") }
+    it { should have_css("p.app-status--aqua-green", text: "Consent given") }
 
     it { should_not have_css("a", text: "Contact #{consent.parent.full_name}") }
   end

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -13,18 +13,23 @@ describe AppConsentStatusComponent, type: :component do
       create(:patient_session, :consent_given_triage_needed)
     end
 
-    it { should have_css("p.app-status", text: "Given") }
+    it { should have_css("p.app-status--aqua-green", text: "Consent given") }
   end
 
   context "when consent is refused" do
     let(:patient_session) { create(:patient_session, :consent_refused) }
 
-    it { should have_css("p.app-status", text: "Refused") }
+    it { should have_css("p.app-status--red", text: "Consent refused") }
   end
 
   context "when consent conflicts" do
     let(:patient_session) { create(:patient_session, :consent_conflicting) }
 
-    it { should have_css("p.app-status", text: "Conflicts") }
+    it do
+      expect(subject).to have_css(
+        "p.app-status--dark-orange",
+        text: "Conflicting consent"
+      )
+    end
   end
 end


### PR DESCRIPTION
Few design-related fixes and updates, bring a few areas inline with the prototype:

- Remove `.app-summary-list--no-bottom-border` class (we previously added a CSS-only fix)
- Remove unused `.app-table--patients` style
- Remove unused `.app-table--select-cohort` style
- Use `app-table--csv` and `app-table--small` styles in combination
- Remove margin from `.nhsuk-button` when inside a `.button_to` Rails form button (which will have inherited any contextual margins)
- Fix alignment within button groups (due to presence of `.button_to` Rails form buttons) 
- Fix colours and micro copy used for overall consent status
- Add status colours to consent responses

## Consent card

| Before | After |
| - | - |
| ![consent-card-before](https://github.com/user-attachments/assets/12d74ff6-3bde-4cb0-a712-f30aa0ca426b) | ![consent-card-after](https://github.com/user-attachments/assets/0c2772ba-6989-449e-8c61-4e381a083169) |

| Before | After |
| - | - |
| ![consent-card-before-2](https://github.com/user-attachments/assets/b1743aa5-aac3-4724-a95e-43f37ca640fd) | ![consent-card-after-2](https://github.com/user-attachments/assets/2d808371-8327-4b04-934b-81aaed13a869) |

## Vaccination details card

| Before | After |
| - | - |
| ![vaccination-card-before](https://github.com/user-attachments/assets/e63bace9-7bfa-41ae-9d0f-474c17ca0ac3) | ![vaccination-card-after](https://github.com/user-attachments/assets/673b246b-31f7-493e-a9c5-934051ac8460) |
