### PR TITLE
Fix bug related to PatientSession#no_consent?

### DIFF
--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -71,8 +71,8 @@ module PatientSessionStatusConcern
     end
 
     def no_consent?
-      consents.empty? || consents.all?(&:response_not_provided?) ||
-        consents.all?(&:invalidated?)
+      consents.empty? ||
+        consents.all? { _1.response_not_provided? || _1.invalidated? }
     end
 
     def triage_needed?

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -68,9 +68,7 @@ FactoryBot.define do
       end
     end
 
-    trait :given do
-      response { :given }
-    end
+    traits_for_enum :response
 
     trait :given_verbally do
       given

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -82,6 +82,49 @@ describe PatientSession do
     it { should eq(later_triage) }
   end
 
+  describe "#no_consent?" do
+    subject(:no_consent?) { patient_session.no_consent? }
+
+    let(:patient) { patient_session.patient }
+
+    context "with no consent" do
+      it { should be(true) }
+    end
+
+    context "with an invalidated consent" do
+      before { create(:consent, :invalidated, patient:, programme:) }
+
+      it { should be(true) }
+    end
+
+    context "with a not provided consent" do
+      before { create(:consent, :not_provided, patient:, programme:) }
+
+      it { should be(true) }
+    end
+
+    context "with both an invalidated and not provided consent" do
+      before do
+        create(:consent, :invalidated, patient:, programme:)
+        create(:consent, :not_provided, patient:, programme:)
+      end
+
+      it { should be(true) }
+    end
+
+    context "with a refused consent" do
+      before { create(:consent, :refused, patient:, programme:) }
+
+      it { should be(false) }
+    end
+
+    context "with a given consent" do
+      before { create(:consent, :given, patient:, programme:) }
+
+      it { should be(false) }
+    end
+  end
+
   describe "#latest_consents" do
     subject(:latest_consents) { patient_session.latest_consents }
 


### PR DESCRIPTION
This method is used in a number of places to determine the status of a patient session. In the case where one consent was invalidated and one consent was not provided, this method was returning `false` which would then lead to consent being shown as given when this was not the case.

I've added some unit tests for this method to make sure we cover this scenario.