### PR TITLE
Add explicit dependency on playwright-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "jest-fetch-mock": "^3.0.3",
     "mutationobserver-shim": "^0.3.7",
     "officecrypto-tool": "^0.0.18",
+    "playwright-core": "^1.49.0",
     "prettier": "^3.4.2"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4823,6 +4823,11 @@ playwright-core@1.49.0:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.0.tgz#8e69ffed3f41855b854982f3632f2922c890afcb"
   integrity sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==
 
+playwright-core@^1.49.0:
+  version "1.49.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.49.1.tgz#32c62f046e950f586ff9e35ed490a424f2248015"
+  integrity sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==
+
 playwright@1.49.0:
   version "1.49.0"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.49.0.tgz#df6b9e05423377a99658202844a294a8afb95d0a"


### PR DESCRIPTION
This silences the warning from `axe-core` that depends on `playwright-core`.