### PR TITLE
Re-enable RSpec/NamedSubject

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,9 +40,6 @@ RSpec/BeforeAfterAll:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/NamedSubject:
-  Enabled: false
-
 RSpec/ImplicitExpect:
   EnforcedStyle: should
 

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe PatientSortingConcern do
-  subject { klass.new(params) }
+  subject(:controller) { klass.new(params) }
 
   let(:klass) do
     Class.new do
@@ -73,7 +73,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "name", direction: "asc" } }
 
       it "sorts patient sessions by name in ascending order" do
-        subject.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Alex Blair Casey]
         )
@@ -84,7 +84,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "dob", direction: "desc" } }
 
       it "sorts patient sessions by date of birth in descending order" do
-        subject.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Alex Blair Casey]
         )
@@ -95,7 +95,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "outcome", direction: "desc" } }
 
       it "sorts patient sessions by state in descending order" do
-        subject.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions)
         expect(patient_sessions.map(&:status)).to eq(
           %w[vaccinated delay_vaccination added_to_session]
         )
@@ -106,7 +106,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "postcode", direction: "desc" } }
 
       it "sorts patient sessions by name in ascending order" do
-        subject.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Casey Blair Alex]
         )
@@ -117,7 +117,7 @@ describe PatientSortingConcern do
       let(:params) { {} }
 
       it "does not change the order of patient sessions" do
-        subject.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Alex Blair Casey]
         )
@@ -130,7 +130,7 @@ describe PatientSortingConcern do
       let(:params) { { name: "Alex" } }
 
       it "filters patient sessions by patient name" do
-        subject.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Alex")
       end
@@ -140,7 +140,7 @@ describe PatientSortingConcern do
       let(:params) { { postcode: "SW2A" } }
 
       it "filters patient sessions by date of birth" do
-        subject.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Blair")
       end
@@ -150,7 +150,7 @@ describe PatientSortingConcern do
       let(:params) { { year_groups: %w[9] } }
 
       it "filters patient sessions by date of birth" do
-        subject.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Blair")
       end
@@ -160,7 +160,7 @@ describe PatientSortingConcern do
       let(:params) { { name: "Alex", year_groups: %w[8] } }
 
       it "filters patient sessions by both name and date of birth" do
-        subject.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Alex")
       end
@@ -170,7 +170,7 @@ describe PatientSortingConcern do
       let(:params) { {} }
 
       it "does not filter patient sessions" do
-        subject.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(3)
       end
     end

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe PatientTabsConcern do
-  subject { Class.new { include PatientTabsConcern }.new }
+  subject(:controller) { Class.new { include PatientTabsConcern }.new }
 
   let(:programme) { create(:programme) }
   let(:session) { create(:session, programme:) }
@@ -64,7 +64,7 @@ describe PatientTabsConcern do
   describe "#group_patient_sessions_by_conditions" do
     it "groups patient sessions by conditions" do
       result =
