### PR TITLE
Remove absent not vaccinated reasons

### DIFF
--- a/app/views/draft_vaccination_records/outcome.html.erb
+++ b/app/views/draft_vaccination_records/outcome.html.erb
@@ -7,34 +7,29 @@
 
 <% editing = @draft_vaccination_record.editing? || @draft_vaccination_record.outcome.present? %>
 
-<% title = editing ? "Vaccination outcome" : t(@programme.type, scope: "vaccinations.reason.title") %>
+<% title = editing ? "Vaccination outcome" : "Why was the vaccine not given?" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset(:outcome,
+  <%= f.govuk_radio_buttons_fieldset :outcome,
                                      caption: { text: @patient.full_name, size: "l" },
-                                     legend: { size: "l", tag: "h1",
-                                               text: title }) do %>
+                                     legend: { size: "l", tag: "h1", text: title } do %>
 
     <% if editing %>
       <%= f.govuk_radio_button :outcome, "administered",
                                label: { text: "Vaccinated" } %>
     <% end %>
 
+    <%= f.govuk_radio_button :outcome, "already_had",
+                             label: { text: "They have already had the vaccine" } %>
+    <%= f.govuk_radio_button :outcome, "contraindications",
+                             label: { text: "They had contraindications" } %>
     <%= f.govuk_radio_button :outcome, "refused",
                              label: { text: "They refused it" } %>
     <%= f.govuk_radio_button :outcome, "not_well",
                              label: { text: "They were not well enough" } %>
-    <%= f.govuk_radio_button :outcome, "contraindications",
-                             label: { text: "They had contraindications" } %>
-    <%= f.govuk_radio_button :outcome, "already_had",
-                             label: { text: "They have already had the vaccine" } %>
-    <%= f.govuk_radio_button :outcome, "absent_from_school",
-                             label: { text: "They were absent from school" } %>
-    <%= f.govuk_radio_button :outcome, "absent_from_session",
-                             label: { text: "They were absent from the session" } %>
   <% end %>
 
   <%= f.govuk_submit "Continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -833,10 +833,6 @@ en:
     index:
       title: Vaccinations
   vaccinations:
-    reason:
-      title:
-        flu: Why was the flu vaccine not given?
-        hpv: Why was the HPV vaccine not given?
     flash:
       given: Vaccination recorded for
       not_given: Record updated for


### PR DESCRIPTION
The user shouldn't be able to get to this page if they've marked the patient as absent for the session so we no longer need this options available. This matches the designs in the prototype.

## Screenshot

![Screenshot 2024-12-05 at 08 05 30](https://github.com/user-attachments/assets/5dcb3853-fee9-4ec0-8023-b59711e1abfe)
