### PR TITLE
Add Reply-To IDs to teams

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -56,6 +56,12 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def reply_to_id
+    team =
+      session&.team || patient_session&.team || consent_form&.team ||
+        vaccination_record&.team
+
+    return team.reply_to_id if team&.reply_to_id
+
     organisation =
       session&.organisation || patient_session&.organisation ||
         consent_form&.organisation || consent&.organisation ||

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organisation_id :bigint           not null
+#  reply_to_id     :uuid
 #
 # Indexes
 #

--- a/db/migrate/20240214115829_add_reply_to_id_to_teams_old.rb
+++ b/db/migrate/20240214115829_add_reply_to_id_to_teams_old.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReplyToIdToTeams < ActiveRecord::Migration[7.1]
+class AddReplyToIdToTeamsOld < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :reply_to_id, :string
   end

--- a/db/migrate/20241213195932_add_reply_to_id_to_teams.rb
+++ b/db/migrate/20241213195932_add_reply_to_id_to_teams.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReplyToIdToTeams < ActiveRecord::Migration[8.0]
+  def change
+    add_column :teams, :reply_to_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -679,6 +679,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_15_123804) do
     t.string "phone", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "reply_to_id"
     t.index ["organisation_id", "name"], name: "index_teams_on_organisation_id_and_name", unique: true
     t.index ["organisation_id"], name: "index_teams_on_organisation_id"
   end

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -21,6 +21,7 @@ teams:
     name: # Name of the team
     email: # Contact email address
     phone: # Contact phone number
+    reply_to_id: # Optional GOV.UK Notify Reply-To UUID
 
 schools:
   team1: [] # URNs managed by a particular team

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organisation_id :bigint           not null
+#  reply_to_id     :uuid
 #
 # Indexes
 #

--- a/spec/fixtures/files/onboarding/valid.yaml
+++ b/spec/fixtures/files/onboarding/valid.yaml
@@ -13,6 +13,7 @@ teams:
     name: Team 1
     email: team-1@trust.nhs.uk
     phone: 07700 900816
+    reply_to_id: 24af66c3-d6bd-4b9f-8067-3844f49e08d0
   team_2:
     name: Team 2
     email: team-2@trust.nhs.uk

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe ApplicationMailer do
+  subject(:mail) do
+    mailer_class.with(session:, parent:, patient:).example_email
+  end
+
+  let(:mailer_class) do
+    Class.new(ApplicationMailer) do
+      def example_email
+        app_template_mail(GOVUK_NOTIFY_EMAIL_TEMPLATES.keys.first)
+      end
+    end
+  end
+
+  let(:programmes) { create_list(:programme, 1) }
+  let(:organisation) { create(:organisation, programmes:) }
+  let(:team) { create(:team, organisation:) }
+
+  let(:location) { create(:school, team:) }
+  let(:session) { create(:session, location:, organisation:, programmes:) }
+  let(:parent) { create(:parent) }
+  let(:patient) { create(:patient) }
+
+  describe "#reply_to_id" do
+    subject { mail.reply_to_id }
+
+    it { should be_nil }
+
+    context "when the organisation has a reply_to_id" do
+      let(:reply_to_id) { SecureRandom.uuid }
+
+      let(:organisation) { create(:organisation, programmes:, reply_to_id:) }
+
+      it { should eq(reply_to_id) }
+    end
+  end
+end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -34,5 +34,24 @@ describe ApplicationMailer do
 
       it { should eq(reply_to_id) }
     end
+
+    context "when the team has a reply_to_id" do
+      let(:reply_to_id) { SecureRandom.uuid }
+
+      let(:team) { create(:team, organisation:, reply_to_id:) }
+
+      it { should eq(reply_to_id) }
+    end
+
+    context "when the team and the organisation has a reply_to_id" do
+      let(:reply_to_id) { SecureRandom.uuid }
+
+      let(:organisation) do
+        create(:organisation, programmes:, reply_to_id: SecureRandom.uuid)
+      end
+      let(:team) { create(:team, organisation:, reply_to_id:) }
+
+      it { should eq(reply_to_id) }
+    end
   end
 end

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -31,10 +31,12 @@ describe Onboarding do
       team1 = organisation.teams.includes(:schools).find_by!(name: "Team 1")
       expect(team1.email).to eq("team-1@trust.nhs.uk")
       expect(team1.phone).to eq("07700 900816")
+      expect(team1.reply_to_id).to eq("24af66c3-d6bd-4b9f-8067-3844f49e08d0")
 
       team2 = organisation.teams.includes(:schools).find_by!(name: "Team 2")
       expect(team2.email).to eq("team-2@trust.nhs.uk")
       expect(team2.phone).to eq("07700 900817")
+      expect(team2.reply_to_id).to be_nil
 
       expect(team1.schools).to contain_exactly(school1, school2)
       expect(team2.schools).to contain_exactly(school3, school4)

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organisation_id :bigint           not null
+#  reply_to_id     :uuid
 #
 # Indexes
 #


### PR DESCRIPTION
This adds the ability to customise the GOV.UK Notify Reply-To ID per team like we already do with contact details (phone and email) to ensure that if users reply to the email they will go to the right place.