### PR TITLE
Delete access log entries in dev reset endpoint

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -45,6 +45,7 @@ class DevController < ApplicationController
 
       SchoolMove.where(patient: patients).destroy_all
       SchoolMove.where(organisation:).destroy_all
+      AccessLogEntry.where(patient: patients).destroy_all
       NotifyLogEntry.where(patient: patients).destroy_all
 
       ConsentForm.where(organisation:).destroy_all


### PR DESCRIPTION
This is necessary as without it we cannot delete the patients.

https://good-machine.sentry.io/issues/6115900064/