### PR TITLE
Simplify `RECORD_STATUS` to `REASON_FOR_INCLUSION` 

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -74,8 +74,9 @@ class Reports::ProgrammeVaccinationsExporter
       REASON_NOT_VACCINATED
       LOCAL_PATIENT_ID
       SNOMED_PROCEDURE_CODE
-      RECORD_STATUS
-      RECORD_DATE_TIME
+      REASON_FOR_INCLUSION
+      RECORD_CREATED
+      RECORD_UPDATED
     ]
   end
 
@@ -182,8 +183,9 @@ class Reports::ProgrammeVaccinationsExporter
       reason_not_vaccinated(vaccination_record:),
       patient.id,
       programme.snomed_procedure_code,
-      record_status(vaccination_record:),
-      record_date_time(vaccination_record:)
+      reason_for_inclusion(vaccination_record:),
+      record_created_at(vaccination_record:),
+      record_updated_at(vaccination_record:)
     ]
   end
 
@@ -200,38 +202,21 @@ class Reports::ProgrammeVaccinationsExporter
     end
   end
 
-  def record_status(vaccination_record:)
-    created_at = vaccination_record.created_at
-    updated_at = vaccination_record.updated_at
-
-    return "created" if created_at == updated_at
-
-    if start_date.nil? && end_date.nil?
-      "updated"
-    elsif start_date.present? && end_date.present?
-      if updated_at >= start_date && updated_at <= end_date
-        "updated"
-      else
-        "created"
-      end
-    elsif start_date.present?
-      if updated_at >= start_date
-        "updated"
-      else
-        "created"
-      end
-    elsif updated_at <= end_date # end_date.present?
-      "updated"
-    else
-      "created"
+  def reason_for_inclusion(vaccination_record:)
+    if start_date.present? && vaccination_record.created_at < start_date
+      return "updated"
     end
+
+    "new"
   end
 
-  def record_date_time(vaccination_record:)
-    if record_status(vaccination_record:) == "created"
-      vaccination_record.created_at.iso8601
-    else
-      vaccination_record.updated_at.iso8601
-    end
+  def record_created_at(vaccination_record:)
+    vaccination_record.created_at.iso8601
+  end
+
+  def record_updated_at(vaccination_record:)
+    return "" if vaccination_record.created_at == vaccination_record.updated_at
+
+    vaccination_record.updated_at.iso8601
   end
 end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -72,8 +72,9 @@ describe Reports::ProgrammeVaccinationsExporter do
           REASON_NOT_VACCINATED
           LOCAL_PATIENT_ID
           SNOMED_PROCEDURE_CODE
-          RECORD_STATUS
-          RECORD_DATE_TIME
+          REASON_FOR_INCLUSION
+          RECORD_CREATED
+          RECORD_UPDATED
         ]
       )
     end
@@ -141,8 +142,9 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERSON_SURNAME" => patient.family_name,
               "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
-              "RECORD_DATE_TIME" => Time.current.iso8601,
-              "RECORD_STATUS" => "created",
+              "RECORD_CREATED" => Time.current.iso8601,
+              "RECORD_UPDATED" => "",
+              "REASON_FOR_INCLUSION" => "new",
               "ROUTE_OF_VACCINATION" => "intramuscular",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
@@ -194,7 +196,9 @@ describe Reports::ProgrammeVaccinationsExporter do
         end
 
         it "includes the information" do
-          expect(rows.first.to_hash).to include("RECORD_STATUS" => "updated")
+          expect(rows.first.to_hash).to include(
+            "REASON_FOR_INCLUSION" => "updated"
+          )
         end
       end
     end
@@ -259,8 +263,9 @@ describe Reports::ProgrammeVaccinationsExporter do
               "PERSON_SURNAME" => patient.family_name,
               "PROGRAMME_NAME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
-              "RECORD_DATE_TIME" => Time.current.iso8601,
-              "RECORD_STATUS" => "created",
+              "RECORD_CREATED" => Time.current.iso8601,
+              "RECORD_UPDATED" => "",
+              "REASON_FOR_INCLUSION" => "new",
               "ROUTE_OF_VACCINATION" => "intramuscular",
               "SCHOOL_NAME" => "",
               "SCHOOL_URN" => "888888",


### PR DESCRIPTION
This makes it more obvious that the field is not whether the record was created or updated at all, but why it's present in the current export.

Also return `new` instead of `updated`, and simplify the logic.

We also include the `CREATED` and `UPDATED` timestamps for clarity. The updated timestamp is only shown if it's different from created_at.