### PR TITLE
Don't create parents by default in tests

### DIFF
--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -57,7 +57,10 @@ FactoryBot.define do
     end
 
     patient
-    parent { patient.parents.first }
+    parent do
+      patient.parents.first ||
+        association(:parent_relationship, patient:).parent
+    end
 
     response { "given" }
     route { "website" }

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
 
   factory :patient do
     transient do
-      parents { [create(:parent, family_name:)] }
+      parents { [] }
       performed_by { association(:user) }
       programme { session&.programmes&.first }
       session { nil }
@@ -109,6 +109,12 @@ FactoryBot.define do
     address_town { Faker::Address.city }
     address_postcode { Faker::Address.uk_postcode }
 
+    parent_relationships do
+      parents.map do |parent|
+        association(:parent_relationship, patient: instance, parent:)
+      end
+    end
+
     after(:create) do |patient, evaluator|
       if evaluator.session
         patient_session =
@@ -119,10 +125,6 @@ FactoryBot.define do
         if evaluator.in_attendance
           create(:session_attendance, :present, patient_session:)
         end
-      end
-
-      evaluator.parents.each do |parent|
-        create(:parent_relationship, parent:, patient:)
       end
     end
 

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -61,15 +61,9 @@ describe "Invalidate consent" do
   end
 
   def and_consent_has_been_given
-    @parent = @patient.parents.first
     @consent =
-      create(
-        :consent,
-        :given,
-        patient: @patient,
-        parent: @parent,
-        programme: @programme
-      )
+      create(:consent, :given, patient: @patient, programme: @programme)
+    @parent = @consent.parent
   end
 
   def and_triaged_as_safe_to_vaccinate

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -35,8 +35,9 @@ describe "Parental consent" do
         location:,
         date: Date.current + 2.days
       )
-    @patient = create(:patient, session: @session)
-    @parent = @patient.parents.first
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
   end
 
   def and_i_am_signed_in

--- a/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
+++ b/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
@@ -15,7 +15,9 @@ describe "Verbal consent recorded by admin" do
     organisation =
       create(:organisation, :with_one_admin, programmes: [programme])
     @session = create(:session, organisation:, programme:)
-    @patient = create(:patient, session: @session)
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
 
     sign_in organisation.users.first, role: :admin_staff
   end
@@ -26,7 +28,7 @@ describe "Verbal consent recorded by admin" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    choose @patient.parents.first.full_name
+    choose @parent.full_name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details
@@ -65,6 +67,6 @@ describe "Verbal consent recorded by admin" do
   end
 
   def then_an_email_is_sent_to_the_parent_about_triage
-    expect_email_to(@patient.parents.first.email, :consent_confirmation_triage)
+    expect_email_to(@parent.email, :consent_confirmation_triage)
   end
 end

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -15,7 +15,9 @@ describe "Verbal consent" do
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
     @session = create(:session, organisation:, programme:)
-    @patient = create(:patient, session: @session)
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
 
     sign_in organisation.users.first
   end
@@ -26,7 +28,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    choose @patient.parents.first.full_name
+    choose @parent.full_name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details
@@ -65,9 +67,6 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_that_the_vaccination_wont_happen
-    expect_email_to(
-      @patient.parents.first.email,
-      :triage_vaccination_wont_happen
-    )
+    expect_email_to(@parent.email, :triage_vaccination_wont_happen)
   end
 end

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -15,7 +15,9 @@ describe "Verbal consent" do
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
     @session = create(:session, organisation:, programme:)
-    @patient = create(:patient, session: @session)
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
 
     sign_in organisation.users.first
   end
@@ -26,7 +28,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    choose @patient.parents.first.full_name
+    choose @parent.full_name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details
@@ -67,6 +69,6 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_about_triage
-    expect_email_to(@patient.parents.first.email, :consent_confirmation_triage)
+    expect_email_to(@parent.email, :consent_confirmation_triage)
   end
 end

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -16,7 +16,9 @@ describe "Verbal consent" do
       create(:organisation, :with_one_nurse, programmes: [programme])
 
     @session = create(:session, organisation:, programme:)
