### PR TITLE
Remove school moves as part of resetting an organisation

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -43,6 +43,7 @@ class DevController < ApplicationController
 
       patients = Patient.joins(:cohort).where(cohorts: { organisation: })
 
+      SchoolMove.where(patient: patients).destroy_all
       NotifyLogEntry.where(patient: patients).destroy_all
 
       ConsentForm.where(organisation:).destroy_all

--- a/spec/features/dev_reset_organisation_spec.rb
+++ b/spec/features/dev_reset_organisation_spec.rb
@@ -10,6 +10,7 @@ describe "Dev endpoint to reset a organisation" do
     and_vaccination_records_have_been_imported
     and_emails_have_been_sent
     and_consent_exists
+    and_school_moves_exist
 
     then_all_associated_data_is_deleted_when_i_reset_the_organisation
   end
@@ -83,6 +84,10 @@ describe "Dev endpoint to reset a organisation" do
         programme: @programme
       )
     end
+  end
+
+  def and_school_moves_exist
+    create(:school_move, :to_school, patient: @patients.first)
   end
 
   def then_all_associated_data_is_deleted_when_i_reset_the_organisation


### PR DESCRIPTION
These need to be deleted as they have a foreign key relation to patients which are deleted as part of resetting an organisation.