### PR TITLE
Allow recording notes offline 

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -135,8 +135,8 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
           "Optional, must be #{tag.i("Y")} or #{tag.i("N")}. If omitted, " \
             "#{tag.i("Y")} is assumed."
       }
-    ] + anatomical_site + reason_not_vaccinated + dose_sequence + care_setting +
-      performing_professional
+    ] + anatomical_site + reason_not_vaccinated_and_notes + dose_sequence +
+      care_setting + performing_professional
   end
 
   def child_columns
@@ -192,7 +192,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
     end
   end
 
-  def reason_not_vaccinated
+  def reason_not_vaccinated_and_notes
     reasons = ImmunisationImportRow::REASONS.keys.sort.map { tag.i(_1) }
     reasons_sentence =
       reasons.to_sentence(
@@ -205,7 +205,8 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
         name: "REASON_NOT_VACCINATED",
         notes:
           "Required if #{tag.code("VACCINATED")} is #{tag.i("N")}, must be #{reasons_sentence}"
-      }
+      },
+      { name: "NOTES", notes: "Optional" }
     ]
   end
 

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -85,6 +85,7 @@ class Reports::OfflineSessionExporter
         "ANATOMICAL_SITE" => :string,
         "DOSE_SEQUENCE" => nil, # should be integer, but that converts nil to 0
         "REASON_NOT_VACCINATED" => :string,
+        "NOTES" => :string,
         "UUID" => :string
       }.tap do |hash|
         hash.delete("CLINIC_NAME") unless location.generic_clinic?
@@ -184,6 +185,7 @@ class Reports::OfflineSessionExporter
           "", # ANATOMICAL_SITE left blank for recording
           1, # DOSE_SEQUENCE is 1 by default TODO: revisit this for other programmes
           "", # REASON_NOT_VACCINATED left blank for recording
+          "", # NOTES left blank for recording
           "" # UUID left blank as new record
         ]
     ).tap do |values|
@@ -212,6 +214,7 @@ class Reports::OfflineSessionExporter
           anatomical_site(vaccination_record:),
           dose_sequence(vaccination_record:),
           reason_not_vaccinated(vaccination_record:),
+          vaccination_record.notes,
           vaccination_record.uuid
         ]
     ).tap do |values|

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -120,9 +120,9 @@ class ImmunisationImportRow
       outcome:,
       patient_session:,
       performed_at:,
-      performed_by_user:,
       performed_by_family_name:,
       performed_by_given_name:,
+      performed_by_user:,
       programme: @programme
     }
 
@@ -140,7 +140,8 @@ class ImmunisationImportRow
       vaccination_record.stage_changes(
         batch_id: batch&.id,
         delivery_method:,
-        delivery_site:
+        delivery_site:,
+        notes:
       )
     else
       # Postgres UUID generation is skipped in bulk import
@@ -149,6 +150,7 @@ class ImmunisationImportRow
       vaccination_record.batch = batch
       vaccination_record.delivery_method = delivery_method
       vaccination_record.delivery_site = delivery_site
+      vaccination_record.notes = notes
     end
 
     vaccination_record
@@ -228,6 +230,10 @@ class ImmunisationImportRow
 
   def reason
     REASONS[@data["REASON_NOT_VACCINATED"]&.strip&.downcase]
+  end
+
+  def notes
+    @data["NOTES"]&.strip&.presence
   end
 
   DELIVERY_SITES = {

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -202,6 +202,7 @@ describe "HPV Vaccination" do
     row_for_unvaccinated_patient["TIME_OF_VACCINATION"] = "10:01"
     row_for_unvaccinated_patient["VACCINATED"] = "N"
     row_for_unvaccinated_patient["REASON_NOT_VACCINATED"] = "did not attend"
+    row_for_unvaccinated_patient["NOTES"] = "Some notes."
     row_for_unvaccinated_patient[
       "PERFORMING_PROFESSIONAL_EMAIL"
     ] = @organisation.users.first.email
@@ -260,6 +261,7 @@ describe "HPV Vaccination" do
     expect(page).to have_content(@unvaccinated_patient.full_name)
     expect(page).to have_content("Could not vaccinate")
     expect(page).to have_content("OutcomeAbsent from session")
+    expect(page).to have_content("NotesSome notes.")
 
     click_on "Back"
     click_on "Vaccinated"

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -69,6 +69,7 @@ describe Reports::OfflineSessionExporter do
             ANATOMICAL_SITE
             DOSE_SEQUENCE
             REASON_NOT_VACCINATED
+            NOTES
             UUID
           ]
         )
