### PR TITLE
Use patient sessions in children view

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -50,24 +50,21 @@ class ProgrammesController < ApplicationController
   def patients
     cohorts = policy_scope(Cohort).for_year_groups(@programme.year_groups)
 
-    patients =
-      policy_scope(Patient)
-        .where(cohort: cohorts)
-        .order_by_name
-        .not_deceased
-        .to_a
-
-    sort_and_filter_patients!(patients)
-    @pagy, @patients = pagy_array(patients)
+    patients = policy_scope(Patient).where(cohort: cohorts).not_deceased
 
     sessions = policy_scope(Session).has_programme(@programme)
 
-    @patient_sessions =
+    patient_sessions =
       PatientSession
-        .where(patient: @patients, session: sessions)
+        .where(patient: patients, session: sessions)
         .eager_load(:session, patient: :cohort)
         .preload_for_state
+        .order_by_name
         .strict_loading
+        .to_a
+
+    sort_and_filter_patients!(patient_sessions)
+    @pagy, @patient_sessions = pagy_array(patient_sessions)
   end
 
   private

--- a/app/views/programmes/patients.html.erb
+++ b/app/views/programmes/patients.html.erb
@@ -23,7 +23,6 @@
       caption: t("children", count: @pagy.count),
       columns: %i[name dob year_group status],
       params:,
-      patients: @patients,
       patient_sessions: @patient_sessions,
       programme: @programme,
       section: :patients,

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -87,6 +87,7 @@ describe "Patient sorting and filtering" do
           :patient,
           session: @session,
           given_name:,
+          family_name: "XXX", # to avoid surname being caught in name filters
           year_group:,
           registration:
         )


### PR DESCRIPTION
This fixes an issue where the status wasn't filtering because it was showing a list of patients which don't have a status. We had previously changed this to show patients who aren't in sessions, but because of the new school moves work, a patient should always belong to at least one session, and if not then a bug has happened elsewhere in the service.