### PR TITLE
Enable Ruby yjit

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,5 +77,7 @@ module ManageVaccinations
     )
 
     config.silence_healthcheck_path = "/up"
+
+    config.yjit = true
   end
 end


### PR DESCRIPTION
Rails 7.2 defaults toggle this to `true` when running Ruby 3.3 or newer. Since we are still using 7.1 defaults, we need to manually toggle it on.

yjit brings significant performance improvements to Ruby.