### PR TITLE
Global school moves

### DIFF
--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -1,21 +1,12 @@
 # frozen_string_literal: true
 
 class SchoolMovesController < ApplicationController
-  before_action :set_session
-  before_action :set_location
-  before_action :set_tab
+  include Pagy::Backend
 
   layout "full"
 
   def index
-    @school_moves =
-      if @tab == :in
-        @location.school_moves_to_this_location
-      elsif @tab == :out
-        @location.school_moves_from_this_location
-      else
-        render "errors/not_found", status: :not_found
-      end
+    @pagy, @school_moves = pagy(policy_scope(SchoolMove).order(:updated_at))
   end
 
   def update
@@ -32,25 +23,11 @@ class SchoolMovesController < ApplicationController
     name = @school_move.patient.full_name
     flash =
       if params[:confirm]
-        { success: "#{name} moved #{@tab}" }
+        { success: "#{name}’s record updated with new school" }
       else
-        { notice: "#{name} move ignored" }
+        { notice: "#{name}’s school move ignored" }
       end
 
-    redirect_to session_moves_path(@session) + "?#{@tab}", flash:
-  end
-
-  private
-
-  def set_session
-    @session = policy_scope(Session).find_by!(slug: params[:session_slug])
-  end
-
-  def set_location
-    @location = @session.location
-  end
-
-  def set_tab
-    @tab = params.key?(:in) ? :in : :out
+    redirect_to school_moves_path, flash:
   end
 end

--- a/app/helpers/school_moves_helper.rb
+++ b/app/helpers/school_moves_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SchoolMovesHelper
+  def school_move_source(school_move)
+    organisation = school_move.school&.organisation || school_move.organisation
+
+    if organisation == current_user.selected_organisation
+      {
+        parental_consent_form: "Consent response updated",
+        class_list_import: "Class list updated",
+        cohort_import: "Cohort record updated"
+      }.fetch(school_move.source.to_sym)
+    else
+      "Another SAIS team updated"
+    end
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -77,25 +77,6 @@ class Location < ApplicationRecord
     generic_clinic? || community_clinic?
   end
 
-  def school_moves_to_this_location
-    school? ? SchoolMove.where(school: self) : SchoolMove.where(organisation:)
-  end
-
-  def school_moves_from_this_location
-    patients =
-      if school?
-        Patient.where(school: self)
-      else
-        Patient.in_organisation(organisation)
-      end
-
-    SchoolMove.where(patient: patients)
-  end
-
-  def has_movers?
-    school_moves_to_this_location.any? || school_moves_from_this_location.any?
-  end
-
   private
 
   def organisation_ods_code

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -262,8 +262,6 @@ class Session < ApplicationRecord
     close_consent_at&.today? || close_consent_at&.future? || false
   end
 
-  delegate :has_movers?, to: :location
-
   private
 
   def set_slug

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -70,6 +70,12 @@
                         "true" : nil } %>
         </li>
         <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
+          <%= link_to t("school_moves.index.title"), school_moves_path,
+                      class: "nhsuk-header__navigation-link",
+                      aria: { current: request.path.start_with?(school_moves_path) ?
+                        "true" : nil } %>
+        </li>
+        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
           <%= link_to "Notices", notices_path,
                       class: "nhsuk-header__navigation-link",
                       aria: { current: request.path.start_with?(notices_path) ?

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -54,6 +54,13 @@
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    <%= render AppCardComponent.new(link_to: school_moves_path, secondary: true) do |card| %>
+      <% card.with_heading { t("school_moves.index.title") } %>
+      <% card.with_description { "Review children who have moved schools" } %>
+    <% end %>
+  </li>
+
+  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: notices_path, secondary: true) do |card| %>
       <% card.with_heading { t("notices.index.title") } %>
       <% card.with_description { "View notices about important updates to patient records" } %>

--- a/app/views/school_moves/index.html.erb
+++ b/app/views/school_moves/index.html.erb
@@ -1,99 +1,69 @@
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: "Home", href: dashboard_path },
-          { text: t("sessions.index.title"), href: sessions_path },
-          { text: @session.location.name, href: session_path(@session) },
-        ],
-      ) %>
-<% end %>
+<%= h1 t(".title"), size: "xl" %>
 
