### PR TITLE
Add superusers and restrict access

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -4,6 +4,8 @@ class NoticesController < ApplicationController
   layout "full"
 
   def index
+    authorize :notices
+
     @deceased_patients = policy_scope(Patient).deceased
     @invalidated_patients = policy_scope(Patient).invalidated
     @restricted_patients = policy_scope(Patient).restricted

--- a/app/policies/notices_policy.rb
+++ b/app/policies/notices_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NoticesPolicy < ApplicationPolicy
+  def index?
+    user.is_superuser?
+  end
+end

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -18,7 +18,7 @@ class VaccinationRecordPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user.is_nurse? && record.session.open?
+    user.is_superuser?
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -75,12 +75,16 @@
                       aria: { current: request.path.start_with?(school_moves_path) ?
                         "true" : nil } %>
         </li>
-        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-          <%= link_to "Notices", notices_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(notices_path) ?
-                        "true" : nil } %>
-        </li>
+
+        <% if policy(:notices).index? %>
+          <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
+            <%= link_to "Notices", notices_path,
+                        class: "nhsuk-header__navigation-link",
+                        aria: { current: request.path.start_with?(notices_path) ?
+                          "true" : nil } %>
+          </li>
+        <% end %>
+
         <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
           <%= link_to t("organisations.show.title"), organisation_path,
                       class: "nhsuk-header__navigation-link",

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -60,12 +60,14 @@
     <% end %>
   </li>
 
-  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: notices_path, secondary: true) do |card| %>
-      <% card.with_heading { t("notices.index.title") } %>
-      <% card.with_description { "View notices about important updates to patient records" } %>
-    <% end %>
-  </li>
+  <% if policy(:notices).index? %>
+    <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+      <%= render AppCardComponent.new(link_to: notices_path, secondary: true) do |card| %>
+        <% card.with_heading { t("notices.index.title") } %>
+        <% card.with_description { "View notices about important updates to patient records" } %>
+      <% end %>
+    </li>
+  <% end %>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: organisation_path, secondary: true) do |card| %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -297,6 +297,11 @@ unless Settings.cis2.enabled
     email: "admin.hope@example.com",
     fallback_role: "admin"
   )
+  create_user(
+    organisation:,
+    email: "superuser@example.com",
+    fallback_role: "superuser"
+  )
 
   attach_sample_of_schools_to(organisation)
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -42,6 +42,7 @@ FactoryBot.define do
 
       selected_role_code { "S8000:G8000:R8001" }
       selected_role_name { "Nurse Access Role" }
+      selected_role_workgroups { %w[schoolagedimmunisations] }
 
       cis2_info_hash do
         {
@@ -52,7 +53,7 @@ FactoryBot.define do
           "selected_role" => {
             "name" => selected_role_name,
             "code" => selected_role_code,
-            "workgroups" => ["schoolagedimmunisations"]
+            "workgroups" => selected_role_workgroups
           }
         }
       end
@@ -77,6 +78,11 @@ FactoryBot.define do
       selected_role_name { "Medical Secretary Access Role" }
       sequence(:email) { |n| "admin-#{n}@example.com" }
       fallback_role { :admin }
+    end
+
+    trait :superuser do
+      selected_role_workgroups { %w[schoolagedimmunisations mavissuperusers] }
+      fallback_role { :superuser }
     end
 
     trait :signed_in do

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -5,7 +5,8 @@ describe "Delete vaccination record" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
 
-    when_i_go_to_a_patient_that_is_vaccinated
+    when_i_sign_in_as_a_superuser
+    and_i_go_to_a_patient_that_is_vaccinated
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -18,7 +19,8 @@ describe "Delete vaccination record" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
 
-    when_i_go_to_a_patient_that_is_vaccinated
+    when_i_sign_in_as_a_superuser
+    and_i_go_to_a_patient_that_is_vaccinated
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -35,7 +37,8 @@ describe "Delete vaccination record" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
 
-    when_i_go_to_a_patient_that_is_vaccinated
+    when_i_sign_in_as_a_superuser
+    and_i_go_to_a_patient_that_is_vaccinated
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -54,7 +57,8 @@ describe "Delete vaccination record" do
     and_an_administered_vaccination_record_exists
     and_a_confirmation_email_has_been_sent
 
-    when_i_go_to_a_patient_that_is_vaccinated
+    when_i_sign_in_as_a_superuser
+    and_i_go_to_a_patient_that_is_vaccinated
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -68,12 +72,13 @@ describe "Delete vaccination record" do
     and_the_parent_receives_an_email
   end
 
-  scenario "User tries to delete a record for a closed session date" do
+  scenario "User can't delete a record without superuser access" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_the_session_has_closed
 
-    when_i_go_to_a_patient_that_is_vaccinated
+    when_i_sign_in
+    and_i_go_to_a_patient_that_is_vaccinated
     then_i_cant_click_on_delete_vaccination_record
   end
 
@@ -126,8 +131,15 @@ describe "Delete vaccination record" do
     @session.close!
   end
 
-  def when_i_go_to_a_patient_that_is_vaccinated
+  def when_i_sign_in
     sign_in @organisation.users.first
