### PR TITLE
Use redirect_back_or_to instead of redirect_to

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ class ApplicationController < ActionController::Base
 
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
-    redirect_to(request.referer || root_path, status: :forbidden)
+    redirect_back_or_to root_path, status: :forbidden, allow_other_host: false
   end
 
   def set_service_guide_url


### PR DESCRIPTION
We need to fall back to the `root_path` if the `referer` is on a different host.

Turns out there's a built-in helper in Rails for this:

- https://api.rubyonrails.org/v7.2.2/classes/ActionController/Redirecting.html#method-i-redirect_back_or_to