### PR TITLE
Delete all patient school moves when confirming

### DIFF
--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -53,7 +53,7 @@ class SchoolMove < ApplicationRecord
     ActiveRecord::Base.transaction do
       update_patient!
       update_sessions!(move_to_school:)
-      destroy! if persisted?
+      SchoolMove.where(patient:).destroy_all
     end
   end
 

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -134,10 +134,15 @@ describe SchoolMove do
     end
 
     shared_examples "destroys the school move" do
-      it "destroys the school move" do
+      it "destroys the school move and any others" do
+        other_school_move = create(:school_move, :to_school, patient:)
+
         expect(school_move).to be_persisted
-        expect { confirm! }.to change(described_class, :count).by(-1)
+        expect { confirm! }.to change(described_class, :count).by(-2)
         expect { school_move.reload }.to raise_error(
+          ActiveRecord::RecordNotFound
+        )
+        expect { other_school_move.reload }.to raise_error(
           ActiveRecord::RecordNotFound
         )
       end


### PR DESCRIPTION
When confirming a school move we should remove any others for the same patient to avoid the nurses needing to manually ignore any other school moves per patient.