### PR TITLE
Refactor GOV.UK Notify personalisation

### DIFF
--- a/app/lib/govuk_notify_parameters.rb
+++ b/app/lib/govuk_notify_parameters.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class GovukNotifyParameters
+  def initialize(
+    consent: nil,
+    consent_form: nil,
+    parent: nil,
+    patient: nil,
+    patient_session: nil,
+    programme: nil,
+    session: nil,
+    vaccination_record: nil
+  )
+    patient_session ||= vaccination_record&.patient_session
+
+    @consent = consent
+    @consent_form = consent_form
+    @parent = parent || consent&.parent
+    @patient = patient || consent&.patient || patient_session&.patient
+    @programme =
+      programme || vaccination_record&.programme || consent_form&.programme ||
+        consent&.programme
+    @session =
+      session || consent_form&.actual_upcoming_session ||
+        consent_form&.original_session || patient_session&.session
+    @organisation =
+      session&.organisation || patient_session&.organisation ||
+        consent_form&.organisation || consent&.organisation ||
+        vaccination_record&.organisation
+    @team =
+      session&.team || patient_session&.team || consent_form&.team ||
+        vaccination_record&.team
+    @vaccination_record = vaccination_record
+  end
+
+  attr_reader :consent,
+              :consent_form,
+              :parent,
+              :patient,
+              :programme,
+              :session,
+              :team,
+              :organisation,
+              :vaccination_record
+end

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -3,8 +3,8 @@
 class GovukNotifyPersonalisation
   include Rails.application.routes.url_helpers
 
-  def initialize(...)
-    @parameters = GovukNotifyParameters.new(...)
+  def initialize(parameters)
+    @parameters = parameters
   end
 
   def call

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -3,36 +3,8 @@
 class GovukNotifyPersonalisation
   include Rails.application.routes.url_helpers
 
-  def initialize(
-    consent: nil,
-    consent_form: nil,
-    parent: nil,
-    patient: nil,
-    patient_session: nil,
-    programme: nil,
-    session: nil,
-    vaccination_record: nil
-  )
-    patient_session ||= vaccination_record&.patient_session
-
-    @consent = consent
-    @consent_form = consent_form
-    @parent = parent || consent&.parent
-    @patient = patient || consent&.patient || patient_session&.patient
-    @programme =
-      programme || vaccination_record&.programme || consent_form&.programme ||
-        consent&.programme
-    @session =
-      session || consent_form&.actual_upcoming_session ||
-        consent_form&.original_session || patient_session&.session
-    @organisation =
-      session&.organisation || patient_session&.organisation ||
-        consent_form&.organisation || consent&.organisation ||
-        vaccination_record&.organisation
-    @team =
-      session&.team || patient_session&.team || consent_form&.team ||
-        vaccination_record&.team
-    @vaccination_record = vaccination_record
+  def initialize(...)
+    @parameters = GovukNotifyParameters.new(...)
   end
 
   def call
@@ -76,15 +48,16 @@ class GovukNotifyPersonalisation
 
   private
 
-  attr_reader :consent,
-              :consent_form,
-              :parent,
-              :patient,
-              :programme,
-              :session,
-              :team,
-              :organisation,
-              :vaccination_record
+  delegate :consent,
+           :consent_form,
+           :parent,
+           :patient,
+           :programme,
+           :session,
+           :team,
+           :organisation,
+           :vaccination_record,
+           to: :@parameters
 
   def batch_name
     vaccination_record&.batch&.name

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -47,7 +47,10 @@ describe TextDeliveryJob do
     let(:vaccination_record) { nil }
 
     it "generates personalisation" do
-      expect(GovukNotifyPersonalisation).to receive(:call).with(
+      parameters =
+        instance_double(GovukNotifyParameters, consent_form:, parent:, patient:)
+
+      allow(GovukNotifyParameters).to receive(:new).with(
         session:,
         consent:,
         consent_form:,
@@ -56,7 +59,10 @@ describe TextDeliveryJob do
         patient_session:,
         programme:,
         vaccination_record:
-      )
+      ).and_return(parameters)
+
+      expect(GovukNotifyPersonalisation).to receive(:call).with(parameters)
+
       perform_now
     end
 

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 describe GovukNotifyPersonalisation do
-  subject(:personalisation) do
-    described_class.call(
+  subject(:personalisation) { described_class.call(parameters) }
+
+  let(:parameters) do
+    GovukNotifyParameters.new(
       patient:,
       session:,
       consent:,


### PR DESCRIPTION
This refactors the personalisation generation for GOV.UK Notify to split the `GovukNotifyPersonalisation` class in to two separate classes (`GovukNotifyParameters` and `GovukNotifyPersonalisation`). This allows the `ApplicationMailer` and `TextDeliveryJob` to use the `GovukNotifyParameters` class to extract a suitable `organisation`, `parent` or `consent_form` from the input parameters to the job.