### PR TITLE
Don't use not_invalidated scope

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -95,7 +95,7 @@ class PatientSession < ApplicationRecord
   def latest_consents
     @latest_consents ||=
       consents
-        .select(&:not_invalidated?)
+        .reject(&:invalidated?)
         .select { _1.response_given? || _1.response_refused? }
         .group_by(&:name)
         .map { |_, consents| consents.max_by(&:created_at) }
@@ -106,7 +106,7 @@ class PatientSession < ApplicationRecord
   end
 
   def latest_triage
-    @latest_triage ||= triages.not_invalidated.max_by(&:updated_at)
+    @latest_triage ||= triages.reject(&:invalidated?).max_by(&:updated_at)
   end
 
   def latest_vaccination_record


### PR DESCRIPTION
When determining the `latest_triage` for a patient session, and therefore the status of a patient session. With a scope it forces the query to re-run even if the triages were preloaded, whereas doing it in Ruby means we avoid an extra query to the database. Because there are unlikely to be lots of triages for a particular patient session, this should improve performance.