### PR TITLE
Include Sentry SDK in staging envs

### DIFF
--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -9,6 +9,7 @@ class SchoolMovesController < ApplicationController
   layout "full"
 
   def index
+    raise "a sentry error"
     @pagy, @school_moves = pagy(policy_scope(SchoolMove).order(:updated_at))
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,13 @@
     <%= turbo_refreshes_with method: :morph, scroll: :preserve  %>
     <%= yield :head %>
     <%= hotwire_livereload_tags if Rails.env.development? %>
+
+    <% if Rails.env.staging? %>
+      <%# Include Sentry SDK to enable session replay in staging envs %>
+      <%= javascript_include_tag "https://js.sentry-cdn.com/f022e362b50c1914d59f03f2193d1eff.min.js",
+                                 crossorigin: "anonymous",
+                                 defer: true %>
+    <% end %>
   </head>
 
   <body class="nhsuk-template__body<%= ' app-signed-in' if current_user.present? %>">

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -1,5 +1,13 @@
 <%= h1 t(".title"), size: "xl" %>
 
+<button id="test-error">Trigger Test Error</button>
+<script>
+  const button = document.getElementById('test-error');
+  button.addEventListener('click', () => {
+    throw new Error('This is a test error');
+  });
+</script>
+
 <div class="nhsuk-table__panel-with-heading-tab">
   <h3 class="nhsuk-table__heading-tab">Adolescent</h3>
 


### PR DESCRIPTION
This enables a feature called Session Replay, which in theory should give us a blow-by-blow list of user interactions that lead to an error. This could be useful for debugging.

This doesn't affect development/test/production, only the staging environments.