### PR TITLE
Hide refused consent patients from offline export

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -153,7 +153,7 @@ class Reports::OfflineSessionExporter
           style:
         )
       end
-    else
+    elsif !patient_session.consent_refused?
       session.programmes.each do |programme|
         sheet.add_row(
           new_row(

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -135,6 +135,14 @@ describe Reports::OfflineSessionExporter do
           )
           expect(rows.first["PERSON_DOB"].to_date).to eq(patient.date_of_birth)
         end
+
+        context "with consent refused" do
+          before { create(:consent, :refused, patient:, programme:) }
+
+          it "does not include the row" do
+            expect(rows.count).to eq(0)
+          end
+        end
       end
 
       context "with a restricted patient" do
@@ -404,6 +412,14 @@ describe Reports::OfflineSessionExporter do
             }
           )
           expect(rows.first["PERSON_DOB"].to_date).to eq(patient.date_of_birth)
+        end
+
+        context "with consent refused" do
+          before { create(:consent, :refused, patient:, programme:) }
+
+          it "does not include the row" do
+            expect(rows.count).to eq(0)
+          end
         end
       end
 


### PR DESCRIPTION
The nurses won't be vaccinating these patients and by keeping them in the spreadsheet they either have to record them as unvaccinated or remove the rows which isn't intuitive.