### PR TITLE
Improve performance on register attendance page

### DIFF
--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -44,7 +44,15 @@ class RegisterAttendancesController < ApplicationController
     @patient_sessions =
       @session
         .patient_sessions
-        .includes(:session_attendances, session: :session_dates)
+        .strict_loading
+        .includes(
+          :patient,
+          :vaccination_records,
+          :triages,
+          :consents,
+          session: :session_dates,
+          session_attendances: :session_date
+        )
         .select { _1.todays_attendance&.attending.nil? }
   end
 


### PR DESCRIPTION
This enables `.strict_loading` and includes the missing relationships to reduce the N+1 queries. 2-3x improvement locally.

The `.select` at the end still causes an N+1, and will be fixed separately.