### PR TITLE
Include workgroups in cis2_info

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -102,7 +102,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       },
       "selected_role" => {
         "name" => selected_cis2_nrbac_role["role_name"],
-        "code" => selected_cis2_nrbac_role["role_code"]
+        "code" => selected_cis2_nrbac_role["role_code"],
+        "workgroups" => selected_cis2_nrbac_role["workgroups"]
       },
       "has_other_roles" => raw_cis2_info["nhsid_nrbac_roles"].length > 1
     }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -51,7 +51,8 @@ FactoryBot.define do
           },
           "selected_role" => {
             "name" => selected_role_name,
-            "code" => selected_role_code
+            "code" => selected_role_code,
+            "workgroups" => ["schoolagedimmunisations"]
           }
         }
       end


### PR DESCRIPTION
This allows us to access the workgroups when determining what permissions a user might have. I'd like to deploy this first to ensure we start to populate this value before using it.