### PR TITLE
Order offline export spreadsheet by patient names

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -99,13 +99,14 @@ class Reports::OfflineSessionExporter
   def patient_sessions
     session
       .patient_sessions
-      .includes(
-        patient: %i[cohort school],
+      .eager_load(patient: %i[cohort school])
+      .preload(
         consents: [:patient, { parent: :parent_relationships }],
         gillick_assessments: :performed_by,
         triages: :performed_by,
         vaccination_records: %i[batch performed_by_user vaccine]
       )
+      .order_by_name
       .strict_loading
   end
 


### PR DESCRIPTION
Currently the order is not specified so the patients can appear in a random order, it probably makes sense to order these by name so they're easier to find.