-<%= h1 "Review children who have changed schools" %>
+<% if @school_moves.any? %>
+  <div class="nhsuk-table__panel-with-heading-tab">
+    <h3 class="nhsuk-table__heading-tab">
+      <%= pluralize(@school_moves.count, "school move") %>
+    </h3>
 
-<%= render AppSecondaryNavigationComponent.new do |nav| %>
-  <% nav.with_item(
-       href: session_moves_path(@session) + "?in",
-       selected: @tab == :in,
-     ) do %>
-    Moved in
-    <%= render AppCountComponent.new(
-          count: @location.school_moves_to_this_location.count,
-        ) %>
-  <% end %>
-
-  <% nav.with_item(
-       href: session_moves_path(@session) + "?out",
-       selected: @tab == :out,
-     ) do %>
-    Moved out
-    <%= render AppCountComponent.new(
-          count: @location.school_moves_from_this_location.count,
-        ) %>
-  <% end %>
-<% end %>
-
-<div class="app-patients">
-  <%= govuk_table(html_attributes: {
-                    class: "nhsuk-table-responsive app-patients__table",
-                  }) do |table| %>
-    <%= table.with_caption(
-          text: "#{t("children", count: @school_moves.count)} #{@tab == :in ? "joined" : "left"} this school",
-          html_attributes: {
-            class: %w[nhsuk-u-secondary-text-color
-                      nhsuk-u-font-weight-normal
-                      nhsuk-u-font-size-19],
-          },
-        ) %>
-
-    <% if @school_moves.any? %>
+    <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
+          <% row.with_cell(text: "Updated") %>
           <% row.with_cell(text: "Full name") %>
-          <% row.with_cell(text: @tab == :in ?
-                             "School joined from" :
-                             "School moved to") %>
+          <% row.with_cell(text: "Move") %>
           <% row.with_cell(text: "Actions") %>
         <% end %>
       <% end %>
-    <% end %>
 
-    <% table.with_body do |body| %>
-      <% @school_moves.each do |school_move| %>
-        <% body.with_row do |row| %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Full name</span>
-            <%= link_to school_move.patient.full_name,
-                        patient_path(school_move.patient) %>
-          <% end %>
-
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">
-              <%= @tab == :in ? "School joined from" : "School moved to" %>
-            </span>
-
-            <% if @tab == :in %>
-              <%= patient_school(school_move.patient) %>
-            <% else %>
-              <%= patient_school(school_move) %>
+      <% table.with_body do |body| %>
+        <% @school_moves.each do |school_move| %>
+          <% body.with_row do |row| %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Updated</span>
+              <%= school_move.updated_at.to_fs(:long) %>
             <% end %>
-          <% end %>
 
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Actions</span>
-            <%= form_with url: session_move_path(@session, school_move) + "?#{@tab}",
-                          method: :patch do |f| %>
-              <%= f.submit "Confirm move",
-                           class: "nhsuk-button app-button--secondary app-button--small",
-                           name: "confirm",
-                           value: "Confirm move" %>
-              <%= f.submit "Ignore move",
-                           class: "nhsuk-button app-button--secondary-warning app-button--small",
-                           name: "ignore",
-                           value: "Ignore move" %>
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Full name</span>
+              <%= school_move.patient.full_name %>
+            <% end %>
+
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Move</span>
+
+              <span>
+                <span class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">
+                  <%= school_move_source(school_move) %>
+                </span>
+                <br />
+                <%= patient_school(school_move.patient) %>
+                <br />
+                <span class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">to</span>
+                <%= patient_school(school_move) %>
+              </span>
+            <% end %>
+
+            <% row.with_cell do %>
+              <span class="nhsuk-table-responsive__heading">Actions</span>
+              <%= form_with url: school_move_path(school_move), method: :patch do |f| %>
+                <%= f.submit "Confirm move",
+                             class: "nhsuk-button app-button--secondary app-button--small",
+                             name: "confirm",
+                             value: "Confirm move" %>
+                <%= f.submit "Ignore move",
+                             class: "nhsuk-button app-button--secondary-warning app-button--small",
+                             name: "ignore",
+                             value: "Ignore move" %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>
       <% end %>
     <% end %>
-  <% end %>
-</div>
+  </div>
+
+  <%= govuk_pagination(pagy: @pagy) %>
+<% else %>
+  <p class="nhsuk-body">There are currently no school moves.</p>
+<% end %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -38,22 +38,6 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
     <ul class="nhsuk-grid-row nhsuk-card-group">
