### PR TITLE
Align docker-entrypoint to Rails 8 conventions

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -1,7 +1,13 @@
 #!/bin/bash -e
 
+# Enable jemalloc for reduced memory usage and latency.
+if [ -z "${LD_PRELOAD+x}" ]; then
+  LD_PRELOAD=$(find /usr/lib -name libjemalloc.so.2 -print -quit)
+  export LD_PRELOAD
+fi
+
 # If running the rails server then create or migrate existing database
-if [ "${*}" == "./bin/rails server" ]; then
+if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
   ./bin/rails db:prepare:ignore_concurrent_migration_exceptions
 fi
 


### PR DESCRIPTION
Because we're running `bin/thrust` before `bin/rails server`, we have to update the conditional for `db:prepare` to take this into account.

Also add the `jemalloc` bit which should significantly improve memory usage.