### PR TITLE
Enable CarePlus export in all environments

### DIFF
--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -4,7 +4,7 @@ class VaccinationReport
   include RequestSessionPersistable
   include WizardStepConcern
 
-  FILE_FORMATS = Settings.export.formats.freeze
+  FILE_FORMATS = %w[careplus mavis].freeze
 
   def self.request_session_key
     "vaccination_report"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,11 +6,6 @@ disallow_database_seeding: true
 fast_reset: false
 web_concurrency: 2
 
-export:
-  formats:
-    # - careplus
-    - mavis
-
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via
 # Devise.
 cis2:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,11 +3,6 @@ disallow_database_seeding: false
 fast_reset: true
 web_concurrency: 0
 
-export:
-  formats:
-    - careplus
-    - mavis
-
 cis2:
   enabled: false
   authentication_assurance_level: 1

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,11 +3,6 @@ disallow_database_seeding: false
 fast_reset: true
 web_concurrency: 0
 
-export:
-  formats:
-    - careplus
-    - mavis
-
 cis2:
   issuer: "http://localhost:4000/test/oidc"
   client_id: "31337.apps.national"


### PR DESCRIPTION
I've decided to do this by removing the settings configuration as we're unlikely to need to disable individual exports again, we can always revert this change if necessary.