### PR TITLE
Don't auto-deploy accessibility and pentest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
         environment: >-
           ${{ fromJSON(github.event_name == 'workflow_dispatch'
               && format('["{0}"]', inputs.environment)
-              || '["accessibility", "pentest", "test", "training"]') }}
+              || '["test", "training"]') }}
     uses: ./.github/workflows/_deploy-template.yml
     with:
       environment: ${{ matrix.environment }}


### PR DESCRIPTION
The `accessibility` env has been torn down, and `pentest` is next.