### PR TITLE
Add a default name to AppBacklinkComponent

### DIFF
--- a/app/components/app_backlink_component.rb
+++ b/app/components/app_backlink_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AppBacklinkComponent < ViewComponent::Base
-  def initialize(href:, name:, classes: nil, attributes: {})
+  def initialize(href, name: "previous page", classes: nil, attributes: {})
     super
 
     @href = href

--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -17,7 +17,7 @@ class DraftConsentsController < ApplicationController
   include WizardControllerConcern
 
   before_action :set_parent_options, if: -> { current_step == :who }
-  before_action :set_back_link_href
+  before_action :set_back_link_path
 
   after_action :verify_authorized
 
@@ -170,8 +170,8 @@ class DraftConsentsController < ApplicationController
         .sort_by(&:label)
   end
 
-  def set_back_link_href
-    @back_link_href =
+  def set_back_link_path
+    @back_link_path =
       if @draft_consent.editing?
         wizard_path("confirm")
       elsif current_step == @draft_consent.wizard_steps.first

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -18,7 +18,7 @@ class DraftVaccinationRecordsController < ApplicationController
   before_action :validate_params, only: :update
   before_action :set_batches, if: -> { current_step == :batch }
   before_action :set_locations, if: -> { current_step == :location }
-  before_action :set_back_link_href
+  before_action :set_back_link_path
 
   after_action :verify_authorized
 
@@ -196,8 +196,8 @@ class DraftVaccinationRecordsController < ApplicationController
     @locations = policy_scope(Location).community_clinic
   end
 
-  def set_back_link_href
-    @back_link_href =
+  def set_back_link_path
+    @back_link_path =
       if @draft_vaccination_record.editing?
         if current_step == :confirm
           programme_vaccination_record_path(@programme, @vaccination_record)

--- a/app/views/batches/archive.html.erb
+++ b/app/views/batches/archive.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: vaccines_path,
-        name: "vaccines",
-      ) %>
+  <%= render AppBacklinkComponent.new(vaccines_path, name: "vaccines") %>
 <% end %>
 
 <% page_title = "Are you sure you want to archive this batch?" %>

--- a/app/views/batches/edit.html.erb
+++ b/app/views/batches/edit.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: vaccines_path,
-        name: "manage vaccines",
-      ) %>
+  <%= render AppBacklinkComponent.new(vaccines_path, name: "manage vaccines") %>
 <% end %>
 
 <% page_title = "Edit batch #{@batch.name}" %>

--- a/app/views/batches/new.html.erb
+++ b/app/views/batches/new.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: vaccines_path,
-        name: "manage vaccines",
-      ) %>
+  <%= render AppBacklinkComponent.new(vaccines_path, name: "manage vaccines") %>
 <% end %>
 
 <% page_title = "Add batch" %>

--- a/app/views/class_imports/new.html.erb
+++ b/app/views/class_imports/new.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_path(@session),
-        name: @session.location.name,
-      ) %>
+  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
 <% end %>
 
 <% title = "Import class list" %>

--- a/app/views/cohort_imports/new.html.erb
+++ b/app/views/cohort_imports/new.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: programme_cohorts_path(@programme),
-        name: @programme.name,
-      ) %>
+  <%= render AppBacklinkComponent.new(programme_cohorts_path(@programme), name: @programme.name) %>
 <% end %>
 
 <% title = "Import child records" %>

--- a/app/views/consent_forms/match.html.erb
+++ b/app/views/consent_forms/match.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: consent_form_path(@consent_form),
-        name: "search for a child record",
-      ) %>
+  <%= render AppBacklinkComponent.new(consent_form_path(@consent_form), name: "search for a child record") %>
 <% end %>
 
 <% page_title = "Link consent response with child record?" %>

--- a/app/views/consent_forms/new_patient.html.erb
+++ b/app/views/consent_forms/new_patient.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: consent_forms_path,
-        name: "unmatched consent responses",
-      ) %>
+  <%= render AppBacklinkComponent.new(consent_forms_path, name: "unmatched consent responses") %>
 <% end %>
 
 <% page_title = "Create a new child record from this consent response?" %>

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: consent_forms_path,
-        name: "unmatched consent responses",
-      ) %>
+  <%= render AppBacklinkComponent.new(consent_forms_path, name: "unmatched consent responses") %>
 <% end %>
 
 <% page_title = "Search for a child record" %>

