### PR TITLE
Allow moving community clinic patients to school

### DIFF
--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -20,7 +20,8 @@ class SchoolMovesController < ApplicationController
     @form =
       SchoolMoveForm.new(
         school_move: @school_move,
-        action: params.dig(:school_move_form, :action)
+        action: params.dig(:school_move_form, :action),
+        move_to_school: params.dig(:school_move_form, :move_to_school)
       )
 
     if @form.save

--- a/app/forms/school_move_form.rb
+++ b/app/forms/school_move_form.rb
@@ -2,21 +2,34 @@
 
 class SchoolMoveForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
 
-  attr_accessor :school_move, :action
+  attr_accessor :school_move
+
+  attribute :action, :string
+  attribute :move_to_school, :boolean
 
   validates :action, inclusion: { in: %w[confirm ignore] }
+  validates :move_to_school,
+            inclusion: {
+              in: [true, false]
+            },
+            if: :show_move_to_school?
 
   def save
     return false unless valid?
 
     case action
     when "confirm"
-      @school_move.confirm!
+      @school_move.confirm!(move_to_school:)
     when "ignore"
       @school_move.ignore!
     end
 
     true
+  end
+
+  def show_move_to_school?
+    school_move.from_clinic? && school_move.school_session.present?
   end
 end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -419,7 +419,7 @@ class ConsentForm < ApplicationRecord
   def actual_upcoming_session
     # HACK: Remove this method once we're only sending emails after the nurse
     # has confirmed the school move, at the moment we're assuming the move
-    # will be confirmed.
+    # will be confirmed and the patient will be left in the community clinic.
 
     patient = Patient.new
 
@@ -430,8 +430,8 @@ class ConsentForm < ApplicationRecord
         SchoolMove.new(patient:, home_educated:, organisation:)
       end
 
-    # Intentionally using a private method, as this method should be removed.
-    school_move.send(:new_session)
+    # Intentionally using a private method, as this is a hack.
+    school_move.send(:find_replacement_session, move_to_school: false)
   end
 
   private

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -49,10 +49,10 @@ class SchoolMove < ApplicationRecord
               unless: -> { school.nil? }
             }
 
-  def confirm!
+  def confirm!(move_to_school: nil)
     ActiveRecord::Base.transaction do
       update_patient!
-      update_sessions!
+      update_sessions!(move_to_school:)
       destroy! if persisted?
     end
   end
@@ -61,14 +61,24 @@ class SchoolMove < ApplicationRecord
     destroy! if persisted?
   end
 
+  def from_clinic?
+    patient.sessions.joins(:location).merge(Location.clinic).exists?
+  end
+
+  def school_session
+    return if school&.organisation.nil?
+
+    school.organisation.sessions.upcoming.find_by(location: school)
+  end
+
   private
 
   def update_patient!
     patient.update!(school:, home_educated:, cohort:)
   end
 
-  def update_sessions!
-    session = new_session
+  def update_sessions!(move_to_school: nil)
+    session = find_replacement_session(move_to_school:)
 
     patient.patient_sessions.find_each(&:destroy_if_safe!)
 
@@ -85,26 +95,16 @@ class SchoolMove < ApplicationRecord
     )
   end
 
-  def new_session
-    if in_clinic?
-      # If they've been booked in to a clinic we don't move them to a
-      # school session as it's likely they're in a clinic for a reason.
-      # TODO: Ask the user what they want to do here.
-
-      (school&.organisation || organisation)&.generic_clinic_session
+  def find_replacement_session(move_to_school: nil)
+    if from_clinic?
+      (move_to_school && school_session) ||
+        (school&.organisation || organisation)&.generic_clinic_session
     elsif home_educated || school.nil?
       organisation.generic_clinic_session
     elsif school.organisation
-      existing_session =
-        school.organisation.sessions.upcoming.find_by(location: school)
-
-      # There are no upcoming sessions available for their chosen school.
-      # This can happen if the parent fills out the form late.
-      existing_session || school.organisation.generic_clinic_session
+      # If there are no upcoming sessions available for their chosen
+      # school the patient should go to the clinic.
+      school_session || school.organisation.generic_clinic_session
     end
-  end
-
-  def in_clinic?
-    patient.patient_sessions.joins(:location).merge(Location.clinic).exists?
   end
 end

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -66,9 +66,10 @@ class SchoolMove < ApplicationRecord
   end
 
   def school_session
