### PR TITLE
Freeze header and patient name cells

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -39,18 +39,26 @@ class Reports::OfflineSessionExporter
       patient_sessions.each do |patient_session|
         rows(patient_session:).each { |row| row.add_to(sheet:, cached_styles:) }
       end
+
+      sheet.sheet_view.pane do |pane|
+        pane.top_left_cell = "C2"
+        pane.state = :frozen_split
+        pane.y_split = 1
+        pane.x_split = 2
+        pane.active_pane = :bottom_right
+      end
     end
   end
 
   def columns
     @columns ||=
       %i[
+        person_forename
+        person_surname
         organisation_code
         school_urn
         school_name
         care_setting
-        person_forename
-        person_surname
         person_dob
         year_group
         person_gender_code
@@ -82,7 +90,7 @@ class Reports::OfflineSessionExporter
         notes
         uuid
       ].tap do |values|
-        values.insert(4, :clinic_name) if location.generic_clinic?
+        values.insert(6, :clinic_name) if location.generic_clinic?
       end
   end
 

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -35,12 +35,12 @@ describe Reports::OfflineSessionExporter do
       it do
         expect(headers).to eq(
           %w[
+            PERSON_FORENAME
+            PERSON_SURNAME
             ORGANISATION_CODE
             SCHOOL_URN
             SCHOOL_NAME
             CARE_SETTING
-            PERSON_FORENAME
-            PERSON_SURNAME
             PERSON_DOB
             YEAR_GROUP
             PERSON_GENDER_CODE
@@ -316,13 +316,13 @@ describe Reports::OfflineSessionExporter do
       it do
         expect(headers).to eq(
           %w[
+            PERSON_FORENAME
+            PERSON_SURNAME
             ORGANISATION_CODE
             SCHOOL_URN
             SCHOOL_NAME
             CARE_SETTING
             CLINIC_NAME
-            PERSON_FORENAME
-            PERSON_SURNAME
             PERSON_DOB
             YEAR_GROUP
             PERSON_GENDER_CODE


### PR DESCRIPTION
When exporting the offline session spreadsheet this ensures that the header row, and the first two columns (the patient first name and last name) are frozen, meaning that they are always visible when scrolling and navigating around the spreadsheet. This should make it easier for nurses to use.