### PR TITLE
Move SNOMED codes to programme

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -88,7 +88,8 @@ class Reports::ProgrammeVaccinationsExporter
           :batch,
           :location,
           :performed_by_user,
-          vaccine: :programme,
+          :programme,
+          :vaccine,
           patient_session: {
             patient: %i[cohort gp_practice school],
             consents: [:patient, { parent: :parent_relationships }],
@@ -133,8 +134,7 @@ class Reports::ProgrammeVaccinationsExporter
     patient = patient_session.patient
     triage = patient_session.latest_triage
     location = vaccination_record.location
-    vaccine = vaccination_record.vaccine
-    programme = vaccine.programme
+    programme = vaccination_record.programme
 
     [
       organisation.ods_code,
@@ -180,7 +180,7 @@ class Reports::ProgrammeVaccinationsExporter
       dose_sequence(vaccination_record:),
       reason_not_vaccinated(vaccination_record:),
       patient.id,
-      vaccine.snomed_procedure_code,
+      programme.snomed_procedure_code,
       record_status(vaccination_record:)
     ]
   end

--- a/app/models/dps_export.rb
+++ b/app/models/dps_export.rb
@@ -41,7 +41,8 @@ class DPSExport < ApplicationRecord
             :performed_by_user,
             :session,
             :organisation,
-            vaccine: :programme
+            :programme,
+            :vaccine
           )
           .order(:performed_at)
           .strict_loading

--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -55,6 +55,7 @@ class DPSExportRow
            :location,
            :patient,
            :organisation,
+           :programme,
            :user,
            :vaccine,
            to: :vaccination_record
@@ -125,11 +126,11 @@ class DPSExportRow
   end
 
   def vaccination_procedure_code
-    vaccine.snomed_procedure_code
+    programme.snomed_procedure_code
   end
 
   def vaccination_procedure_term
-    vaccine.snomed_procedure_term
+    programme.snomed_procedure_term
   end
 
   def dose_sequence

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -52,4 +52,23 @@ class Programme < ApplicationRecord
   def to_param
     type
   end
+
+  SNOMED_PROCEDURE_CODES = {
+    "hpv" => "761841000",
+    "flu" => "822851000000102"
+  }.freeze
+
+  def snomed_procedure_code
+    SNOMED_PROCEDURE_CODES.fetch(type)
+  end
+
+  SNOMED_PROCEDURE_TERMS = {
+    "hpv" =>
+      "Administration of vaccine product containing only Human papillomavirus antigen (procedure)",
+    "flu" => "Seasonal influenza vaccination (procedure)"
+  }.freeze
+
+  def snomed_procedure_term
+    SNOMED_PROCEDURE_TERMS.fetch(type)
+  end
 end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -92,23 +92,4 @@ class Vaccine < ApplicationRecord
   def available_delivery_methods
     AVAILABLE_DELIVERY_METHODS_BY_TYPE.fetch(programme.type)
   end
-
-  SNOMED_PROCEDURE_CODES = {
-    "hpv" => "761841000",
-    "flu" => "822851000000102"
-  }.freeze
-
-  def snomed_procedure_code
-    SNOMED_PROCEDURE_CODES.fetch(programme.type)
-  end
-
-  SNOMED_PROCEDURE_TERMS = {
-    "hpv" =>
-      "Administration of vaccine product containing only Human papillomavirus antigen (procedure)",
-    "flu" => "Seasonal influenza vaccination (procedure)"
-  }.freeze
-
-  def snomed_procedure_term
-    SNOMED_PROCEDURE_TERMS.fetch(programme.type)
-  end
 end


### PR DESCRIPTION
These seem to be the same per vaccine across a programme so we can move these to the programme model, which allows us to get these for vaccination records even if there's no vaccine (because the vaccination wasn't administered), to include them in the vaccinations report export.

https://good-machine.sentry.io/issues/6115142159/