### PR TITLE
Exclude unadministered vaccinations records from Care Plus

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -99,7 +99,7 @@ class Reports::CareplusExporter
   def rows(patient_session:)
     patient = patient_session.patient
     vaccination_records =
-      patient_session.vaccination_records.order(:performed_at)
+      patient_session.vaccination_records.administered.order(:performed_at)
 
     if vaccination_records.any?
       [existing_row(patient:, patient_session:, vaccination_records:)]
@@ -145,13 +145,7 @@ class Reports::CareplusExporter
     [
       record.vaccine.snomed_product_code, # Vaccine X
       "#{record.dose_sequence}P", # Dose X field
-      (
-        if record.administered?
-          ""
-        else
-          VaccinationRecord.human_enum_name(:outcome, record.outcome)
-        end
-      ), # Reason Not Given X
+      "", # Reason Not Given X
       coded_site(record.delivery_site), # Site X; Coded value
       record.vaccine.manufacturer, # Manufacturer X
       record.batch.name # Batch No X
@@ -198,8 +192,6 @@ class Reports::CareplusExporter
       right_buttock: "RB",
       nose: "N"
       # We don't implement the other codes currently
-    }[
-      site.to_sym
-    ]
+    }.fetch(site.to_sym)
   end
 end

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -99,4 +99,11 @@ describe Reports::CareplusExporter do
 
     expect(data_rows.first).to be_nil
   end
+
+  it "excludes not administered vaccination records" do
+    patient_session = create(:patient_session, session:)
+    create(:vaccination_record, :not_administered, programme:, patient_session:)
+
+    expect(data_rows.first).to be_nil
+  end
 end


### PR DESCRIPTION
We don't need to include these records in the Care Plus export and they're not being sent currently.