### PR TITLE
Delete incoming schools for an organisation when resetting

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -44,6 +44,7 @@ class DevController < ApplicationController
       patients = Patient.joins(:cohort).where(cohorts: { organisation: })
 
       SchoolMove.where(patient: patients).destroy_all
+      SchoolMove.where(organisation:).destroy_all
       NotifyLogEntry.where(patient: patients).destroy_all
 
       ConsentForm.where(organisation:).destroy_all


### PR DESCRIPTION
Currently we're deleting school moves within or out of the organisation, but not moves where the patient is moving in to the organisation.