### PR TITLE
Include GP information in Mavis-format export

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -43,6 +43,8 @@ class Reports::ProgrammeVaccinationsExporter
       PERSON_ADDRESS_LINE_1
       PERSON_POSTCODE
       NHS_NUMBER
+      GP_ORGANISATION_CODE
+      GP_NAME
       CONSENT_STATUS
       CONSENT_DETAILS
       HEALTH_QUESTION_ANSWERS
@@ -84,7 +86,7 @@ class Reports::ProgrammeVaccinationsExporter
           :programme,
           :vaccine,
           patient_session: {
-            patient: %i[cohort school],
+            patient: %i[cohort gp_practice school],
             consents: [:patient, { parent: :parent_relationships }],
             gillick_assessments: :performed_by,
             triages: :performed_by
@@ -125,6 +127,8 @@ class Reports::ProgrammeVaccinationsExporter
       patient.restricted? ? "" : patient.address_line_1,
       patient.restricted? ? "" : patient.address_postcode,
       patient.nhs_number,
+      patient.gp_practice&.ods_code || "",
+      patient.gp_practice&.name || "",
       consents.first&.response&.humanize || "",
       consent_details(consents:),
       health_question_answers(consents:),

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -67,8 +67,6 @@ FactoryBot.define do
       name { "#{Faker::University.name} Practice" }
 
       sequence(:ods_code, 100) { "GP#{_1}" }
-
-      organisation
     end
 
     factory :school do

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -43,6 +43,8 @@ describe Reports::ProgrammeVaccinationsExporter do
           PERSON_ADDRESS_LINE_1
           PERSON_POSTCODE
           NHS_NUMBER
+          GP_ORGANISATION_CODE
+          GP_NAME
           CONSENT_STATUS
           CONSENT_DETAILS
           HEALTH_QUESTION_ANSWERS
@@ -115,6 +117,8 @@ describe Reports::ProgrammeVaccinationsExporter do
               "GILLICK_ASSESSMENT_DATE" => "",
               "GILLICK_ASSESSMENT_NOTES" => "",
               "GILLICK_STATUS" => "",
+              "GP_NAME" => "",
+              "GP_ORGANISATION_CODE" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
@@ -186,6 +190,8 @@ describe Reports::ProgrammeVaccinationsExporter do
               "GILLICK_ASSESSMENT_DATE" => "",
               "GILLICK_ASSESSMENT_NOTES" => "",
               "GILLICK_STATUS" => "",
+              "GP_NAME" => "",
+              "GP_ORGANISATION_CODE" => "",
               "HEALTH_QUESTION_ANSWERS" => "",
               "NHS_NUMBER" => patient.nhs_number,
               "ORGANISATION_CODE" => organisation.ods_code,
@@ -214,6 +220,24 @@ describe Reports::ProgrammeVaccinationsExporter do
             }
           )
         end
+      end
+    end
+
+    context "with a GP practice" do
+      let(:gp_practice) do
+        create(:gp_practice, name: "Practice", ods_code: "GP")
+      end
+      let(:session) { create(:session, programme:, organisation:) }
+
+      before do
+        create(:patient, :vaccinated, gp_practice:, session:, programme:)
+      end
+
+      it "includes the information" do
+        expect(rows.first.to_hash).to include(
+          "GP_NAME" => "Practice",
+          "GP_ORGANISATION_CODE" => "GP"
+        )
       end
     end
 


### PR DESCRIPTION
When exporting information using the Mavis-format, we want to include the GP information about the patient, if it's available. This will be included in a `GP_ORGANISATION_CODE` and `GP_NAME` column.