### PR TITLE
Add Rake task for displaying access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ roll-over.
 
 ## Rake tasks
 
+- `access_log:for_patient[id]`
+- `access_log:for_user[id]`
 - `clinics:create[name,address,town,postcode,ods_code,organisation_ods_code]`
 - `schools:add_to_organisation[ods_code,team_name,urn,...]`
 - `teams:create[ods_code,name,email,phone]`

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -1,5 +1,15 @@
 # Rake Tasks
 
+## Access log
+
+### `access_log:for_patient[id]`
+
+Displays the access log for a particular patient identified by their ID.
+
+### `access_log:for_user[email]`
+
+Displays the access log for a particular user identified by an email address.
+
 ## Clinics
 
 ### `clinics:create[name,address,town,postcode,ods_code,organisation_ods_code]`

--- a/lib/tasks/access_log.rake
+++ b/lib/tasks/access_log.rake
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+namespace :access_log do
+  desc "Print access log entries for a user."
+  task :for_user, [:email] => :environment do |_task, args|
+    user = User.find_by!(email: args[:email])
+    entries = AccessLogEntry.where(user:)
+    print_log_entries(entries, show_patient: true)
+  end
+
+  desc "Print access log entries for a patient."
+  task :for_patient, [:id] => :environment do |_task, args|
+    patient = Patient.find(args[:id])
+    entries = AccessLogEntry.where(patient:)
+    print_log_entries(entries, show_user: true)
+  end
+end
+
+def print_log_entries(entries, show_patient: false, show_user: false)
+  entries
+    .eager_load(:patient, :user)
+    .find_each do |entry|
+      parts = [
+        entry.created_at.iso8601,
+        "#{entry.controller}/#{entry.action}",
+        show_patient ? entry.patient.full_name : nil,
+        show_user ? entry.user.full_name : nil
+      ].compact
+
+      puts parts.join(" - ")
+    end
+end


### PR DESCRIPTION
This displays the access logs either for a patient or for a user depending on the Rake task and the argument passed in. For now this just displayes the date/time, the controller and action, and the user or patient name.

```
❯ bundle exec rails access_log:for_user[nurse.joy@example.com]
2024-12-06T09:42:40+00:00 - patients/show - Alejandro Schuster
2024-12-06T09:43:53+00:00 - patients/show - Alejandro Schuster
2024-12-06T10:25:34+00:00 - patients/show - Alejandro Schuster
```