+  end
+
+  def when_i_sign_in_as_a_superuser
+    sign_in @organisation.users.first, superuser: true
+  end
+
+  def and_i_go_to_a_patient_that_is_vaccinated
     visit session_vaccinations_path(@session)
     click_link "Vaccinated"
     click_link @patient.full_name

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -62,7 +62,16 @@ describe "Manage children" do
   end
 
   scenario "Viewing important notices" do
-    when_i_click_on_notices
+    when_i_go_to_the_dashboard
+    then_i_cannot_see_notices
+
+    when_i_go_to_the_notices_page
+    then_i_see_permission_denied
+  end
+
+  scenario "Viewing important notices as a superuser" do
+    when_i_go_to_the_dashboard_as_a_superuser
+    and_i_click_on_notices
     then_i_see_no_notices
 
     when_a_deceased_patient_exists
@@ -219,10 +228,31 @@ describe "Manage children" do
     expect(page).to have_content("No sessions")
   end
 
-  def when_i_click_on_notices
+  def when_i_go_to_the_dashboard
     sign_in @organisation.users.first
 
     visit "/dashboard"
+  end
+
+  def when_i_go_to_the_dashboard_as_a_superuser
+    sign_in @organisation.users.first, superuser: true
+
+    visit "/dashboard"
+  end
+
+  def then_i_cannot_see_notices
+    expect(page).not_to have_content("Notices")
+  end
+
+  def when_i_go_to_the_notices_page
+    visit "/notices"
+  end
+
+  def then_i_see_permission_denied
+    expect(page.status_code).to eq(403)
+  end
+
+  def when_i_click_on_notices
     click_on "Notices"
   end
 

--- a/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
@@ -55,7 +55,7 @@ describe "User CIS2 authentication", :cis2 do
       org_code: @organisation.ods_code,
       org_name: @organisation.name,
       role: :nurse,
-      workgroup: "schoolagedimmunisations"
+      workgroups: %w[schoolagedimmunisations]
     )
     click_button "Change role"
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,7 @@ describe User do
   end
 
   describe "#is_admin?" do
-    subject { user.is_admin? }
+    subject(:is_admin?) { user.is_admin? }
 
     context "cis2 is enabled", cis2: :enabled do
       context "when the user is an admin" do
@@ -89,7 +89,7 @@ describe User do
   end
 
   describe "#is_nurse?" do
-    subject { user.is_nurse? }
+    subject(:is_nurse?) { user.is_nurse? }
 
     context "cis2 is enabled", cis2: :enabled do
       context "when the user is a nurse" do
@@ -116,6 +116,62 @@ describe User do
         let(:user) { build(:admin) }
 
         it { should be false }
+      end
+    end
+  end
+
+  describe "#is_superuser?" do
+    subject(:is_superuser?) { user.is_superuser? }
+
+    context "cis2 is enabled", cis2: :enabled do
+      context "when the user is an admin" do
+        let(:user) { build(:admin) }
+
+        it { should be false }
+
+        context "with superuser access" do
+          let(:user) { build(:admin, :superuser) }
+
+          it { should be true }
+        end
+      end
+
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be false }
+
+        context "with superuser access" do
+          let(:user) { build(:nurse, :superuser) }
+
+          it { should be true }
+        end
+      end
+    end
+
+    context "cis2 is disabled", cis2: :disabled do
+      context "when the user is an admin" do
+        let(:user) { build(:admin) }
+
+        it { should be false }
+
+        context "with superuser access" do
+          let(:user) { build(:admin, :superuser) }
+
+          it { should be true }
+        end
+      end
+
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be false }
+
+        context "with superuser access" do
+          let(:user) { build(:nurse, :superuser) }
+
+          it { should be true }
+        end
       end
     end
   end

--- a/spec/policies/vaccination_record_policy_spec.rb
+++ b/spec/policies/vaccination_record_policy_spec.rb
@@ -6,40 +6,29 @@ describe VaccinationRecordPolicy do
   describe "destroy?" do
     subject(:destroy?) { policy.destroy? }
 
-    let(:programme) { create(:programme) }
-    let(:vaccination_record) do
-      create(:vaccination_record, session:, programme:)
-    end
+    let(:vaccination_record) { create(:vaccination_record) }
 
-    context "when session is open" do
-      let(:session) { create(:session, :scheduled, programme:) }
+    context "with an admin" do
+      let(:user) { build(:admin) }
 
-      context "with an admin" do
-        let(:user) { create(:admin) }
+      it { should be(false) }
 
-        it { should be(false) }
-      end
-
-      context "with a nurse" do
-        let(:user) { create(:nurse) }
+      context "and superuser access" do
+        let(:user) { build(:admin, :superuser) }
 
         it { should be(true) }
       end
     end
 
-    context "when session is not open" do
-      let(:session) { create(:session, :closed, programme:) }
+    context "with a nurse" do
+      let(:user) { build(:nurse) }
 
-      context "with an admin" do
-        let(:user) { create(:admin) }
+      it { should be(false) }
 
-        it { should be(false) }
-      end
+      context "and superuser access" do
+        let(:user) { build(:nurse, :superuser) }
 
-      context "with a nurse" do
-        let(:user) { create(:nurse) }
-
-        it { should be(false) }
+        it { should be(true) }
       end
     end
   end


### PR DESCRIPTION
This adds the concept of a user with superuser access (via the `mavissuperusers` workgroup in CIS2) and restricts access to the important notices and deleting vaccinations records to superusers.