### PR TITLE
Add ability to delete from vaccination record page

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -113,7 +113,7 @@
       <% end %>
 
       <% if helpers.policy(vaccination_record).destroy? %>
-        <%= govuk_link_to "Delete vaccination record", destroy_vaccination_record_session_patient_vaccinations_path(patient_id: patient.id, vaccination_record_id: vaccination_record.id) %>
+        <%= govuk_link_to "Delete vaccination record", destroy_programme_vaccination_record_path(vaccination_record.programme, vaccination_record, return_to: session_patient_path(id: patient.id)) %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/vaccination_records/destroy.html.erb
+++ b/app/views/vaccination_records/destroy.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: "patient") %>
+  <%= render AppBacklinkComponent.new(@return_to, name: "patient") %>
 <% end %>
 
 <% page_title = "Are you sure you want to delete this vaccination record?" %>
@@ -11,9 +11,10 @@
   <%= page_title %>
 <% end %>
 
-<%= form_with url: vaccination_record_session_patient_vaccinations_path, method: :delete do |f| %>
+<%= form_with url: programme_vaccination_record_path, method: :delete do |f| %>
+  <%= f.hidden_field :return_to, value: @return_to %>
   <div class="app-button-group">
     <%= f.govuk_submit "Yes, delete this vaccination record", warning: true %>
-    <%= govuk_link_to "No, return to patient", session_patient_path(id: @patient.id) %>
+    <%= govuk_link_to "No, return to patient", @return_to %>
   </div>
 <% end %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -22,4 +22,8 @@
                         programme_vaccination_record_path(@programme, @vaccination_record),
                         method: :put, class: "app-button--secondary" %>
   <% end %>
+
+  <% if policy(@vaccination_record).destroy? %>
+    <%= govuk_link_to "Delete vaccination record", destroy_programme_vaccination_record_path(@programme, @vaccination_record) %>
+  <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,10 +154,14 @@ Rails.application.routes.draw do
 
     resources :vaccination_records,
               path: "vaccination-records",
-              only: %i[index show update] do
-      post "export-dps", on: :collection
-      constraints -> { Flipper.enabled?(:dev_tools) } do
-        post "reset-dps-export", on: :collection
+              only: %i[index show update destroy] do
+      get "destroy", action: :confirm_destroy, on: :member, as: "destroy"
+
+      collection do
+        post "export-dps"
+        constraints -> { Flipper.enabled?(:dev_tools) } do
+          post "reset-dps-export"
+        end
       end
     end
 
@@ -315,16 +319,7 @@ Rails.application.routes.draw do
 
         resource :gillick_assessment, path: "gillick", only: %i[edit update]
         resource :triages, only: %i[new create]
-        resource :vaccinations, only: %i[create] do
-          member do
-            delete ":vaccination_record_id",
-                   action: :destroy,
-                   as: :vaccination_record
-            get ":vaccination_record_id/destroy",
-                action: :confirm_destroy,
-                as: :destroy_vaccination_record
-          end
-        end
+        resource :vaccinations, only: %i[create]
 
         resource :attendance,
                  controller: "session_attendances",

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -6,7 +6,7 @@ describe "Delete vaccination record" do
     and_an_administered_vaccination_record_exists
 
     when_i_sign_in_as_a_superuser
-    and_i_go_to_a_patient_that_is_vaccinated
+    and_i_go_to_a_patient_that_is_vaccinated_in_the_session
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -20,7 +20,7 @@ describe "Delete vaccination record" do
     and_an_administered_vaccination_record_exists
 
     when_i_sign_in_as_a_superuser
-    and_i_go_to_a_patient_that_is_vaccinated
+    and_i_go_to_a_patient_that_is_vaccinated_in_the_session
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -38,7 +38,7 @@ describe "Delete vaccination record" do
     and_an_administered_vaccination_record_exists
 
     when_i_sign_in_as_a_superuser
-    and_i_go_to_a_patient_that_is_vaccinated
+    and_i_go_to_a_patient_that_is_vaccinated_in_the_session
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -58,7 +58,7 @@ describe "Delete vaccination record" do
     and_a_confirmation_email_has_been_sent
 
     when_i_sign_in_as_a_superuser
-    and_i_go_to_a_patient_that_is_vaccinated
+    and_i_go_to_a_patient_that_is_vaccinated_in_the_session
     and_i_click_on_delete_vaccination_record
     then_i_see_the_delete_vaccination_page
 
@@ -72,13 +72,28 @@ describe "Delete vaccination record" do
     and_the_parent_receives_an_email
   end
 
+  scenario "User deletes a record from children page" do
+    given_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_sign_in_as_a_superuser
+    and_i_go_to_a_patient_for_the_programme_that_is_vaccinated
+    and_i_click_on_delete_vaccination_record
+    then_i_see_the_delete_vaccination_page
+
+    when_i_delete_the_vaccination_record
+    then_i_see_the_patient
+    and_i_see_a_successful_message
+    and_they_have_no_vaccinations
+  end
+
   scenario "User can't delete a record without superuser access" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_the_session_has_closed
 
     when_i_sign_in
-    and_i_go_to_a_patient_that_is_vaccinated
+    and_i_go_to_a_patient_that_is_vaccinated_in_the_session
     then_i_cant_click_on_delete_vaccination_record
   end
 
@@ -101,6 +116,7 @@ describe "Delete vaccination record" do
         :triage_ready_to_vaccinate,
         given_name: "John",
         family_name: "Smith",
+        year_group: 8,
         programme: @programme,
         organisation: @organisation
       )
@@ -139,10 +155,16 @@ describe "Delete vaccination record" do
     sign_in @organisation.users.first, superuser: true
   end
 
-  def and_i_go_to_a_patient_that_is_vaccinated
+  def and_i_go_to_a_patient_that_is_vaccinated_in_the_session
     visit session_vaccinations_path(@session)
     click_link "Vaccinated"
     click_link @patient.full_name
+  end
+
+  def and_i_go_to_a_patient_for_the_programme_that_is_vaccinated
+    visit patients_programme_path(@programme)
+    click_link @patient.full_name
+    click_link "Gardasil 9 (HPV)"
   end
 
   def and_i_click_on_delete_vaccination_record
@@ -178,6 +200,10 @@ describe "Delete vaccination record" do
   def and_they_can_be_vaccinated
     expect(page).to have_content("Safe to vaccinate")
     expect(page).not_to have_content("Vaccinated")
+  end
+
+  def and_they_have_no_vaccinations
+    expect(page).to have_content("No vaccinations")
   end
 
   def when_i_click_on_the_log


### PR DESCRIPTION
When looking at an individual vaccination record for a patient this adds a "Delete vaccination record" button similar to the one we have when deleting a vaccination record from a session.