### PR TITLE
Prevent attendance being edited after vaccination

### DIFF
--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -47,9 +47,6 @@ class PatientSessionsController < ApplicationController
   end
 
   def set_back_link
-    @back_link =
-      session_section_tab_path @session,
-                               section: params[:section],
-                               tab: params[:tab]
+    @back_link = session_section_tab_path(@session)
   end
 end

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -4,10 +4,10 @@ class RegisterAttendancesController < ApplicationController
   include PatientSortingConcern
 
   before_action :set_session, only: %i[index create]
-  before_action :set_patient_sessions, only: %i[index]
-  before_action :set_patient, only: %i[create]
-  before_action :set_session_date, only: %i[create]
-  before_action :set_patient_session, only: %i[create]
+  before_action :set_patient_sessions, only: :index
+  before_action :set_patient, only: :create
+  before_action :set_session_date, only: :create
+  before_action :set_patient_session, only: :create
 
   layout "full"
 
@@ -17,17 +17,20 @@ class RegisterAttendancesController < ApplicationController
 
   def create
     session_attendance =
-      @patient_session.session_attendances.create!(
-        session_date: @session_date,
-        attending: params[:state] == "attending"
-      )
+      authorize @patient_session.session_attendances.find_or_initialize_by(
+                  session_date: @session_date
+                )
+
+    session_attendance.update!(attending: params[:state] == "attending")
 
     name = @patient.full_name
+
     flash[:info] = if session_attendance.attending?
       t("attendance_flash.#{@patient_session.status}", name:)
     else
       t("attendance_flash.absent", name:)
     end
+
     redirect_to session_attendances_path(@session)
   end
 
@@ -39,7 +42,10 @@ class RegisterAttendancesController < ApplicationController
 
   def set_patient_sessions
     @patient_sessions =
-      @session.patient_sessions.select { _1.current_attendance.nil? }
+      @session
+        .patient_sessions
+        .includes(:session_attendances, session: :session_dates)
+        .select { _1.todays_attendance&.attending.nil? }
   end
 
   def set_patient

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -5,7 +5,6 @@ class SessionAttendancesController < ApplicationController
   before_action :set_session
   before_action :set_patient
   before_action :set_section_and_tab
-  before_action :set_back_link
   before_action :set_session_date
   before_action :set_session_attendance
 
@@ -67,10 +66,6 @@ class SessionAttendancesController < ApplicationController
   def set_section_and_tab
     @section = params[:section]
     @tab = params[:tab]
-  end
-
-  def set_back_link
-    @back_link = session_patient_path(id: @patient.id)
   end
 
   def set_session_date

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -74,9 +74,9 @@ class SessionAttendancesController < ApplicationController
 
   def set_session_attendance
     @session_attendance =
-      @patient_session.session_attendances.find_or_initialize_by(
-        session_date: @session_date
-      )
+      authorize @patient_session.session_attendances.find_or_initialize_by(
+                  session_date: @session_date
+                )
   end
 
   def session_attendance_params

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -25,14 +25,16 @@ class SessionAttendancesController < ApplicationController
 
     if success
       name = @patient.full_name
+
       flash[:info] = if @session_attendance.attending?
-        "#{name} is attending today’s session. They are ready for the nurse."
+        t("attendance_flash.#{@patient_session.status}", name:)
       elsif @session_attendance.attending.nil?
-        "#{name} is not registered yet."
+        t("attendance_flash.not_registered", name:)
       else
-        "#{name} is absent from today’s session."
+        t("attendance_flash.absent", name:)
       end
-      redirect_to(session_patient_path(id: @patient.id))
+
+      redirect_to session_patient_path(id: @patient.id)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -112,15 +112,14 @@ class PatientSession < ApplicationRecord
     @latest_vaccination_record ||= vaccination_records.max_by(&:created_at)
   end
 
-  def current_attendance
-    session_attendances.joins(:session_date).find_by(
-      session_date: {
-        value: Date.current
-      }
-    )
+  def todays_attendance
+    @todays_attendance ||=
+      if (session_date = session.session_dates.find(&:today?))
+        session_attendances.find_or_initialize_by(session_date:)
+      end
   end
 
   def attending_today?
-    current_attendance&.attending?
+    todays_attendance&.attending?
   end
 end

--- a/app/models/patient_session_stats.rb
+++ b/app/models/patient_session_stats.rb
@@ -58,7 +58,7 @@ class PatientSessionStats
         patient_session.triaged_do_not_vaccinate? ||
         patient_session.unable_to_vaccinate?
     when :not_registered
-      patient_session.current_attendance.nil?
+      patient_session.todays_attendance&.attending.nil?
     end
   end
 end

--- a/app/policies/session_attendance_policy.rb
+++ b/app/policies/session_attendance_policy.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class SessionAttendancePolicy < ApplicationPolicy
+  def create?
+    super && !was_seen_by_nurse?
+  end
+
+  def update?
+    super && !was_seen_by_nurse?
+  end
+
+  private
+
+  delegate :patient_session, :session_date, to: :record
+
+  def was_seen_by_nurse?
+    patient_session
+      .vaccination_records
+      .where(performed_at: session_date.value.all_day)
+      .exists?
+  end
+end

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -10,25 +10,27 @@
   <%= @patient.full_name %>
 <% end %>
 