-      <% if @session.has_movers? %>
-        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-          <%= render AppCardComponent.new(
-                link_to: session_moves_path(@session) + "?in",
-              ) do |c| %>
-            <% c.with_heading { "Review children who have changed schools" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @session.location.school_moves_to_this_location.count) %>
-              joined this school<br />
-              <%= t("children", count: @session.location.school_moves_from_this_location.count) %>
-              left this school
-            <% end %>
-          <% end %>
-        </li>
-      <% end %>
-
       <% if @session.unscheduled? %>
         <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: edit_session_path) do |c| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -779,6 +779,9 @@ en:
         completed: All sessions completed
         scheduled: Sessions scheduled
         unscheduled: No sessions scheduled
+  school_moves:
+    index:
+      title: School moves
   service:
     email: england.mavis@nhs.net
     guide:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,8 @@ Rails.application.routes.draw do
               only: %i[create]
   end
 
+  resources :school_moves, path: "school-moves", only: %i[index update]
+
   resources :sessions, only: %i[edit index show], param: :slug do
     collection do
       get "closed"
@@ -214,8 +216,6 @@ Rails.application.routes.draw do
     resources :class_imports, path: "class-imports", except: %i[index destroy]
 
     resource :dates, controller: "session_dates", only: %i[show update]
-
-    resources :moves, controller: "school_moves", only: %i[index update]
   end
 
   scope "/sessions/:session_slug/:section", as: "session" do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -139,7 +139,7 @@ def create_session(user, organisation, completed:)
 
   # Add extra consent forms with a successful NHS number lookup
   2.times do