-    return if school&.organisation.nil?
-
-    school.organisation.sessions.upcoming.find_by(location: school)
+    @school_session ||=
+      if (org = school&.organisation).present?
+        org.sessions.upcoming.find_by(location: school)
+      end
   end
 
   private

--- a/app/views/school_moves/show.html.erb
+++ b/app/views/school_moves/show.html.erb
@@ -39,7 +39,26 @@
     ) do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_collection_radio_buttons :action, %w[confirm ignore], :itself, nil %>
+  <%= f.govuk_radio_buttons_fieldset :action, legend: { text: "Update the child’s record with this new information?" } do %>
+    <%= f.govuk_radio_button :action, :confirm, label: { text: "Update record with new school" }, link_errors: true do %>
+      <% if @form.show_move_to_school? %>
+        <% hint = if @school_move.school_session.today_or_future_dates.count == 1
+               "There is an upcoming session at #{@school_move.school_session.location.name} on #{@school_move.school_session.today_or_future_dates.first.to_fs(:long)}."
+             else
+               "There are upcoming sessions at #{@school_move.school_session.location.name} on #{@school_move.school_session.today_or_future_dates.map { _1.to_fs(:long) }.to_sentence}."
+             end %>
+
+        <%= f.govuk_radio_buttons_fieldset :move_to_school,
+                                           legend: { text: "Move #{@patient.given_name} to the upcoming school session?", size: "s" },
+                                           hint: { text: hint } do %>
+          <%= f.govuk_radio_button :move_to_school, :false, label: { text: "No, keep them in the community clinic" }, link_errors: true %>
+          <%= f.govuk_radio_button :move_to_school, :true, label: { text: "Yes, move them to the upcoming school session" } %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= f.govuk_radio_button :action, :ignore, label: { text: "Ignore new information" } %>
+  <% end %>
 
   <%= f.govuk_submit "Update child record" %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,6 +298,8 @@ en:
           attributes:
             action:
               inclusion: Choose whether to update the child’s record with this new information
+            move_to_school:
+              inclusion: Choose whether to move the child to the upcoming school session
         vaccination_report:
           attributes:
             file_format:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -3,8 +3,6 @@ en:
     legend:
       import_duplicate_form:
         apply_changes: Which record do you want to keep?
-      school_move_form:
-        action: Update the child’s record with this new information?
 
     hint:
       import_duplicate_form:
@@ -20,9 +18,9 @@ en:
           discard: Keep previously uploaded record
           keep_both: Keep both records
       school_move_form:
-        action_options:
-          confirm: Update record with new school
-          ignore: Ignore new information
+        move_to_school_options:
+          false: No, keep them in the community clinic
+          true: Yes, move them to the upcoming school session
       vaccination_report:
         file_format_options:
           careplus: CarePlus

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -106,9 +106,8 @@ FactoryBot.define do
     address_postcode { Faker::Address.uk_postcode }
 
     after(:create) do |patient, evaluator|
-      if evaluator.session &&
-           !PatientSession.exists?(patient:, session: evaluator.session)
-        create(:patient_session, patient:, session: evaluator.session)
+      if evaluator.session
+        patient.patient_sessions.find_or_create_by!(session: evaluator.session)
       end
 
       evaluator.parents.each do |parent|

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -49,7 +49,9 @@ describe SchoolMove do
   end
 
   describe "#confirm!" do
