### PR TITLE
Refactor OfflineSessionExporter

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -8,9 +8,10 @@ class Reports::OfflineSessionExporter
   end
 
   def call
-    sheet.add_row(headers_and_types.keys)
-    patient_sessions.each { |patient_session| add_rows(patient_session:) }
-    package.to_stream.read
+    Axlsx::Package
+      .new { |package| add_vaccinations_sheet(package) }
+      .to_stream
+      .read
   end
 
   def self.call(*args, **kwargs)
@@ -25,92 +26,63 @@ class Reports::OfflineSessionExporter
 
   delegate :location, :organisation, to: :session
 
-  def package
-    @package ||= Axlsx::Package.new(use_shared_strings: true)
-  end
+  def add_vaccinations_sheet(package)
+    package.use_shared_strings = true
 
-  delegate :workbook, to: :package
+    workbook = package.workbook
 
-  def sheet
-    @sheet ||= workbook.add_worksheet(name: "Vaccinations")
-  end
+    cached_styles = CachedStyles.new(workbook)
 
-  def date_style
-    @date_style ||= workbook.styles.add_style(format_code: "dd/mm/yyyy")
-  end
+    workbook.add_worksheet(name: "Vaccinations") do |sheet|
+      sheet.add_row(columns.map { _1.to_s.upcase })
 
-  def wrap_style
-    @wrap_style ||= workbook.styles.add_style(alignment: { wrap_text: true })
-  end
-
-  def strike_style
-    @strike_style ||= workbook.styles.add_style(strike: true)
-  end
-
-  def headers_and_types
-    @headers_and_types ||=
-      {
-        "ORGANISATION_CODE" => :string,
-        "SCHOOL_URN" => :string,
-        "SCHOOL_NAME" => :string,
-        "CARE_SETTING" => :integer,
-        "CLINIC_NAME" => :string,
-        "PERSON_FORENAME" => :string,
-        "PERSON_SURNAME" => :string,
-        "PERSON_DOB" => :date,
-        "YEAR_GROUP" => nil, # should be integer, but that converts nil to 0
-        "PERSON_GENDER_CODE" => :string,
-        "PERSON_ADDRESS_LINE_1" => :string,
-        "PERSON_POSTCODE" => :string,
-        "NHS_NUMBER" => :string,
-        "CONSENT_STATUS" => :string,
-        "CONSENT_DETAILS" => :string,
-        "HEALTH_QUESTION_ANSWERS" => :string,
-        "TRIAGE_STATUS" => :string,
-        "TRIAGED_BY" => :string,
-        "TRIAGE_DATE" => :date,
-        "TRIAGE_NOTES" => :string,
-        "GILLICK_STATUS" => :string,
-        "GILLICK_ASSESSMENT_DATE" => :date,
-        "GILLICK_ASSESSED_BY" => :string,
-        "GILLICK_ASSESSMENT_NOTES" => :string,
-        "VACCINATED" => :string,
-        "DATE_OF_VACCINATION" => :date,
-        "TIME_OF_VACCINATION" => :string,
-        "PROGRAMME_NAME" => :string,
-        "VACCINE_GIVEN" => :string,
-        "PERFORMING_PROFESSIONAL_EMAIL" => :string,
-        "BATCH_NUMBER" => :string,
-        "BATCH_EXPIRY_DATE" => :date,
-        "ANATOMICAL_SITE" => :string,
-        "DOSE_SEQUENCE" => nil, # should be integer, but that converts nil to 0
-        "REASON_NOT_VACCINATED" => :string,
-        "NOTES" => :string,
-        "UUID" => :string
-      }.tap do |hash|
-        hash.delete("CLINIC_NAME") unless location.generic_clinic?
+      patient_sessions.each do |patient_session|
+        rows(patient_session:).each { |row| row.add_to(sheet:, cached_styles:) }
       end
+    end
   end
 
-  def row_types
-    @row_types ||= headers_and_types.values
-  end
-
-  def row_style
-    @row_style ||=
-      headers_and_types.map do |header, type|
-        if type == :date
-          date_style
-        elsif header == "HEALTH_QUESTION_ANSWERS"
-          wrap_style
-        end
-      end
-  end
-
-  def row_style_with_nhs_number_strike
-    @row_style_with_nhs_number_strike ||=
-      row_style.dup.tap do |style|
-        style[headers_and_types.keys.index("NHS_NUMBER")] = strike_style
+  def columns
+    @columns ||=
+      %i[
+        organisation_code
+        school_urn
+        school_name
+        care_setting
+        person_forename
+        person_surname
+        person_dob
+        year_group
+        person_gender_code
+        person_address_line_1
+        person_postcode
+        nhs_number
+        consent_status
+        consent_details
+        health_question_answers
+        triage_status
+        triaged_by
+        triage_date
+        triage_notes
+        gillick_status
+        gillick_assessment_date
+        gillick_assessed_by
+        gillick_assessment_notes
+        vaccinated
+        date_of_vaccination
+        time_of_vaccination
+        programme_name
+        vaccine_given
+        performing_professional_email
+        batch_number
+        batch_expiry_date
+        anatomical_site
+        dose_sequence
+        reason_not_vaccinated
+        notes
+        uuid
+      ].tap do |values|
+        values.insert(4, :clinic_name) if location.generic_clinic?
       end
   end
 
