### PR TITLE
Mark JavaScript tests with `:js`

### DIFF
--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -34,7 +34,7 @@ describe "Patient sorting and filtering" do
     then_i_see_patients_with_year_group_10
   end
 
-  scenario "Users can sort and filter patients with JS", type: :system do
+  scenario "Users can sort and filter patients with JS", :js do
     given_that_i_am_signed_in
     when_i_visit_the_consents_page
     then_i_see_patients_ordered_by_name_asc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -121,8 +121,10 @@ Capybara.register_driver(:cuprite_custom) do |app|
     process_timeout: 30
   )
 end
-Capybara.javascript_driver = :cuprite_custom
+
 Capybara.asset_host = "http://localhost:4000"
+Capybara.javascript_driver = :cuprite_custom
+Capybara.server = :puma, { Silent: true }
 
 ActiveJob::Base.queue_adapter = :test
 
@@ -202,12 +204,8 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.before(:each, type: :system) do
-    WebMock.disable!
-    driven_by(:cuprite_custom)
-  end
-
-  config.after(:each, type: :system) { WebMock.enable! }
+  config.before(:each, :js) { WebMock.allow_net_connect! }
+  config.after(:each, :js) { WebMock.disable_net_connect! }
 
   config.before do
     ActionMailer::Base.deliveries.clear
@@ -218,7 +216,6 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Capybara::RSpecMatchers, type: :component
   config.include Devise::Test::IntegrationHelpers, type: :feature
-  config.include Devise::Test::IntegrationHelpers, type: :system
   config.include CIS2AuthHelper, type: :feature
   config.include PDSHelper, type: :feature
   config.include EmailExpectations, type: :feature


### PR DESCRIPTION
This ensures that Capybara automatically uses the `javascript_driver` and we don't need to mark the test as a system test. This avoids the need to use `driven_by` and mark the test as a `:system` test while being in the directory for feature tests.

In the future we might want to switch all these tests over to be `:system` tests, as this is the standard Rails approach now, but for now we can leave it like this.