### PR TITLE
Revert "Set Care Plus vaccine to programme name"

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -148,7 +148,7 @@ class Reports::CareplusExporter
     return blank_vaccine_fields unless record
 
     [
-      record.programme.name, # Vaccine X
+      record.vaccine.snomed_product_code, # Vaccine X
       "#{record.dose_sequence}P", # Dose X field
       "", # Reason Not Given X
       coded_site(record.delivery_site), # Site X; Coded value

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -90,7 +90,9 @@ describe Reports::CareplusExporter do
     row = data_rows.first
 
     expect(row[attended_index]).to eq("Y")
-    expect(row[vaccine_index]).to eq("HPV")
+    expect(row[vaccine_index]).to eq(
+      vaccination_record.vaccine.snomed_product_code
+    )
     expect(row[batch_index]).to eq(vaccination_record.batch.name)
     expect(row[site_index]).to eq("ULA")
     expect(row[staff_type_index]).to eq("IN")


### PR DESCRIPTION
Reverts nhsuk/manage-vaccinations-in-schools#2619

We've got confirmation that CarePlus supports SNOMED codes in this column.