### PR TITLE
Add and configure semantic logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 7.2.2"
 
 gem "activerecord-import"
 gem "activerecord-session_store"
+gem "amazing_print"
 gem "audited", git: "https://github.com/tvararu/audited", branch: "encryption"
 gem "awesome_print"
 gem "bootsnap", require: false
@@ -43,12 +44,13 @@ gem "phonelib"
 gem "propshaft"
 gem "puma", "~> 6.5"
 gem "pundit"
+gem "rails_semantic_logger"
 gem "rainbow"
 gem "ruby-progressbar"
 gem "rubyzip"
 gem "sentry-rails"
 gem "sentry-ruby"
-gem "silencer", require: false
+gem "splunk-sdk-ruby"
 gem "stimulus-rails"
 gem "turbo-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     aes_key_wrap (1.1.0)
+    amazing_print (1.6.0)
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
@@ -464,6 +465,10 @@ GEM
     rails-html-sanitizer (1.6.1)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails_semantic_logger (4.17.0)
+      rack
+      railties (>= 5.1)
+      semantic_logger (~> 4.16)
     railties (7.2.2)
       actionpack (= 7.2.2)
       activesupport (= 7.2.2)
@@ -559,6 +564,8 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     securerandom (0.4.0)
+    semantic_logger (4.16.1)
+      concurrent-ruby (~> 1.0)
     sentry-rails (5.21.0)
       railties (>= 5.0)
       sentry-ruby (~> 5.21.0)
@@ -567,7 +574,6 @@ GEM
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (6.4.0)
       activesupport (>= 5.2.0)
-    silencer (2.0.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -593,6 +599,7 @@ GEM
     solargraph-rails (1.1.0)
       activesupport
       solargraph
+    splunk-sdk-ruby (1.0.5)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.2)
@@ -672,6 +679,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-import
   activerecord-session_store
+  amazing_print
   annotate
   asciidoctor
   asciidoctor-diagram
@@ -724,6 +732,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.2.2)
   rails-erd
+  rails_semantic_logger
   rainbow
   rladr
   rspec
@@ -737,10 +746,10 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers
-  silencer
   simplecov
   solargraph
   solargraph-rails
+  splunk-sdk-ruby
   stimulus-rails
   syntax_tree
   syntax_tree-haml

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,13 +60,6 @@ Rails.application.configure do
     }
   }
 
-  # Log to STDOUT by default
-  config.logger =
-    ActiveSupport::Logger
-      .new($stdout)
-      .tap { |logger| logger.formatter = ::Logger::Formatter.new }
-      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
@@ -74,6 +67,21 @@ Rails.application.configure do
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+
+  # Semantic logger Heroku configuration
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    $stdout.sync = true
+    config.rails_semantic_logger.add_file_appender = false
+    config.semantic_logger.add_appender(
+      io: $stdout,
+      formatter: config.rails_semantic_logger.format
+    )
+  end
+
+  # Also for Semantic logger Heroku configuration
+  if ENV["LOG_LEVEL"].present?
+    config.log_level = ENV["LOG_LEVEL"].downcase.strip.to_sym
+  end
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+SemanticLogger.add_appender(
+  appender: :splunk_http,
+  url: Settings.splunk.hec_endpoint,
+  token: Settings.splunk.hec_token,
+  index: Settings.splunk.index
+)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,4 +82,5 @@ pds:
 
 splunk:
   index: /splunk/apps/aws_hec_receiver/logs_mavis_prod
+  hec_endpoint: https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event
   hec_token: <%= Rails.application.credentials.splunk&.hec_token %>

--- a/script/aws_splunk_setup.rb
+++ b/script/aws_splunk_setup.rb
@@ -18,9 +18,8 @@ ENVIRONMENT = ARGV[0]
 usage if ENVIRONMENT.blank? || !defined?(Settings)
 
 SPLUNK_INDEX = Settings.splunk.index
+HEC_ENDPOINT = Settings.splunk.hec_endpoint
 HEC_TOKEN = Settings.splunk.hec_token
-HEC_ENDPOINT =
-  "https://firehose.inputs.splunk.aws.digital.nhs.uk/services/collector/event"
 
 # Get AWS account ID and region
 ACCOUNT_ID = `aws sts get-caller-identity --query "Account" --output text`.strip


### PR DESCRIPTION
Semantic logger can be used as a drop-in replacement for Rails STDOUT logging. It also supports sending logs to Splunk.

TODO:

- [ ] Check that this work on the review app
- [ ] Add setting to disable logging to Splunk per-env
- [ ] Add fork to Puma.rb to log asynchronously