### PR TITLE
Pass privacy policy URL to GOV.UK Notify templates

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -48,6 +48,7 @@ class GovukNotifyPersonalisation
       next_session_dates:,
       next_session_dates_or:,
       not_catch_up:,
+      organisation_privacy_policy_url:,
       outcome_administered:,
       outcome_not_administered:,
       parent_full_name:,
@@ -156,6 +157,10 @@ class GovukNotifyPersonalisation
       .today_or_future_dates
       .map { _1.to_fs(:short_day_of_week) }
       .to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
+  end
+
+  def organisation_privacy_policy_url
+    organisation.privacy_policy_url
   end
 
   def outcome_administered

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -60,6 +60,7 @@ describe GovukNotifyPersonalisation do
         next_session_dates: "Thursday 1 January",
         next_session_dates_or: "Thursday 1 January",
         not_catch_up: "yes",
+        organisation_privacy_policy_url: "https://example.com/privacy",
         programme_name: "HPV",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",


### PR DESCRIPTION
This allows the privacy policy to be included in any email communication sent to parents.