### PR TITLE
Handle sorting by year group with no registration

### DIFF
--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -32,7 +32,13 @@ module PatientSortingConcern
     when "year_group"
       [
         obj.try(:year_group) || obj.patient.year_group || "",
-        obj.try(:registration) || obj.patient.registration || ""
+        (
+          if obj.respond_to?(:registration)
+            obj.registration
+          else
+            obj.patient.registration
+          end
+        ) || ""
       ]
     end
   end


### PR DESCRIPTION
If the patient has no registration it can return `nil`, and we using `try(:registration)` which also returns `nil` if the object doesn't respond to that method. This lead to us thinking the object wasn't a patient, and instead tried to call `.patient` on it which would then fail. Instead we need to first check if the object responds to the method before calling it.

https://good-machine.sentry.io/issues/6092014304/