### PR TITLE
Re-enable accessibility tests on release 1B pages

### DIFF
--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -28,15 +28,13 @@ test("Accessibility", async ({ page }) => {
   await expect(page.locator("h1")).toContainText("Mavis");
   await checkAccessibility(page);
 
-  // RE-ENABLE FOR RELEASE 1B
-
   // Vaccines page
-  // await page.getByRole("heading", { name: "Vaccines" }).click();
-  // await expect(page.locator("h1")).toContainText("Vaccines");
-  // await checkAccessibility(page);
+  await page.getByRole("heading", { name: "Vaccines" }).click();
+  await expect(page.locator("h1")).toContainText("Vaccines");
+  await checkAccessibility(page);
 
   // Vaccine page
-  // await page.getByRole("link", { name: "Gardasil 9" }).click();
-  // await expect(page.locator("h1")).toContainText("Gardasil 9");
-  // await checkAccessibility(page);
+  await page.getByRole("link", { name: "Gardasil 9" }).click();
+  await expect(page.locator("h1")).toContainText("Gardasil 9");
+  await checkAccessibility(page);
 });


### PR DESCRIPTION
These were commented out previously.