### PR TITLE
Add school move confirmation page

### DIFF
--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -3,31 +3,55 @@
 class SchoolMovesController < ApplicationController
   include Pagy::Backend
 
+  before_action :set_school_move, except: :index
+  before_action :set_patient, except: :index
+
   layout "full"
 
   def index
     @pagy, @school_moves = pagy(policy_scope(SchoolMove).order(:updated_at))
   end
 
+  def show
+    @form = SchoolMoveForm.new(school_move: @school_move)
+  end
+
   def update
-    @school_move = policy_scope(SchoolMove).find(params[:id])
+    @form =
+      SchoolMoveForm.new(
+        school_move: @school_move,
+        action: params.dig(:school_move_form, :action)
+      )
 
-    if params[:confirm]
-      @school_move.confirm!
-    elsif params[:ignore]
-      @school_move.ignore!
+    if @form.save
+      name = @school_move.patient.full_name
+      flash =
+        if @form.action == "confirm"
+          { success: "#{name}’s record updated with new school" }
+        else
+          { notice: "#{name}’s school move ignored" }
+        end
+
+      redirect_to school_moves_path, flash:
     else
-      render "errors/not_found", status: :not_found
+      render :show, status: :unprocessable_entity
     end
+  end
 
-    name = @school_move.patient.full_name
-    flash =
-      if params[:confirm]
-        { success: "#{name}’s record updated with new school" }
-      else
-        { notice: "#{name}’s school move ignored" }
+  private
+
+  def set_school_move
+    @school_move = policy_scope(SchoolMove).find(params[:id])
+  end
+
+  def set_patient
+    @patient = @school_move.patient
+
+    @patient_with_changes =
+      @patient.dup.tap do |patient|
+        patient.clear_changes_information
+        patient.school = @school_move.school
+        patient.home_educated = @school_move.home_educated
       end
-
-    redirect_to school_moves_path, flash:
   end
 end

--- a/app/forms/school_move_form.rb
+++ b/app/forms/school_move_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class SchoolMoveForm
+  include ActiveModel::Model
+
+  attr_accessor :school_move, :action
+
+  validates :action, inclusion: { in: %w[confirm ignore] }
+
+  def save
+    return false unless valid?
+
+    case action
+    when "confirm"
+      @school_move.confirm!
+    when "ignore"
+      @school_move.ignore!
+    end
+
+    true
+  end
+end

--- a/app/views/school_moves/index.html.erb
+++ b/app/views/school_moves/index.html.erb
@@ -46,16 +46,7 @@
 
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Actions</span>
-              <%= form_with url: school_move_path(school_move), method: :patch do |f| %>
-                <%= f.submit "Confirm move",
-                             class: "nhsuk-button app-button--secondary app-button--small",
-                             name: "confirm",
-                             value: "Confirm move" %>
-                <%= f.submit "Ignore move",
-                             class: "nhsuk-button app-button--secondary-warning app-button--small",
-                             name: "ignore",
-                             value: "Ignore move" %>
-              <% end %>
+              <%= link_to "Review", school_move_path(school_move) %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/school_moves/show.html.erb
+++ b/app/views/school_moves/show.html.erb
@@ -1,0 +1,45 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(
+        items: [
+          { text: "Home", href: dashboard_path },
+          { text: t("school_moves.index.title"), href: school_moves_path },
+        ],
+      ) %>
+<% end %>
+
+<% page_title = "Review school move" %>
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-one-half">
+    <%= render AppCardComponent.new(colour: "blue") do |card| %>
+      <% card.with_heading { "#{@school_move.source.humanize} record" } %>
+      <%= render AppPatientSummaryComponent.new(@patient_with_changes) %>
+    <% end %>
+  </div>
+
+  <div class="nhsuk-grid-column-one-half">
+    <%= render AppCardComponent.new(colour: "blue") do |card| %>
+      <% card.with_heading { "Child record" } %>
+      <%= render AppPatientSummaryComponent.new(@patient) %>
+    <% end %>
+  </div>
+</div>
+
+<%= form_with(
+      model: @form,
+      url: school_move_path(@school_move),
+      method: :patch,
+      class: "nhsuk-u-width-two-thirds",
+    ) do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_collection_radio_buttons :action, %w[confirm ignore], :itself, nil %>
+
+  <%= f.govuk_submit "Update child record" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,6 +294,10 @@ en:
           attributes:
             apply_changes:
               inclusion: Choose which record to keep
+        school_move_form:
+          attributes:
+            action:
+              inclusion: Choose whether to update the child’s record with this new information
         vaccination_report:
           attributes:
             file_format:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -3,6 +3,8 @@ en:
     legend:
       import_duplicate_form:
         apply_changes: Which record do you want to keep?
+      school_move_form:
+        action: Update the child’s record with this new information?
 
     hint:
       import_duplicate_form:
@@ -17,6 +19,10 @@ en:
           apply: Use duplicate record
           discard: Keep previously uploaded record
           keep_both: Keep both records
+      school_move_form:
+        action_options:
+          confirm: Update record with new school
+          ignore: Ignore new information
       vaccination_report:
         file_format_options:
           careplus: CarePlus

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,7 @@ Rails.application.routes.draw do
               only: %i[create]
   end
 
-  resources :school_moves, path: "school-moves", only: %i[index update]
+  resources :school_moves, path: "school-moves", only: %i[index show update]
 
   resources :sessions, only: %i[edit index show], param: :slug do
     collection do

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -110,7 +110,9 @@ describe "Import class lists - Moving patients" do
   end
 
   def when_i_confirm_a_move
-    click_button "Confirm move", match: :first
+    click_on "Review", match: :first
+    choose "Update record with new school"
+    click_on "Update child record"
   end
 
   def then_i_should_see_a_success_flash
@@ -118,7 +120,9 @@ describe "Import class lists - Moving patients" do
   end
 
   def when_i_ignore_a_move
-    click_button "Ignore move", match: :first
+    click_on "Review", match: :first
+    choose "Ignore new information"
+    click_on "Update child record"
   end
 
   def then_i_should_see_a_notice_flash

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -242,7 +242,9 @@ describe "Parental consent school" do
 
   def and_the_nurse_confirms_the_move
     expect(page).to have_content(@child.full_name)
-    click_on "Confirm"
+    click_on "Review"
+    choose "Update record with new school"
+    click_on "Update child record"
   end
 
   def then_the_nurse_should_see_no_moves


### PR DESCRIPTION
This changes how school moves are confirmed or ignored to add a new page which gives the user the option to choose from radio buttons on what action to take.

This will be extended in the future to allow the user to choose whether to keep the patient in the community clinic or not.

## Screenshots

<img width="763" alt="Screenshot 2024-11-28 at 20 13 27" src="https://github.com/user-attachments/assets/958a5204-620c-4875-974d-b542ab3fe151">
<img width="1227" alt="Screenshot 2024-11-28 at 20 13 24" src="https://github.com/user-attachments/assets/174ef9dc-19e9-4b66-93b7-0e7a54899128">
<img width="722" alt="Screenshot 2024-11-28 at 20 10 39" src="https://github.com/user-attachments/assets/8b94b158-c5f1-4d2d-ae1b-27b9245c6c02">
<img width="1225" alt="Screenshot 2024-11-28 at 20 10 36" src="https://github.com/user-attachments/assets/99023a36-d6a7-4bf9-8f3d-a9980e9ea974">
<img width="1212" alt="Screenshot 2024-11-28 at 20 09 42" src="https://github.com/user-attachments/assets/5c0f3af8-7512-4a88-996c-e13f2363d74b">