-<ul class="app-action-list">
-  <li class="app-action-list__item">
-    <% if @patient_session.current_attendance %>
-      <% if @patient_session.current_attendance.attending? %>
+<% if (session_attendance = @patient_session.todays_attendance) %>
+  <ul class="app-action-list">
+    <li class="app-action-list__item">
+      <% if session_attendance.attending %>
         <%= govuk_tag(text: "Attending today’s session") %>
-      <% else %>
+      <% elsif session_attendance.attending == false %>
         <%= govuk_tag(text: "Absent from today’s session", colour: "red") %>
+      <% else %>
+        <%= govuk_tag(text: "Not registered yet", colour: "blue") %>
       <% end %>
-    <% else %>
-      <%= govuk_tag(text: "Not registered yet", colour: "blue") %>
-    <% end %>
-  </li>
-  <li class="app-action-list__item">
-    <%= link_to(
-          "Update attendance",
-          edit_session_patient_attendance_path(patient_id: @patient.id)
-        ) %>
-  </li>
-</ul>
+    </li>
+    <li class="app-action-list__item">
+      <% if policy(session_attendance).edit? %>
+        <%= link_to(
+              "Update attendance",
+              edit_session_patient_attendance_path(patient_id: @patient.id)
+            ) %>
+      <% end %>
+    </li>
+  </ul>
+<% end %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(

--- a/app/views/session_attendances/edit.html.erb
+++ b/app/views/session_attendances/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: @back_link,
+        href: session_patient_path(id: @patient.id),
         name: "#{@section.pluralize} page",
       ) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -856,6 +856,7 @@ en:
     consent_given_triage_not_needed: "%{name} is attending today’s session. They are ready for the nurse."
     consent_refused: "%{name} needs to leave the session because their parent or guardian refused to give consent."
     delay_vaccination: "%{name} needs to leave the session because their vaccination is delayed to a later date."
+    not_registered: "%{name} is not registered yet."
     triaged_do_not_vaccinate: "%{name} needs to leave the session because their parent or guardian refused to give consent."
     triaged_kept_in_triage: "%{name} is attending today’s session. A nurse needs to triage their record."
     triaged_ready_to_vaccinate: "%{name} is attending today’s session. They are safe to vaccinate."

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -34,6 +34,7 @@ describe "End-to-end journey" do
     when_i_click_on_the_vaccination_section
     and_i_record_the_successful_vaccination
     then_i_see_that_the_child_is_vaccinated
+    and_i_cant_edit_attendance
 
     # Activity log
     when_i_click_on_the_child_we_registered
@@ -230,6 +231,8 @@ describe "End-to-end journey" do
   def and_i_record_the_successful_vaccination
     click_link "Bobby Tables"
 
+    expect(page).to have_content("Update attendance")
+
     choose "Yes, they got the HPV vaccine"
     choose "Left arm (upper position)"
     click_button "Continue"
@@ -243,6 +246,10 @@ describe "End-to-end journey" do
   def then_i_see_that_the_child_is_vaccinated
     click_link "Vaccinated ( 1 )"
     expect(page).to have_content "1 child vaccinated"
+  end
+
+  def and_i_cant_edit_attendance
+    expect(page).not_to have_content("Update attendance")
   end
 
   def then_i_see_the_activity_log_link

--- a/spec/policies/session_attendance_policy_spec.rb
+++ b/spec/policies/session_attendance_policy_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+describe SessionAttendancePolicy do
+  subject(:policy) { described_class.new(user, session_attendance) }
+
+  let(:user) { create(:nurse) }
+
+  let(:programme) { create(:programme) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:session) { create(:session, organisation:, programme:) }
+  let(:patient_session) { create(:patient_session, session:) }
+
+  shared_examples "allow if not yet seen by nurse" do
+    context "with a new session attendance" do
+      let(:session_attendance) { build(:session_attendance, patient_session:) }
+
+      it { should be(true) }
+    end
+
+    context "with session attendance and a vaccination record" do
+      let(:session_attendance) { build(:session_attendance, patient_session:) }
+
+      before do
+        create(
+          :vaccination_record,
+          patient_session:,
+          programme:,
+          performed_at: Time.current
+        )
+      end
+
+      it { should be(false) }
+    end
+
+    context "with session attendance and a vaccination record from a different date" do
+      let(:session_attendance) { build(:session_attendance, patient_session:) }
+
+      before do
+        create(
+          :vaccination_record,
+          patient_session:,
+          programme:,
+          performed_at: Time.zone.yesterday
+        )
+      end
+
+      it { should be(true) }
+    end
+  end
+
+  describe "#new?" do
+    subject(:new?) { policy.new? }
+
+    include_examples "allow if not yet seen by nurse"
+  end
+
+  describe "#create?" do
+    subject(:create?) { policy.create? }
+
+    include_examples "allow if not yet seen by nurse"
+  end
+
+  describe "#edit?" do
+    subject(:edit?) { policy.edit? }
+
+    include_examples "allow if not yet seen by nurse"
+  end
+
+  describe "#update?" do
+    subject(:update?) { policy.update? }
+
+    include_examples "allow if not yet seen by nurse"
+  end
+end


### PR DESCRIPTION
This updates the logic around session attendance to prevent the attendance record from being edited once a patient has been vaccinated, or an un-administered vaccination record has been recorded.