### PR TITLE
Handle accessing vaccination report with no programme

### DIFF
--- a/app/controllers/vaccination_reports_controller.rb
+++ b/app/controllers/vaccination_reports_controller.rb
@@ -47,6 +47,7 @@ class VaccinationReportsController < ApplicationController
 
   def set_programme
     @programme = @vaccination_report.programme
+    redirect_to dashboard_path if @programme.nil?
   end
 
   def set_steps


### PR DESCRIPTION
This can happen if the user navigates directly to one of the URLs without going through the normal UI flow, so a `programme` won't be stored in the session and we get an exception. The best alternative would be to redirect the user to the dashboard page.

https://good-machine.sentry.io/issues/6074722817/
https://good-machine.sentry.io/issues/6115196006/