### PR TITLE
Add yarn version to `.tool-versions` file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ postgres 17.2
 ruby 3.3.5
 aws-copilot 1.34.0
 awscli 2.13.31
+yarn 1.22.19


### PR DESCRIPTION
Otherwise running `bin/dev` will fail with:

```
No version is set for command yarn
Consider adding one of the following versions in your config file at /path/to/manage-vaccinations-in-schools/.tool-versions
yarn 1.22.19
```