### PR TITLE
Add additional columns to programme export 

### DIFF
--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -125,11 +125,11 @@ class DPSExportRow
   end
 
   def vaccination_procedure_code
-    vaccine.snomed_procedure_code_and_term.first
+    vaccine.snomed_procedure_code
   end
 
   def vaccination_procedure_term
-    vaccine.snomed_procedure_code_and_term.last
+    vaccine.snomed_procedure_term
   end
 
   def dose_sequence

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -93,15 +93,22 @@ class Vaccine < ApplicationRecord
     AVAILABLE_DELIVERY_METHODS_BY_TYPE.fetch(programme.type)
   end
 
-  SNOMED_PROCEDURE_CODE_AND_TERM_BY_TYPE = {
-    "hpv" => [
-      "761841000",
-      "Administration of vaccine product containing only Human papillomavirus antigen (procedure)"
-    ],
-    "flu" => ["822851000000102", "Seasonal influenza vaccination (procedure)"]
+  SNOMED_PROCEDURE_CODES = {
+    "hpv" => "761841000",
+    "flu" => "822851000000102"
   }.freeze
 
-  def snomed_procedure_code_and_term
-    SNOMED_PROCEDURE_CODE_AND_TERM_BY_TYPE.fetch(programme.type)
+  def snomed_procedure_code
+    SNOMED_PROCEDURE_CODES.fetch(programme.type)
+  end
+
+  SNOMED_PROCEDURE_TERMS = {
+    "hpv" =>
+      "Administration of vaccine product containing only Human papillomavirus antigen (procedure)",
+    "flu" => "Seasonal influenza vaccination (procedure)"
+  }.freeze
+
+  def snomed_procedure_term
+    SNOMED_PROCEDURE_TERMS.fetch(programme.type)
   end
 end


### PR DESCRIPTION
These `CSDS` columns are used by the reporting team so they need to be included in the export.