### PR TITLE
Add foreign key on patient sessions

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -15,6 +15,11 @@
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
 #  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
 #
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
 
 class PatientSession < ApplicationRecord
   audited

--- a/db/migrate/20241213102755_add_foreign_key_on_patient_sessions.rb
+++ b/db/migrate/20241213102755_add_foreign_key_on_patient_sessions.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddForeignKeyOnPatientSessions < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :patient_sessions, :patients
+    add_foreign_key :patient_sessions, :sessions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_12_145341) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_13_102755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -826,6 +826,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_12_145341) do
   add_foreign_key "organisation_programmes", "programmes"
   add_foreign_key "parent_relationships", "parents"
   add_foreign_key "parent_relationships", "patients"
+  add_foreign_key "patient_sessions", "patients"
+  add_foreign_key "patient_sessions", "sessions"
   add_foreign_key "patients", "cohorts"
   add_foreign_key "patients", "locations", column: "gp_practice_id"
   add_foreign_key "patients", "locations", column: "school_id"

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -15,6 +15,11 @@
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
 #  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
 #
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
 FactoryBot.define do
   factory :patient_session do
     transient do

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -15,6 +15,11 @@
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
 #  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
 #
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
 
 describe PatientSession do
   let(:programme) { create(:programme) }


### PR DESCRIPTION
This adds a foreign key to patients and sessions from the patient sessions table, ensuring that patient sessions always refer to patients and sessions that exist.

It seems like this was missed when the table was set up originally.