### PR TITLE
Don't send emails for self-consent

### DIFF
--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -8,6 +8,7 @@ module TriageMailerConcern
     patient = patient_session.patient
 
     return unless patient.send_notifications?
+    return if consent.via_self_consent?
 
     params = { consent:, session:, sent_by: current_user }
 

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -121,6 +121,27 @@ describe TriageMailerConcern do
       end
     end
 
+    context "when the patient self-consented" do
+      let(:patient_session) { create(:patient_session) }
+      let(:consent) do
+        create(
+          :consent,
+          :self_consent,
+          :given,
+          patient: patient_session.patient,
+          programme: patient_session.session.programmes.first
+        )
+      end
+
+      it "doesn't send an email" do
+        expect { send_triage_confirmation }.not_to have_enqueued_email
+      end
+
+      it "doesn't send a text message" do
+        expect { send_triage_confirmation }.not_to have_enqueued_text
+      end
+    end
+
     context "when the parents have verbally refused consent" do
       let(:patient_session) { create(:patient_session, :consent_refused) }
 

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -20,6 +20,7 @@ describe "Self-consent" do
     when_the_nurse_views_the_childs_record
     then_they_see_that_the_child_has_consent
     and_the_child_should_be_safe_to_vaccinate
+    and_enqueued_jobs_run_with_no_errors
   end
 
   def given_an_hpv_programme_is_underway
@@ -214,5 +215,9 @@ describe "Self-consent" do
 
   def and_the_child_should_be_safe_to_vaccinate
     expect(page).to have_content("Safe to vaccinate")
+  end
+
+  def and_enqueued_jobs_run_with_no_errors
+    expect { perform_enqueued_jobs }.not_to raise_error
   end
 end


### PR DESCRIPTION
These consent instances won't have a parent attached to them so the subsequent emails and texts won't be able to be sent anyway so there's no need to try, and this reduces errors that we might see in Sentry.

https://good-machine.sentry.io/issues/5990496051/