--- a/app/views/consents/invalidate.html.erb
+++ b/app/views/consents/invalidate.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_consent_path,
-        name: "consent page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_consent_path, name: "consent page") %>
 <% end %>
 
 <%= form_with model: @consent, url: invalidate_session_patient_consent_path, method: :post do |f| %>

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_path(id: @consent.patient.id),
-        name: "patient page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_path(id: @consent.patient.id), name: @consent.patient.full_name) %>
 <% end %>
 
 <%= h1 "Consent response from #{@consent.name}" %>

--- a/app/views/consents/withdraw.html.erb
+++ b/app/views/consents/withdraw.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_consent_path,
-        name: "consent page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_consent_path, name: "consent page") %>
 <% end %>
 
 <%= form_with model: @consent, url: withdraw_session_patient_consent_path, method: :post do |f| %>

--- a/app/views/draft_consents/agree.html.erb
+++ b/app/views/draft_consents/agree.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% title = t(@draft_consent.programme.type, scope: "draft_consents.agree.title") %>

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = "Check and confirm answers" %>

--- a/app/views/draft_consents/notes.html.erb
+++ b/app/views/draft_consents/notes.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <%= form_with model: @draft_consent, url: wizard_path, method: :put do |f| %>

--- a/app/views/draft_consents/notify_parents.html.erb
+++ b/app/views/draft_consents/notify_parents.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% title = "Does the child want their parent or guardian to get confirmation of the vaccination?" %>

--- a/app/views/draft_consents/parent_details.html.erb
+++ b/app/views/draft_consents/parent_details.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = if @parent.persisted?

--- a/app/views/draft_consents/questions.html.erb
+++ b/app/views/draft_consents/questions.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = "Health questions" %>

--- a/app/views/draft_consents/reason.html.erb
+++ b/app/views/draft_consents/reason.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% title = "Why are they refusing to give consent?" %>

--- a/app/views/draft_consents/route.html.erb
+++ b/app/views/draft_consents/route.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% title = "How was the response given?" %>

--- a/app/views/draft_consents/triage.html.erb
+++ b/app/views/draft_consents/triage.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = "Is it safe to vaccinate?" %>

--- a/app/views/draft_consents/who.html.erb
+++ b/app/views/draft_consents/who.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = "Who are you trying to get consent from?" %>

--- a/app/views/draft_vaccination_records/batch.html.erb
+++ b/app/views/draft_vaccination_records/batch.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% content_for :page_title, "Which batch did you use?" %>

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% if @draft_vaccination_record.editing? %>

--- a/app/views/draft_vaccination_records/date_and_time.html.erb
+++ b/app/views/draft_vaccination_records/date_and_time.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = "Tell us how the vaccination was given" %>

--- a/app/views/draft_vaccination_records/location.html.erb
+++ b/app/views/draft_vaccination_records/location.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% title = "Where was the vaccination given?" %>

--- a/app/views/draft_vaccination_records/outcome.html.erb
+++ b/app/views/draft_vaccination_records/outcome.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% editing = @draft_vaccination_record.editing? || @draft_vaccination_record.outcome.present? %>

--- a/app/views/draft_vaccination_records/vaccine.html.erb
+++ b/app/views/draft_vaccination_records/vaccine.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: @back_link_href,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
 <% page_title = "Vaccine" %>

--- a/app/views/gillick_assessments/edit.html.erb
+++ b/app/views/gillick_assessments/edit.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_path(id: @patient.id),
-        name: "patient page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: @patient.full_name) %>
 <% end %>
 
 <% page_title = @is_first_assessment ? "Assess Gillick competence" : "Edit Gillick competence" %>

--- a/app/views/immunisation_imports/new.html.erb
+++ b/app/views/immunisation_imports/new.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: programme_vaccination_records_path(@programme),
-        name: "vaccinations",
-      ) %>
+  <%= render AppBacklinkComponent.new(programme_vaccination_records_path(@programme), name: "vaccinations") %>
 <% end %>
 
 <% title = "Import vaccination records" %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -1,12 +1,8 @@
 <% title = "What type of records are you importing?" %>
-
 <% content_for :page_title, title %>
 
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: programme_imports_path,
-        name: "imports",
-      ) %>
+  <%= render AppBacklinkComponent.new(programme_imports_path, name: "imports") %>
 <% end %>
 
 <%= form_with(url: programme_imports_path) do |f| %>

--- a/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: parent_interface_consent_form_edit_path(@consent_form, :parent),
+        parent_interface_consent_form_edit_path(@consent_form, :parent),
         name: "edit your details page",
       ) %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: parent_interface_consent_form_edit_path(@consent_form, :consent),
