### PR TITLE
Fix typo on school movers confirmation screen

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -375,7 +375,7 @@ en:
       school_move:
         sources:
           class_list_import: Class list
-          cohort_import: Cohort record
+          cohort_import: Cohort
           parental_consent_form: Consent response
       triage:
         statuses:


### PR DESCRIPTION
Without the fix, the screen reads "Cohort record record":

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/1583171d-adfa-4b93-855c-e7c92de937e2" />
