### PR TITLE
Add gp_practices:smoke Rake task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -347,4 +347,5 @@ create_school_moves(organisation)
 
 UnscheduledSessionsFactory.new.call
 
+Rake::Task["gp_practices:smoke"].execute
 Rake::Task["schools:smoke_test"].execute

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -348,4 +348,4 @@ create_school_moves(organisation)
 UnscheduledSessionsFactory.new.call
 
 Rake::Task["gp_practices:smoke"].execute
-Rake::Task["schools:smoke_test"].execute
+Rake::Task["schools:smoke"].execute

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -25,6 +25,12 @@ If none of the arguments are provided (`rake clinics:create`), the user will be 
 
 This creates a new clinic location and attaches it to a organisation.
 
+## GP Practices
+
+### `gp_practices:smoke`
+
+Creates a GP practice location suitable for smoke testing in production.
+
 ## Schools
 
 ### `schools:add_to_organisation[ods_code,team_name,urn,...]`

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -41,6 +41,10 @@ Creates a GP practice location suitable for smoke testing in production.
 
 This adds a school or schools to the list of schools that a particular organisation manages.
 
+### `schools:smoke`
+
+Creates a school location suitable for smoke testing in production.
+
 ## Teams
 
 ### `teams:create[ods_code,name,email,phone]`

--- a/lib/tasks/gp_practices.rake
+++ b/lib/tasks/gp_practices.rake
@@ -85,4 +85,13 @@ namespace :gp_practices do
 
     puts "\nGP practices import completed. Total locations: #{Location.gp_practice.count}"
   end
+
+  desc "Create a GP practice for smoke testing in production."
+  task smoke: :environment do
+    Location.find_or_create_by!(
+      name: "XXX Smoke Test GP XXX",
+      ods_code: "Y90001", # https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir/pds-fhir-api-test-data#production-smoke-testing
+      type: :gp_practice
+    )
+  end
 end

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -192,15 +192,17 @@ namespace :schools do
     UnscheduledSessionsFactory.new.call
   end
 
-  desc "Create smoke test school"
-  task smoke_test: :environment do
-    Location.create(
+  desc "Create a school for smoke testing in production."
+  task smoke: :environment do
+    Location.find_or_create_by!(
       name: "XXX Smoke Test School XXX",
       urn: "XXXXXX",
       type: :school,
       address_line_1: "1 Test Street",
       address_town: "Test Town",
       address_postcode: "TE1 1ST",
+      gias_establishment_number: 999_999,
+      gias_local_authority_code: 999_999,
       year_groups: [8, 9, 10, 11]
     )
   end


### PR DESCRIPTION
This adds a Rake task which creates a GP practice suitable for smoke testing in production. We're using an ODS code that doesn't exist but is used by the smoke test patient in PDS in production.

I've also fixed an issue in the equivalent task for schools.