### PR TITLE
Rename deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,8 @@
 name: Deploy
 run-name: >-
   ${{ github.event_name == 'workflow_dispatch'
-      && format('Deploy ({0})', inputs.environment)
-      || 'Deploy (All staging environments)' }}
+      && format('Copilot ({0})', inputs.environment)
+      || 'Copilot (All staging environments)' }}
 
 on:
   push:


### PR DESCRIPTION
The name is a bit redundant currently. ("Deploy / Deploy")

![Screenshot 2024-12-09 at 10 25 49](https://github.com/user-attachments/assets/7d1bcb0a-82c5-4b91-9fad-103ce937b398)
