### PR TITLE
Use GET when filtering patients

### DIFF
--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -2,6 +2,7 @@
 
 <%= render AppDetailsComponent.new(summary: "Filter children", expander: true, open: @filtered) do %>
   <%= form_with url: patients_path,
+                method: :get,
                 data: { module: "autosubmit", turbo: "true" },
                 role: "search" do |f| %>
     <div class="nhsuk-form-group">


### PR DESCRIPTION
We're currently submitting this form with a `POST` request, which means that the pagination resets the filters as these are plain links and we lose the filter parameters. Switching to `GET` means the filters work with the pagination links.