### PR TITLE
Add programme and first line of address to exports

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -60,6 +60,7 @@ class Reports::OfflineSessionExporter
         "PERSON_DOB" => :date,
         "YEAR_GROUP" => nil, # should be integer, but that converts nil to 0
         "PERSON_GENDER_CODE" => :string,
+        "PERSON_ADDRESS_LINE_1" => :string,
         "PERSON_POSTCODE" => :string,
         "NHS_NUMBER" => :string,
         "CONSENT_STATUS" => :string,
@@ -231,6 +232,7 @@ class Reports::OfflineSessionExporter
       patient.date_of_birth,
       patient.year_group,
       patient.gender_code.humanize,
+      patient.restricted? ? "" : patient.address_line_1,
       patient.restricted? ? "" : patient.address_postcode,
       patient.nhs_number,
       consents.first&.response&.humanize,

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -76,6 +76,7 @@ class Reports::OfflineSessionExporter
         "VACCINATED" => :string,
         "DATE_OF_VACCINATION" => :date,
         "TIME_OF_VACCINATION" => :string,
+        "PROGRAMME_NAME" => :string,
         "VACCINE_GIVEN" => :string,
         "PERFORMING_PROFESSIONAL_EMAIL" => :string,
         "BATCH_NUMBER" => :string,
@@ -151,21 +152,30 @@ class Reports::OfflineSessionExporter
         )
       end
     else
-      sheet.add_row(
-        new_row(patient:, consents:, gillick_assessment:, triage:),
-        types: row_types,
-        style:
-      )
+      session.programmes.each do |programme|
+        sheet.add_row(
+          new_row(
+            patient:,
+            consents:,
+            gillick_assessment:,
+            triage:,
+            programme:
+          ),
+          types: row_types,
+          style:
+        )
+      end
     end
   end
 
