### PR TITLE
Speed up deploys with docker layer caching

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -17,8 +17,12 @@ http:
 # Configuration for your containers and service.
 image:
   # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
-  build: Dockerfile
-  # Port exposed through your container to route traffic to it.
+  build:
+    dockerfile: Dockerfile
+    cache_from:
+      - 393416225559.dkr.ecr.eu-west-2.amazonaws.com/mavis/webapp:latest
+    args:
+      BUILDKIT_INLINE_CACHE: 1
   port: 4000
 
 platform: linux/x86_64
@@ -102,6 +106,10 @@ environments:
       MAVIS__PDS__PERFORM_JOBS: false
       MAVIS__SPLUNK__ENABLED: false
   production:
+    image:
+      build:
+        cache_from:
+          - 820242920762.dkr.ecr.eu-west-2.amazonaws.com/mavis/webapp:latest
     http:
       alias:
         - "www.manage-vaccinations-in-schools.nhs.uk"


### PR DESCRIPTION
Based on: https://github.com/aws/copilot-cli/issues/3919

This tells the Docker daemon to pull from ECR before it builds the image locally.

This allows `docker build` to skip some of the initial layers, speeding up deploys. In my local testing, installing `apt` deps is about 30 seconds, `bundle` about 30 seconds, `yarn` about 15 seconds. So if a PR doesn't make any changes to those (most don't), then that PR will deploy maybe 1-2 minutes faster, which is significant. At the time of writing, our last deploy was about 8-9 minutes.

Without this change, no local cache:

```bash
$ docker system prune -af
$ time copilot svc deploy --env preview
...
✔ Deployed service webapp.
Recommended follow-up action:
  - Your service is accessible at https://preview.mavistesting.com over the internet.

________________________________________________________
Executed in  549.35 secs    fish           external
   usr time    3.62 secs    0.16 millis    3.62 secs
   sys time    3.20 secs    3.69 millis    3.19 secs
```

With this change, no local cache:

```bash
$ docker system prune -af
$ time copilot svc deploy --env preview
...
=> importing cache manifest from 393416225559.dkr.ecr.eu-west-2.amazonaws.com/mavis/webapp:latest             0.4s
...
=> CACHED [base 2/3] WORKDIR /rails                                                                           0.0s
=> CACHED [base 3/3] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y curl libjemall  0.0s
=> CACHED [build  1/10] RUN apt-get update -qq &&     apt-get install --no-install-recommends -y build-essen  0.0s
=> CACHED [build  2/10] RUN curl -sL --ssl https://github.com/nodenv/node-build/archive/master.tar.gz | tar   0.0s
=> CACHED [build  3/10] COPY Gemfile Gemfile.lock .ruby-version ./                                            0.0s
=> CACHED [build  4/10] RUN bundle install &&     rm -rf ~/.bundle/ "/usr/local/bundle"/ruby/*/cache "/usr/l  0.0s
=> CACHED [build  5/10] COPY package.json yarn.lock ./                                                        0.0s
=> CACHED [build  6/10] RUN yarn install --ignore-scripts --frozen-lockfile                                   0.0s
=> CACHED [build  7/10] COPY . .                                                                              0.0s
=> CACHED [build  8/10] RUN bundle exec bootsnap precompile app/ lib/                                         0.0s
=> CACHED [build  9/10] RUN SECRET_KEY_BASE_DUMMY=1     MAVIS__CIS2__ENABLED=false     MAVIS__SPLUNK__ENABLE  0.0s
=> CACHED [build 10/10] RUN rm -rf node_modules                                                               0.0s
=> CACHED [stage-2 1/3] COPY --from=build /usr/local/bundle /usr/local/bundle                                 0.0s
=> CACHED [stage-2 2/3] COPY --from=build /rails /rails                                                       0.0s
...
✔ Deployed service webapp.
Recommended follow-up action:
  - Your service is accessible at https://preview.mavistesting.com over the internet.

________________________________________________________
Executed in  395.48 secs    fish           external
   usr time    3.50 secs    0.11 millis    3.50 secs
   sys time    2.30 secs    2.95 millis    2.30 secs
```

So that's a noticeable ~150 seconds faster.