### PR TITLE
Update seed schools for automated testing

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -305,17 +305,11 @@ unless Settings.cis2.enabled
 
   attach_sample_of_schools_to(organisation)
 
-  # Sidney Stringer Academy - used by automated tests
+  # Bohunt School Wokingham - used by automated tests
   attach_specific_school_to_organisation_if_present(
     organisation:,
-    urn: "136126"
+    urn: "142181"
   )
-
-  # Grange School - used by automated tests
-  attach_specific_school_to_organisation_if_present(
-    organisation:,
-    urn: "145377"
-  ) # needed for automated testing
 
   Audited
     .audit_class
@@ -334,12 +328,6 @@ organisation = create_organisation(ods_code: "A9A5A")
 user = create_user(organisation:, uid: "555057896106")
 
 attach_sample_of_schools_to(organisation)
-
-# Sidney Stringer Academy - used by automated tests
-attach_specific_school_to_organisation_if_present(organisation:, urn: "136126")
-
-# Grange School - used by automated tests
-attach_specific_school_to_organisation_if_present(organisation:, urn: "145377")
 
 Audited
   .audit_class


### PR DESCRIPTION
The testers need a different URN.

Also don't re-attach the same URNs to a different organisation - this messes up the setup.