### PR TITLE
Refactor draft model back links

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -17,6 +17,7 @@ class DraftConsentsController < ApplicationController
   include WizardControllerConcern
 
   before_action :set_parent_options, if: -> { current_step == :who }
+  before_action :set_back_link_href
 
   after_action :verify_authorized
 
@@ -167,6 +168,22 @@ class DraftConsentsController < ApplicationController
         .compact
         .uniq
         .sort_by(&:label)
+  end
+
+  def set_back_link_href
+    @back_link_href =
+      if @draft_consent.editing?
+        wizard_path("confirm")
+      elsif current_step == @draft_consent.wizard_steps.first
+        session_patient_path(
+          @session,
+          @patient,
+          section: "consents",
+          tab: "no-consent"
+        )
+      else
+        previous_wizard_path
+      end
   end
 
   # Returns:

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -18,6 +18,7 @@ class DraftVaccinationRecordsController < ApplicationController
   before_action :validate_params, only: :update
   before_action :set_batches, if: -> { current_step == :batch }
   before_action :set_locations, if: -> { current_step == :location }
+  before_action :set_back_link_href
 
   after_action :verify_authorized
 
@@ -193,6 +194,26 @@ class DraftVaccinationRecordsController < ApplicationController
 
   def set_locations
     @locations = policy_scope(Location).community_clinic
+  end
+
+  def set_back_link_href
+    @back_link_href =
+      if @draft_vaccination_record.editing?
+        if current_step == :confirm
+          programme_vaccination_record_path(@programme, @vaccination_record)
+        else
+          wizard_path("confirm")
+        end
+      elsif current_step == @draft_vaccination_record.wizard_steps.first
+        session_patient_path(
+          @session,
+          @patient,
+          section: "vaccinations",
+          tab: "vaccinate"
+        )
+      else
+        previous_wizard_path
+      end
   end
 
   def update_default_batch_for_today

--- a/app/helpers/consents_helper.rb
+++ b/app/helpers/consents_helper.rb
@@ -16,21 +16,4 @@ module ConsentsHelper
       Consent.human_enum_name(:response, consent.response).humanize
     end
   end
-
-  # rubocop:disable Rails/HelperInstanceVariable
-  def consents_back_link_path
-    if @draft_consent.editing?
-      wizard_path("confirm")
-    elsif current_step?(@draft_consent.wizard_steps.first.to_s)
-      session_patient_path(
-        @session,
-        id: @patient.id,
-        section: "consents",
-        tab: "no-consent"
-      )
-    else
-      previous_wizard_path
-    end
-  end
-  # rubocop:enable Rails/HelperInstanceVariable
 end

--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -38,21 +38,4 @@ module VaccinationsHelper
   def in_tab_not_vaccinated?(_action, outcome)
     outcome.in? %i[do_not_vaccinate not_vaccinated]
   end
-
-  # rubocop:disable Rails/HelperInstanceVariable
-  def draft_vaccinations_back_link_path
-    if @draft_vaccination_record.editing?
-      wizard_path("confirm")
-    elsif current_step?(@draft_vaccination_record.wizard_steps.first.to_s)
-      session_patient_path(
-        @session,
-        @patient,
-        section: "vaccinations",
-        tab: "vaccinate"
-      )
-    else
-      previous_wizard_path
-    end
-  end
-  # rubocop:enable Rails/HelperInstanceVariable
 end

--- a/app/views/draft_consents/agree.html.erb
+++ b/app/views/draft_consents/agree.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "contact details page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
+        href: @back_link_href,
         name: "previous page",
       ) %>
 <% end %>

--- a/app/views/draft_consents/notes.html.erb
+++ b/app/views/draft_consents/notes.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: backlink_path,
+        href: @back_link_href,
         name: "previous page",
       ) %>
 <% end %>

--- a/app/views/draft_consents/notify_parents.html.erb
+++ b/app/views/draft_consents/notify_parents.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
+        href: @back_link_href,
         name: "previous page",
       ) %>
 <% end %>

--- a/app/views/draft_consents/parent_details.html.erb
+++ b/app/views/draft_consents/parent_details.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "patient page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_consents/questions.html.erb
+++ b/app/views/draft_consents/questions.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "consent page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_consents/reason.html.erb
+++ b/app/views/draft_consents/reason.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "consent page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_consents/route.html.erb
+++ b/app/views/draft_consents/route.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "consent page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_consents/triage.html.erb
+++ b/app/views/draft_consents/triage.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "consent page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_consents/who.html.erb
+++ b/app/views/draft_consents/who.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: consents_back_link_path,
-        name: "patient page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/batch.html.erb
+++ b/app/views/draft_vaccination_records/batch.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: @draft_vaccination_record.editing? ? programme_vaccination_record_path(@programme, @vaccination_record) : draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/date_and_time.html.erb
+++ b/app/views/draft_vaccination_records/date_and_time.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/location.html.erb
+++ b/app/views/draft_vaccination_records/location.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/outcome.html.erb
+++ b/app/views/draft_vaccination_records/outcome.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 

--- a/app/views/draft_vaccination_records/vaccine.html.erb
+++ b/app/views/draft_vaccination_records/vaccine.html.erb
@@ -1,7 +1,7 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: draft_vaccinations_back_link_path,
-        name: "vaccination page",
+        href: @back_link_href,
+        name: "previous page",
       ) %>
 <% end %>
 


### PR DESCRIPTION
This changes the back links used in the consent and vaccination record wizards, mostly to fix a bug where clicking back on the first page of the wizard would reload the page. This was happening because the `current_page?` method doesn't handle the URL translations correctly. For vaccination records, the page was `"date-and-time"` and the first wizard step is `:date_and_time` and the comparison was failing.