### PR TITLE
Don't raise UnknownGPPractice errors in staging

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -74,6 +74,7 @@ nhs_api:
 
 pds:
   perform_jobs: true
+  raise_unknown_gp_practice: true
 
 splunk:
   enabled: true

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -11,3 +11,6 @@ nhs_api:
 # Devise.
 cis2:
   issuer: "https://am.nhsint.auth-ptl.cis2.spineservices.nhs.uk:443/openam/oauth2/realms/root/realms/NHSIdentity/realms/Healthcare"
+
+pds:
+  raise_unknown_gp_practice: false

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -421,8 +421,11 @@ describe Patient do
         PDS::Patient.new(nhs_number: "0123456789", gp_ods_code: "GP")
       end
 
-      it "raises an error" do
-        expect { update_from_pds! }.to raise_error(Patient::UnknownGPPractice)
+      it "records an error in Sentry" do
+        expect(Sentry).to receive(:capture_exception).with(
+          an_instance_of(Patient::UnknownGPPractice)
+        )
+        update_from_pds!
       end
     end
   end


### PR DESCRIPTION
This also records the error in Sentry directly rather than raising an exception, which ensures that the patient is still updated from PDS even if the GP practice couldn't be located.