### PR TITLE
Disable Splunk when precompiling assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,11 @@ COPY --link . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-# CIS2 needs to be disabled because RAILS_ENV=production is used
-RUN SECRET_KEY_BASE_DUMMY=1 MAVIS__CIS2__ENABLED=false ./bin/rails assets:precompile
+# CIS2 and Splunk need to be disabled because RAILS_ENV=production is used
+RUN SECRET_KEY_BASE_DUMMY=1 \
+    MAVIS__CIS2__ENABLED=false \
+    MAVIS__SPLUNK__ENABLED=false \
+    ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base


### PR DESCRIPTION
This ensures the Docker build doesn't attempt to log to Splunk.