### PR TITLE
Add VaccinateForm

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -72,23 +72,21 @@
 <% if display_health_questions? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "All answers to health questions" } %>
-    <%= render AppHealthQuestionsComponent.new(
-          consents: @patient_session.consents,
-        ) %>
+    <%= render AppHealthQuestionsComponent.new(consents: patient_session.consents) %>
   <% end %>
 <% end %>
 
-<% if @patient_session.triages.any? %>
+<% if patient_session.triages.any? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Triage notes" } %>
     <%= render AppTriageNotesComponent.new(patient_session:) %>
   <% end %>
 <% end %>
 
-<% if helpers.policy(Triage).create? && @patient_session.next_step == :triage && @patient_session.session.open? %>
+<% if helpers.policy(Triage).create? && patient_session.next_step == :triage && patient_session.session.open? %>
   <%= render AppCardComponent.new do %>
     <%= render AppTriageFormComponent.new(
-          patient_session: @patient_session,
+          patient_session:,
           url: session_patient_triages_path(
             session,
             patient,
@@ -102,7 +100,7 @@
   <% end %>
 <% end %>
 
-<% @patient_session.vaccination_records.each do |vaccination_record| %>
+<% patient_session.vaccination_records.each do |vaccination_record| %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Vaccination details" } %>
     <%= render AppVaccinationRecordSummaryComponent.new(vaccination_record, current_user:) %>
@@ -121,6 +119,6 @@
   <% end %>
 <% end %>
 
-<% if helpers.policy(VaccinationRecord).create? && @patient_session.attending_today? %>
-  <%= render AppVaccinateFormComponent.new(@vaccination_record, section: @section, tab: @tab) %>
+<% if helpers.policy(VaccinationRecord).create? %>
+  <%= render AppVaccinateFormComponent.new(patient_session:, vaccinate_form:, section:, tab:) %>
 <% end %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -3,31 +3,30 @@
 class AppPatientPageComponent < ViewComponent::Base
   include ApplicationHelper
 
-  attr_reader :patient_session, :current_user, :section, :tab
+  attr_reader :patient_session, :current_user, :section, :tab, :vaccinate_form
 
   def initialize(
     patient_session:,
     section:,
     tab:,
+    current_user: nil,
     triage: nil,
-    vaccination_record: nil,
-    current_user: nil
+    vaccinate_form: nil
   )
     super
 
     @patient_session = patient_session
     @section = section
     @tab = tab
-    @triage = triage
-    @vaccination_record = vaccination_record
     @current_user = current_user
+    @triage = triage
+    @vaccinate_form = vaccinate_form || VaccinateForm.new
   end
 
-  delegate :patient, to: :patient_session
-  delegate :session, to: :patient_session
+  delegate :patient, :session, to: :patient_session
 
   def display_health_questions?
-    @patient_session.consents.any?(&:response_given?)
+    patient_session.consents.any?(&:response_given?)
   end
 
   def display_gillick_assessment_card?

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(
-     model: @vaccination_record,
+     model: vaccinate_form,
      url:,
      method: :post,
      class: "nhsuk-card",
@@ -9,32 +9,21 @@
 
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
-      Did they get the <%= programme.name %> vaccine?
+      Is <%= patient.given_name %> ready to vaccinate in this session?
     </h2>
 
-    <%= f.govuk_radio_buttons_fieldset(:administered, legend: nil) do %>
-      <%= f.govuk_radio_button(
-            :administered, true,
-            label: { text: t(programme.type, scope: "vaccinations.form.label") },
-            link_errors: true,
-          ) do %>
-        <%= f.govuk_collection_radio_buttons(
-              :delivery_site,
-              common_delivery_sites_options,
-              :value,
-              :label,
-              legend: {
-                text: "Where did they get it?",
-                hidden: true,
-              },
-              bold_labels: false,
-            ) %>
+    <%= f.govuk_radio_buttons_fieldset :administered, legend: nil do %>
+      <%= f.govuk_radio_button :administered, true, label: { text: "Yes" }, link_errors: true do %>
+        <%= f.govuk_collection_radio_buttons :delivery_site,
+                                             common_delivery_sites_options,
+                                             :value,
+                                             :label,
+                                             legend: {
+                                               text: "Where will the injection be given?",
+                                               size: "s",
+                                             } %>
       <% end %>
-      <%= f.govuk_radio_button(
-            :administered,
-            false,
-            label: { text: "No, they did not get it" },
-          ) %>
+      <%= f.govuk_radio_button :administered, false, label: { text: "No" } %>
     <% end %>
 
     <%= f.hidden_field :delivery_method, value: delivery_method %>

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -1,33 +1,33 @@
 # frozen_string_literal: true
 
 class AppVaccinateFormComponent < ViewComponent::Base
-  def initialize(vaccination_record, section:, tab:)
+  def initialize(patient_session:, vaccinate_form:, section:, tab:)
     super
 
-    @vaccination_record = vaccination_record
-    @patient_session = vaccination_record.patient_session
+    @patient_session = patient_session
+    @vaccinate_form = vaccinate_form
     @section = section
     @tab = tab
   end
 
-  def url
-    @url ||=
-      session_patient_vaccinations_path(
-        @patient_session.session,
-        @patient_session.patient,
-        section: @section,
-        tab: @tab
-      )
-  end
-
   def render?
-    @patient_session.next_step == :vaccinate && session.open? && session.today?
+    patient_session.next_step == :vaccinate && session.open? &&
+      (patient_session.attending_today? || false)
   end
 
   private
 
-  def session
-    @patient_session.session
+  attr_reader :patient_session, :vaccinate_form
+
+  delegate :patient, :session, to: :patient_session
+
+  def url
+    session_patient_vaccinations_path(
+      session,
+      patient,
+      section: @section,
+      tab: @tab
+    )
   end
 
   # TODO: this code will need to be revisited in future as it only really
@@ -37,7 +37,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
   # injectable vaccines.
 
   def programme
-    @patient_session.programmes.first
+    patient_session.programmes.first
   end
 
   def vaccine

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -10,8 +10,6 @@ class PatientSessionsController < ApplicationController
   layout "three_quarters"
 
   def show
-    @draft_vaccination_record =
-      VaccinationRecord.new(patient_session: @patient_session)
   end
 
   def log

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -59,8 +59,6 @@ class TriagesController < ApplicationController
 
       redirect_to redirect_path
     else
-      @draft_vaccination_record =
-        VaccinationRecord.new(patient_session: @patient_session)
       render "patient_sessions/show", status: :unprocessable_entity
     end
   end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -51,27 +51,28 @@ class VaccinationsController < ApplicationController
   def create
     authorize VaccinationRecord
 
-    @draft_vaccination_record =
-      DraftVaccinationRecord.new(request_session: session, current_user:).tap(
-        &:reset!
+    draft_vaccination_record =
+      DraftVaccinationRecord.new(request_session: session, current_user:)
+
+    @vaccinate_form =
+      VaccinateForm.new(
+        patient_session: @patient_session,
+        current_user:,
+        todays_batch: @todays_batch,
+        **vaccinate_form_params
       )
 
-    @draft_vaccination_record.patient_session = @patient_session
-
-    if create_params.nil?
-      @draft_vaccination_record.errors.add(:administered, :blank)
-      render "patient_sessions/show", status: :unprocessable_entity
-    elsif @draft_vaccination_record.update(create_params)
-      steps = @draft_vaccination_record.wizard_steps
+    if @vaccinate_form.save(draft_vaccination_record:)
+      steps = draft_vaccination_record.wizard_steps
 
       steps.delete(:date_and_time)
-      steps.delete(:outcome) if @draft_vaccination_record.administered?
-      if @draft_vaccination_record.delivery_method.present? &&
-           @draft_vaccination_record.delivery_site.present?
+      steps.delete(:outcome) if draft_vaccination_record.administered?
+      if draft_vaccination_record.delivery_method.present? &&
+           draft_vaccination_record.delivery_site.present?
         steps.delete(:delivery)
       end
-      steps.delete(:vaccine) if @draft_vaccination_record.vaccine.present?
-      steps.delete(:batch) if @draft_vaccination_record.batch.present?
+      steps.delete(:vaccine) if draft_vaccination_record.vaccine.present?
+      steps.delete(:batch) if draft_vaccination_record.batch.present?
 
       redirect_to draft_vaccination_record_path(
                     I18n.t(steps.first, scope: :wicked)
@@ -126,39 +127,15 @@ class VaccinationsController < ApplicationController
 
   private
 
-  def vaccination_record_params
-    params
-      .require(:vaccination_record)
-      .permit(
-        :administered,
-        :delivery_method,
-        :delivery_site,
-        :dose_sequence,
-        :programme_id,
-        :vaccine_id
-      )
-      .merge(performed_at: Time.current, performed_by_user: current_user)
-  end
-
-  def create_params
-    administered = vaccination_record_params[:administered]
-    return if administered.blank?
-
-    if administered == "true"
-      create_params =
-        if vaccination_record_params[:delivery_site] == "other"
-          vaccination_record_params.except(:delivery_site, :delivery_method)
-        else
-          vaccination_record_params
-        end
-
-      create_params.except(:administered).merge(
-        batch_id: @todays_batch&.id,
-        outcome: "administered"
-      )
-    else
-      vaccination_record_params.except(:administered)
-    end
+  def vaccinate_form_params
+    params.require(:vaccinate_form).permit(
+      :administered,
+      :delivery_method,
+      :delivery_site,
+      :dose_sequence,
+      :programme_id,
+      :vaccine_id
+    )
   end
 
   def set_session

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class VaccinateForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :patient_session, :current_user, :todays_batch
+
+  attribute :administered, :boolean
+  attribute :delivery_method, :string
+  attribute :delivery_site, :string
+  attribute :dose_sequence, :integer
+  attribute :programme_id, :integer
+  attribute :vaccine_id, :integer
+
+  validates :administered, inclusion: { in: [true, false] }
+  validates :delivery_method, presence: true, if: :administered
+  validates :delivery_site, presence: true, if: :administered
+  validates :dose_sequence, presence: true
+  validates :programme_id, presence: true
+  validates :vaccine_id, presence: true, if: :administered
+
+  def save(draft_vaccination_record:)
+    return nil if invalid?
+
+    draft_vaccination_record.reset!
+
+    if administered
+      draft_vaccination_record.outcome = "administered"
+
+      if delivery_site != "other"
+        draft_vaccination_record.delivery_method = delivery_method
+        draft_vaccination_record.delivery_site = delivery_site
+      end
+    end
+
+    draft_vaccination_record.dose_sequence = dose_sequence
+    draft_vaccination_record.patient_session = patient_session
+    draft_vaccination_record.performed_at = Time.current
+    draft_vaccination_record.performed_by_user = current_user
+    draft_vaccination_record.programme_id = programme_id
+    draft_vaccination_record.vaccine_id = vaccine_id
+    draft_vaccination_record.batch_id = todays_batch&.id
+
+    draft_vaccination_record.save # rubocop:disable Rails/SaveBang
+  end
+end

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -17,27 +17,21 @@
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_collection_radio_buttons(
-        :delivery_method,
-        vaccination_delivery_methods_for(@draft_vaccination_record.vaccine),
-        :first,
-        :second,
-        legend: {
-          text: "How was the vaccination given?",
-        },
-        bold_labels: false,
-      ) %>
+  <%= f.govuk_collection_radio_buttons :delivery_method,
+                                       vaccination_delivery_methods_for(@draft_vaccination_record.vaccine),
+                                       :first,
+                                       :second,
+                                       legend: {
+                                         text: "How was the vaccination given?",
+                                       } %>
 
-  <%= f.govuk_collection_radio_buttons(
-        :delivery_site,
-        vaccination_delivery_sites_for(@draft_vaccination_record.vaccine),
-        :first,
-        :second,
-        legend: {
-          text: "Site",
-        },
-        bold_labels: false,
-      ) %>
+  <%= f.govuk_collection_radio_buttons :delivery_site,
+                                       vaccination_delivery_sites_for(@draft_vaccination_record.vaccine),
+                                       :first,
+                                       :second,
+                                       legend: {
+                                         text: "Site",
+                                       } %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -19,7 +19,6 @@
   <%= f.govuk_text_field :family_name, label: { text: "Last name" } %>
 
   <%= f.govuk_radio_buttons_fieldset :use_preferred_name,
-                                     bold_labels: false,
                                      legend: { size: "s",
                                                text: "Do they use a different name in school?" } do %>
     <%= f.govuk_radio_button :use_preferred_name,

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -46,7 +46,7 @@
 
 <%= render AppPatientPageComponent.new(
       patient_session: @patient_session,
-      vaccination_record: @draft_vaccination_record,
+      vaccinate_form: @vaccinate_form,
       triage: @triage,
       section: @section,
       tab: @tab,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,8 +194,6 @@ en:
               inclusion: Choose a status
         draft_vaccination_record:
           attributes:
-            administered:
-              blank: Choose if they got the vaccine
             batch_id:
               blank: Choose a batch
               incorrect_vaccine: Choose a batch of the %{vaccine_brand} vaccine
@@ -300,6 +298,12 @@ en:
               inclusion: Choose whether to update the child’s record with this new information
             move_to_school:
               inclusion: Choose whether to move the child to the upcoming school session
+        vaccinate_form:
+          attributes:
+            administered:
+              inclusion: Choose if they are ready to vaccinate
+            delivery_site:
+              blank: Choose where the injection will be given
         vaccination_report:
           attributes:
             file_format:
@@ -833,10 +837,6 @@ en:
       title:
         flu: Why was the flu vaccine not given?
         hpv: Why was the HPV vaccine not given?
-    form:
-      label:
-        flu: Yes, they got the flu vaccine
-        hpv: Yes, they got the HPV vaccine
     flash:
       given: Vaccination recorded for
       not_given: Record updated for

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -18,7 +18,6 @@ describe AppPatientPageComponent do
   let(:component) do
     described_class.new(
       patient_session:,
-      vaccination_record: VaccinationRecord.new(patient_session:),
       section: "triage",
       tab: "needed",
       triage: nil
@@ -39,31 +38,16 @@ describe AppPatientPageComponent do
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should_not have_css(".nhsuk-card__heading", text: "Triage notes") }
 
-    it "shows the triage form" do
-      expect(rendered).to have_selector(
-        :heading,
-        text: "Is it safe to vaccinate"
-      )
-    end
+    it { should have_content("Is it safe to vaccinate") }
 
-    it "does not show the vaccination form" do
-      expect(rendered).not_to have_css(
-        ".nhsuk-card",
-        text: "Did they get the HPV vaccine?"
-      )
-    end
+    it { should_not have_content("ready to vaccinate in this session?") }
 
     it { should have_css("a", text: "Assess Gillick competence") }
 
     context "user is not allowed to triage or vaccinate" do
       before { stub_authorization(allowed: false) }
 
-      it "does not show the triage form" do
-        expect(rendered).not_to have_css(
-          ".nhsuk-card__heading",
-          text: "Is it safe to vaccinate"
-        )
-      end
+      it { should_not have_content("Is it safe to vaccinate") }
     end
   end
 
@@ -77,19 +61,9 @@ describe AppPatientPageComponent do
       )
     end
 
-    it "does not show the triage form" do
-      expect(rendered).not_to have_selector(
-        :heading,
-        text: "Is it safe to vaccinate"
-      )
-    end
+    it { should_not have_content("Is it safe to vaccinate") }
 
-    it "does not show the vaccination form" do
-      expect(rendered).not_to have_css(
-        ".nhsuk-card",
-        text: "Did they get the HPV vaccine?"
-      )
-    end
+    it { should_not have_content("ready to vaccinate in this session?") }
   end
 
   context "session in progress, patient ready to vaccinate" do
@@ -107,29 +81,14 @@ describe AppPatientPageComponent do
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should have_css(".nhsuk-card__heading", text: "Triage notes") }
 
-    it "does not show the triage form" do
-      expect(rendered).not_to have_css(
-        ".nhsuk-card__heading",
-        text: "Is it safe to vaccinate"
-      )
-    end
+    it { should_not have_content("Is it safe to vaccinate") }
 
-    it "shows the vaccination form" do
-      expect(rendered).to have_css(
-        ".nhsuk-card__heading",
-        text: "Did they get the HPV vaccine?"
-      )
-    end
+    it { should have_content("ready to vaccinate in this session?") }
 
     context "user is not allowed to triage or vaccinate" do
       before { stub_authorization(allowed: false) }
 
-      it "does not show the vaccination form" do
-        expect(rendered).not_to have_css(
-          ".nhsuk-card__heading",
-          text: "Did they get the HPV vaccine?"
-        )
-      end
+      it { should_not have_content("ready to vaccinate in this session?") }
     end
   end
 

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -8,31 +8,38 @@ describe AppVaccinateFormComponent do
   let(:programme) { create(:programme, :hpv) }
   let(:session) { create(:session, :today, programme:) }
   let(:vaccine) { programme.vaccines.first }
-  let(:patient_session) do
+  let(:patient) do
     create(
-      :patient_session,
+      :patient,
       :consent_given_triage_not_needed,
       programme:,
-      session:
+      given_name: "Hari"
     )
   end
-  let(:vaccination_record) { VaccinationRecord.new(patient_session:) }
+  let(:patient_session) do
+    create(:patient_session, :in_attendance, programme:, patient:, session:)
+  end
 
   let(:component) do
-    described_class.new(vaccination_record, section: "vaccinate", tab: "needed")
+    described_class.new(
+      patient_session:,
+      vaccinate_form: VaccinateForm.new,
+      section: "vaccinate",
+      tab: "needed"
+    )
   end
 
   it { should have_css(".nhsuk-card") }
 
   it "has the correct heading" do
-    expect(subject).to have_css(
-      "h2.nhsuk-card__heading",
-      text: "Did they get the HPV vaccine?"
+    expect(rendered).to have_css(
+      ".nhsuk-card__heading",
+      text: "Is Hari ready to vaccinate in this session?"
     )
   end
 
-  it { should have_field("Yes, they got the HPV vaccine") }
-  it { should have_field("No, they did not get it") }
+  it { should have_field("Yes") }
+  it { should have_field("No") }
 
   describe "#render?" do
     subject(:render) { component.render? }
@@ -45,13 +52,13 @@ describe AppVaccinateFormComponent do
       context "session is in progress" do
         let(:session) { create(:session, :today, programme:) }
 
-        it { should be_falsey }
+        it { should be(false) }
       end
 
       context "session is in the future" do
         let(:session) { create(:session, :scheduled, programme:) }
 
-        it { should be_falsey }
+        it { should be(false) }
       end
     end
 
@@ -63,13 +70,13 @@ describe AppVaccinateFormComponent do
       context "session is progress" do
         let(:session) { create(:session, :today, programme:) }
 
-        it { should be_truthy }
+        it { should be(true) }
       end
 
       context "session is in the future" do
         let(:session) { create(:session, :scheduled, programme:) }
 
-        it { should be_falsey }
+        it { should be(false) }
       end
     end
   end

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -233,7 +233,7 @@ describe "End-to-end journey" do
 
     expect(page).to have_content("Update attendance")
 
-    choose "Yes, they got the HPV vaccine"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -94,7 +94,7 @@ describe "HPV Vaccination" do
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated
-    choose "Yes, they got the HPV vaccine"
+    choose "Yes"
     choose "Left arm"
     click_button "Continue"
   end

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -50,7 +50,7 @@ describe "HPV Vaccination" do
   end
 
   def and_i_record_that_the_patient_wasnt_vaccinated
-    choose "No, they did not get it"
+    choose "No"
     click_button "Continue"
   end
 

--- a/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
@@ -32,6 +32,6 @@ describe "HPV vaccination" do
   end
 
   def then_i_cannot_record_that_the_patient_has_been_vaccinated
-    expect(page).not_to have_content("Did they get the HPV vaccine?")
+    expect(page).not_to have_content("ready to vaccinate in this session?")
   end
 end

--- a/spec/features/hpv_vaccination_cannot_record_closed_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_closed_spec.rb
@@ -29,6 +29,6 @@ describe "HPV vaccination" do
   end
 
   def then_i_cannot_record_that_the_patient_has_been_vaccinated
-    expect(page).not_to have_content("Did they get the HPV vaccine?")
+    expect(page).not_to have_content("ready to vaccinate in this session?")
   end
 end

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -62,7 +62,7 @@ describe "HPV Vaccination" do
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated
-    choose "Yes, they got the HPV vaccine"
+    choose "Yes"
     choose "Left arm"
     click_button "Continue"
   end

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -56,7 +56,7 @@ describe "HPV Vaccination" do
     visit session_vaccinations_path(@session)
     click_link @patient.full_name
 
-    choose "Yes, they got the HPV vaccine"
+    choose "Yes"
     choose "Left arm"
     click_button "Continue"
 
@@ -81,7 +81,7 @@ describe "HPV Vaccination" do
     visit session_vaccinations_path(@session)
     click_link @patient2.full_name
 
-    choose "Yes, they got the HPV vaccine"
+    choose "Yes"
     choose "Left arm"
     click_button "Continue"
   end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -51,7 +51,7 @@ describe "HPV Vaccination" do
   end
 
   def and_i_record_that_the_patient_was_unwell
-    choose "No, they did not get it"
+    choose "No"
     click_button "Continue"
 
     choose "They were not well enough"

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -126,6 +126,6 @@ describe "Invalidate consent" do
 
   def and_i_am_not_able_to_record_a_vaccination
     expect(page).to have_content("No response")
-    expect(page).not_to have_content("Did they get the HPV vaccine?")
+    expect(page).not_to have_content("ready to vaccinate in this session?")
   end
 end

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -102,7 +102,7 @@ describe "Manage attendance" do
   end
 
   def and_i_am_not_able_to_vaccinate
-    expect(page).not_to have_content("Did they get the HPV vaccine?")
+    expect(page).not_to have_content("ready to vaccinate in this session?")
   end
 
   def when_i_choose_the_patient_has_not_been_registered_yet
@@ -146,7 +146,7 @@ describe "Manage attendance" do
   alias_method :then_i_see_the_attending_flash, :and_i_see_the_attending_flash
 
   def and_i_can_vaccinate
-    expect(page).to have_content("Did they get the HPV vaccine?")
+    expect(page).to have_content("ready to vaccinate in this session?")
   end
 
   def when_i_go_to_the_activity_log

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -104,7 +104,7 @@ describe "Triage" do
   end
 
   def and_i_am_able_to_record_a_vaccination
-    choose "Yes, they got the HPV vaccine"
+    choose "Yes"
   end
 
   def when_i_go_to_the_community_clinics

--- a/spec/features/withdraw_consent_spec.rb
+++ b/spec/features/withdraw_consent_spec.rb
@@ -133,6 +133,6 @@ describe "Withdraw consent" do
 
   def and_i_am_not_able_to_record_a_vaccination
     expect(page).to have_content("Consent refused")
-    expect(page).not_to have_content("Did they get the HPV vaccine?")
+    expect(page).not_to have_content("ready to vaccinate in this session?")
   end
 end


### PR DESCRIPTION
This adds a new form which represents the form shown on the vaccination section of the patient page and updates the UI to match the latest version in the prototype, in preparation for adding the new pre-screening questions.

## Screenshots

![Screenshot 2024-12-04 at 17 38 41](https://github.com/user-attachments/assets/6da9c08e-201b-42af-990d-cd845fab5118)
![Screenshot 2024-12-04 at 17 38 44](https://github.com/user-attachments/assets/84455ad8-1d0a-4df0-a522-d6f6b158a2be)
![Screenshot 2024-12-04 at 17 38 48](https://github.com/user-attachments/assets/4a6d4354-cab4-4351-971a-970aeef60377)
![Screenshot 2024-12-04 at 17 38 56](https://github.com/user-attachments/assets/aac1c757-b5a2-4670-a08c-8a7e7eeaef16)
