### PR TITLE
User should have admin permissions if they're a superuser

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,9 +95,11 @@ class User < ApplicationRecord
   end
 
   def is_admin?
-    return fallback_role_admin? unless Settings.cis2.enabled
-
-    cis2_info.dig("selected_role", "code")&.ends_with?("R8006")
+    if Settings.cis2.enabled
+      cis2_info.dig("selected_role", "code")&.ends_with?("R8006")
+    else
+      fallback_role_admin? || fallback_role_superuser?
+    end
   end
 
   def is_nurse?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -71,11 +71,23 @@ describe User do
 
         it { should be false }
       end
+
+      context "when the user is a nurse and superuser" do
+        let(:user) { build(:nurse, :superuser) }
+
+        it { should be false }
+      end
     end
 
     context "cis2 is disabled", cis2: :disabled do
       context "when the user is an admin" do
         let(:user) { build(:admin) }
+
+        it { should be true }
+      end
+
+      context "when the user is an admin and superuser" do
+        let(:user) { build(:admin, :superuser) }
 
         it { should be true }
       end


### PR DESCRIPTION
This applies only in non-CIS2 environments (local development and testing) to partially mimic the behaviour of CIS2 where a user has a role and a superuser status that are independent from each other. Currently in a non-CIS2 environment, the superuser status acts as its own role, which means users with that status have very limited access (they're able to access superuser actions only). To aid with testing, we can assume that if the user is a superuser they should also have admin permissions.

It's not currently possible to log in as a nurse user with superuser permissions at the same time.