### PR TITLE
Choose an organisation on login without CIS2

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -94,3 +94,22 @@
     padding-top: nhsuk-spacing(0);
   }
 }
+
+// Used only to simulate CIS2 role switcher
+// @link https://digital.nhs.uk/services/care-identity-service/applications-and-services/cis2-authentication/guidance-for-developers/detailed-guidance/role-selection
+.nhsuk-card--button {
+  text-align: left;
+
+  .nhsuk-card__heading {
+    color: $nhsuk-link-color;
+    text-decoration: underline;
+  }
+
+  &:hover .nhsuk-card__heading {
+    color: $nhsuk-link-hover-color;
+  }
+
+  &:active .nhsuk-card__heading {
+    color: $nhsuk-link-active-color;
+  }
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_user_location!
   before_action :authenticate_user!
+  before_action :set_selected_organisation
   before_action :set_user_cis2_info
   before_action :set_disable_cache_headers
   before_action :set_header_path
@@ -32,6 +33,14 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
+
+  def set_selected_organisation
+    return if Settings.cis2.enabled
+    return unless current_user
+    return if session["cis2_info"].present?
+
+    redirect_to new_users_organisations_path
+  end
 
   def set_header_path
     @header_path = dashboard_path

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -87,7 +87,7 @@ module AuthenticationConcern
     end
 
     def set_user_cis2_info
-      return unless Settings.cis2.enabled && current_user
+      return unless current_user
 
       current_user.cis2_info = session["cis2_info"]
     end

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class Users::OrganisationsController < ApplicationController
+  skip_before_action :set_selected_organisation
+  skip_after_action :verify_policy_scoped
+
+  before_action :redirect_to_dashboard_if_cis2_is_enabled
+
+  layout "two_thirds"
+
+  def new
+    @organisations = current_user.organisations
+  end
+
+  def create
+    organisation = current_user.organisations.find(params[:organisation_id])
+
+    if organisation.present?
+      session["cis2_info"] = {
+        "selected_org" => {
+          "name" => organisation.name,
+          "code" => organisation.ods_code
+        },
+        "selected_role" => {
+          "code" => valid_cis2_roles.first,
+          "workgroups" => ["schoolagedimmunisations"]
+        }
+      }
+
+      redirect_to dashboard_path
+    else
+      @organisations = current_user.organisations
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def redirect_to_dashboard_if_cis2_is_enabled
+    redirect_to dashboard_path if Settings.cis2.enabled
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,11 +83,7 @@ class User < ApplicationRecord
 
   def selected_organisation
     @selected_organisation ||=
-      if Settings.cis2.enabled
-        Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
-      else
-        organisations.first
-      end
+      Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
   end
 
   def requires_email_and_password?

--- a/app/views/users/organisations/new.html.erb
+++ b/app/views/users/organisations/new.html.erb
@@ -1,0 +1,22 @@
+<%= h1 "Select a role" %>
+
+<%= form_with url: users_organisations_path, method: :post do |f| %>
+  <% @organisations.each do |organisation| %>
+    <%= f.button type: :submit,
+                 name: :organisation_id,
+                 value: organisation.id,
+                 class: "nhsuk-card nhsuk-card--button nhsuk-card--clickable nhsuk-u-margin-bottom-3" do %>
+      <div class="nhsuk-card__content">
+        <h2 class="nhsuk-card__heading nhsuk-heading-s nhsuk-u-margin-bottom-2">
+          <%= organisation.name %> (<%= organisation.ods_code %>)
+        </h2>
+
+        <% if current_user.is_admin? %>
+          <p class="nhsuk-card__description">Administrator</p>
+        <% elsif current_user.is_nurse? %>
+          <p class="nhsuk-card__description">Nurse</p>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -352,6 +352,8 @@ Rails.application.routes.draw do
     get "organisation-not-found", controller: :errors
     get "workgroup-not-found", controller: :errors
     get "role-not-found", controller: :errors
+
+    resource :organisations, only: %i[new create]
   end
 
   scope via: :all do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -41,13 +41,6 @@ describe User do
   describe "#selected_organisation" do
     subject(:selected_organisation) { user.selected_organisation }
 
-    context "cis2 is disabled", cis2: :disabled do
-      let(:organisation) { build(:organisation) }
-      let(:user) { build(:user, organisation:) }
-
-      it { should eq(organisation) }
-    end
-
     context "cis2 is enabled", cis2: :enabled do
       let(:organisation) { create(:organisation) }
       let(:user) { create(:user, organisation:) }

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -25,6 +25,7 @@ test("Accessibility", async ({ page }) => {
     .getByLabel("Password", { exact: true })
     .fill("nurse.joy@example.com");
   await page.getByRole("button", { name: "Log in" }).click();
+  await page.getByRole("button", { name: "R1L" }).click();
   await expect(page.locator("h1")).toContainText("Mavis");
   await checkAccessibility(page);
 


### PR DESCRIPTION
We currently default to `current_user.organisations.first` if users aren't signed in using CIS2 when deciding their `selected_organisation`.

This makes testing certain features harder, as there is no way for users to sign into multiple organisations. Amongst other things, we could use this capability in the training environment to set up 2 different organisations; one that is a blank slate, one that has data in it, to train on different scenarios.

This adds a page that simulates the "Select a role" page that users see when they login via CIS2. However, it asks the users to choose an organisation, not a role. The user is only asked on login, or during their current session if they haven't chosen one already. In environments where CIS2 is enabled, this functionality should not affect anything.

### Choosing an organisation on login

![Screenshot 2024-12-13 at 17 52 15](https://github.com/user-attachments/assets/0bf50c3a-5f78-44d2-b820-3fcc50de7c94)