@@ -109,6 +110,7 @@ describe Reports::OfflineSessionExporter do
               "GILLICK_STATUS" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
+              "NOTES" => "",
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "",
               "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
@@ -153,7 +155,8 @@ describe Reports::OfflineSessionExporter do
             batch:,
             patient_session:,
             programme:,
-            performed_by: user
+            performed_by: user,
+            notes: "Some notes."
           )
         end
 
@@ -179,6 +182,7 @@ describe Reports::OfflineSessionExporter do
               "GILLICK_STATUS" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
+              "NOTES" => "Some notes.",
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
               "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
@@ -235,7 +239,8 @@ describe Reports::OfflineSessionExporter do
             patient_session:,
             programme:,
             performed_at:,
-            performed_by: user
+            performed_by: user,
+            notes: "Some notes."
           )
         end
 
@@ -256,6 +261,7 @@ describe Reports::OfflineSessionExporter do
               "GILLICK_STATUS" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
+              "NOTES" => "Some notes.",
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
               "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
@@ -337,6 +343,7 @@ describe Reports::OfflineSessionExporter do
             ANATOMICAL_SITE
             DOSE_SEQUENCE
             REASON_NOT_VACCINATED
+            NOTES
             UUID
           ]
         )
@@ -373,6 +380,7 @@ describe Reports::OfflineSessionExporter do
               "GILLICK_STATUS" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
+              "NOTES" => "",
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "",
               "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
@@ -418,7 +426,8 @@ describe Reports::OfflineSessionExporter do
             patient_session:,
             programme:,
             location_name: "A Clinic",
-            performed_by: user
+            performed_by: user,
+            notes: "Some notes."
           )
         end
 
@@ -445,6 +454,7 @@ describe Reports::OfflineSessionExporter do
               "GILLICK_STATUS" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
+              "NOTES" => "Some notes.",
               "ORGANISATION_CODE" => organisation.ods_code,
               "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
               "PERSON_ADDRESS_LINE_1" => patient.address_line_1,

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1038,6 +1038,28 @@ describe ImmunisationImportRow do
     end
   end
 
+  describe "#notes" do
+    subject(:notes) { immunisation_import_row.notes }
+
+    context "without notes" do
+      let(:data) { {} }
+
+      it { expect(notes).to be_nil }
+    end
+
+    context "with blank notes" do
+      let(:data) { { "NOTES" => "" } }
+
+      it { expect(notes).to be_nil }
+    end
+
+    context "with notes" do
+      let(:data) { { "NOTES" => "Some notes." } }
+
+      it { expect(notes).to eq("Some notes.") }
+    end
+  end
+
   describe "#delivery_method" do
     subject(:delivery_method) { immunisation_import_row.delivery_method }
 
@@ -1513,6 +1535,14 @@ describe ImmunisationImportRow do
 
       it { should_not be_nil }
       it { should eq(existing_vaccination_record) }
+    end
+
+    context "with notes" do
+      let(:data) { valid_data.merge("NOTES" => "Some notes.") }
+
+      it "sets the notes" do
+        expect(vaccination_record.notes).to eq("Some notes.")
+      end
     end
   end
 


### PR DESCRIPTION
This adds the ability to upload vaccination records offline with notes by adding a `NOTES` column to the immunisations import CSV file.