### PR TITLE
Raise UnknownGPPractice if GP practice doesn't exist

### DIFF
--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -415,6 +415,16 @@ describe Patient do
         ).to(gp_practice)
       end
     end
+
+    context "with a GP practice that doesn't exist" do
+      let(:pds_patient) do
+        PDS::Patient.new(nhs_number: "0123456789", gp_ods_code: "GP")
+      end
+
+      it "raises an error" do
+        expect { update_from_pds! }.to raise_error(Patient::UnknownGPPractice)
+      end
+    end
   end
 
   describe "#invalidate!" do


### PR DESCRIPTION
Currently we raise an `ActiveRecord::RecordNotFound` error, but this causes the job to be discarded by ActiveJob without an exception being raised in Sentry as this kind of error can occur in other scenarios.

Instead, we can raise a specific error which is good practice anyway as it ensures these get treated in a special way which allows us to get a good idea of how often these happen anyway.