-  def new_row(patient:, consents:, gillick_assessment:, triage:)
+  def new_row(patient:, consents:, gillick_assessment:, triage:, programme:)
     (
       patient_values(patient:, consents:, gillick_assessment:, triage:) +
         [
           "", # VACCINATED left blank for recording
           "", # DATE_OF_VACCINATION left blank for recording
           "", # TIME_OF_VACCINATION left blank for recording
+          programme.name,
           "", # VACCINE_GIVEN left blank for recording
           "", # PERFORMING_PROFESSIONAL_EMAIL left blank for recording
           "", # BATCH_NUMBER left blank for recording
@@ -193,6 +203,7 @@ class Reports::OfflineSessionExporter
           vaccinated(vaccination_record:),
           vaccination_record.performed_at.to_date,
           vaccination_record.performed_at.strftime("%H:%M:%S"),
+          vaccination_record.programme.name,
           vaccination_record.vaccine&.nivs_name,
           vaccination_record.performed_by_user&.email,
           vaccination_record.batch&.name,

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -56,6 +56,7 @@ class Reports::ProgrammeVaccinationsExporter
       VACCINATED
       DATE_OF_VACCINATION
       TIME_OF_VACCINATION
+      PROGRAMME_NAME
       VACCINE_GIVEN
       PERFORMING_PROFESSIONAL_EMAIL
       PERFORMING_PROFESSIONAL_FORENAME
@@ -79,6 +80,7 @@ class Reports::ProgrammeVaccinationsExporter
           :batch,
           :location,
           :performed_by_user,
+          :programme,
           :vaccine,
           patient_session: {
             patient: %i[cohort school],
@@ -106,6 +108,7 @@ class Reports::ProgrammeVaccinationsExporter
     patient = patient_session.patient
     triage = patient_session.latest_triage
     location = vaccination_record.location
+    programme = vaccination_record.programme
 
     [
       organisation.ods_code,
@@ -134,6 +137,7 @@ class Reports::ProgrammeVaccinationsExporter
       vaccinated(vaccination_record:),
       vaccination_record.performed_at.strftime("%Y%m%d"),
       vaccination_record.performed_at.strftime("%H:%M:%S"),
+      programme.name,
       vaccination_record.vaccine&.nivs_name || "",
       vaccination_record.performed_by_user&.email || "",
       vaccination_record.performed_by&.given_name || "",

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -40,6 +40,7 @@ class Reports::ProgrammeVaccinationsExporter
       PERSON_DOB
       YEAR_GROUP
       PERSON_GENDER_CODE
+      PERSON_ADDRESS_LINE_1
       PERSON_POSTCODE
       NHS_NUMBER
       CONSENT_STATUS
@@ -121,6 +122,7 @@ class Reports::ProgrammeVaccinationsExporter
       patient.date_of_birth.strftime("%Y%m%d"),
       patient.year_group || "",
       patient.gender_code.humanize,
+      patient.restricted? ? "" : patient.address_line_1,
       patient.restricted? ? "" : patient.address_postcode,
       patient.nhs_number,
       consents.first&.response&.humanize || "",

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -60,6 +60,7 @@ describe Reports::OfflineSessionExporter do
             VACCINATED
             DATE_OF_VACCINATION
             TIME_OF_VACCINATION
+            PROGRAMME_NAME
             VACCINE_GIVEN
             PERFORMING_PROFESSIONAL_EMAIL
             BATCH_NUMBER
@@ -113,6 +114,7 @@ describe Reports::OfflineSessionExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
@@ -180,6 +182,7 @@ describe Reports::OfflineSessionExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
@@ -255,6 +258,7 @@ describe Reports::OfflineSessionExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "unwell",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
@@ -319,6 +323,7 @@ describe Reports::OfflineSessionExporter do
             VACCINATED
             DATE_OF_VACCINATION
             TIME_OF_VACCINATION
+            PROGRAMME_NAME
             VACCINE_GIVEN
             PERFORMING_PROFESSIONAL_EMAIL
             BATCH_NUMBER
@@ -368,6 +373,7 @@ describe Reports::OfflineSessionExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "",
               "SCHOOL_URN" => "888888",
@@ -438,6 +444,7 @@ describe Reports::OfflineSessionExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "Waterloo Road",
               "SCHOOL_URN" => "123456",

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -44,6 +44,7 @@ describe Reports::OfflineSessionExporter do
             PERSON_DOB
             YEAR_GROUP
             PERSON_GENDER_CODE
+            PERSON_ADDRESS_LINE_1
             PERSON_POSTCODE
             NHS_NUMBER
             CONSENT_STATUS
@@ -110,6 +111,7 @@ describe Reports::OfflineSessionExporter do
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
@@ -136,8 +138,9 @@ describe Reports::OfflineSessionExporter do
       context "with a restricted patient" do
         before { create(:patient, :restricted, session:) }
 
-        it "doesn't include the postcode" do
+        it "doesn't include the address or postcode" do
           expect(rows.count).to eq(1)
+          expect(rows.first["PERSON_ADDRESS_LINE_1"]).to be_blank
           expect(rows.first["PERSON_POSTCODE"]).to be_blank
         end
       end
@@ -178,6 +181,7 @@ describe Reports::OfflineSessionExporter do
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
@@ -254,6 +258,7 @@ describe Reports::OfflineSessionExporter do
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
@@ -307,6 +312,7 @@ describe Reports::OfflineSessionExporter do
             PERSON_DOB
             YEAR_GROUP
             PERSON_GENDER_CODE
+            PERSON_ADDRESS_LINE_1
             PERSON_POSTCODE
             NHS_NUMBER
             CONSENT_STATUS
@@ -369,6 +375,7 @@ describe Reports::OfflineSessionExporter do
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
@@ -440,6 +447,7 @@ describe Reports::OfflineSessionExporter do
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -40,6 +40,7 @@ describe Reports::ProgrammeVaccinationsExporter do
           PERSON_DOB
           YEAR_GROUP
           PERSON_GENDER_CODE
+          PERSON_ADDRESS_LINE_1
           PERSON_POSTCODE
           NHS_NUMBER
           CONSENT_STATUS
@@ -120,6 +121,7 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
               "PERFORMING_PROFESSIONAL_FORENAME" => "Nurse",
               "PERFORMING_PROFESSIONAL_SURNAME" => "Test",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_DOB" => patient.date_of_birth.strftime("%Y%m%d"),
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",
@@ -190,6 +192,7 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
               "PERFORMING_PROFESSIONAL_FORENAME" => "Nurse",
               "PERFORMING_PROFESSIONAL_SURNAME" => "Test",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
               "PERSON_DOB" => patient.date_of_birth.strftime("%Y%m%d"),
               "PERSON_FORENAME" => patient.given_name,
               "PERSON_GENDER_CODE" => "Not known",

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -56,6 +56,7 @@ describe Reports::ProgrammeVaccinationsExporter do
           VACCINATED
           DATE_OF_VACCINATION
           TIME_OF_VACCINATION
+          PROGRAMME_NAME
           VACCINE_GIVEN
           PERFORMING_PROFESSIONAL_EMAIL
           PERFORMING_PROFESSIONAL_FORENAME
@@ -124,6 +125,7 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "ROUTE_OF_VACCINATION" => "intramuscular",
               "SCHOOL_NAME" => location.name,
@@ -193,6 +195,7 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERSON_GENDER_CODE" => "Not known",
               "PERSON_POSTCODE" => patient.address_postcode,
               "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "ROUTE_OF_VACCINATION" => "intramuscular",
               "SCHOOL_NAME" => "",


### PR DESCRIPTION
This adds a `PROGRAMME_NAME` column to the offline session and "Mavis format" programme exports as otherwise this has to be inferred from the name of the vaccine.

This also adds a `PERSON_ADDRESS_LINE_1` column to the offline session and "Mavis format" programme exports to make these files more useful to nurses.