### PR TITLE
Switch from asdf to mise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,11 +79,11 @@ jobs:
           ruby-version: .tool-versions
           bundler-cache: true
       - name: Get Node.js version
-        id: asdf
+        id: mise
         run: echo "::set-output name=VERSION::$(grep nodejs .tool-versions | awk '{print $2}')"
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.asdf.outputs.VERSION }}
+          node-version: ${{ steps.mise.outputs.VERSION }}
           cache: "yarn"
       - run: bundle
       - run: yarn install --frozen-lockfile

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,5 @@
 nodejs 22.5.1
 postgres 17.2
 ruby 3.3.5
-yarn 1.22.19
 aws-copilot 1.34.0
 awscli 2.13.31

--- a/README.md
+++ b/README.md
@@ -69,17 +69,6 @@ brew install yarn
 mise install
 ```
 
-When installing the `pg` gem, bundle changes directory outside of this
-project directory, causing it lose track of which version of postgres has
-been selected in the project's `.tool-versions` file. To ensure the `pg` gem
-installs correctly, you'll want to set the version of postgres that `mise`
-will use:
-
-```sh
-# Temporarily set the version of postgres to use to build the pg gem
-MISE_POSTGRES_VERSION=17.2 bundle install
-```
-
 After installing Postgres via `mise`, run the database in the background, and
 connect to it to create a user:
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ bin/bundle exec rladr new title
 
 #### mise
 
-This project uses `mise`. Use the following to install the required tools
-(replace `brew` and package names depending on your platform):
+This project uses `mise`. Use the following to set up (replace `brew` and
+package names depending on your platform):
 
 ```sh
 # Dependencies for ruby
@@ -64,8 +64,12 @@ brew install mise
 
 # Yarn via brew as this skips installing `gpg`
 brew install yarn
+```
 
-# To install (or update, following a change to .tool-versions)
+Then to install the required tools (or update, following a change to
+`.tool-versions`):
+
+```
 mise install
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ brew install libyaml
 # Dependencies for postgres
 brew install gcc readline zlib curl ossp-uuid icu4c pkg-config
 
-# # Dependencies for yarn
-# brew install gpg
-
 # Env vars for postgres
 export OPENSSL_PATH=$(brew --prefix openssl)
 export CMAKE_PREFIX_PATH=$(brew --prefix icu4c)
@@ -64,6 +61,9 @@ export PKG_CONFIG_PATH="$CMAKE_PREFIX_PATH/lib/pkgconfig"
 
 # Version manager
 brew install mise
+
+# Yarn via brew as this skips installing `gpg`
+brew install yarn
 
 # To install (or update, following a change to .tool-versions)
 mise install

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project depends on:
 - [Yarn](https://yarnpkg.com/)
 - [Postgres](https://www.postgresql.org/)
 
-The instructions below assume you are using `asdf` to manage the necessary
+The instructions below assume you are using `mise` to manage the necessary
 versions of the above.
 
 ### Application architecture
@@ -39,42 +39,48 @@ bin/bundle exec rladr new title
 
 ### Development toolchain
 
-#### asdf
+#### mise
 
-This project uses `asdf`. Use the following to install the required tools:
+This project uses `mise`. Use the following to install the required tools
+(replace `brew` and package names depending on your platform):
 
 ```sh
-# Install dependencies
-brew install gcc readline zlib curl ossp-uuid # Mac-specific
-export HOMEBREW_PREFIX=/opt/homebrew          # Mac-specific
+# Dependencies for ruby
+brew install libyaml
 
-# The first time
-brew install asdf                             # Mac-specific
-asdf plugin add aws-copilot
-asdf plugin add awscli
-asdf plugin add nodejs
-asdf plugin add postgres
-asdf plugin add ruby
-asdf plugin add yarn
+# Dependencies for postgres
+brew install gcc readline zlib curl ossp-uuid icu4c pkg-config
+
+# # Dependencies for yarn
+# brew install gpg
+
+# Env vars for postgres
+export OPENSSL_PATH=$(brew --prefix openssl)
+export CMAKE_PREFIX_PATH=$(brew --prefix icu4c)
+export PATH="$OPENSSL_PATH/bin:$CMAKE_PREFIX_PATH/bin:$PATH"
+export LDFLAGS="-L$OPENSSL_PATH/lib $LDFLAGS"
+export CPPFLAGS="-I$OPENSSL_PATH/include $CPPFLAGS"
+export PKG_CONFIG_PATH="$CMAKE_PREFIX_PATH/lib/pkgconfig"
+
+# Version manager
+brew install mise
 
 # To install (or update, following a change to .tool-versions)
-asdf install
+mise install
 ```
-
-Following installation of `asdf` with `homebrew`, it needs to be sourced in your shell to complete the installation. Refer to the `asdf` [getting started guide](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf) for the correct command given your shell, OS and `asdf` installation method.
 
 When installing the `pg` gem, bundle changes directory outside of this
 project directory, causing it lose track of which version of postgres has
 been selected in the project's `.tool-versions` file. To ensure the `pg` gem
-installs correctly, you'll want to set the version of postgres that `asdf`
+installs correctly, you'll want to set the version of postgres that `mise`
 will use:
 
 ```sh
 # Temporarily set the version of postgres to use to build the pg gem
-ASDF_POSTGRES_VERSION=17.2 bundle install
+MISE_POSTGRES_VERSION=17.2 bundle install
 ```
 
-After installing Postgres via `asdf`, run the database in the background, and
+After installing Postgres via `mise`, run the database in the background, and
 connect to it to create a user:
 
 ```sh
@@ -88,20 +94,6 @@ To run the project locally:
 
 ```bash
 $ bin/setup
-```
-
-#### Yarn
-
-If you encounter:
-
-```sh
-No yarn executable found for nodejs 22.5.1
-```
-
-You need to reshim nodejs:
-
-```sh
-asdf reshim nodejs
 ```
 
 ### Linting
@@ -134,9 +126,8 @@ You'll also need to configure your editor's `solargraph` plugin to
 ### PostgreSQL
 
 The script `bin/db` is included to start up PostgreSQL for setups that don't use
-system-started services, such as `asdf` which is our default. Note that this is
-meant to be a handy script to manage PostgreSQL, not run a console like `rails db`
-does.
+system-started services. Note that this is meant to be a handy script to manage
+PostgreSQL, not run a console like `rails db` does.
 
 ```
 $ bin/db
@@ -146,7 +137,6 @@ waiting for server to start.... done
 server started
 $ bin/db
 pg_ctl: server is running (PID: 79113)
-/Users/misaka/.asdf/installs/postgres/13.5/bin/postgres
 ```
 
 This script attempts to be installation agnostic by relying on `pg_config` to


### PR DESCRIPTION
Our team is using it instead, it's a near drop-in replacement, so it makes sense to update our docs.

Latest postgres also requires some new deps/env vars but less workarounds now with `mise`.