### PR TITLE
Only attach unknown schools to organisations

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,6 +70,7 @@ end
 def attach_sample_of_schools_to(organisation)
   Location
     .school
+    .where(team_id: nil)
     .order("RANDOM()")
     .limit(50)
     .update_all(team_id: organisation.generic_team.id)


### PR DESCRIPTION
When seeding the database for the first time, this helps to avoid issues where the same location is shared by sessions across the two organisations.