### PR TITLE
Validate community clinic ODS code doesn't match organisation

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -65,8 +65,12 @@ class Location < ApplicationRecord
     validates :team, presence: true
   end
 
+  with_options if: :community_clinic? do
+    validates :ods_code, exclusion: { in: :organisation_ods_code }
+  end
+
   with_options if: :generic_clinic? do
-    validates :ods_code, comparison: { equal_to: :organisation_ods_code }
+    validates :ods_code, inclusion: { in: :organisation_ods_code }
   end
 
   with_options if: :gp_practice? do
@@ -92,6 +96,6 @@ class Location < ApplicationRecord
   private
 
   def organisation_ods_code
-    team&.organisation&.ods_code
+    [team&.organisation&.ods_code]
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -51,13 +51,21 @@ describe Location do
     it { should validate_presence_of(:name) }
 
     context "with a community clinic" do
-      subject(:location) { build(:community_clinic, ods_code: "abc") }
+      subject(:location) { build(:community_clinic, organisation:) }
+
+      let(:organisation) { create(:organisation) }
 
       it { should_not validate_presence_of(:gias_establishment_number) }
       it { should_not validate_presence_of(:gias_local_authority_code) }
 
       it { should_not validate_presence_of(:ods_code) }
       it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
+
+      it do
+        expect(location).to validate_exclusion_of(:ods_code).in_array(
+          [organisation.ods_code]
+        )
+      end
 
       it { should_not validate_presence_of(:urn) }
       it { should validate_uniqueness_of(:urn) }
@@ -71,12 +79,12 @@ describe Location do
       it { should_not validate_presence_of(:gias_establishment_number) }
       it { should_not validate_presence_of(:gias_local_authority_code) }
 
-      it { should validate_presence_of(:ods_code) }
+      it { should_not validate_presence_of(:ods_code) }
       it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
 
       it do
-        expect(location).to validate_comparison_of(:ods_code).is_equal_to(
-          organisation.ods_code
+        expect(location).to validate_inclusion_of(:ods_code).in_array(
+          [organisation.ods_code]
         )
       end
 


### PR DESCRIPTION
The generic clinic location will use the ODS code of the organisation, so the community clinics cannot use this ODS code as there's a unique index on the column.