### PR TITLE
Handle generating consent forms for community clinics

### DIFF
--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -69,7 +69,6 @@ FactoryBot.define do
     use_preferred_name { false }
     date_of_birth { Faker::Date.birthday(min_age: 3, max_age: 9) }
     response { "given" }
-    school_confirmed { true }
     address_line_1 { Faker::Address.street_address }
     address_town { Faker::Address.city }
     address_postcode { Faker::Address.uk_postcode }
@@ -90,7 +89,10 @@ FactoryBot.define do
 
     programme { session.programmes.first }
     organisation { session.organisation }
+
     location { session.location }
+    school { location.school? ? location : association(:school, organisation:) }
+    school_confirmed { true }
 
     health_answers do
       [


### PR DESCRIPTION
In this case, the location would be the community clinic, but the user would've been forced to choose a school so it would be different to the location of the community clinic.

This should have no impact on the existing tests, but will fix an issue in the `consent_forms:generate` Rake task.

https://good-machine.sentry.io/issues/6047022099/