+        parent_interface_consent_form_edit_path(@consent_form, :consent),
         name: "edit consent page",
       ) %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/address.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/address.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <%= form_with model: @consent_form, url: wizard_path, method: :put do |f| %>

--- a/app/views/parent_interface/consent_forms/edit/confirm_school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/confirm_school.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <%= h1 "Confirm your child’s school" %>

--- a/app/views/parent_interface/consent_forms/edit/consent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/consent.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <% title = t("consent_forms.consent.title.#{@consent_form.programme.type}") %>

--- a/app/views/parent_interface/consent_forms/edit/contact_method.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/contact_method.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <% title = "Phone contact method" %>

--- a/app/views/parent_interface/consent_forms/edit/date_of_birth.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/date_of_birth.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <% content_for :page_title, "What is your child’s date of birth?" %>

--- a/app/views/parent_interface/consent_forms/edit/education_setting.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/education_setting.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <% title = "Is your child home-schooled?" %>

--- a/app/views/parent_interface/consent_forms/edit/health_question.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/health_question.html.erb
@@ -1,7 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: health_question_backlink_path(@consent_form, @health_answer),
-        name: "previous page",
+        health_question_backlink_path(@consent_form, @health_answer)
       ) %>
 <% end %>
 

--- a/app/views/parent_interface/consent_forms/edit/injection.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/injection.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <%= h1 "Your child may be able to have an injection instead" %>

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: start_parent_interface_consent_forms_path(@session, @programme),
+        start_parent_interface_consent_forms_path(@session, @programme),
         name: "start consent page",
       ) %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/parent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/parent.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 

--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <% title = "Why are you refusing to give consent?" %>

--- a/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <%= form_with model: @consent_form, url: wizard_path, method: :put do |f| %>

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: backlink_path,
-        name: "previous page",
-      ) %>
+  <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
 <%= form_with model: @consent_form, url: wizard_path, method: :put do |f| %>

--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: session_section_tab_path(@session),
+        session_section_tab_path(@session),
         name: "#{@section.pluralize} page",
       ) %>
 <% end %>

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        href: session_section_tab_path(@session),
+        session_section_tab_path(@session),
         name: "#{@section.pluralize} page",
       ) %>
 <% end %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: patient_path(@patient),
-        name: @patient.full_name,
-      ) %>
+  <%= render AppBacklinkComponent.new(patient_path(@patient), name: @patient.full_name) %>
 <% end %>
 
 <% page_title = "Edit child record" %>

--- a/app/views/patients/edit/nhs_number.html.erb
+++ b/app/views/patients/edit/nhs_number.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: edit_patient_path(@patient),
-        name: "edit patient",
-      ) %>
+  <%= render AppBacklinkComponent.new(edit_patient_path(@patient), name: "edit patient") %>
 <% end %>
 
 <% legend = "What is the child’s NHS number?" %>

--- a/app/views/patients/edit/nhs_number_merge.html.erb
+++ b/app/views/patients/edit/nhs_number_merge.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: edit_nhs_number_patient_path(@patient),
-        name: "edit NHS number",
-      ) %>
+  <%= render AppBacklinkComponent.new(edit_nhs_number_patient_path(@patient), name: "edit NHS number") %>
 <% end %>
 
 <% page_title = "Do you want to merge this record?" %>

--- a/app/views/session_attendances/edit.html.erb
+++ b/app/views/session_attendances/edit.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_path(id: @patient.id),
-        name: "#{@section.pluralize} page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: "#{@section.pluralize} page") %>
 <% end %>
 
 <% title = "Is #{@patient.full_name} attending today’s session?" %>

--- a/app/views/session_dates/show.html.erb
+++ b/app/views/session_dates/show.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: edit_session_path(@session),
-        name: "edit session",
-      ) %>
+  <%= render AppBacklinkComponent.new(edit_session_path(@session), name: "edit session") %>
 <% end %>
 
 <%= h1 "When will sessions be held?" %>

--- a/app/views/sessions/close.html.erb
+++ b/app/views/sessions/close.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_path(@session),
-        name: @session.location.name,
-      ) %>
+  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
 <% end %>
 
 <%= h1 "Close session" do %>

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_path(@session),
-        name: @session.location.name,
-      ) %>
+  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
 <% end %>
 
 <%= h1 "Edit session" do %>