-    @patient = create(:patient, session: @session)
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
 
     sign_in organisation.users.first
   end
@@ -27,7 +29,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    choose @patient.parents.first.full_name
+    choose @parent.full_name
     click_button "Continue"
 
     # Details for parent or guardian: leave existing contact details
@@ -66,9 +68,6 @@ describe "Verbal consent" do
   end
 
   def then_an_email_is_sent_to_the_parent_that_vaccination_will_happen
-    expect_email_to(
-      @patient.parents.first.email,
-      :triage_vaccination_will_happen
-    )
+    expect_email_to(@parent.email, :triage_vaccination_will_happen)
   end
 end

--- a/spec/features/verbal_consent_refused_personal_choice_spec.rb
+++ b/spec/features/verbal_consent_refused_personal_choice_spec.rb
@@ -17,7 +17,9 @@ describe "Verbal consent" do
     organisation =
       create(:organisation, :with_one_nurse, programmes: [programme])
     @session = create(:session, organisation:, programme:)
-    @patient = create(:patient, session: @session)
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
 
     sign_in organisation.users.first
   end

--- a/spec/features/withdraw_consent_spec.rb
+++ b/spec/features/withdraw_consent_spec.rb
@@ -64,15 +64,9 @@ describe "Withdraw consent" do
   end
 
   def and_consent_has_been_given
-    @parent = @patient.parents.first
     @consent =
-      create(
-        :consent,
-        :given,
-        patient: @patient,
-        parent: @parent,
-        programme: @programme
-      )
+      create(:consent, :given, patient: @patient, programme: @programme)
+    @parent = @consent.parent
   end
 
   def and_triaged_as_safe_to_vaccinate

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -12,6 +12,7 @@ describe SchoolConsentRemindersJob do
       :patient,
       :consent_request_sent,
       :initial_consent_reminder_sent,
+      parents:,
       programme:
     )
   end

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -4,8 +4,8 @@ describe PatientMerger do
   describe "#call" do
     subject(:call) do
       described_class.call(
-        to_keep: patient_to_keep,
-        to_destroy: patient_to_destroy
+        to_keep: patient_to_keep.reload,
+        to_destroy: patient_to_destroy.reload
       )
     end
 

--- a/spec/mailers/consent_mailer_spec.rb
+++ b/spec/mailers/consent_mailer_spec.rb
@@ -69,8 +69,8 @@ describe ConsentMailer do
       ).school_request
     end
 
-    let(:patient) { create(:patient) }
-    let(:parent) { patient.parents.first }
+    let(:parent) { create(:parent) }
+    let(:patient) { create(:patient, parents: [parent]) }
     let(:programme) { create(:programme) }
     let(:date) { Date.current }
     let(:session) { create(:session, date:, patients: [patient], programme:) }
@@ -107,8 +107,8 @@ describe ConsentMailer do
       ).clinic_request
     end
 
-    let(:patient) { create(:patient) }
-    let(:parent) { patient.parents.first }
+    let(:parent) { create(:parent) }
+    let(:patient) { create(:patient, parents: [parent]) }
     let(:programme) { create(:programme) }
     let(:date) { Date.current }
     let(:session) { create(:session, date:, patients: [patient], programme:) }
@@ -141,8 +141,8 @@ describe ConsentMailer do
       ).school_initial_reminder
     end
 
-    let(:patient) { create(:patient) }
-    let(:parent) { patient.parents.first }
+    let(:parent) { create(:parent) }
+    let(:patient) { create(:patient, parents: [parent]) }
     let(:programme) { create(:programme) }
     let(:date) { Date.current }
     let(:session) { create(:session, date:, patients: [patient], programme:) }
