### PR TITLE
Upgrade to Rails 7.2 configuration defaults

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+ARGV.unshift("--ensure-latest")
+
+load Gem.bin_path("brakeman", "brakeman")

--- a/bin/lint
+++ b/bin/lint
@@ -2,10 +2,10 @@
 
 set -e
 
-bin/bundle exec rubocop --autocorrect-all $*
+bin/rubocop --autocorrect-all $*
 yarn prettier --write --list-different --ignore-unknown ${*:-'**/*'}
 bin/bundle exec rufo ${*:-app}
 if [ -z "$*" ]
 then
-   bin/bundle exec brakeman --quiet --no-summary --no-pager
+   bin/brakeman --quiet --no-summary --no-pager
 fi

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+require "rubygems"
+require "bundler/setup"
+
+# explicit rubocop config increases performance slightly while avoiding config confusion.
+ARGV.unshift("--config", File.expand_path("../.rubocop.yml", __dir__))
+
+load Gem.bin_path("rubocop", "rubocop")

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 require "fileutils"
 
-# path to your application root.
 APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,12 +23,12 @@ Bundler.require(*Rails.groups)
 module ManageVaccinations
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.1
+    config.load_defaults 7.2
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[core_ext tasks])
+    config.autoload_lib(ignore: %w[assets core_ext tasks])
 
     # DB_SECRET is a JSON string containing the database credentials on AWS.
     # We need to parse it in order to set the DATABASE_URL variable.
@@ -77,7 +77,5 @@ module ManageVaccinations
     )
 
     config.silence_healthcheck_path = "/up"
-
-    config.yjit = true
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable server timing
+  # Enable server timing.
   config.server_timing = true
 
   # Enable/disable caching. By default caching is disabled.
@@ -41,6 +41,8 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  # Disable caching for Action Mailer templates even if Action Controller
+  # caching is enabled.
   config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
@@ -68,12 +70,12 @@ Rails.application.configure do
   config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
-  # config.action_view.annotate_rendered_view_with_filenames = true
+  config.action_view.annotate_rendered_view_with_filenames = true
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  # Raise error when a before_action's only/except options reference missing actions
+  # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
   # Use Turbo Streams for hotwire livereload, improving local DX

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Don't force SSL for healthcheck endpoint.
+  # Skip http-to-https redirect for the default health check endpoint.
   config.ssl_options = {
     redirect: {
       exclude: ->(request) { request.path =~ /up/ }
@@ -63,7 +63,7 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = { request_id: :request_id }
 
-  # Info include generic and useful information about system operation, but avoids logging too much
+  # "Info" include generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
@@ -87,6 +87,8 @@ Rails.application.configure do
   # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "manage_vaccinations_production"
 
+  # Disable caching for Action Mailer templates even if Action Controller
+  # caching is enabled.
   config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -102,6 +104,9 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Only use :id for inspections in production.
+  config.active_record.attributes_for_inspect = [:id]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,8 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 
+  # Disable caching for Action Mailer templates even if Action Controller
+  # caching is enabled.
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
@@ -61,7 +63,7 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Raise error when a before_action's only/except options reference missing actions
+  # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.action_mailer.default_url_options = { host: "localhost:4000" }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,31 +1,51 @@
 # frozen_string_literal: true
 
-# Puma can serve each request in a thread from an internal thread pool.
-# The `threads` method setting takes two numbers: a minimum and maximum.
-# Any libraries that use thread pools should be configured to match
-# the maximum value specified for Puma. Default is set to 5 threads for minimum
-# and maximum; this matches the default thread size of Active Record.
+# This configuration file will be evaluated by Puma. The top-level methods that
+# are invoked here are part of Puma's configuration DSL. For more information
+# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
+
+# Puma starts a configurable number of processes (workers) and each process
+# serves each request in a thread from an internal thread pool.
 #
+# The ideal number of threads per worker depends both on how much time the
+# application spends waiting for IO operations and on how much you wish to
+# to prioritize throughput over latency.
+#
+# As a rule of thumb, increasing the number of threads will increase how much
+# traffic a given process can handle (throughput), but due to CRuby's
+# Global VM Lock (GVL) it has diminishing returns and will degrade the
+# response time (latency) of the application.
+#
+# The default is set to 3 threads as it's deemed a decent compromise between
+# throughput and latency for the average Rails application.
+#
+# Any libraries that use a connection pool or another resource pool should
+# be configured to provide at least as many connections as the number of
+# threads. This includes Active Record's `pool` parameter in `database.yml`.
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-# Specifies the `worker_timeout` threshold that Puma will use to wait before
-# terminating a worker in development environments.
-#
-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
-
+# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 if File.exist? "tmp/offline.txt"
   port 4444
 else
   port ENV.fetch("PORT", 4000)
 end
 
+# Allow puma to be restarted by `bin/rails restart` command.
+plugin :tmp_restart
+
+# Specify the PID file. Defaults to tmp/pids/server.pid in development.
+# In other environments, only set the PID file if requested.
+pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+# Specifies the `worker_timeout` threshold that Puma will use to wait before
+# terminating a worker in development environments.
+worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+
 # Specifies the `environment` that Puma will run in.
 environment ENV.fetch("RAILS_ENV", "development")
-
-# Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together
@@ -52,6 +72,3 @@ end
 
 # Re-open appenders after forking the process; needed for Semantic Logger
 on_worker_boot { SemanticLogger.reopen }
-
-# Allow puma to be restarted by `bin/rails restart` command.
-plugin :tmp_restart


### PR DESCRIPTION
This upgrades the default configuration values we're using to Rails version 7.2, matching the version of Rails we're using, and making any future upgrade to 8.0 slightly easier by reducing the number of potential changes.