### PR TITLE
Prevent double-vaccination by navigating back

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -97,6 +97,10 @@ class DraftVaccinationRecordsController < ApplicationController
 
     send_vaccination_confirmation(@vaccination_record) if should_notify_parents
 
+    # In case the user navigates back to try and edit the newly created
+    # vaccination record.
+    @draft_vaccination_record.update!(editing_id: @vaccination_record.id)
+
     heading =
       if @vaccination_record.administered?
         t("vaccinations.flash.given")
@@ -122,10 +126,10 @@ class DraftVaccinationRecordsController < ApplicationController
   end
 
   def finish_wizard_path
-    if @draft_vaccination_record.editing?
-      programme_vaccination_record_path(@programme, @vaccination_record)
-    else
+    if @session.today?
       session_vaccinations_path(@session)
+    else
+      programme_vaccination_record_path(@programme, @vaccination_record)
     end
   end
 

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -260,6 +260,7 @@ describe "Edit vaccination record" do
     @session =
       create(
         :session,
+        :completed,
         organisation: @organisation,
         programme: @programme,
         location:

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -46,6 +46,9 @@ describe "HPV vaccination" do
     then_i_see_the_record_vaccinations_page
     and_a_success_message
 
+    when_i_go_back
+    and_i_save_changes
+
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_vaccinated
     and_i_see_the_vaccination_details
@@ -180,6 +183,14 @@ describe "HPV vaccination" do
     )
   end
 
+  def when_i_go_back
+    visit draft_vaccination_record_path("confirm")
+  end
+
+  def and_i_save_changes
+    click_button "Save changes"
+  end
+
   def when_i_go_to_the_patient
     click_link @patient.full_name
   end
@@ -189,7 +200,7 @@ describe "HPV vaccination" do
   end
 
   def and_i_see_the_vaccination_details
-    expect(page).to have_content("Vaccination details")
+    expect(page).to have_content("Vaccination details").once
   end
 
   def when_vaccination_confirmations_are_sent


### PR DESCRIPTION
When using the vaccinate flow it's possible to inadvertently record two vaccinations for the same patient by navigating back to the confirmation after submitting it and then submitting it again. Instead, once recorded, we associate the draft vaccination record with the saved one so this changes to the edit vaccination record flow.