### PR TITLE
Don't allow nurses to submit online consent

### DIFF
--- a/app/views/draft_consents/route.html.erb
+++ b/app/views/draft_consents/route.html.erb
@@ -12,7 +12,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :route,
-                                       Consent.routes.keys.excluding("self_consent"),
+                                       Consent.routes.keys.excluding("online", "self_consent"),
                                        ->(option) { option },
                                        ->(option) { Consent.human_enum_name(:route, option) },
                                        caption: { size: "l",


### PR DESCRIPTION
Online consent means it came from the parental consent form directly, we shouldn't be giving the nurses the option to record consent via this route.

Having this route here could also be confusing, as the nurses will be using an online service to record consent.