### PR TITLE
Handle nil workgroups in User#is_superuser?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,7 +109,8 @@ class User < ApplicationRecord
   def is_superuser?
     return fallback_role_superuser? unless Settings.cis2.enabled
 
-    cis2_info.dig("selected_role", "workgroups").include?("mavissuperusers")
+    cis2_info.dig("selected_role", "workgroups")&.include?("mavissuperusers") ||
+      false
   end
 
   def role_description

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -134,6 +134,12 @@ describe User do
 
           it { should be true }
         end
+
+        context "without workgroups" do
+          let(:user) { build(:admin, selected_role_workgroups: nil) }
+
+          it { should be false }
+        end
       end
 
       context "when the user is a nurse" do
@@ -145,6 +151,12 @@ describe User do
           let(:user) { build(:nurse, :superuser) }
 
           it { should be true }
+        end
+
+        context "without workgroups" do
+          let(:user) { build(:nurse, selected_role_workgroups: nil) }
+
+          it { should be false }
         end
       end
     end


### PR DESCRIPTION
This can sometimes happen, if the user has no workgroups, so we need to handle this case gracefully rather than raising an exception.