@@ -127,128 +99,169 @@ class Reports::OfflineSessionExporter
       .strict_loading
   end
 
-  def add_rows(patient_session:)
+  def rows(patient_session:)
+    vaccination_records =
+      patient_session.vaccination_records.order(:performed_at)
+
+    row_style = { strike: patient_session.patient.invalidated? }
+
+    if vaccination_records.any?
+      vaccination_records.map do |vaccination_record|
+        Row.new(columns, style: row_style) do |row|
+          add_patient_cells(row, patient_session:)
+          add_existing_row_cells(row, vaccination_record:)
+        end
+      end
+    elsif patient_session.consent_refused?
+      []
+    else
+      session.programmes.map do |programme|
+        Row.new(columns, style: row_style) do |row|
+          add_patient_cells(row, patient_session:)
+          add_new_row_cells(row, programme:)
+        end
+      end
+    end
+  end
+
+  def add_patient_cells(row, patient_session:)
     consents = patient_session.latest_consents
     gillick_assessment = patient_session.latest_gillick_assessment
     patient = patient_session.patient
     triage = patient_session.latest_triage
 
-    vaccination_records =
-      patient_session.vaccination_records.order(:performed_at)
-
-    style =
-      (patient.invalidated? ? row_style_with_nhs_number_strike : row_style)
-
-    if vaccination_records.any?
-      vaccination_records.each do |vaccination_record|
-        sheet.add_row(
-          existing_row(
-            patient:,
-            consents:,
-            gillick_assessment:,
-            triage:,
-            vaccination_record:
-          ),
-          types: row_types,
-          style:
-        )
-      end
-    elsif !patient_session.consent_refused?
-      session.programmes.each do |programme|
-        sheet.add_row(
-          new_row(
-            patient:,
-            consents:,
-            gillick_assessment:,
-            triage:,
-            programme:
-          ),
-          types: row_types,
-          style:
-        )
-      end
-    end
-  end
-
-  def new_row(patient:, consents:, gillick_assessment:, triage:, programme:)
-    (
-      patient_values(patient:, consents:, gillick_assessment:, triage:) +
-        [
-          "", # VACCINATED left blank for recording
-          "", # DATE_OF_VACCINATION left blank for recording
-          "", # TIME_OF_VACCINATION left blank for recording
-          programme.name,
-          "", # VACCINE_GIVEN left blank for recording
-          "", # PERFORMING_PROFESSIONAL_EMAIL left blank for recording
-          "", # BATCH_NUMBER left blank for recording
-          "", # BATCH_EXPIRY_DATE left blank for recording
-          "", # ANATOMICAL_SITE left blank for recording
-          1, # DOSE_SEQUENCE is 1 by default TODO: revisit this for other programmes
-          "", # REASON_NOT_VACCINATED left blank for recording
-          "", # NOTES left blank for recording
-          "" # UUID left blank as new record
-        ]
-    ).tap do |values|
-      values.insert(4, "") if location.generic_clinic? # CLINIC_NAME left blank for recording
-    end
-  end
-
-  def existing_row(
-    patient:,
-    consents:,
-    gillick_assessment:,
-    triage:,
-    vaccination_record:
-  )
-    (
-      patient_values(patient:, consents:, gillick_assessment:, triage:) +
-        [
-          vaccinated(vaccination_record:),
-          vaccination_record.performed_at.to_date,
-          vaccination_record.performed_at.strftime("%H:%M:%S"),
-          vaccination_record.programme.name,
-          vaccination_record.vaccine&.nivs_name,
-          vaccination_record.performed_by_user&.email,
-          vaccination_record.batch&.name,
-          vaccination_record.batch&.expiry,
-          anatomical_site(vaccination_record:),
-          dose_sequence(vaccination_record:),
-          reason_not_vaccinated(vaccination_record:),
-          vaccination_record.notes,
-          vaccination_record.uuid
-        ]
-    ).tap do |values|
-      if location.generic_clinic?
-        values.insert(4, vaccination_record.location_name)
-      end
-    end
-  end
-
-  def patient_values(patient:, consents:, gillick_assessment:, triage:)
-    [
-      organisation.ods_code,
-      school_urn(location:, patient:),
-      school_name(location:, patient:),
-      care_setting(location:),
-      patient.given_name,
-      patient.family_name,
-      patient.date_of_birth,
-      patient.year_group,
-      patient.gender_code.humanize,
-      patient.restricted? ? "" : patient.address_line_1,
-      patient.restricted? ? "" : patient.address_postcode,
-      patient.nhs_number,
-      consents.first&.response&.humanize,
-      consent_details(consents:),
+    row[:organisation_code] = organisation.ods_code
+    row[:school_urn] = school_urn(location:, patient:)
+    row[:school_name] = school_name(location:, patient:)
+    row[:care_setting] = Cell.new(care_setting(location:), type: :integer)
+    row[:person_forename] = patient.given_name
+    row[:person_surname] = patient.family_name
+    row[:person_dob] = patient.date_of_birth
+    row[:year_group] = patient.year_group
+    row[:person_gender_code] = patient.gender_code.humanize
+    row[:person_address_line_1] = (
+      patient.address_line_1 unless patient.restricted?
+    )
+    row[:person_postcode] = (
+      patient.address_postcode unless patient.restricted?
+    )
+    row[:nhs_number] = patient.nhs_number
+    row[:consent_status] = consents.first&.response&.humanize
+    row[:consent_details] = consent_details(consents:)
+    row[:health_question_answers] = Cell.new(
       health_question_answers(consents:),
-      triage&.status&.humanize,
-      triage&.performed_by&.full_name,
-      triage&.created_at,
-      triage&.notes,
-      gillick_status(gillick_assessment:),
-      gillick_assessment&.updated_at,
-      gillick_assessment&.performed_by&.full_name,
-      gillick_assessment&.notes
-    ]
+      style: {
+        alignment: {
+          wrap_text: true
+        }
+      }
+    )
+    row[:triage_status] = triage&.status&.humanize
+    row[:triaged_by] = triage&.performed_by&.full_name
+    row[:triage_date] = triage&.created_at
+    row[:triage_notes] = triage&.notes
+    row[:gillick_status] = gillick_status(gillick_assessment:)
+    row[:gillick_assessment_date] = gillick_assessment&.created_at
+    row[:gillick_assessed_by] = gillick_assessment&.performed_by&.full_name
+    row[:gillick_assessment_notes] = gillick_assessment&.notes
+  end
+
+  def add_existing_row_cells(row, vaccination_record:)
+    row[:vaccinated] = vaccinated(vaccination_record:)
+    row[:date_of_vaccination] = vaccination_record.performed_at.to_date
+    row[:time_of_vaccination] = vaccination_record.performed_at.strftime(
+      "%H:%M:%S"
+    )
+    row[:programme_name] = vaccination_record.programme.name
+    row[:vaccine_given] = vaccination_record.vaccine&.nivs_name
+    row[
+      :performing_professional_email
+    ] = vaccination_record.performed_by_user&.email
+    row[:batch_number] = vaccination_record.batch&.name
+    row[:batch_expiry_date] = vaccination_record.batch&.expiry
+    row[:anatomical_site] = anatomical_site(vaccination_record:)
+    row[:dose_sequence] = dose_sequence(vaccination_record:)
+    row[:reason_not_vaccinated] = reason_not_vaccinated(vaccination_record:)
+    row[:notes] = vaccination_record.notes
+    row[:uuid] = vaccination_record.uuid
+
+    if location.generic_clinic?
+      row[:clinic_name] = vaccination_record.location_name
+    end
+  end
+
+  def add_new_row_cells(row, programme:)
+    row[:date_of_vaccination] = Cell.new(type: :date)
+    row[:programme_name] = programme.name
+    row[:batch_expiry_date] = Cell.new(type: :date)
+    row[:dose_sequence] = 1 # TODO: revisit this for other programmes
+  end
+
+  class CachedStyles
+    attr_reader :workbook
+
+    def initialize(workbook)
+      @workbook = workbook
+      @cache = {}
+    end
+
+    def find_or_create(attributes)
+      @cache[attributes] ||= workbook.styles.add_style(attributes)
+    end
+  end
+
+  class Row
+    attr_reader :columns, :row_style, :cells
+
+    def initialize(columns, style: {})
+      @columns = columns
+      @row_style = style
+      @cells = columns.map { Cell.new }
+      yield self if block_given?
+    end
+
+    def []=(column, value)
+      index = columns.index(column)
+      raise "Column #{column} not in row." if index.nil?
+
+      @cells[index] = (value.is_a?(Cell) ? value : Cell.new(value))
+    end
+
+    def add_to(sheet:, cached_styles:)
+      values = cells.map(&:value)
+      types = cells.map(&:type)
+      style =
+        cells.map { cached_styles.find_or_create(row_style.merge(_1.style)) }
+      sheet.add_row(values, types:, style:)
+    end
+  end
+
+  class Cell
+    attr_reader :value, :type, :style
+
+    def initialize(value = "", type: nil, style: {})
+      @value = value
+      @type = type || Cell.default_type_for(value)
+      @style = Cell.default_style_for(@type).merge(style)
+    end
+
+    def self.default_type_for(value)
+      case value
+      when Date
+        :date
+      when Integer
+        :integer
+      else
+        :string
+      end
+    end
+
+    def self.default_style_for(type)
+      if type == :date
+        { format_code: "dd/mm/yyyy" }
+      else
+        {}
+      end
+    end
   end
 end


### PR DESCRIPTION
This refactors the offline session exporter to move the types and styles on a `Cell` class, meaning they can be controlled at an individual cell level, while also keeping a cache of styles to ensure the same style isn't created multiple times in the same sheet.

This change will also make it easier to implement row-level styles, such as coloured backgrounds which we need for patients without consent.