-        subject.group_patient_sessions_by_conditions(
+        controller.group_patient_sessions_by_conditions(
           patient_sessions,
           section: :consents
         )
@@ -91,7 +91,7 @@ describe PatientTabsConcern do
     context "some of the groups are empty" do
       it "returns an empty array for all the empty groups" do
         result =
-          subject.group_patient_sessions_by_conditions(
+          controller.group_patient_sessions_by_conditions(
             [consent_given_triage_not_needed],
             section: :consents
           )
@@ -112,7 +112,7 @@ describe PatientTabsConcern do
     context "triage section" do
       it "groups patient sessions by triage states" do
         result =
-          subject.group_patient_sessions_by_state(
+          controller.group_patient_sessions_by_state(
             patient_sessions,
             section: :triage
           )
@@ -139,7 +139,7 @@ describe PatientTabsConcern do
     context "vaccinations section" do
       it "groups patient sessions by vaccination states" do
         result =
-          subject.group_patient_sessions_by_state(
+          controller.group_patient_sessions_by_state(
             patient_sessions,
             section: :vaccinations
           )
@@ -168,7 +168,7 @@ describe PatientTabsConcern do
 
       it "returns an empty array for all the empty groups" do
         result =
-          subject.group_patient_sessions_by_state(
+          controller.group_patient_sessions_by_state(
             [patient_session],
             section: :triage
           )
@@ -200,7 +200,7 @@ describe PatientTabsConcern do
         consent_refused: [refuser_patient_session]
       }
 
-      result = subject.count_patient_sessions(patient_sessions)
+      result = controller.count_patient_sessions(patient_sessions)
 
       expect(result).to eq(
         { no_consent: 2, consent_given: 0, consent_refused: 1 }

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -169,9 +169,7 @@ describe GovukNotifyPersonalisation do
   context "with a parent" do
     let(:parent) { create(:parent, full_name: "John Smith") }
 
-    it do
-      expect(subject).to match(hash_including(parent_full_name: "John Smith"))
-    end
+    it { should include(parent_full_name: "John Smith") }
   end
 
   context "with a vaccination record" do

--- a/spec/lib/nhs/cis2_spec.rb
+++ b/spec/lib/nhs/cis2_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe NHS::CIS2 do
-  describe "jwks_fetcher" do
+  describe "#jwks_fetcher" do
     subject { described_class.send(:jwks_fetcher).call({}) }
 
     let(:jwks_uri) { "http://localhost:4000/jwks" }
@@ -28,20 +28,20 @@ describe NHS::CIS2 do
         allow(Rails.cache).to receive(:fetch).with(
           "cis2:jwks"
         ).and_call_original
-      end
 
-      it "fetches the jwks" do
         allow(JWT::JWK::Set).to receive(:new).and_return(
           [{ kid: "key1", use: "sig" }, kid: "key2", use: "enc"]
         )
-
-        expect(subject).to eq [{ kid: "key1", use: "sig" }]
       end
+
+      it { should eq [{ kid: "key1", use: "sig" }] }
     end
   end
 
-  describe "openid_configuration" do
-    subject { described_class.send(:openid_configuration) }
+  describe "#openid_configuration" do
+    subject(:openid_configuration) do
+      described_class.send(:openid_configuration)
+    end
 
     let(:config_uri) do
       "http://localhost:4000/test/oidc/.well-known/openid-configuration"
@@ -67,7 +67,7 @@ describe NHS::CIS2 do
         expires_in: 1.day
       ).and_call_original
 
-      subject
+      openid_configuration
 
       expect(Rails.cache).to have_received(:fetch)
     end

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -64,7 +64,7 @@ describe Batch do
     end
 
     it do
-      expect(subject).to validate_uniqueness_of(:expiry).scoped_to(
+      expect(batch).to validate_uniqueness_of(:expiry).scoped_to(
         :organisation_id,
         :name,
         :vaccine_id

--- a/spec/models/concerns/wizard_step_concern_spec.rb
+++ b/spec/models/concerns/wizard_step_concern_spec.rb
@@ -6,14 +6,14 @@ class Dummy
 end
 
 describe WizardStepConcern do
-  describe ".wizard_step" do
+  describe "#wizard_step" do
     subject { Dummy.new.wizard_step }
 
     it { should be_nil }
   end
 
-  describe "on_wizard_step" do
-    subject { Dummy.new }
+  describe "#on_wizard_step" do
+    subject(:dummy) { Dummy.new }
 
     before do
       Dummy.class_eval do
@@ -40,55 +40,55 @@ describe WizardStepConcern do
     it { should be_valid }
 
     context "when no step is set" do
-      before { subject.valid?(:update) }
+      before { dummy.valid?(:update) }
 
       it "runs all required validations" do
-        expect(subject.errors).not_to be_empty
-        expect(subject.errors[:foo]).to include("can't be blank")
-        expect(subject.errors[:bar]).to be_empty
-        expect(subject.errors[:qux]).to include("can't be blank")
+        expect(dummy.errors).not_to be_empty
+        expect(dummy.errors[:foo]).to include("can't be blank")
+        expect(dummy.errors[:bar]).to be_empty
+        expect(dummy.errors[:qux]).to include("can't be blank")
       end
     end
 
     context "when updating on the first step" do
       before do
-        subject.wizard_step = :first_step
-        subject.valid?(:update)
+        dummy.wizard_step = :first_step
+        dummy.valid?(:update)
       end
 
       it "runs only first step validations" do
-        expect(subject.errors).not_to be_empty
-        expect(subject.errors[:foo]).to include("can't be blank")
-        expect(subject.errors[:bar]).to be_empty
-        expect(subject.errors[:qux]).to be_empty
+        expect(dummy.errors).not_to be_empty
+        expect(dummy.errors[:foo]).to include("can't be blank")
+        expect(dummy.errors[:bar]).to be_empty
+        expect(dummy.errors[:qux]).to be_empty
       end
     end
 
     context "when updating on the optional step" do
       before do
-        subject.wizard_step = :optional_step
-        subject.valid?(:update)
+        dummy.wizard_step = :optional_step
+        dummy.valid?(:update)
       end
 
       it "runs first and optional step validations" do
-        expect(subject.errors).not_to be_empty
-        expect(subject.errors[:foo]).to include("can't be blank")
-        expect(subject.errors[:bar]).to include("can't be blank")
-        expect(subject.errors[:qux]).to be_empty
+        expect(dummy.errors).not_to be_empty
+        expect(dummy.errors[:foo]).to include("can't be blank")
+        expect(dummy.errors[:bar]).to include("can't be blank")
+        expect(dummy.errors[:qux]).to be_empty
       end
     end
 
     context "when updating on the last step" do
       before do
-        subject.wizard_step = :last_step
-        subject.valid?(:update)
+        dummy.wizard_step = :last_step
+        dummy.valid?(:update)
       end
 
       it "runs first and last step validations" do
-        expect(subject.errors).not_to be_empty
-        expect(subject.errors[:foo]).to include("can't be blank")
-        expect(subject.errors[:bar]).to be_empty
-        expect(subject.errors[:qux]).to include("can't be blank")
+        expect(dummy.errors).not_to be_empty
+        expect(dummy.errors[:foo]).to include("can't be blank")
+        expect(dummy.errors[:bar]).to be_empty
+        expect(dummy.errors[:qux]).to include("can't be blank")
       end
     end
   end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -124,11 +124,11 @@ describe ConsentForm do
         before { travel_to(Date.new(2022, 1, 1)) }
 
         it "has the correct error message" do
-          subject.date_of_birth = 2.years.ago.to_date
-          subject.valid?(:update)
+          consent_form.date_of_birth = 2.years.ago.to_date
+          consent_form.valid?(:update)
           # the date formatting below relies on the
           # custom interpolation from I18n::CustomInterpolation
-          expect(subject.errors[:date_of_birth]).to contain_exactly(
+          expect(consent_form.errors[:date_of_birth]).to contain_exactly(
             "The child cannot be younger than 3. Enter a date before 1 January 2019."
           )
         end
@@ -138,11 +138,11 @@ describe ConsentForm do
         before { travel_to(Date.new(2022, 1, 1)) }
 
         it "has the correct error message" do
-          subject.date_of_birth = 23.years.ago.to_date
-          subject.valid?(:update)
+          consent_form.date_of_birth = 23.years.ago.to_date
+          consent_form.valid?(:update)
           # the date formatting below relies on the
           # custom interpolation from I18n::CustomInterpolation
-          expect(subject.errors[:date_of_birth]).to contain_exactly(
+          expect(consent_form.errors[:date_of_birth]).to contain_exactly(
             "The child cannot be older than 22. Enter a date after 1 January 2000."
           )
         end
@@ -231,9 +231,9 @@ describe ConsentForm do
       it { should validate_presence_of(:address_postcode).on(:update) }
 
       it do
-        expect(subject).not_to allow_value("invalid").for(:address_postcode).on(
-          :update
-        )
+        expect(consent_form).not_to allow_value("invalid").for(
+          :address_postcode
+        ).on(:update)
       end
     end
 

--- a/spec/models/consolidated_health_answers_spec.rb
+++ b/spec/models/consolidated_health_answers_spec.rb
@@ -1,129 +1,156 @@
 # frozen_string_literal: true
 
 describe ConsolidatedHealthAnswers do
-  it "returns a questionnaire from one responder in the order it was given, including notes" do
-    subject.add_answer(
-      responder: "Mum",
-      question: "First question?",
-      answer: "No"
-    )
-    subject.add_answer(
-      responder: "Mum",
-      question: "Second question?",
-      answer: "No"
-    )
-    subject.add_answer(
-      responder: "Mum",
-      question: "Third question?",
-      answer: "Yes",
-      notes: "Notes"
-    )
+  subject(:to_h) { consolidated_health_answers.to_h }
 
-    expect(subject.to_h).to eq(
-      {
-        "First question?" => [{ responder: "Mum", answer: "No", notes: nil }],
-        "Second question?" => [{ responder: "Mum", answer: "No", notes: nil }],
-        "Third question?" => [
-          { responder: "Mum", answer: "Yes", notes: "Notes" }
-        ]
-      }
-    )
+  let(:consolidated_health_answers) { described_class.new }
+
+  context "with one responder in the order it was given, including notes" do
+    before do
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "First question?",
+        answer: "No"
+      )
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "Second question?",
+        answer: "No"
+      )
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "Third question?",
+        answer: "Yes",
+        notes: "Notes"
+      )
+    end
+
+    it do
+      expect(to_h).to eq(
+        {
+          "First question?" => [{ responder: "Mum", answer: "No", notes: nil }],
+          "Second question?" => [
+            { responder: "Mum", answer: "No", notes: nil }
+          ],
+          "Third question?" => [
+            { responder: "Mum", answer: "Yes", notes: "Notes" }
+          ]
+        }
+      )
+    end
   end
 
-  it "groups answers from multiple responders to the same question" do
-    subject.add_answer(
-      responder: "Mum",
-      question: "First question?",
-      answer: "No"
-    )
-    subject.add_answer(
-      responder: "Dad",
-      question: "First question?",
-      answer: "Yes",
-      notes: "Notes"
-    )
+  context "with multiple responders to the same question" do
+    before do
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "First question?",
+        answer: "No"
+      )
+      consolidated_health_answers.add_answer(
+        responder: "Dad",
+        question: "First question?",
+        answer: "Yes",
+        notes: "Notes"
+      )
+    end
 
-    expect(subject.to_h).to eq(
-      {
-        "First question?" => [
-          { responder: "Mum", answer: "No", notes: nil },
-          { responder: "Dad", answer: "Yes", notes: "Notes" }
-        ]
-      }
-    )
+    it do
+      expect(to_h).to eq(
+        {
+          "First question?" => [
+            { responder: "Mum", answer: "No", notes: nil },
+            { responder: "Dad", answer: "Yes", notes: "Notes" }
+          ]
+        }
+      )
+    end
   end
 
-  it "consolidates answers to the same question" do
-    subject.add_answer(
-      responder: "Mum",
-      question: "First question?",
-      answer: "No"
-    )
-    subject.add_answer(
-      responder: "Dad",
-      question: "First question?",
-      answer: "No"
-    )
+  context "with same answers to the same question" do
+    before do
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "First question?",
+        answer: "No"
+      )
+      consolidated_health_answers.add_answer(
+        responder: "Dad",
+        question: "First question?",
+        answer: "No"
+      )
+    end
 
-    expect(subject.to_h).to eq(
-      { "First question?" => [{ responder: "All", answer: "No", notes: nil }] }
-    )
+    it do
+      expect(to_h).to eq(
+        {
+          "First question?" => [{ responder: "All", answer: "No", notes: nil }]
+        }
+      )
+    end
   end
 
-  it "correctly handles several responses from the same parent (or two same-sex parents)" do
-    subject.add_answer(
-      responder: "Mum",
-      question: "First question?",
-      answer: "Yes",
-      notes: "Notes"
-    )
+  context "with several responses from the same parent (or two same-sex parents)" do
+    before do
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "First question?",
+        answer: "Yes",
+        notes: "Notes"
+      )
 
-    subject.add_answer(
-      responder: "Mum",
-      question: "First question?",
-      answer: "Yes",
-      notes: "Different notes"
-    )
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "First question?",
+        answer: "Yes",
+        notes: "Different notes"
+      )
+    end
 
-    expect(subject.to_h).to eq(
-      {
-        "First question?" => [
-          { responder: "Mum", answer: "Yes", notes: "Notes" },
-          { responder: "Mum", answer: "Yes", notes: "Different notes" }
-        ]
-      }
-    )
+    it do
+      expect(to_h).to eq(
+        {
+          "First question?" => [
+            { responder: "Mum", answer: "Yes", notes: "Notes" },
+            { responder: "Mum", answer: "Yes", notes: "Different notes" }
+          ]
+        }
+      )
+    end
   end
 
-  it "handles consent forms with variable numbers of questions, when some questions branch" do
-    subject.add_answer(
-      responder: "Mum",
-      question: "First question?",
-      answer: "Yes"
-    )
-    subject.add_answer(
-      responder: "Mum",
-      question: "Second question?",
-      answer: "Yes",
-      notes: "Notes"
-    )
+  context "with consent forms with variable numbers of questions, when some questions branch" do
+    before do
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "First question?",
+        answer: "Yes"
+      )
+      consolidated_health_answers.add_answer(
+        responder: "Mum",
+        question: "Second question?",
+        answer: "Yes",
+        notes: "Notes"
+      )
+      consolidated_health_answers.add_answer(
+        responder: "Dad",
+        question: "First question?",
+        answer: "No"
+      )
+    end
 
