### PR TITLE
Don't force SSL on healtcheck endpoint

### DIFF
--- a/app/javascript/serviceworker/online-status.js
+++ b/app/javascript/serviceworker/online-status.js
@@ -32,7 +32,7 @@ export const refreshOnlineStatus = async (cb) => {
   await sleep(REFRESH_INTERVAL);
 
   try {
-    await fetchWithTimeout("/ping");
+    await fetchWithTimeout("/up");
 
     await cb();
   } catch (err) {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   # Don't force SSL for healthcheck endpoint.
   config.ssl_options = {
     redirect: {
-      exclude: ->(request) { request.path =~ /ping/ }
+      exclude: ->(request) { request.path =~ /up/ }
     }
   }
 


### PR DESCRIPTION
This was forgotten in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2621.