### PR TITLE
Design fixes, part 2

### DIFF
--- a/app/assets/stylesheets/_button-group.scss
+++ b/app/assets/stylesheets/_button-group.scss
@@ -7,50 +7,51 @@
   flex-wrap: wrap;
   gap: nhsuk-spacing(3) nhsuk-spacing(4);
 
+  .nhsuk-link {
+    @include nhsuk-font($size: 19, $line-height: 19px);
+    display: inline-block;
+    margin-bottom: nhsuk-spacing(2);
+    margin-top: nhsuk-spacing(2);
+    max-width: 100%;
+    text-align: center;
+  }
+
+  .nhsuk-button {
+    margin-bottom: 0;
+    width: 100%;
+  }
+
   @include mq($from: tablet) {
     flex-direction: row;
     flex-wrap: wrap;
-  }
 
-  &--table {
-    @include nhsuk-responsive-margin(1, "bottom");
-    gap: nhsuk-spacing(2);
-    justify-content: end;
-    margin-top: #{nhsuk-spacing(1) * -1};
-    width: 100%;
-
-    @include mq($from: mobile) {
-      flex-direction: row;
-
-      .nhsuk-button {
-        width: auto;
-      }
+    .nhsuk-button {
+      width: auto;
     }
 
-    @include mq($from: desktop) {
-      flex-wrap: nowrap;
+    .nhsuk-link {
+      text-align: left;
     }
   }
 }
 
-.app-button-group .nhsuk-link {
-  @include nhsuk-font($size: 19, $line-height: 19px);
-  display: inline-block;
-  margin-bottom: nhsuk-spacing(2);
-  margin-top: nhsuk-spacing(2);
-  max-width: 100%;
-  text-align: center;
-
-  @include mq($from: tablet) {
-    text-align: left;
-  }
-}
-
-.app-button-group .nhsuk-button {
-  margin-bottom: 0;
+.app-button-group--table {
+  @include nhsuk-responsive-margin(1, "bottom");
+  gap: nhsuk-spacing(2);
+  justify-content: end;
+  margin-top: #{nhsuk-spacing(1) * -1};
   width: 100%;
 
-  @include mq($from: tablet) {
-    width: auto;
+  @include mq($from: mobile) {
+    flex-direction: row;
+
+    .nhsuk-button {
+      width: auto;
+    }
+  }
+
+  @include mq($from: desktop) {
+    flex-wrap: nowrap;
+    justify-content: start;
   }
 }

--- a/app/assets/stylesheets/_button.scss
+++ b/app/assets/stylesheets/_button.scss
@@ -72,19 +72,29 @@ $button-shadow-size: 4px;
     color: $nhsuk-focus-text-color;
   }
 
+  &:focus:visited:active {
+    // Override .nhsuk-button turning colour white
+    color: $button-color;
+  }
+
   &:active {
     background-color: rgba($button-color, 15%);
+    border-bottom: $nhsuk-border-width-form-element solid; // Reintroduce 2px bottom border
     border-color: $button-color;
-    border-bottom: 2px solid; // Reintroduce 2px bottom border
     color: $button-color;
     // Revert padding to account for reintroduction of 2px bottom border
     padding-bottom: 12px;
     padding-top: 12px;
   }
 
-  &:focus:visited:active {
-    // Override .nhsuk-button turning colour white
-    color: $button-color;
+  &::before {
+    bottom: #{$button-shadow-size * -1};
+    top: #{$nhsuk-border-width-form-element * -1};
+  }
+
+  &:active::before {
+    bottom: #{($nhsuk-border-width-form-element + $button-shadow-size) * -1};
+    top: #{($nhsuk-border-width-form-element + $button-shadow-size) * -1};
   }
 }
 
@@ -102,7 +112,15 @@ $button-shadow-size: 4px;
 
   &.app-button--secondary,
   &.app-button--secondary-warning {
+    // Adjust padding to account for removal of 2px bottom border
     padding-bottom: #{nhsuk-spacing(1) + 1px};
     padding-top: #{nhsuk-spacing(1) + 1px};
+
+    &:active {
+      margin-bottom: -1px;
+      // Revert padding to account for reintroduction of 2px bottom border
+      padding-bottom: nhsuk-spacing(1);
+      padding-top: nhsuk-spacing(1);
+    }
   }
 }

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -47,7 +47,7 @@
                                      patient,
                                      section: @section,
                                      tab: @tab,
-                                   ), class: "app-button--secondary" %>
+                                   ), class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
         </p>
       <% end %>
     <% elsif gillick_assessment_can_be_recorded? %>
@@ -58,7 +58,7 @@
                                    patient,
                                    section: @section,
                                    tab: @tab,
-                                 ), class: "app-button--secondary" %>
+                                 ), class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
       </p>
     <% end %>
   <% end %>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -20,6 +20,6 @@
 
 <%= govuk_button_link_to "Import records",
                          new_programme_import_path,
-                         class: "app-button--secondary" %>
+                         class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
 
 <%= render AppImportsTableComponent.new(organisation: @organisation, programme: @programme) %>

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -10,7 +10,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :overview) %>
 
-<%= govuk_button_to "Download vaccination report", programme_vaccination_reports_path(@programme), class: "app-button--secondary" %>
+<%= govuk_button_to "Download vaccination report", programme_vaccination_reports_path(@programme), class: "app-button--secondary nhsuk-u-margin-bottom-5" %>
 
 <div class="nhsuk-grid-row nhsuk-card-group">
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -11,7 +11,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :vaccination_records) %>
 
-<%= govuk_button_link_to "Import vaccination records", new_programme_immunisation_import_path, class: "app-button--secondary" %>
+<%= govuk_button_link_to "Import vaccination records", new_programme_immunisation_import_path, class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
 
 <%= render AppVaccinationRecordTableComponent.new(@vaccination_records, count: @pagy.count) %>
 


### PR DESCRIPTION
Bring across updated CSS styles from the prototype:

- Updates secondary buttons so that they don’t shift surrounding layout when active/pressed
- Updates button groups to fix alignment for table variant (and be clearer to read)

Also:

- Fix button margins on various buttons spotted in the app (containing `button_to` forms are a bit of a pain 🫤) 