### PR TITLE
Add and use `AppNoticeStatusComponent`, remove GOVUK Warning Text component

### DIFF
--- a/app/assets/stylesheets/_status.scss
+++ b/app/assets/stylesheets/_status.scss
@@ -12,6 +12,10 @@
     color: $color_nhsuk-aqua-green;
   }
 
+  &--blue {
+    color: $color_nhsuk-blue;
+  }
+
   &--dark-orange {
     color: $color_app-dark-orange;
   }

--- a/app/assets/stylesheets/_warning_text.scss
+++ b/app/assets/stylesheets/_warning_text.scss
@@ -1,8 +1,0 @@
-.govuk-warning-text__icon {
-  background: $color_nhsuk-blue;
-  border: 3px solid $color_nhsuk-blue;
-}
-
-.govuk-warning-text__text {
-  color: $color_nhsuk-blue;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,7 +15,6 @@ $govuk-assets-path: "/";
 @import "govuk-frontend/dist/govuk/components/notification-banner/index";
 @import "govuk-frontend/dist/govuk/components/pagination/index";
 @import "govuk-frontend/dist/govuk/components/panel/index";
-@import "govuk-frontend/dist/govuk/components/warning-text/index";
 
 // Configure and import NHS.UK Frontend
 $nhsuk-fonts-path: "/";
@@ -66,7 +65,6 @@ $color_app-dark-orange: color.scale(
 @import "tag";
 @import "typography";
 @import "utilities";
-@import "warning_text";
 
 // Fix checkbox check sizing
 .nhsuk-checkboxes__label::after {

--- a/app/components/app_notice_status_component.rb
+++ b/app/components/app_notice_status_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AppNoticeStatusComponent < ViewComponent::Base
+  def call
+    icon_warning @text, "blue"
+  end
+
+  def initialize(text:)
+    super
+
+    @text = text
+  end
+
+  private
+
+  def icon_warning(content, color)
+    template = <<-ERB
+      <p class="app-status app-status--#{color}">
+        <svg class="nhsuk-icon app-icon__warning"
+             xmlns="http://www.w3.org/2000/svg"
+             viewBox="0 0 24 24"
+             aria-hidden="true">
+          <path d="M12 2a10 10 0 1 1 0 20 10 10 0 0 1 0-20Zm0 14a1.5 1.5 0 1 0 0 3 1.5 1.5 0 0 0 0-3Zm-1.5-9.5V13a1.5 1.5 0 0 0 3 0V6.5a1.5 1.5 0 0 0-3 0Z" fill="currentColor"></path>
+        </svg>
+        #{content}
+      </p>
+    ERB
+    template.html_safe
+  end
+end

--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -7,15 +7,21 @@ class AppPatientCardComponent < ViewComponent::Base
       
       <% if Flipper.enabled?(:release_1_2) %>
         <% if @patient.date_of_death.present? %>
-          <%= govuk_warning_text(text: "Record updated with child’s date of death") %>
+          <%= render AppNoticeStatusComponent.new(
+            text: "Record updated with child’s date of death"
+          ) %>
         <% end %>
         
         <% if @patient.invalidated? %>
-          <%= govuk_warning_text(text: "Record flagged as invalid") %>
+          <%= render AppNoticeStatusComponent.new(
+            text: "Record flagged as invalid"
+          ) %>
         <% end %>
         
         <% if @patient.restricted? %>
-          <%= govuk_warning_text(text: "Record flagged as sensitive") %>
+          <%= render AppNoticeStatusComponent.new(
+            text: "Record flagged as sensitive"
+          ) %>
         <% end %>
       <% end %>
 

--- a/config/initializers/govuk_components.rb
+++ b/config/initializers/govuk_components.rb
@@ -5,7 +5,6 @@ Govuk::Components.configure do |config|
   config.brand_overrides = {
     "GovukComponent::NotificationBannerComponent" => "govuk",
     "GovukComponent::PaginationComponent" => "govuk",
-    "GovukComponent::PanelComponent" => "govuk",
-    "GovukComponent::WarningTextComponent" => "govuk"
+    "GovukComponent::PanelComponent" => "govuk"
   }
 end


### PR DESCRIPTION
Use a new `AppNoticeStatusComponent` (possibly too similar to `AppConsentStatusComponent` to suggest some broader refactoring needed given they both share the same style (`app-status`), that replaces the need to use GOVUK Warning Text component. 

### Before

<img width="722" alt="Screenshot 2024-12-12 at 15 44 34" src="https://github.com/user-attachments/assets/f13b9989-aa92-4e20-a68d-b2959d332d68" />

### After

<img width="722" alt="Screenshot 2024-12-12 at 15 40 43" src="https://github.com/user-attachments/assets/ae52264f-6229-484b-91a1-4d8c3bd07a68" />

