### PR TITLE
Use find_by! when looking up patient sessions

### DIFF
--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -33,7 +33,10 @@ class GillickAssessmentsController < ApplicationController
 
   def set_patient_session
     @patient_session =
-      policy_scope(PatientSession).find_by(session: @session, patient: @patient)
+      policy_scope(PatientSession).find_by!(
+        session: @session,
+        patient: @patient
+      )
   end
 
   def set_is_first_assessment

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -57,6 +57,6 @@ class RegisterAttendancesController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session = @patient.patient_sessions.find_by(session: @session)
+    @patient_session = @patient.patient_sessions.find_by!(session: @session)
   end
 end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -77,7 +77,7 @@ class TriagesController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session = @patient.patient_sessions.find_by(session: @session)
+    @patient_session = @patient.patient_sessions.find_by!(session: @session)
   end
 
   def set_triage

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -153,7 +153,7 @@ class VaccinationsController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session = @patient.patient_sessions.find_by(session: @session)
+    @patient_session = @patient.patient_sessions.find_by!(session: @session)
   end
 
   def set_vaccination_record


### PR DESCRIPTION
This ensures that the user will see a 404 error if they try to access a page for a patient session that doesn't exist, rather than a 500 error they would see currently.