### PR TITLE
Add new patients to upcoming sessions

### DIFF
--- a/app/controllers/import_issues_controller.rb
+++ b/app/controllers/import_issues_controller.rb
@@ -55,6 +55,7 @@ class ImportIssuesController < ApplicationController
         .with_pending_changes
         .distinct
         .eager_load(:cohort, :gp_practice, :school)
+        .preload(:school_moves, :upcoming_sessions)
         .strict_loading
 
     @import_issues =

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -329,6 +329,25 @@ class Patient < ApplicationRecord
     end
   end
 
+  def dup_for_pending_changes
+    dup.tap do |new_patient|
+      new_patient.nhs_number = nil
+
+      upcoming_sessions.each do |session|
+        new_patient.patient_sessions.build(session:)
+      end
+
+      school_moves.each do |school_move|
+        new_patient.school_moves.build(
+          home_educated: school_move.home_educated,
+          source: school_move.source,
+          organisation_id: school_move.organisation_id,
+          school_id: school_move.school_id
+        )
+      end
+    end
+  end
+
   def self.from_consent_form(consent_form)
     cohort =
       Cohort.find_or_create_by!(
@@ -383,9 +402,5 @@ class Patient < ApplicationRecord
     patient_sessions.where(session: upcoming_sessions).find_each(
       &:destroy_if_safe!
     )
-  end
-
-  def dup_for_pending_changes
-    dup.tap { |record| record.nhs_number = nil }
   end
 end

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -55,7 +55,14 @@ describe "Child record imports duplicates" do
       organisation: @organisation,
       programme: @programme
     )
-    @location = create(:school, urn: "123456", organisation: @organisation)
+    @school = create(:school, urn: "123456", organisation: @organisation)
+    @session =
+      create(
+        :session,
+        organisation: @organisation,
+        location: @school,
+        programme: @programme
+      )
   end
 
   def and_an_existing_patient_record_exists
@@ -87,9 +94,10 @@ describe "Child record imports duplicates" do
         address_line_2: "",
         address_town: "London",
         address_postcode: "SW11 1AA",
-        school: @location,
+        school: @school,
         organisation: @organisation
       )
+
     @third_patient =
       create(
         :patient,
@@ -102,8 +110,9 @@ describe "Child record imports duplicates" do
         address_line_2: "",
         address_town: "London",
         address_postcode: "SW1A 1AA",
-        school: @location,
-        organisation: @organisation
+        school: @school,
+        organisation: @organisation,
+        session: @session
       )
   end
 
@@ -199,15 +208,20 @@ describe "Child record imports duplicates" do
 
   def and_a_new_patient_record_should_be_created
     expect(Patient.count).to eq(4)
+
     patient = Patient.last
     expect(patient.given_name).to eq("Mark")
     expect(patient.family_name).to eq("Doe")
     expect(patient.pending_changes).to eq({})
-    expect(patient.school).to eq(@location)
+    expect(patient.school).to eq(@school)
     expect(patient.date_of_birth).to eq(Date.new(2010, 1, 3))
     expect(patient.gender_code).to eq("male")
     expect(patient.address_postcode).to eq("SW1A 1AA")
     expect(patient.nhs_number).to be_nil
+    expect(patient.sessions.count).to eq(1)
+
+    session = patient.sessions.first
+    expect(session).to eq(@session)
   end
 
   def when_i_review_the_third_duplicate_record


### PR DESCRIPTION
When resolving a duplicate patient by keeping both patients, we need to ensure that the new patient is also included in any sessions that the old patient was part of, otherwise the patient will end up in the global children view but without any sessions.

This also ensures that any outstanding school moves for the old patient are also copied to the new patient, this is necessary because a nurse might resolve the duplicate before confirming the school move, so the old patient might not be in the right session when it is duplicated.