### PR TITLE
Add hertfordshire onboarding ymls

### DIFF
--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -34,7 +34,9 @@ class Onboarding
       config
         .fetch(:users, [])
         .map do |user_config|
-          User.new(**user_config, organisations: [organisation])
+          User
+            .find_or_initialize_by(email: user_config[:email])
+            .tap { |user| user.assign_attributes(user_config) }
         end
 
     @schools =
@@ -79,6 +81,7 @@ class Onboarding
     ActiveRecord::Base.transaction do
       models.each(&:save!)
       organisation.generic_clinic
+      @users.each { |user| user.organisations << organisation }
       UnscheduledSessionsFactory.new.call
     end
   end

--- a/config/onboarding/hertfordshire-training-with-sessions.yaml
+++ b/config/onboarding/hertfordshire-training-with-sessions.yaml
@@ -1,0 +1,61 @@
+organisation:
+  name: Norfolk, Suffolk and Cambridgeshire and Peterborough Community and School Age Immunisation Service (With existing sessions)
+  email: hct.csaiscambspb@nhs.net
+  phone: 0300 555 5055
+  ods_code: RY4-2
+  careplus_venue_code: UNUSED
+  privacy_policy_url: https://www.hct.nhs.uk/privacy
+
+programmes: [hpv]
+
+teams:
+  generic:
+    name: Norfolk, Suffolk and Cambridgeshire and Peterborough Community and School Age Immunisation Service (With existing sessions)
+    email: hct.csaiscambspb@nhs.net
+    phone: 0300 555 5055
+
+users:
+  - email: nurse.ry4@example.com
+    password: nurse.ry4@example.com
+    given_name: Nurse
+    family_name: RY4
+
+schools:
+  generic:
+    # - 110861 # These are used by the main organisation
+    # - 110862
+    # - 110867
+    # - 110907
+    # - 110910
+    # - 110923
+    # - 110924
+    # - 110925
+    # - 110926
+    # - 131205
+    # - 135263
+    # - 135739
+    # - 135980
+    # - 136266
+    # - 136398
+    # - 136580
+    # - 136610
+    # - 136992
+    # - 137082
+    # - 137248
+    # - 137867
+    # - 138053
+    - 139082
+    - 139408
+    - 142902
+    - 145051
+    - 146369
+
+# !IMPORTANT! The ODS codes of these clinics are not correct.
+
+clinics:
+  generic:
+    - name: North Cambridgeshire Hospital
+      address_line_1: Churchill Road
+      address_town: Wisbech
+      address_postcode: PE13 3AB
+      ods_code: PE133AB2

--- a/config/onboarding/hertfordshire-training.yaml
+++ b/config/onboarding/hertfordshire-training.yaml
@@ -1,0 +1,61 @@
+organisation:
+  name: Norfolk, Suffolk and Cambridgeshire and Peterborough Community and School Age Immunisation Service
+  email: hct.csaiscambspb@nhs.net
+  phone: 0300 555 5055
+  ods_code: RY4
+  careplus_venue_code: UNUSED
+  privacy_policy_url: https://www.hct.nhs.uk/privacy
+
+programmes: [hpv]
+
+teams:
+  generic:
+    name: Norfolk, Suffolk and Cambridgeshire and Peterborough Community and School Age Immunisation Service
+    email: hct.csaiscambspb@nhs.net
+    phone: 0300 555 5055
+
+users:
+  - email: nurse.ry4@example.com
+    password: nurse.ry4@example.com
+    given_name: Nurse
+    family_name: RY4
+
+schools:
+  generic:
+    - 110861
+    - 110862
+    - 110867
+    - 110907
+    - 110910
+    - 110923
+    - 110924
+    - 110925
+    - 110926
+    - 131205
+    - 135263
+    - 135739
+    - 135980
+    - 136266
+    - 136398
+    - 136580
+    - 136610
+    - 136992
+    - 137082
+    - 137248
+    - 137867
+    - 138053
+    # - 139082 # Last schools removed, it's in use by the "with sessions" yml
+    # - 139408
+    # - 142902
+    # - 145051
+    # - 146369
+
+# !IMPORTANT! The ODS codes of these clinics are not correct.
+
+clinics:
+  generic:
+    - name: North Cambridgeshire Hospital
+      address_line_1: Churchill Road
+      address_town: Wisbech
+      address_postcode: PE13 3AB
+      ods_code: PE133AB


### PR DESCRIPTION
These will be used to set up the training environment.

Also make some updates to the onboarding script to allow running two different orgs in parallel with the same `nurse.x` user.