### PR TITLE
Remove slash in DfE number

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -87,7 +87,7 @@ class Location < ApplicationRecord
   end
 
   def dfe_number
-    "#{gias_local_authority_code}/#{gias_establishment_number}" if school?
+    "#{gias_local_authority_code}#{gias_establishment_number}" if school?
   end
 
   private

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -100,7 +100,7 @@ describe Reports::CareplusExporter do
     expect(row[staff_type_index]).to eq("IN")
     expect(row[staff_code_index]).to eq("LW5PM")
     expect(row[venue_type_index]).to eq("SC")
-    expect(row[venue_code_index]).to eq("123/456")
+    expect(row[venue_code_index]).to eq("123456")
   end
 
   context "in a community clinic" do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -161,7 +161,7 @@ describe Location do
         )
       end
 
-      it { should eq("123/456") }
+      it { should eq("123456") }
     end
   end
 end


### PR DESCRIPTION
Although presented this way on the GIAS website, it looks like the CarePlus format doesn't include the slash, since this is the only place we're using this number we can safely remove it.