-    temporary_patient = FactoryBot.build(:patient)
+    temporary_patient = FactoryBot.build(:patient, organisation:)
     FactoryBot.create(
       :consent_form,
       :recorded,
@@ -250,6 +250,28 @@ def create_imports(user, organisation)
   end
 end
 
+def create_school_moves(organisation)
+  patients = Patient.in_organisation(organisation).sample(10)
+
+  patients.each do |patient|
+    if [true, false].sample
+      FactoryBot.create(
+        :school_move,
+        :to_home_educated,
+        patient:,
+        organisation:
+      )
+    else
+      FactoryBot.create(
+        :school_move,
+        :to_school,
+        patient:,
+        school: organisation.schools.sample
+      )
+    end
+  end
+end
+
 set_feature_flags
 
 seed_vaccines
@@ -289,6 +311,7 @@ unless Settings.cis2.enabled
     end
   create_patients(organisation)
   create_imports(user, organisation)
+  create_school_moves(organisation)
 end
 
 # CIS2 organisation - the ODS code and user UID need to match the values in the CIS2 env
@@ -311,6 +334,7 @@ Audited
   end
 create_patients(organisation)
 create_imports(user, organisation)
+create_school_moves(organisation)
 
 UnscheduledSessionsFactory.new.call
 

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -18,14 +18,8 @@ describe "Import class lists - Moving patients" do
     and_i_upload_a_valid_file
     then_i_should_see_the_import_complete_page
 
-    when_i_visit_a_session_page_for_the_hpv_programme
-    then_i_should_see_pending_moves_out
-
-    when_i_click_on_the_pending_moves_card
-    then_i_should_see_the_patients_moving_out_tab
-
-    when_i_click_on_the_moved_out_tab
-    then_i_should_see_the_patients_moving_out_table
+    when_i_visit_the_school_moves
+    then_i_should_see_the_school_moves
 
     when_i_confirm_a_move
     then_i_should_see_a_success_flash
@@ -107,24 +101,12 @@ describe "Import class lists - Moving patients" do
     expect(page).to have_content("Imported by")
   end
 
-  def then_i_should_see_pending_moves_out
-    expect(page).to have_content("4 children left this school")
+  def when_i_visit_the_school_moves
+    click_on "School moves"
   end
 
-  def when_i_click_on_the_pending_moves_card
-    click_link "Review children who have changed schools"
-  end
-
-  def then_i_should_see_the_patients_moving_out_tab
-    expect(page).to have_content("Moved out ( 4 )")
-  end
-
-  def when_i_click_on_the_moved_out_tab
-    click_link "Moved out"
-  end
-
-  def then_i_should_see_the_patients_moving_out_table
-    expect(page).to have_content("4 children left this school")
+  def then_i_should_see_the_school_moves
+    expect(page).to have_content("4 school moves")
   end
 
   def when_i_confirm_a_move

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -26,9 +26,9 @@ describe "Parental consent school" do
     when_i_submit_the_consent_form
     then_i_see_a_confirmation_page
 
-    when_the_nurse_checks_the_community_clinic
-    then_the_nurse_should_see_one_mover
-    and_the_nurse_confirms_the_mover
+    when_the_nurse_checks_the_school_moves
+    then_the_nurse_should_see_one_move
+    and_the_nurse_confirms_the_move
 
     when_the_nurse_checks_the_patient
     then_the_nurse_should_see_the_school
@@ -56,9 +56,9 @@ describe "Parental consent school" do
     when_i_submit_the_consent_form
     then_i_see_a_confirmation_page
 
-    when_the_nurse_checks_the_community_clinic
-    then_the_nurse_should_see_one_mover
-    and_the_nurse_confirms_the_mover
+    when_the_nurse_checks_the_school_moves
+    then_the_nurse_should_see_one_move
+    and_the_nurse_confirms_the_move
 
     when_the_nurse_checks_the_patient
     then_the_nurse_should_see_home_schooled
@@ -86,8 +86,8 @@ describe "Parental consent school" do
     when_i_submit_the_consent_form
     then_i_see_a_confirmation_page
 
-    when_the_nurse_checks_the_community_clinic
-    then_the_nurse_should_see_no_movers
+    when_the_nurse_checks_the_school_moves
+    then_the_nurse_should_see_no_moves
 
     when_the_nurse_checks_the_patient
     then_the_nurse_should_see_unknown_school
@@ -227,35 +227,36 @@ describe "Parental consent school" do
     perform_enqueued_jobs # match consent form with patient
   end
 
-  def when_the_nurse_checks_the_community_clinic
+  def when_the_nurse_checks_the_school_moves
     sign_in @organisation.users.first
     visit "/dashboard"
 
+    within ".nhsuk-navigation" do
+      click_on "School moves"
+    end
+  end
+
+  def then_the_nurse_should_see_one_move
+    expect(page).to have_content("1 school move")
+  end
+
+  def and_the_nurse_confirms_the_move
+    expect(page).to have_content(@child.full_name)
+    click_on "Confirm"
+  end
+
+  def then_the_nurse_should_see_no_moves
+    expect(page).to have_content("There are currently no school moves.")
+  end
+
+  def when_the_nurse_checks_the_patient
     click_on "Programmes", match: :first
     click_on "HPV"
     within ".app-secondary-navigation" do
       click_on "Sessions"
     end
     click_on "Community clinics"
-  end
 
-  def then_the_nurse_should_see_one_mover
-    expect(page).to have_content("Review children who have changed schools")
-  end
-
-  def and_the_nurse_confirms_the_mover
-    click_on "Review children who have changed schools"
-    click_on "Moved out"
-    expect(page).to have_content(@child.full_name)
-    click_on "Confirm"
-    click_on "Back"
-  end
-
-  def then_the_nurse_should_see_no_movers
-    expect(page).not_to have_content("Review children who have changed schools")
-  end
-
-  def when_the_nurse_checks_the_patient
     click_on "Record vaccinations"
     click_on @child.full_name
   end


### PR DESCRIPTION
This replaces the existing school moves section on each session to instead be a single global school moves which displays all moves across the organisation.

## Screenshots

<img width="1200" alt="Screenshot 2024-11-28 at 19 18 31" src="https://github.com/user-attachments/assets/d60a5d4d-c7f8-4aa2-9a95-cfd397e060c8">
<img width="1202" alt="Screenshot 2024-11-28 at 19 18 24" src="https://github.com/user-attachments/assets/305a7634-4895-47d7-b8fa-9ebf3b7c9f82">
<img width="413" alt="Screenshot 2024-11-28 at 19 11 18" src="https://github.com/user-attachments/assets/6a2e6ce1-e3b1-419f-892d-64252a856f3b">
<img width="290" alt="Screenshot 2024-11-28 at 19 08 50" src="https://github.com/user-attachments/assets/0f218fbf-6289-4602-b13d-29ae1687a808">
<img width="454" alt="Screenshot 2024-11-28 at 19 08 48" src="https://github.com/user-attachments/assets/2b6d7d55-a752-48ed-a72d-5630a560a0ca">
