### PR TITLE
Revert "Hide refused consent patients from offline export"

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -130,8 +130,6 @@ class Reports::OfflineSessionExporter
           add_existing_row_cells(row, vaccination_record:)
         end
       end
-    elsif patient_session.consent_refused?
-      []
     else
       session.programmes.map do |programme|
         Row.new(columns, style: row_style) do |row|

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -135,14 +135,6 @@ describe Reports::OfflineSessionExporter do
           )
           expect(rows.first["PERSON_DOB"].to_date).to eq(patient.date_of_birth)
         end
-
-        context "with consent refused" do
-          before { create(:consent, :refused, patient:, programme:) }
-
-          it "does not include the row" do
-            expect(rows.count).to eq(0)
-          end
-        end
       end
 
       context "with a restricted patient" do
@@ -412,14 +404,6 @@ describe Reports::OfflineSessionExporter do
             }
           )
           expect(rows.first["PERSON_DOB"].to_date).to eq(patient.date_of_birth)
-        end
-
-        context "with consent refused" do
-          before { create(:consent, :refused, patient:, programme:) }
-
-          it "does not include the row" do
-            expect(rows.count).to eq(0)
-          end
         end
       end
 


### PR DESCRIPTION
This reverts commit fbde8a18c7a7d1c1b10764f8cb7866d33e046637.

We think these should be included in the offline export to handle cases where a Gillick assessment would be done instead.