### PR TITLE
Avoid creating duplicate gillick assessments

### DIFF
--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -11,6 +11,7 @@ class GillickAssessmentsController < ApplicationController
   end
 
   def update
+    @gillick_assessment.clear_changes_information
     @gillick_assessment.assign_attributes(gillick_assessment_params)
 
     if !@gillick_assessment.changed? || @gillick_assessment.save


### PR DESCRIPTION
If the user submits the Gillick assessment form with no changes, we want to avoid creating unnecessary duplicate records (which also leads to them showing in the activity log).

This was supposed to be working before but wasn't because `dup` creates a duplicate record with changes so the new record was always being saved.