### PR TITLE
Upgrade PostgreSQL in local development

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:13.5
+        image: postgres:17.2
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:13.5
+        image: postgres:17.2
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 nodejs 22.5.1
-postgres 13.5
+postgres 17.2
 ruby 3.3.5
 yarn 1.22.19
 aws-copilot 1.34.0

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ will use:
 
 ```sh
 # Temporarily set the version of postgres to use to build the pg gem
-ASDF_POSTGRES_VERSION=13.5 bundle install
+ASDF_POSTGRES_VERSION=17.2 bundle install
 ```
 
 After installing Postgres via `asdf`, run the database in the background, and

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -26,4 +26,4 @@ pds:
   perform_jobs: false
 
 splunk:
-  enable: false
+  enabled: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -18,4 +18,4 @@ nhs_api:
   disable_authentication: true
 
 splunk:
-  enable: false
+  enabled: false


### PR DESCRIPTION
We were using version 13.5 which is relatively old now, the latest version is 17.2. In production we're using a 16.3 compatible version via AWS Aurora, which auto updates and should catch up eventually.