### PR TITLE
Don't link to patients out of the organisation

### DIFF
--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -18,7 +18,16 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Full name</span>
-            <%= link_to patient.full_name, patient_path(patient) %>
+
+            <% if can_link_to?(patient) %>
+              <%= link_to patient.full_name, patient_path(patient) %>
+            <% else %>
+              <%= patient.full_name %>
+              <br />
+              <span class="nhsuk-u-secondary-text-color">
+                Child has moved out of the area
+              </span>
+            <% end %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,19 +1,32 @@
 # frozen_string_literal: true
 
 class AppPatientTableComponent < ViewComponent::Base
-  def initialize(patients, count: nil, heading: nil)
+  def initialize(patients, current_user:, count: nil, heading: nil)
     super
 
     @patients = patients
+    @current_user = current_user
     @count = count
     @heading = heading
   end
 
   private
 
-  attr_reader :patients
+  attr_reader :patients, :current_user
 
   def heading
     @heading.presence || I18n.t("children", count: @count)
+  end
+
+  def can_link_to?(patient)
+    allowed_patient_ids.include?(patient.id)
+  end
+
+  def allowed_patient_ids
+    # FIXME: Can we use helpers.policy_scope here?
+    # We can remove this once we show a page for the patient that contains
+    # limited information for the old organisation.
+    @allowed_patient_ids ||=
+      PatientPolicy::Scope.new(current_user, Patient).resolve.ids
   end
 end

--- a/app/policies/school_move_policy.rb
+++ b/app/policies/school_move_policy.rb
@@ -5,9 +5,10 @@ class SchoolMovePolicy < ApplicationPolicy
     def resolve
       organisation = user.selected_organisation
 
-      scope.where(school: organisation.schools).or(
-        scope.where(patient: Patient.in_organisation(organisation))
-      )
+      scope
+        .where(school: organisation.schools)
+        .or(scope.where(organisation:))
+        .or(scope.where(patient: Patient.in_organisation(organisation)))
     end
   end
 end

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -8,6 +8,6 @@
 
 <%= h1 format_year_group(@cohort.year_group) %>
 
-<%= render AppPatientTableComponent.new(@patients, count: @pagy.count) %>
+<%= render AppPatientTableComponent.new(@patients, current_user:, count: @pagy.count) %>
 
 <%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -155,6 +155,7 @@
 
   <% if @patients.present? %>
     <%= render AppPatientTableComponent.new(@patients,
+                                            current_user:,
                                             count: @pagy.count) %>
   <% end %>
 

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -37,7 +37,7 @@
     <p class="app-patients__no-results nhsuk-caption-m">No children</p>
   </div>
 <% else %>
-  <%= render AppPatientTableComponent.new(@patients, heading: @heading) %>
+  <%= render AppPatientTableComponent.new(@patients, current_user:, heading: @heading) %>
 <% end %>
 
 <%= govuk_pagination(pagy: @pagy) %>

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -3,7 +3,7 @@
 describe AppPatientTableComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(patients, count:) }
+  let(:component) { described_class.new(patients, current_user:, count:) }
 
   let(:patients) do
     [
@@ -26,6 +26,8 @@ describe AppPatientTableComponent do
       )
     ] + create_list(:patient, 8)
   end
+
+  let(:current_user) { create(:nurse) }
 
   let(:count) { 10 }
 
@@ -59,5 +61,18 @@ describe AppPatientTableComponent do
 
   it "doesn't show postcode of restricted patients" do
     expect(rendered).not_to have_text("SW1B 1AA")
+  end
+
+  it "renders links" do
+    expect(rendered).to have_link("John Smith")
+  end
+
+  context "with a patient not in the cohort" do
+    before { patients.first.update!(cohort_id: nil) }
+
+    it "doesn't render a link" do
+      expect(rendered).not_to have_link("John Smith")
+      expect(rendered).to have_content("Child has moved out of the area")
+    end
   end
 end


### PR DESCRIPTION
If a user clicks on this link they are taken to a 404 error page which is not a good user experience, we should instead hide the link and explain why the patient is not available.

## Screenshot

<img width="312" alt="Screenshot 2024-12-12 at 12 49 34" src="https://github.com/user-attachments/assets/7afb3579-4b73-49d9-9ff4-6a801ddc60df" />
