### PR TITLE
Disable `:js` tests if Chrome is unavailable

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -175,6 +175,14 @@ RSpec.configure do |config|
 
   config.filter_run_excluding :local_users
 
+  if ENV["CI"].blank?
+    begin
+      Ferrum::Browser.new
+    rescue Ferrum::BinaryNotFoundError
+      config.filter_run_excluding :js
+    end
+  end
+
   config.infer_spec_type_from_file_location!
 
   config.define_derived_metadata(file_path: %r{/spec/components/}) do |metadata|


### PR DESCRIPTION
We use Google Chrome (via Cuprite) to run feature tests with client-side JavaScript. This updates the `spec_helper` to first detect whether Chrome is available, and if not, disable `:js` tests. This is because not all developers will have Chrome available on their machine.

We've only got one test that requires JavaScript so I thought this would be a simpler approach for now, if we add more then we might want to consider adding a Selenium WebDriver for Firefox or Safari as an alternative.