--- a/app/views/sessions/edit/send_consent_requests_at.html.erb
+++ b/app/views/sessions/edit/send_consent_requests_at.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: edit_session_path(@session),
-        name: "edit session",
-      ) %>
+  <%= render AppBacklinkComponent.new(edit_session_path(@session), name: "edit session") %>
 <% end %>
 
 <% legend = "When should parents get a request to give consent?" %>

--- a/app/views/sessions/edit/send_invitations_at.html.erb
+++ b/app/views/sessions/edit/send_invitations_at.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: edit_session_path(@session),
-        name: "edit session",
-      ) %>
+  <%= render AppBacklinkComponent.new(edit_session_path(@session), name: "edit session") %>
 <% end %>
 
 <% legend = "When should parents get an invitation?" %>

--- a/app/views/sessions/edit/weeks_before_consent_reminders.html.erb
+++ b/app/views/sessions/edit/weeks_before_consent_reminders.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: edit_session_path(@session),
-        name: "edit session",
-      ) %>
+  <%= render AppBacklinkComponent.new(edit_session_path(@session), name: "edit session") %>
 <% end %>
 
 <% legend = "When should parents get a reminder to give consent?" %>

--- a/app/views/triages/new.html.erb
+++ b/app/views/triages/new.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_path(id: @patient.id),
-        name: "patient page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: @patient.full_name) %>
 <% end %>
 
 <%= h1 page_title: "Update triage outcome" do %>

--- a/app/views/vaccination_reports/dates.html.erb
+++ b/app/views/vaccination_reports/dates.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: programme_path(@programme),
-        name: "programme page",
-      ) %>
+  <%= render AppBacklinkComponent.new(programme_path(@programme), name: @programme.name) %>
 <% end %>
 
 <%= form_with model: @vaccination_report, url: wizard_path, method: :put do |f| %>

--- a/app/views/vaccination_reports/file_format.html.erb
+++ b/app/views/vaccination_reports/file_format.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: previous_wizard_path,
-        name: "previous step",
-      ) %>
+  <%= render AppBacklinkComponent.new(previous_wizard_path) %>
 <% end %>
 
 <% title = "Select file format" %>

--- a/app/views/vaccinations/batch.html.erb
+++ b/app/views/vaccinations/batch.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_vaccinations_path(@session.id),
-        name: "vaccinations page",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_vaccinations_path(@session.id), name: "vaccinations page") %>
 <% end %>
 
 <% page_title = "Select a default batch for this session" %>

--- a/app/views/vaccinations/destroy.html.erb
+++ b/app/views/vaccinations/destroy.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: session_patient_path(id: @patient.id),
-        name: "patient",
-      ) %>
+  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: "patient") %>
 <% end %>
 
 <% page_title = "Are you sure you want to delete this vaccination record?" %>

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        href: vaccines_path,
-        name: "vaccines page",
-      ) %>
+  <%= render AppBacklinkComponent.new(vaccines_path, name: "vaccines page") %>
 <% end %>
 
 <%= h1 vaccine_heading(@vaccine), size: "l" %>

--- a/spec/components/app_backlink_component_spec.rb
+++ b/spec/components/app_backlink_component_spec.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-describe AppBacklinkComponent, type: :component do
-  subject { page }
+describe AppBacklinkComponent do
+  subject(:rendered) { render_inline(component) }
 
-  before { render_inline(component) }
-
-  let(:component) { described_class.new(href:, name:, classes:, attributes:) }
+  let(:component) { described_class.new(href, name:, classes:, attributes:) }
   let(:href) { "/previous_page" }
   let(:name) { "Previous Page" }
   let(:classes) { "additional-class" }
@@ -17,4 +15,10 @@ describe AppBacklinkComponent, type: :component do
   it { should have_css(".nhsuk-width-container.additional-class") }
   it { should have_css('[id="back-link"]') }
   it { should have_css(".nhsuk-u-visually-hidden", text: "to #{name}") }
+
+  context "without a name" do
+    let(:component) { described_class.new(href) }
+
+    it { should have_css(".nhsuk-u-visually-hidden", text: "to previous page") }
+  end
 end

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -176,7 +176,7 @@ describe "Parental consent" do
     )
     expect(page).to have_content(["School", "Pilot School"].join)
 
-    click_on "Back to patient page"
+    click_on "Back to #{@child.full_name}"
     click_on "Back to consents page"
   end
 


### PR DESCRIPTION
This component is often used as part of a wizard where we've got "previous page" hard coded as the name of the link, so instead we can move this in to the component itself to avoid repeating the string in lots of places.

I've also changed the first argument to not be a keyword argument as it's likely to be obvious that it's the path of the backlink, since it's the only required argument.