### PR TITLE
Update PatientSession indexes

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
+#  index_patient_sessions_on_patient_id                 (patient_id)
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
-#  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#  index_patient_sessions_on_session_id                 (session_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20241213104730_update_patient_session_indexes.rb
+++ b/db/migrate/20241213104730_update_patient_session_indexes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class UpdatePatientSessionIndexes < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :patient_sessions, %i[session_id patient_id], unique: true
+    add_index :patient_sessions, :patient_id
+    add_index :patient_sessions, :session_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_13_102755) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_13_104730) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -541,7 +541,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_13_102755) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["patient_id", "session_id"], name: "index_patient_sessions_on_patient_id_and_session_id", unique: true
-    t.index ["session_id", "patient_id"], name: "index_patient_sessions_on_session_id_and_patient_id", unique: true
+    t.index ["patient_id"], name: "index_patient_sessions_on_patient_id"
+    t.index ["session_id"], name: "index_patient_sessions_on_session_id"
   end
 
   create_table "patients", force: :cascade do |t|

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
+#  index_patient_sessions_on_patient_id                 (patient_id)
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
-#  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#  index_patient_sessions_on_session_id                 (session_id)
 #
 # Foreign Keys
 #

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -12,8 +12,9 @@
 #
 # Indexes
 #
+#  index_patient_sessions_on_patient_id                 (patient_id)
 #  index_patient_sessions_on_patient_id_and_session_id  (patient_id,session_id) UNIQUE
-#  index_patient_sessions_on_session_id_and_patient_id  (session_id,patient_id) UNIQUE
+#  index_patient_sessions_on_session_id                 (session_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
This updates the indexes on the patient session model to remove an unnecessary unique index and add missing indexes on the patient and session column.

The index on the individual columns should improve performance when looking up individual patient sessions for a patient or a session, related to the foreign key added in
b350c8eebae2097e008ee39f14db29d72ce55412.

The unique index on `session_id` and `patient_id` is unnecessary as we already have an index on `patient_id` and `session_id`.