-    subject(:confirm!) { school_move.confirm! }
+    subject(:confirm!) { school_move.confirm!(move_to_school:) }
+
+    let(:move_to_school) { nil }
 
     let(:programme) { create(:programme) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
@@ -122,7 +124,7 @@ describe SchoolMove do
     end
 
     shared_examples "keeps the patient in the community clinics" do
-      it "adds the patient to the community clinics" do
+      it "keeps the patient in the community clinics" do
         expect(patient.sessions).to contain_exactly(generic_clinic_session)
         confirm!
         expect(patient.reload.sessions).to contain_exactly(
@@ -355,7 +357,7 @@ describe SchoolMove do
         end
 
         let(:school) { create(:school, organisation:) }
-        let(:new_session) do
+        let!(:new_session) do # rubocop:disable RSpec/LetSetup
           create(
             :session,
             :scheduled,
@@ -367,9 +369,15 @@ describe SchoolMove do
 
         include_examples "sets the patient school"
         include_examples "keeps the patient cohort"
-        # TODO: ask the user if they should stay in the clinic or not
         include_examples "keeps the patient in the community clinics"
         include_examples "destroys the school move"
+
+        context "when the user asks to move the patient to the new school" do
+          let(:move_to_school) { true }
+
+          include_examples "removes the patient from the community clinics"
+          include_examples "adds the patient to the new school session"
+        end
       end
 
       context "to a school with a completed session" do
@@ -378,7 +386,7 @@ describe SchoolMove do
         end
 
         let(:school) { create(:school, organisation:) }
-        let(:new_session) do
+        let!(:new_session) do # rubocop:disable RSpec/LetSetup
           create(
             :session,
             :completed,
@@ -392,6 +400,13 @@ describe SchoolMove do
         include_examples "keeps the patient cohort"
         include_examples "keeps the patient in the community clinics"
         include_examples "destroys the school move"
+
+        context "when the user asks to move the patient to the new school" do
+          let(:move_to_school) { true }
+
+          include_examples "removes the patient from the community clinics"
+          include_examples "adds the patient to the new school session"
+        end
       end
 
       context "to a school with a closed session" do
@@ -400,7 +415,7 @@ describe SchoolMove do
         end
 
         let(:school) { create(:school, organisation:) }
-        let(:new_session) do
+        let!(:new_session) do # rubocop:disable RSpec/LetSetup
           create(:session, :closed, location: school, organisation:, programme:)
         end
 
@@ -408,6 +423,12 @@ describe SchoolMove do
         include_examples "keeps the patient cohort"
         include_examples "keeps the patient in the community clinics"
         include_examples "destroys the school move"
+
+        context "when the user asks to move the patient to the new school" do
+          let(:move_to_school) { true }
+
+          include_examples "keeps the patient in the community clinics"
+        end
       end
 
       context "to home-schooled" do
@@ -492,7 +513,7 @@ describe SchoolMove do
         end
 
         let(:school) { create(:school, organisation:) }
-        let(:new_session) do
+        let!(:new_session) do # rubocop:disable RSpec/LetSetup
           create(
             :session,
             :scheduled,
@@ -503,9 +524,15 @@ describe SchoolMove do
         end
 
         include_examples "sets the patient school"
-        # TODO: ask the user if they should stay in the clinic or not
         include_examples "keeps the patient in the community clinics"
         include_examples "destroys the school move"
+
+        context "when the user asks to move the patient to the new school" do
+          let(:move_to_school) { true }
+
+          include_examples "removes the patient from the community clinics"
+          include_examples "adds the patient to the new school session"
+        end
       end
 
       context "to a school with a completed session" do
@@ -514,7 +541,7 @@ describe SchoolMove do
         end
 
         let(:school) { create(:school, organisation:) }
-        let(:new_session) do
+        let!(:new_session) do # rubocop:disable RSpec/LetSetup
           create(
             :session,
             :completed,
@@ -527,6 +554,13 @@ describe SchoolMove do
         include_examples "sets the patient school"
         include_examples "keeps the patient in the community clinics"
         include_examples "destroys the school move"
+
+        context "when the user asks to move the patient to the new school" do
+          let(:move_to_school) { true }
+
+          include_examples "removes the patient from the community clinics"
+          include_examples "adds the patient to the new school session"
+        end
       end
 
       context "to a school with a closed session" do
@@ -542,6 +576,12 @@ describe SchoolMove do
         include_examples "sets the patient school"
         include_examples "keeps the patient in the community clinics"
         include_examples "destroys the school move"
+
+        context "when the user asks to move the patient to the new school" do
+          let(:move_to_school) { true }
+
+          include_examples "keeps the patient in the community clinics"
+        end
       end
 
       context "to home-schooled" do


### PR DESCRIPTION
This adds an option when confirming a school move that allows the nurses to confirm whether to keep the patient in the community clinic or move them to an upcoming school session if that's available.

This is necessary to handle the situation where a parent fills in the consent form for a community clinic and tells us that their child belongs to a school, however we can't move them to the school in case the parent has already booked them in to a clinic.

## Screenshot

<img width="840" alt="Screenshot 2024-11-29 at 10 01 09" src="https://github.com/user-attachments/assets/37fb569b-1cd8-4bff-802e-4a44645d3a87">
