### PR TITLE
Handle situation where cis2 returns empty role

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -93,6 +93,8 @@ module AuthenticationConcern
     end
 
     def selected_cis2_nrbac_role
+      return {} if raw_cis2_info["selected_roleid"].blank?
+
       @selected_cis2_nrbac_role ||=
         raw_cis2_info["nhsid_nrbac_roles"].find do
           _1["person_roleid"] == raw_cis2_info["selected_roleid"]
@@ -100,6 +102,8 @@ module AuthenticationConcern
     end
 
     def selected_cis2_org
+      return {} if selected_cis2_nrbac_role.empty?
+
       @selected_cis2_org ||=
         raw_cis2_info["nhsid_user_orgs"].find do
           _1["org_code"] == selected_cis2_nrbac_role["org_code"]

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -14,12 +14,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def cis2
     set_cis2_session_info
 
-    if !selected_cis2_org_is_registered?
+    if !selected_cis2_role_is_valid?
+      redirect_to users_role_not_found_path
+    elsif !selected_cis2_org_is_registered?
       redirect_to users_organisation_not_found_path
     elsif !selected_cis2_workgroup_is_valid?
       redirect_to users_workgroup_not_found_path
-    elsif !selected_cis2_role_is_valid?
-      redirect_to users_role_not_found_path
     else
       @user = User.find_or_create_from_cis2_oidc(user_cis2_info)
 

--- a/spec/features/user_cis2_authentication_with_empty_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_empty_role_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe "User CIS2 authentication", :cis2 do
+  scenario "user does not have a role selected" do
+    given_i_am_setup_in_mavis_and_cis2_but_with_an_empty_role
+    when_i_go_to_the_sessions_page
+    then_i_am_on_the_start_page
+    when_i_click_the_cis2_login_button
+    then_i_see_the_organisation_not_found_error
+  end
+
+  def given_i_am_setup_in_mavis_and_cis2_but_with_an_empty_role
+    @organisation = create :organisation, ods_code: "AB12"
+
+    mock_cis2_auth(
+      uid: "123",
+      given_name: "Nurse",
+      family_name: "Test",
+      org_code: @organisation.ods_code,
+      org_name: @organisation.name,
+      role_code: "S8002:G8003:R0001",
+      selected_roleid: nil
+    )
+  end
+
+  def when_i_click_the_cis2_login_button
+    click_button "Care Identity"
+  end
+
+  def then_i_am_on_the_start_page
+    expect(page).to have_current_path start_path
+  end
+
+  def when_i_go_to_the_sessions_page
+    visit sessions_path
+  end
+
+  def then_i_see_the_sessions_page
+    expect(page).to have_current_path sessions_path
+  end
+
+  def then_i_see_the_organisation_not_found_error
+    expect(
+      page
+    ).to have_heading "You do not have permission to use this service"
+  end
+end

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -117,7 +117,8 @@ module CIS2AuthHelper
     user_only_has_one_org: false,
     workgroups: nil,
     no_workgroup: false,
-    sid: nil
+    sid: nil,
+    selected_roleid: "5555666677778888"
   )
     mock_auth = cis2_auth_info
     raw_info = mock_auth["extra"]["raw_info"]
@@ -156,6 +157,7 @@ module CIS2AuthHelper
     raw_info["family_name"] = family_name
     raw_info["name"] = "#{given_name} #{family_name}"
     raw_info["email"] = email
+    raw_info["selected_roleid"] = selected_roleid
 
     OmniAuth.config.add_mock(:cis2, mock_auth)
   end


### PR DESCRIPTION
We had a Sentry error where our logging showed that in some scenarios (we assume Smartcard native app use) CIS2 will send a user payload with an empty selected role. Since we can't match their selected role to an existing role and org, we should show an error in this scenario.

https://good-machine.sentry.io/issues/6122678933