### PR TITLE
Remove remaining explicit type from specs

### DIFF
--- a/spec/helpers/consent_forms_helper_spec.rb
+++ b/spec/helpers/consent_forms_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe ConsentFormsHelper, type: :helper do
+describe ConsentFormsHelper do
   include ActionView::Helpers
 
   before do

--- a/spec/jobs/mesh_dps_export_job_spec.rb
+++ b/spec/jobs/mesh_dps_export_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe MESHDPSExportJob, type: :job do # rubocop:disable RSpec/SpecFilePathFormat
+describe MESHDPSExportJob do # rubocop:disable RSpec/SpecFilePathFormat
   before { allow(MESH).to receive(:send_file).and_return(response_double) }
 
   after { Flipper.disable(:mesh_jobs) }

--- a/spec/jobs/remove_import_csv_job_spec.rb
+++ b/spec/jobs/remove_import_csv_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe RemoveImportCSVJob, type: :job do
+describe RemoveImportCSVJob do
   describe "#perform" do
     subject(:perform) { described_class.new.perform }
 

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -30,7 +30,7 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 
-describe Vaccine, type: :model do
+describe Vaccine do
   describe "validation" do
     it { should validate_inclusion_of(:method).in_array(%w[injection nasal]) }
   end

--- a/spec/routing/vaccinations_routing_spec.rb
+++ b/spec/routing/vaccinations_routing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe VaccinationsController, type: :routing do
+describe VaccinationsController do
   describe "routing" do
     it "routes to #index" do
       expect(get: "/sessions/slug/vaccinations/actions").to route_to(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -171,31 +171,17 @@ RSpec.configure do |config|
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     describe UsersController, type: :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-
   config.filter_run_excluding :local_users
 
-  config.define_derived_metadata(
-    file_path: Regexp.new("/spec/components/")
-  ) { |metadata| metadata[:type] = :component }
-
-  config.define_derived_metadata(
-    file_path: Regexp.new("/spec/forms/")
-  ) { |metadata| metadata[:type] = :model }
-
   config.infer_spec_type_from_file_location!
+
+  config.define_derived_metadata(file_path: %r{/spec/components/}) do |metadata|
+    metadata[:type] ||= :component
+  end
+
+  config.define_derived_metadata(file_path: %r{/spec/forms/}) do |metadata|
+    metadata[:type] ||= :model
+  end
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
The type can be inferred from the filename so we don't need to specify a type in any of these files.