-    subject.add_answer(
-      responder: "Dad",
-      question: "First question?",
-      answer: "No"
-    )
-
-    expect(subject.to_h).to eq(
-      {
-        "First question?" => [
-          { responder: "Mum", answer: "Yes", notes: nil },
-          { responder: "Dad", answer: "No", notes: nil }
-        ],
-        "Second question?" => [
-          { responder: "Mum", answer: "Yes", notes: "Notes" }
-        ]
-      }
-    )
+    it do
+      expect(to_h).to eq(
+        {
+          "First question?" => [
+            { responder: "Mum", answer: "Yes", notes: nil },
+            { responder: "Dad", answer: "No", notes: nil }
+          ],
+          "Second question?" => [
+            { responder: "Mum", answer: "Yes", notes: "Notes" }
+          ]
+        }
+      )
+    end
   end
 end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -606,7 +606,7 @@ describe ImmunisationImportRow do
 
       it "does not stage any changes as vaccs history data is potentially out of date" do
         create(:patient, nhs_number:, address_postcode: "CB1 1AA")
-        expect(subject.pending_changes).to be_empty
+        expect(patient.pending_changes).to be_empty
       end
     end
 


### PR DESCRIPTION
This refactors the final tests that don't use named subjects which then allows us to re-enable this linting rule.