### PR TITLE
Don't validate dose_sequence if not administered

### DIFF
--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -144,12 +144,13 @@ class VaccinationRecord < ApplicationRecord
               if: :requires_location_name?
             }
 
+  validates :dose_sequence, presence: true
   validates :dose_sequence,
-            presence: true,
             comparison: {
               greater_than_or_equal_to: 1,
               less_than_or_equal_to: :maximum_dose_sequence
-            }
+            },
+            if: :administered?
 
   validates :performed_at,
             comparison: {
@@ -199,6 +200,6 @@ class VaccinationRecord < ApplicationRecord
   end
 
   def maximum_dose_sequence
-    vaccine&.maximum_dose_sequence || 1
+    vaccine.maximum_dose_sequence
   end
 end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -83,6 +83,16 @@ describe VaccinationRecord do
         )
       end
     end
+
+    context "when administered is false and dose_sequence is not 1" do
+      let(:vaccination_record) do
+        build(:vaccination_record, outcome: :refused, dose_sequence: 2)
+      end
+
+      it "is valid" do
+        expect(vaccination_record).to be_valid
+      end
+    end
   end
 
   describe "#performed_by" do


### PR DESCRIPTION
A vaccine that isn't administered doesn't have a batch, which means it doesn't have a vaccine. Without the vaccine, `maximum_dose_sequence` defaults to 1. If the `dose_sequence` is > 1, this breaks the validation.

We can also remove the `vaccine& || 1` default with this change.