### PR TITLE
Redirect to dashboard path if signed in

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,5 +6,6 @@ class PagesController < ApplicationController
   skip_before_action :store_user_location!, only: :start
 
   def start
+    redirect_to dashboard_path if current_user
   end
 end

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -109,7 +109,7 @@ describe "Child record imports duplicates" do
 
   def when_i_visit_the_cohort_page_for_the_hpv_programme
     visit "/"
-    click_link "Programmes"
+    click_link "Programmes", match: :first
     click_link "HPV"
     click_link "Cohorts"
   end

--- a/spec/features/scheduled_consent_requests_spec.rb
+++ b/spec/features/scheduled_consent_requests_spec.rb
@@ -73,7 +73,7 @@ describe "Scheduled consent requests" do
 
   def when_i_go_to_my_organisation_page
     visit "/"
-    click_link "Your organisation"
+    click_link "Your organisation", match: :first
   end
 
   def then_i_see_consent_requests_are_sent_3_weeks_before


### PR DESCRIPTION
Without this, the user sees the "Sign in" button even if they're already signed in.