@@ -179,8 +179,8 @@ describe ConsentMailer do
       ).school_subsequent_reminder
     end
 
-    let(:patient) { create(:patient) }
-    let(:parent) { patient.parents.first }
+    let(:parent) { create(:parent) }
+    let(:patient) { create(:patient, parents: [parent]) }
     let(:programme) { create(:programme) }
     let(:date) { Date.current }
     let(:session) { create(:session, date:, patients: [patient], programme:) }

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -12,11 +12,13 @@ describe SessionMailer do
     end
 
     let(:programme) { create(:programme) }
-    let(:patient) { create(:patient, preferred_given_name: "Joey") }
+    let(:parent) { create(:parent) }
+    let(:patient) do
+      create(:patient, preferred_given_name: "Joey", parents: [parent])
+    end
     let(:session) { create(:session, programme:, patients: [patient]) }
-    let(:parent) { patient.parents.first }
 
-    it { should have_attributes(to: [patient.parents.first.email]) }
+    it { should have_attributes(to: [parent.email]) }
 
     describe "personalisation" do
       subject(:personalisation) do
@@ -58,16 +60,17 @@ describe SessionMailer do
         organisation:
       )
     end
+    let(:parent) { create(:parent) }
     let(:patient) do
       create(
         :patient,
         given_name: "John",
         family_name: "Smith",
-        preferred_given_name: "Joey"
+        preferred_given_name: "Joey",
+        parents: [parent]
       )
     end
     let(:session) { create(:session, organisation:, programme:, team:) }
-    let(:parent) { patient.parents.first }
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
     it { should have_attributes(to: [parent.email]) }
@@ -108,16 +111,17 @@ describe SessionMailer do
         organisation:
       )
     end
+    let(:parent) { create(:parent) }
     let(:patient) do
       create(
         :patient,
         given_name: "John",
         family_name: "Smith",
-        preferred_given_name: "Joey"
+        preferred_given_name: "Joey",
+        parents: [parent]
       )
     end
     let(:session) { create(:session, organisation:, programme:, team:) }
-    let(:parent) { patient.parents.first }
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
     it { should have_attributes(to: [parent.email]) }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -571,11 +571,9 @@ describe Patient do
   end
 
   describe "#destroy_childless_parents" do
-    let(:patient) { create(:patient, parents: []) }
-    let(:parent) { create(:parent) }
-
     context "when parent has only one child" do
-      before { create(:parent_relationship, parent:, patient:) }
+      let(:parent) { create(:parent) }
+      let!(:patient) { create(:patient, parents: [parent]) }
 
       it "destroys the parent when the patient is destroyed" do
         expect { patient.destroy }.to change(Parent, :count).by(-1)
@@ -583,12 +581,10 @@ describe Patient do
     end
 
     context "when parent has multiple children" do
-      let(:sibling) { create(:patient) }
+      let(:parent) { create(:parent) }
+      let!(:patient) { create(:patient, parents: [parent]) }
 
-      before do
-        create(:parent_relationship, parent:, patient:)
-        create(:parent_relationship, parent:, patient: sibling)
-      end
+      before { create(:patient, parents: [parent]) }
 
       it "does not destroy the parent when one patient is destroyed" do
         expect { patient.destroy }.not_to change(Parent, :count)
@@ -596,12 +592,7 @@ describe Patient do
     end
 
     context "when patient has multiple parents" do
-      let(:other_parent) { create(:parent) }
-
-      before do
-        create(:parent_relationship, parent:, patient:)
-        create(:parent_relationship, parent: other_parent, patient:)
-      end
+      let!(:patient) { create(:patient, parents: create_list(:parent, 2)) }
 
       it "destroys only the childless parents" do
         expect { patient.destroy }.to change(Parent, :count).by(-2)


### PR DESCRIPTION
This simplifies the patient factory to not create parents by default to improve test performance and match production where patients won't necessarily always have parents attached to them.