### PR TITLE
Enable strict loading globally

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -30,6 +30,7 @@ class AppActivityLogComponent < ViewComponent::Base
     @consents = (patient || patient_session).consents
     @gillick_assessments = (patient || patient_session).gillick_assessments
     @pre_screenings = (patient || patient_session).pre_screenings
+    @session_attendances = (patient || patient_session).session_attendances
     @triages = (patient || patient_session).triages
     @vaccination_records =
       (patient || patient_session).vaccination_records.with_discarded
@@ -40,6 +41,7 @@ class AppActivityLogComponent < ViewComponent::Base
               :consents,
               :gillick_assessments,
               :pre_screenings,
+              :session_attendances,
               :triages,
               :vaccination_records
 
@@ -203,13 +205,19 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def attendance_events
-    patient_sessions
-      .flat_map(&:session_attendances)
-      .map do
-        title = (_1.attending? ? "Attended session" : "Absent from session")
-        title += " at #{_1.patient_session.location.name}"
+    session_attendances.map do |session_attendance|
+      title =
+        (
+          if session_attendance.attending?
+            "Attended session"
+          else
+            "Absent from session"
+          end
+        )
 
-        { title:, at: _1.created_at }
-      end
+      title += " at #{session_attendance.location.name}"
+
+      { title:, at: session_attendance.created_at }
+    end
   end
 end

--- a/app/components/app_compare_consent_form_and_patient_component.html.erb
+++ b/app/components/app_compare_consent_form_and_patient_component.html.erb
@@ -44,7 +44,7 @@
 
       <%= body.with_row do |row| %>
         <%= row.with_cell(text: "Parent", header: true) %>
-        <%= row.with_cell(text: helpers.format_parent(consent_form_parent, patient:)) %>
+        <%= row.with_cell(text: helpers.patient_parents(consent_form_patient)) %>
         <%= row.with_cell(text: helpers.patient_parents(patient)) %>
       <% end %>
     <% end %>

--- a/app/components/app_compare_consent_form_and_patient_component.rb
+++ b/app/components/app_compare_consent_form_and_patient_component.rb
@@ -32,11 +32,25 @@ class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
       consent_form.school == patient.school
   end
 
-  def consent_form_parent
-    Parent.new(
-      full_name: consent_form.parent_full_name,
-      email: consent_form.parent_email,
-      phone: consent_form.parent_phone
+  def consent_form_patient
+    parent =
+      Parent.new(
+        full_name: consent_form.parent_full_name,
+        email: consent_form.parent_email,
+        phone: consent_form.parent_phone
+      )
+
+    parent_relationship =
+      ParentRelationship.new(
+        parent:,
+        type: consent_form.parent_relationship_type,
+        other_name: consent_form.parent_relationship_other_name
+      )
+
+    Patient.new(
+      school: consent_form.school,
+      home_educated: consent_form.home_educated,
+      parent_relationships: [parent_relationship]
     )
   end
 

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -15,7 +15,7 @@ class AppConsentComponent < ViewComponent::Base
   delegate :session, to: :patient_session
 
   def consents
-    @consents ||= patient_session.consents.order(created_at: :desc)
+    @consents ||= patient_session.consents.sort_by(&:created_at).reverse
   end
 
   def latest_consent_request

--- a/app/components/app_imports_table_component.rb
+++ b/app/components/app_imports_table_component.rb
@@ -31,7 +31,6 @@ class AppImportsTableComponent < ViewComponent::Base
       .left_outer_joins(:patients)
       .includes(:session, :uploaded_by)
       .group("class_imports.id")
-      .strict_loading
   end
 
   def cohort_import_records
@@ -41,7 +40,6 @@ class AppImportsTableComponent < ViewComponent::Base
       .left_outer_joins(:patients)
       .includes(:uploaded_by)
       .group("cohort_imports.id")
-      .strict_loading
   end
 
   def immunisation_import_records
@@ -54,7 +52,6 @@ class AppImportsTableComponent < ViewComponent::Base
       .left_outer_joins(:vaccination_records)
       .includes(:uploaded_by)
       .group("immunisation_imports.id")
-      .strict_loading
   end
 
   def path(programme, import)

--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -67,10 +67,10 @@ class AppPatientSummaryComponent < ViewComponent::Base
         end
       end
       if @show_parent_or_guardians && !@patient.restricted? &&
-           @patient.parents.present?
+           @patient.parent_relationships.present?
         summary_list.with_row do |row|
           row.with_key do
-            "Parent or guardian".pluralize(@patient.parents.count)
+            "Parent or guardian".pluralize(@patient.parent_relationships.count)
           end
           row.with_value { format_parent_or_guardians }
         end
@@ -144,23 +144,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
   end
 
   def format_parent_or_guardians
-    tag.ul(class: "nhsuk-list") do
-      safe_join(
-        @patient.parents.map do |parent|
-          tag.li do
-            [
-              parent.label_to(patient: @patient),
-              if (email = parent.email).present?
-                tag.span(email, class: "nhsuk-u-secondary-text-color")
-              end,
-              if (phone = parent.phone).present?
-                tag.span(phone, class: "nhsuk-u-secondary-text-color")
-              end
-            ].compact.join(tag.br).html_safe
-          end
-        end
-      )
-    end
+    helpers.patient_parents(@patient)
   end
 
   def highlight_if(value, condition)

--- a/app/components/app_patient_vaccination_table_component.html.erb
+++ b/app/components/app_patient_vaccination_table_component.html.erb
@@ -24,7 +24,7 @@
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Location</span>
-            <% location = vaccination_record.session.location %>
+            <% location = vaccination_record.location %>
             <%= ([location.name] + location.address_parts).join(", ") %>
           <% end %>
         <% end %>

--- a/app/components/app_patient_vaccination_table_component.rb
+++ b/app/components/app_patient_vaccination_table_component.rb
@@ -12,6 +12,10 @@ class AppPatientVaccinationTableComponent < ViewComponent::Base
   attr_reader :patient
 
   def vaccination_records
-    patient.vaccination_records.administered.order(performed_at: :desc)
+    patient
+      .vaccination_records
+      .select(&:administered?)
+      .sort_by(&:performed_at)
+      .reverse
   end
 end

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -16,12 +16,15 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   end
 
   def most_recent_vaccination
-    @most_recent_vaccination ||=
-      @patient_session.vaccination_records.order(:created_at).last
+    @most_recent_vaccination ||= @patient_session.latest_vaccination_record
   end
 
   def who_refused
-    @patient_session.consents.response_refused.map(&:who_responded).last
+    @patient_session
+      .consents
+      .select(&:response_refused?)
+      .map(&:who_responded)
+      .last
   end
 
   def full_name

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -29,21 +29,25 @@ class AppTriageNotesComponent < ViewComponent::Base
   end
 
   def triage_events
-    @patient_session.triages.map do |triage|
-      {
-        title: "Triaged decision: #{triage.human_enum_name(:status)}",
-        body: triage.notes,
-        at: triage.created_at,
-        by: triage.performed_by,
-        invalidated: triage.invalidated?
-      }
-    end
+    @patient_session
+      .triages
+      .includes(:performed_by)
+      .map do |triage|
+        {
+          title: "Triaged decision: #{triage.human_enum_name(:status)}",
+          body: triage.notes,
+          at: triage.created_at,
+          by: triage.performed_by,
+          invalidated: triage.invalidated?
+        }
+      end
   end
 
   def pre_screening_events
     @patient_session
       .pre_screenings
       .where.not(notes: "")
+      .includes(:performed_by)
       .map do |pre_screening|
         {
           title: "Completed pre-screening checks",

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -37,7 +37,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
   # injectable vaccines.
 
   def programme
-    patient_session.programmes.first
+    session.programmes.first
   end
 
   def vaccine

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -16,7 +16,7 @@ class ConsentsController < ApplicationController
     all_patient_sessions =
       @session
         .patient_sessions
-        .preload_for_state
+        .preload_for_status
         .preload(consents: %i[parent patient])
         .eager_load(patient: :cohort)
         .order_by_name

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -20,7 +20,6 @@ class ConsentsController < ApplicationController
         .preload(consents: %i[parent patient])
         .eager_load(patient: :cohort)
         .order_by_name
-        .strict_loading
 
     tab_patient_sessions =
       group_patient_sessions_by_conditions(

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -67,7 +67,7 @@ class DevController < ApplicationController
   def random_consent_form
     Faker::Config.locale = "en-GB"
 
-    session = Session.find(params[:session_id])
+    session = Session.includes(programmes: :vaccines).find(params[:session_id])
     programme = session.programmes.first
 
     attributes =

--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -55,7 +55,11 @@ class DraftConsentsController < ApplicationController
     @draft_consent.write_to!(@consent, triage: @triage)
 
     ActiveRecord::Base.transaction do
-      @triage&.save! if @draft_consent.response_given?
+      if @triage
+        @triage.save! if @draft_consent.response_given?
+        @patient_session.reload
+      end
+
       @consent.parent&.save!
       @consent.save!
     end
@@ -165,7 +169,7 @@ class DraftConsentsController < ApplicationController
   def set_parent_options
     @parent_options =
       (
-        @patient.parent_relationships +
+        @patient.parent_relationships.includes(:parent) +
           @patient_session.consents.filter_map(&:parent_relationship)
       ).compact.uniq.sort_by(&:label)
   end

--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -164,10 +164,10 @@ class DraftConsentsController < ApplicationController
 
   def set_parent_options
     @parent_options =
-      (@patient.parents + @patient_session.consents.filter_map(&:parent))
-        .compact
-        .uniq
-        .sort_by(&:label)
+      (
+        @patient.parent_relationships +
+          @patient_session.consents.filter_map(&:parent_relationship)
+      ).compact.uniq.sort_by(&:label)
   end
 
   def set_back_link_path

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -50,6 +50,7 @@ class ImmunisationImportsController < ApplicationController
       @immunisation_import.vaccination_records.includes(
         :location,
         :patient,
+        :programme,
         :session
       )
 

--- a/app/controllers/import_issues_controller.rb
+++ b/app/controllers/import_issues_controller.rb
@@ -48,7 +48,6 @@ class ImportIssuesController < ApplicationController
           patient: %i[cohort gp_practice school],
           vaccine: :programme
         )
-        .strict_loading
 
     @patients =
       policy_scope(Patient)
@@ -56,7 +55,6 @@ class ImportIssuesController < ApplicationController
         .distinct
         .eager_load(:cohort, :gp_practice, :school)
         .preload(:school_moves, :upcoming_sessions)
-        .strict_loading
 
     @import_issues =
       (@vaccination_records + @patients).uniq do |record|

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -22,7 +22,7 @@ class PatientSessionsController < ApplicationController
       policy_scope(PatientSession)
         .includes(:patient, :vaccination_records)
         .eager_load(:session)
-        .preload(:consents, :gillick_assessments, :pre_screenings, :triages)
+        .preload(:consents, :gillick_assessments, :triages)
         .find_by!(
           session: {
             slug: params.fetch(:session_slug)

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -19,16 +19,28 @@ class PatientSessionsController < ApplicationController
 
   def set_patient_session
     @patient_session =
-      policy_scope(PatientSession)
-        .includes(:patient, :vaccination_records)
-        .eager_load(:session)
-        .preload(:consents, :gillick_assessments, :triages)
-        .find_by!(
-          session: {
-            slug: params.fetch(:session_slug)
-          },
-          patient_id: params.fetch(:id, params[:patient_id])
-        )
+      policy_scope(PatientSession).includes(
+        :gillick_assessments,
+        :location,
+        :session,
+        :session_attendances,
+        consents: %i[parent],
+        patient: [
+          :cohort,
+          :gp_practice,
+          :school,
+          { parent_relationships: :parent }
+        ],
+        triages: :performed_by,
+        vaccination_records: {
+          vaccine: :programme
+        }
+      ).find_by!(
+        session: {
+          slug: params[:session_slug]
+        },
+        patient_id: params.fetch(:id, params[:patient_id])
+      )
   end
 
   def set_session

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -85,18 +85,16 @@ class PatientsController < ApplicationController
   def set_patient
     @patient =
       policy_scope(Patient).includes(
+        :gillick_assessments,
         :gp_practice,
+        :pre_screenings,
         :school,
-        :session_attendances,
+        :triages,
         cohort: :organisation,
-        consents: %i[consent_form parent patient recorded_by],
-        gillick_assessments: :performed_by,
-        notify_log_entries: :sent_by,
+        consents: %i[parent patient],
         parent_relationships: :parent,
         patient_sessions: %i[location session_attendances],
-        pre_screenings: :performed_by,
-        triages: :performed_by,
-        vaccination_records: [:performed_by_user, { vaccine: :programme }]
+        vaccination_records: [{ vaccine: :programme }]
       ).find(params[:id])
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -89,6 +89,7 @@ class PatientsController < ApplicationController
         .includes(
           :gp_practice,
           :school,
+          :session_attendances,
           cohort: :organisation,
           consents: %i[consent_form parent patient recorded_by],
           gillick_assessments: :performed_by,

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -40,7 +40,6 @@ class PatientsController < ApplicationController
         .joins(:patients)
         .where(patients: @patient)
         .includes(:location)
-        .strict_loading
   end
 
   def log
@@ -85,23 +84,20 @@ class PatientsController < ApplicationController
 
   def set_patient
     @patient =
-      policy_scope(Patient)
-        .includes(
-          :gp_practice,
-          :school,
-          :session_attendances,
-          cohort: :organisation,
-          consents: %i[consent_form parent patient recorded_by],
-          gillick_assessments: :performed_by,
-          notify_log_entries: :sent_by,
-          parent_relationships: :parent,
-          patient_sessions: %i[location session_attendances],
-          pre_screenings: :performed_by,
-          triages: :performed_by,
-          vaccination_records: [:performed_by_user, { vaccine: :programme }]
-        )
-        .strict_loading
-        .find(params[:id])
+      policy_scope(Patient).includes(
+        :gp_practice,
+        :school,
+        :session_attendances,
+        cohort: :organisation,
+        consents: %i[consent_form parent patient recorded_by],
+        gillick_assessments: :performed_by,
+        notify_log_entries: :sent_by,
+        parent_relationships: :parent,
+        patient_sessions: %i[location session_attendances],
+        pre_screenings: :performed_by,
+        triages: :performed_by,
+        vaccination_records: [:performed_by_user, { vaccine: :programme }]
+      ).find(params[:id])
   end
 
   def record_access_log_entry

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -87,7 +87,6 @@ class PatientsController < ApplicationController
       policy_scope(Patient).includes(
         :gillick_assessments,
         :gp_practice,
-        :pre_screenings,
         :school,
         :triages,
         cohort: :organisation,

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -93,7 +93,7 @@ class PatientsController < ApplicationController
           consents: %i[consent_form parent patient recorded_by],
           gillick_assessments: :performed_by,
           notify_log_entries: :sent_by,
-          parents: %i[parent_relationships],
+          parent_relationships: :parent,
           patient_sessions: %i[location session_attendances],
           pre_screenings: :performed_by,
           triages: :performed_by,

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -59,6 +59,7 @@ class PatientsController < ApplicationController
       if cohort_id.nil?
         @patient
           .patient_sessions
+          .includes(:session_attendances)
           .where(session: old_cohort.organisation.sessions)
           .find_each(&:destroy_if_safe!)
       end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -58,7 +58,7 @@ class ProgrammesController < ApplicationController
       PatientSession
         .where(patient: patients, session: sessions)
         .eager_load(:session, patient: :cohort)
-        .preload_for_state
+        .preload_for_status
         .order_by_name
         .strict_loading
         .to_a

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -44,7 +44,6 @@ class ProgrammesController < ApplicationController
           ]
         )
         .order("locations.name")
-        .strict_loading
   end
 
   def patients
@@ -60,7 +59,6 @@ class ProgrammesController < ApplicationController
         .eager_load(:session, patient: :cohort)
         .preload_for_status
         .order_by_name
-        .strict_loading
         .to_a
 
     sort_and_filter_patients!(patient_sessions)
@@ -70,7 +68,6 @@ class ProgrammesController < ApplicationController
   private
 
   def set_programme
-    @programme =
-      policy_scope(Programme).strict_loading.find_by!(type: params[:type])
+    @programme = policy_scope(Programme).find_by!(type: params[:type])
   end
 end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -36,11 +36,11 @@ class ProgrammesController < ApplicationController
         .eager_load(:location)
         .preload(
           :session_dates,
-          patient_sessions: %i[
-            consents
-            gillick_assessments
-            triages
-            vaccination_records
+          patient_sessions: [
+            :gillick_assessments,
+            :triages,
+            :vaccination_records,
+            { consents: :parent }
           ]
         )
         .order("locations.name")

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -46,7 +46,7 @@ class RegisterAttendancesController < ApplicationController
         :patient,
         :vaccination_records,
         :triages,
-        :consents,
+        consents: :parent,
         session: :session_dates,
         session_attendances: :session_date
       )

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -42,7 +42,7 @@ class RegisterAttendancesController < ApplicationController
 
   def set_patient_sessions
     ps =
-      @session.patient_sessions.strict_loading.includes(
+      @session.patient_sessions.includes(
         :patient,
         :vaccination_records,
         :triages,

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -42,7 +42,7 @@ class RegisterAttendancesController < ApplicationController
 
   def set_patient_sessions
     ps =
-      @session.patient_sessions.includes(
+      @session.patient_sessions.preload_for_status.includes(
         :patient,
         :vaccination_records,
         :triages,

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -74,9 +74,10 @@ class SessionAttendancesController < ApplicationController
 
   def set_session_attendance
     @session_attendance =
-      authorize @patient_session.session_attendances.find_or_initialize_by(
-                  session_date: @session_date
-                )
+      authorize @patient_session
+                  .session_attendances
+                  .includes(:session_date)
+                  .find_or_initialize_by(session_date: @session_date)
   end
 
   def session_attendance_params

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
     respond_to do |format|
       format.html do
         patient_sessions =
-          @session.patient_sessions.preload_for_state.strict_loading
+          @session.patient_sessions.preload_for_status.strict_loading
 
         @stats = PatientSessionStats.new(patient_sessions)
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -37,8 +37,7 @@ class SessionsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        patient_sessions =
-          @session.patient_sessions.preload_for_status.strict_loading
+        patient_sessions = @session.patient_sessions.preload_for_status
 
         @stats = PatientSessionStats.new(patient_sessions)
 
@@ -108,6 +107,6 @@ class SessionsController < ApplicationController
       :session_dates,
       location: :organisation,
       organisation: :programmes
-    ).strict_loading
+    )
   end
 end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -17,7 +17,7 @@ class TriagesController < ApplicationController
     all_patient_sessions =
       @session
         .patient_sessions
-        .preload_for_state
+        .preload_for_status
         .eager_load(patient: :cohort)
         .order_by_name
         .strict_loading

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -72,7 +72,11 @@ class TriagesController < ApplicationController
   end
 
   def set_patient
-    @patient = @session.patients.find_by(id: params[:patient_id])
+    @patient =
+      @session
+        .patients
+        .includes(:consents, :school, parent_relationships: :parent)
+        .find_by(id: params[:patient_id])
   end
 
   def set_patient_session

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -20,7 +20,6 @@ class TriagesController < ApplicationController
         .preload_for_status
         .eager_load(patient: :cohort)
         .order_by_name
-        .strict_loading
 
     @current_tab = TAB_PATHS[:triage][params[:tab]]
     tab_patient_sessions =

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -93,7 +93,6 @@ class VaccinationRecordsController < ApplicationController
         )
         .where(programme:)
         .order(:performed_at)
-        .strict_loading
   end
 
   def dps_export

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -79,14 +79,14 @@ class VaccinationRecordsController < ApplicationController
               :cohort,
               :gp_practice,
               :school,
-              { parents: :parent_relationships }
+              { parent_relationships: :parent }
             ]
           },
           patient: [
             :cohort,
             :gp_practice,
             :school,
-            { parents: :parent_relationships }
+            { parent_relationships: :parent }
           ],
           session: %i[session_dates],
           vaccine: :programme

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -25,7 +25,6 @@ class VaccinationsController < ApplicationController
         .preload_for_status
         .eager_load(patient: :cohort)
         .order_by_name
-        .strict_loading
 
     grouped_patient_sessions =
       group_patient_sessions_by_state(

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -22,7 +22,7 @@ class VaccinationsController < ApplicationController
     all_patient_sessions =
       @session
         .patient_sessions
-        .preload_for_state
+        .preload_for_status
         .eager_load(patient: :cohort)
         .order_by_name
         .strict_loading

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -138,7 +138,17 @@ class VaccinationsController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session = @patient.patient_sessions.find_by!(session: @session)
+    @patient_session =
+      @patient
+        .patient_sessions
+        .includes(
+          patient: {
+            parent_relationships: :parent
+          },
+          session: :programmes
+        )
+        .preload_for_status
+        .find_by!(session: @session)
   end
 
   def set_section_and_tab

--- a/app/helpers/parents_helper.rb
+++ b/app/helpers/parents_helper.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
 module ParentsHelper
-  def format_parent(parent, patient:)
+  def format_parents_with_relationships(parent_relationships)
+    tag.ul(class: "nhsuk-list") do
+      safe_join(
+        parent_relationships.map do |parent_relationship|
+          tag.li { format_parent_with_relationship(parent_relationship) }
+        end
+      )
+    end
+  end
+
+  def format_parent_with_relationship(parent_relationship)
+    parent = parent_relationship.parent
+
     [
-      parent.label_to(patient:),
+      parent_relationship.label_with_parent,
       if (email = parent.email).present?
         tag.span(email, class: "nhsuk-u-secondary-text-color")
       end,

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -43,12 +43,6 @@ module PatientsHelper
   end
 
   def patient_parents(patient)
-    tag.ul(class: "nhsuk-list") do
-      safe_join(
-        patient.parents.map do |parent|
-          tag.li { format_parent(parent, patient:) }
-        end
-      )
-    end
+    format_parents_with_relationships(patient.parent_relationships)
   end
 end

--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -19,7 +19,6 @@ class ClinicSessionInvitationsJob < ApplicationJob
         .preload(:session_dates)
         .joins(:location)
         .merge(Location.clinic)
-        .strict_loading
 
     sessions.each do |session|
       session_date = session.today_or_future_dates.first

--- a/app/jobs/consent_form_matching_job.rb
+++ b/app/jobs/consent_form_matching_job.rb
@@ -49,7 +49,8 @@ class ConsentFormMatchingJob < ApplicationJob
   def match_with_exact_nhs_number
     return false unless pds_patient
 
-    patient = Patient.find_by(nhs_number: pds_patient.nhs_number)
+    patient =
+      Patient.includes(:school).find_by(nhs_number: pds_patient.nhs_number)
     return false unless patient
 
     patient.update_from_pds!(pds_patient)
@@ -58,14 +59,16 @@ class ConsentFormMatchingJob < ApplicationJob
 
   def session_patients
     @session_patients ||=
-      @consent_form.original_session.patients.match_existing(
-        nhs_number: nil,
-        **query
-      )
+      @consent_form
+        .original_session
+        .patients
+        .includes(:school)
+        .match_existing(nhs_number: nil, **query)
   end
 
   def matching_patients
-    @matching_patients ||= Patient.match_existing(nhs_number: nil, **query)
+    @matching_patients ||=
+      Patient.includes(:school).match_existing(nhs_number: nil, **query)
   end
 
   def update_consent_form_nhs_number

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -14,7 +14,6 @@ class SchoolConsentRemindersJob < ApplicationJob
         .preload(:session_dates)
         .eager_load(:location)
         .merge(Location.school)
-        .strict_loading
 
     sessions.each do |session|
       next unless session.open_for_consent?

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -14,7 +14,6 @@ class SchoolConsentRequestsJob < ApplicationJob
         .preload(:session_dates)
         .eager_load(:location)
         .merge(Location.school)
-        .strict_loading
 
     sessions.each do |session|
       next unless session.open_for_consent?

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -20,7 +20,6 @@ class SchoolSessionRemindersJob < ApplicationJob
         .merge(Location.school)
         .merge(Session.has_date(date))
         .notification_not_sent(date)
-        .strict_loading
 
     patient_sessions.each do |patient_session|
       next unless should_send_notification?(patient_session:)

--- a/app/jobs/vaccination_confirmations_job.rb
+++ b/app/jobs/vaccination_confirmations_job.rb
@@ -15,6 +15,7 @@ class VaccinationConfirmationsJob < ApplicationJob
     academic_year = Date.current.academic_year
 
     VaccinationRecord
+      .includes(patient_session: { consents: :parent })
       .kept
       .where("created_at >= ?", since)
       .where(confirmation_sent_at: nil)

--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -80,7 +80,6 @@ class Reports::CareplusExporter
         )
         .where.not(vaccination_records: { id: nil })
         .merge(VaccinationRecord.administered)
-        .strict_loading
 
     if start_date.present?
       scope =
@@ -108,7 +107,7 @@ class Reports::CareplusExporter
         )
     end
 
-    scope.strict_loading
+    scope
   end
 
   def rows(patient_session:)

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -129,7 +129,6 @@ class Reports::OfflineSessionExporter
         vaccination_records: %i[batch performed_by_user vaccine]
       )
       .order_by_name
-      .strict_loading
   end
 
   def rows(patient_session:)

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -123,7 +123,7 @@ class Reports::OfflineSessionExporter
       .patient_sessions
       .eager_load(patient: %i[cohort school])
       .preload(
-        consents: [:patient, { parent: :parent_relationships }],
+        consents: [:parent, { patient: :parent_relationships }],
         gillick_assessments: :performed_by,
         triages: :performed_by,
         vaccination_records: %i[batch performed_by_user vaccine]

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -126,7 +126,7 @@ class Reports::ProgrammeVaccinationsExporter
         )
     end
 
-    scope.strict_loading
+    scope
   end
 
   def row(vaccination_record:)

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -93,9 +93,9 @@ class Reports::ProgrammeVaccinationsExporter
           :programme,
           :vaccine,
           patient_session: {
-            patient: %i[cohort gp_practice school],
-            consents: [:patient, { parent: :parent_relationships }],
+            consents: [:parent, { patient: :parent_relationships }],
             gillick_assessments: :performed_by,
+            patient: %i[cohort gp_practice school],
             triages: :performed_by
           }
         )

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -126,7 +126,7 @@ class Consent < ApplicationRecord
   end
 
   def parent_relationship
-    parent&.relationship_to(patient:)
+    patient.parent_relationships.find { _1.parent_id == parent_id }
   end
 
   def who_responded

--- a/app/models/dps_export.rb
+++ b/app/models/dps_export.rb
@@ -45,7 +45,6 @@ class DPSExport < ApplicationRecord
             :vaccine
           )
           .order(:performed_at)
-          .strict_loading
           .find_each { csv << DPSExportRow.new(_1).to_a }
       end
   end

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -188,7 +188,7 @@ class DraftConsent
   def parent=(value)
     self.parent_id = value&.id
 
-    parent_relationship = value&.relationship_to(patient:)
+    parent_relationship = value&.parent_relationships&.find_by(patient_id:)
 
     self.parent_email = patient.restricted? ? "" : value&.email
     self.parent_full_name = value&.full_name
@@ -287,7 +287,7 @@ class DraftConsent
   end
 
   def parent_relationship
-    parent&.relationship_to(patient:)
+    parent&.parent_relationships&.find { _1.patient_id == patient_id }
   end
 
   def who_responded

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -202,6 +202,7 @@ class DraftConsent
     PatientSessionPolicy::Scope
       .new(@current_user, PatientSession)
       .resolve
+      .preload_for_status
       .find_by(id: patient_session_id)
   end
 
@@ -287,7 +288,10 @@ class DraftConsent
   end
 
   def parent_relationship
-    parent&.parent_relationships&.find { _1.patient_id == patient_id }
+    parent
+      &.parent_relationships
+      &.find { _1.patient_id == patient_id }
+      .tap { _1&.patient = patient } # acts as preload
   end
 
   def who_responded

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -121,6 +121,7 @@ class DraftVaccinationRecord
     PatientSessionPolicy::Scope
       .new(@current_user, PatientSession)
       .resolve
+      .preload_for_status
       .find_by(id: patient_session_id)
   end
 
@@ -153,6 +154,7 @@ class DraftVaccinationRecord
     VaccinationRecordPolicy::Scope
       .new(@current_user, VaccinationRecord)
       .resolve
+      .includes(patient_session: { consents: :parent })
       .find_by(id: editing_id)
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -77,10 +77,10 @@ class Organisation < ApplicationRecord
     academic_year = Date.current.academic_year
     location = generic_clinic
 
-    sessions.create_with(programmes:).find_or_create_by!(
-      academic_year:,
-      location:
-    )
+    sessions
+      .includes(:location, :programmes, :session_dates)
+      .create_with(programmes:)
+      .find_or_create_by!(academic_year:, location:)
   end
 
   def weeks_before_consent_reminders

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -92,19 +92,6 @@ class Parent < ApplicationRecord
     [email, phone].compact_blank.join(" / ")
   end
 
-  def label_to(patient:)
-    relationship = relationship_to(patient:)
-    if relationship && !relationship.unknown?
-      "#{label} (#{relationship.label})"
-    else
-      label
-    end
-  end
-
-  def relationship_to(patient:)
-    parent_relationships.find { _1.patient_id == patient.id }
-  end
-
   def contact_method_description
     if contact_method_other?
       "Other – #{contact_method_other_details}"

--- a/app/models/parent_relationship.rb
+++ b/app/models/parent_relationship.rb
@@ -53,4 +53,8 @@ class ParentRelationship < ApplicationRecord
   def label
     (other? ? other_name : human_enum_name(:type)).capitalize
   end
+
+  def label_with_parent
+    unknown? ? parent.label : "#{parent.label} (#{label})"
+  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -249,10 +249,6 @@ class Patient < ApplicationRecord
     results
   end
 
-  def relationship_to(parent:)
-    parent_relationships.find { _1.parent == parent }
-  end
-
   def has_consent?(programme)
     consents.any? { _1.programme_id == programme.id }
   end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -108,7 +108,7 @@ class PatientSession < ApplicationRecord
   end
 
   def latest_gillick_assessment
-    @latest_gillick_assessment = gillick_assessments.max_by(&:updated_at)
+    @latest_gillick_assessment ||= gillick_assessments.max_by(&:updated_at)
   end
 
   def latest_triage

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -41,7 +41,7 @@ class PatientSession < ApplicationRecord
   has_many :vaccination_records, -> { kept }
 
   # TODO: Only fetch consents and triages for the relevant programme.
-  has_many :consents, -> { eager_load(:parent) }, through: :patient
+  has_many :consents, through: :patient
   has_many :triages, through: :patient
 
   has_many :session_notifications,
@@ -69,11 +69,11 @@ class PatientSession < ApplicationRecord
   scope :preload_for_state,
         -> do
           preload(
-            :consents,
             :gillick_assessments,
             :triages,
             :vaccination_records,
-            :session_attendances
+            :session_attendances,
+            consents: :parent
           )
         end
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -66,7 +66,7 @@ class PatientSession < ApplicationRecord
           )
         end
 
-  scope :preload_for_state,
+  scope :preload_for_status,
         -> do
           preload(
             :gillick_assessments,

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -122,7 +122,9 @@ class PatientSession < ApplicationRecord
   def todays_attendance
     @todays_attendance ||=
       if (session_date = session.session_dates.find(&:today?))
-        session_attendances.find_or_initialize_by(session_date:)
+        session_attendances.eager_load(:session_date).find_or_initialize_by(
+          session_date:
+        )
       end
   end
 

--- a/app/models/session_attendance.rb
+++ b/app/models/session_attendance.rb
@@ -25,4 +25,7 @@
 class SessionAttendance < ApplicationRecord
   belongs_to :patient_session
   belongs_to :session_date
+
+  has_one :session, through: :patient_session
+  has_one :location, through: :session
 end

--- a/app/views/draft_consents/parent_details.html.erb
+++ b/app/views/draft_consents/parent_details.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% page_title = if @parent.persisted?
-       "Details for #{@parent.label_to(patient: @patient)}"
+       "Details for #{@draft_consent.parent_relationship.label_with_parent}"
      else
        "Details for parent or guardian"
      end %>

--- a/app/views/draft_consents/who.html.erb
+++ b/app/views/draft_consents/who.html.erb
@@ -22,9 +22,10 @@
     <% end %>
 
     <% if @parent_options.present? %>
-      <% @parent_options.each.with_index do |parent, i| %>
+      <% @parent_options.each.with_index do |parent_relationship, i| %>
+        <% parent = parent_relationship.parent %>
         <%= f.govuk_radio_button :new_or_existing_contact, parent.id,
-                                 label: { text: parent.label_to(patient: @patient) },
+                                 label: { text: parent_relationship.label_with_parent },
                                  hint: { text: parent.contact_label },
                                  link_errors: !@patient_session.gillick_competent? && i == 0 %>
       <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -99,4 +99,8 @@ Rails.application.configure do
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"
+
+  # Enable strict loading to catch N+1 problems.
+  config.active_record.strict_loading_by_default = true
+  config.active_record.strict_loading_mode = :n_plus_one_only
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,4 +58,8 @@ Rails.application.configure do
 
   # Set up GoodJob for inline execution in test mode
   config.good_job.execution_mode = :inline
+
+  # Enable strict loading to catch N+1 problems.
+  config.active_record.strict_loading_by_default = true
+  config.active_record.strict_loading_mode = :n_plus_one_only
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -232,7 +232,7 @@ def create_patients(organisation)
 end
 
 def create_imports(user, organisation)
-  programme = organisation.programmes.find_by(type: "hpv")
+  programme = organisation.programmes.includes(:sessions).find_by(type: "hpv")
 
   %i[pending invalid processed].each do |status|
     FactoryBot.create(

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -30,6 +30,9 @@ describe AppActivityLogComponent do
   before do
     create(:parent_relationship, :mother, parent: mum, patient:)
     create(:parent_relationship, :father, parent: dad, patient:)
+
+    patient_session.strict_loading!(false)
+    patient_session.patient.strict_loading!(false)
   end
 
   shared_examples "card" do |title:, date:, notes: nil, by: nil|

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -10,6 +10,8 @@ describe AppConsentComponent do
   let(:consent) { patient_session.consents.first }
   let(:relation) { consent.parent_relationship.label }
 
+  before { patient_session.strict_loading!(false) }
+
   context "consent is not present" do
     let(:patient_session) { create(:patient_session) }
 

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -6,6 +6,8 @@ describe AppConsentStatusComponent do
   let(:component) { described_class.new(patient_session:) }
   let(:patient_session) { create(:patient_session) }
 
+  before { patient_session.strict_loading!(false) }
+
   context "when consent is given" do
     let(:patient_session) do
       create(:patient_session, :consent_given_triage_needed)

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -3,7 +3,7 @@
 describe AppHealthQuestionsComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(consents:) }
+  let(:component) { described_class.new(consents: consents.map(&:reload)) }
 
   context "with one consent" do
     let(:consents) do

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -12,6 +12,8 @@ describe AppOutcomeBannerComponent do
   let(:location_name) { patient_session.session.location.name }
   let(:patient_name) { patient_session.patient.full_name }
 
+  before { patient_session.strict_loading!(false) }
+
   prepend_before do
     patient_session.patient.update!(given_name: "Alya", family_name: "Merton")
   end

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -10,6 +10,8 @@ describe AppPatientPageComponent do
     ).and_return("/session/patient/triage/new")
     # rubocop:enable RSpec/AnyInstance
     stub_authorization(allowed: true)
+
+    patient_session.strict_loading!(false)
   end
 
   let(:programme) { create(:programme, :hpv) }

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -76,7 +76,16 @@ describe AppPatientSummaryComponent do
 
   context "when showing parents or guardians" do
     let(:component) do
-      described_class.new(patient, show_parent_or_guardians: true)
+      described_class.new(patient.reload, show_parent_or_guardians: true)
+    end
+
+    before do
+      create(
+        :parent_relationship,
+        :father,
+        patient:,
+        parent: build(:parent, full_name: "Mark Doe")
+      )
     end
 
     it { should have_content("Parent or guardian") }

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -32,7 +32,10 @@ describe AppPatientSummaryComponent do
     )
   end
 
-  before { create(:parent_relationship, :father, parent:, patient:) }
+  before do
+    create(:parent_relationship, :father, parent:, patient:)
+    patient.strict_loading!(false)
+  end
 
   it { should have_content("NHS number") }
   it { should have_content("123\u00A0\u200D456\u00A0\u200D7890") }

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -7,6 +7,8 @@ describe AppPatientVaccinationTableComponent do
 
   let(:patient) { create(:patient) }
 
+  before { patient.strict_loading!(false) }
+
   context "without a vaccination record" do
     let(:sessions) { [] }
 

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -6,13 +6,9 @@ describe AppProgrammeSessionTableComponent do
   let(:component) { described_class.new(sessions) }
 
   let(:programme) { create(:programme) }
-
   let(:location) { create(:school, name: "Waterloo Road") }
-
   let(:session) { create(:session, programme:, location:) }
-
   let(:sessions) { [session] + create_list(:session, 2, programme:) }
-
   let(:patient_session) { create(:patient_session, session:) }
 
   before do
@@ -20,6 +16,8 @@ describe AppProgrammeSessionTableComponent do
 
     create(:consent, :given, programme:, patient: patient_session.patient)
     create(:vaccination_record, programme:, patient_session:)
+
+    sessions.each { _1.strict_loading!(false) }
   end
 
   it { should have_content("3 sessions") }

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -7,6 +7,8 @@ describe AppSessionPatientTableComponent do
     allow(component).to receive(:session_patient_path).and_return(
       "/session/patient/"
     )
+
+    patient_sessions.each { _1.strict_loading!(false) }
   end
 
   let(:section) { :consent }

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -8,6 +8,8 @@ describe AppSimpleStatusBannerComponent do
       "/session/patient/triage/new"
     )
     stub_authorization(allowed: true)
+
+    patient_session.strict_loading!(false)
   end
 
   let(:user) { create :user }

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -9,6 +9,8 @@ describe AppTriageNotesComponent do
   let(:patient_session) { create(:patient_session, programme:) }
   let(:patient) { patient_session.patient }
 
+  before { patient_session.strict_loading!(false) }
+
   context "triage notes are not present" do
     it "does not render" do
       expect(component.render?).to be(false)

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -29,6 +29,8 @@ describe AppVaccinateFormComponent do
     )
   end
 
+  before { patient_session.strict_loading!(false) }
+
   it { should have_css(".nhsuk-card") }
 
   it "has the correct heading" do

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -164,12 +164,14 @@ describe PatientTabsConcern do
     end
 
     context "some of the groups are empty" do
-      let(:patient_session) { create(:patient_session, :consent_refused) }
+      let(:patient_sessions) do
+        create_list(:patient_session, 1, :consent_refused)
+      end
 
       it "returns an empty array for all the empty groups" do
         result =
           controller.group_patient_sessions_by_state(
-            [patient_session],
+            patient_sessions,
             section: :triage
           )
 
@@ -177,7 +179,7 @@ describe PatientTabsConcern do
           {
             needs_triage: [],
             triage_complete: [],
-            no_triage_needed: [patient_session]
+            no_triage_needed: patient_sessions
           }.with_indifferent_access
         )
       end

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -61,6 +61,8 @@ describe PatientTabsConcern do
     ]
   end
 
+  before { patient_sessions.each { _1.strict_loading!(false) } }
+
   describe "#group_patient_sessions_by_conditions" do
     it "groups patient sessions by conditions" do
       result =

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -11,6 +11,8 @@ describe TriageMailerConcern do
         @current_user = current_user
       end
     end
+
+    patient_session.strict_loading!(false)
   end
 
   let(:sample) { SampleClass.new(current_user:) }

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -11,6 +11,9 @@ describe VaccinationMailerConcern do
         @current_user = current_user
       end
     end
+
+    vaccination_record.strict_loading!(false)
+    vaccination_record.patient_session.strict_loading!(false)
   end
 
   let(:sample) { SampleClass.new(current_user:) }

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -98,15 +98,21 @@ FactoryBot.define do
 
     trait :from_mum do
       parent do
-        patient.parent_relationships.find(&:mother?)&.parent ||
-          create(:parent_relationship, :mother, patient:).parent
+        patient
+          .parent_relationships
+          .eager_load(:parent)
+          .find(&:mother?)
+          &.parent || create(:parent_relationship, :mother, patient:).parent
       end
     end
 
     trait :from_dad do
       parent do
-        patient.parent_relationships.find(&:father?)&.parent ||
-          create(:parent_relationship, :father, patient:).parent
+        patient
+          .parent_relationships
+          .eager_load(:parent)
+          .find(&:father?)
+          &.parent || create(:parent_relationship, :father, patient:).parent
       end
     end
 

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -44,7 +44,12 @@
 FactoryBot.define do
   factory :vaccination_record do
     transient do
-      session { association :session, programme: }
+      organisation do
+        programme.organisations.first ||
+          association(:organisation, programmes: [programme])
+      end
+
+      session { association :session, programme:, organisation: }
       patient do
         association :patient,
                     school: session.location.school? ? session.location : nil
@@ -64,12 +69,7 @@ FactoryBot.define do
     delivery_method { "intramuscular" }
     vaccine { programme.vaccines.active.first }
     batch do
-      if vaccine
-        association :batch,
-                    organisation: patient_session.organisation,
-                    vaccine:,
-                    strategy: :create
-      end
+      association :batch, organisation:, vaccine:, strategy: :create if vaccine
     end
 
     performed_by

--- a/spec/features/dev_reset_organisation_spec.rb
+++ b/spec/features/dev_reset_organisation_spec.rb
@@ -40,12 +40,11 @@ describe "Dev endpoint to reset a organisation" do
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
 
-    @patients = @organisation.cohorts.flat_map(&:patients)
+    @patients =
+      @organisation.cohorts.includes(patients: :parents).flat_map(&:patients)
 
     expect(@patients.size).to eq(3)
-    expect(
-      @organisation.cohorts.flat_map(&:patients).flat_map(&:parents).size
-    ).to eq(3)
+    expect(@patients.flat_map(&:parents).size).to eq(3)
   end
 
   def and_vaccination_records_have_been_imported

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -5,6 +5,7 @@ describe "Manage children" do
 
   scenario "Viewing children" do
     given_patients_exist
+    and_the_patient_is_vaccinated
 
     when_i_click_on_children
     then_i_see_the_children
@@ -115,7 +116,6 @@ describe "Manage children" do
         family_name: "Smith",
         school:
       )
-    create(:vaccination_record, patient: @patient, programme: @programme)
     create_list(:patient, 9, organisation: @organisation, school:)
 
     @existing_patient =
@@ -125,6 +125,10 @@ describe "Manage children" do
         family_name: "Doe",
         cohort: @organisation.cohorts.first
       )
+  end
+
+  def and_the_patient_is_vaccinated
+    create(:vaccination_record, patient: @patient, programme: @programme)
   end
 
   def and_the_patient_belongs_to_a_session

--- a/spec/features/parental_consent_school_session_completed_spec.rb
+++ b/spec/features/parental_consent_school_session_completed_spec.rb
@@ -24,8 +24,8 @@ describe "Parental consent" do
 
     team = create(:team, organisation: @organisation)
 
-    @scheduled_school = create(:school, :secondary, team:)
-    @completed_school = create(:school, :secondary, team:)
+    @scheduled_school = create(:school, :secondary, name: "School 1", team:)
+    @completed_school = create(:school, :secondary, name: "School 2", team:)
 
     @scheduled_session =
       create(

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -109,29 +109,20 @@ describe "Triage" do
   end
 
   def and_needs_triage_emails_are_sent_to_both_parents
-    expect_email_to @patient.consents.first.parent.email,
-                    :consent_confirmation_triage,
-                    :any
-    expect_email_to @patient.consents.second.parent.email,
-                    :consent_confirmation_triage,
-                    :any
+    @patient.parents.each do |parent|
+      expect_email_to parent.email, :consent_confirmation_triage, :any
+    end
   end
 
   def and_vaccination_wont_happen_emails_are_sent_to_both_parents
-    expect_email_to @patient.consents.first.parent.email,
-                    :triage_vaccination_wont_happen,
-                    :any
-    expect_email_to @patient.consents.second.parent.email,
-                    :triage_vaccination_wont_happen,
-                    :any
+    @patient.parents.each do |parent|
+      expect_email_to parent.email, :triage_vaccination_wont_happen, :any
+    end
   end
 
   def and_vaccination_will_happen_emails_are_sent_to_both_parents
-    expect_email_to @patient.consents.first.parent.email,
-                    :triage_vaccination_will_happen,
-                    :any
-    expect_email_to @patient.consents.second.parent.email,
-                    :triage_vaccination_will_happen,
-                    :any
+    @patient.parents.each do |parent|
+      expect_email_to parent.email, :triage_vaccination_will_happen, :any
+    end
   end
 end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -34,12 +34,12 @@ describe "Verbal consent" do
       "Choose who you are trying to get consent from"
     )
 
-    choose "#{@parent.full_name} (#{@parent.relationship_to(patient: @patient).label})"
+    choose "#{@parent.full_name} (#{@patient.parent_relationships.first.label})"
     click_button "Continue"
 
     # Details for parent or guardian
     expect(page).to have_content(
-      "Details for #{@parent.full_name} (#{@parent.relationship_to(patient: @patient).label})"
+      "Details for #{@parent.full_name} (#{@patient.parent_relationships.first.label})"
     )
     # don't change any details
     click_button "Continue"
@@ -82,7 +82,7 @@ describe "Verbal consent" do
 
     expect(page).to have_content("Consent response from #{@parent.full_name}")
     expect(page).to have_content(
-      ["Response date", Time.zone.today.to_fs(:long)].join
+      ["Response date", Date.current.to_fs(:long)].join
     )
     expect(page).to have_content(["Decision", "Consent given"].join)
     expect(page).to have_content(["Response method", "By phone"].join)
@@ -95,14 +95,14 @@ describe "Verbal consent" do
 
     expect(page).to have_content(["Name", @parent.full_name].join)
     expect(page).to have_content(
-      ["Relationship", @parent.relationship_to(patient: @patient).label].join
+      ["Relationship", @patient.parent_relationships.first.label].join
     )
     expect(page).to have_content(["Email address", @parent.email].join)
     expect(page).to have_content(["Phone number", @parent.phone].join)
 
     expect(page).to have_content("Answers to health questions")
     expect(page).to have_content(
-      "#{@parent.relationship_to(patient: @patient).label} responded: No",
+      "#{@patient.parent_relationships.first.label} responded: No",
       count: 4
     )
   end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -42,7 +42,12 @@ feature "Verbal consent" do
   end
 
   def when_i_record_the_consent_given_for_that_child_from_the_same_parent
-    @refusing_parent = @session.patient_sessions.first.consents.first.parent
+    patient_session =
+      PatientSession.includes(consents: :parent).find_by(
+        session: @session,
+        patient: @child
+      )
+    @refusing_parent = patient_session.consents.first.parent
 
     visit "/dashboard"
     click_on "Programmes", match: :first

--- a/spec/features/verbal_consent_refused_personal_choice_spec.rb
+++ b/spec/features/verbal_consent_refused_personal_choice_spec.rb
@@ -30,7 +30,7 @@ describe "Verbal consent" do
     click_button "Get consent"
 
     # Who are you trying to get consent from?
-    choose @patient.parents.first.full_name
+    choose @parent.full_name
     click_button "Continue"
 
     # Details for parent or guardian: leave prepopulated details
@@ -52,9 +52,7 @@ describe "Verbal consent" do
 
     # Confirm
     expect(page).to have_content(["Decision", "Consent refused"].join)
-    expect(page).to have_content(
-      ["Name", @patient.parents.first.full_name].join
-    )
+    expect(page).to have_content(["Name", @parent.full_name].join)
     click_button "Confirm"
 
     expect(page).to have_content("Check consent responses")
@@ -64,7 +62,7 @@ describe "Verbal consent" do
   def and_the_patients_status_is_consent_refused
     click_link @patient.full_name
 
-    relation = @patient.parents.first.relationship_to(patient: @patient).label
+    relation = @patient.parent_relationships.first.label
     expect(page).to have_content("Consent refused")
     expect(page).to have_content("#{relation} refused to give consent.")
   end
@@ -87,12 +85,12 @@ describe "Verbal consent" do
     )
     expect(page).to have_content(["School", @patient.school.name].join)
 
-    expect(page).to have_content(["Name", parent.full_name].join)
+    expect(page).to have_content(["Name", @parent.full_name].join)
     expect(page).to have_content(
-      ["Relationship", parent.relationship_to(patient: @patient).label].join
+      ["Relationship", @patient.parent_relationships.first.label].join
     )
-    expect(page).to have_content(["Email address", parent.email].join)
-    expect(page).to have_content(["Phone number", parent.phone].join)
+    expect(page).to have_content(["Email address", @parent.email].join)
+    expect(page).to have_content(["Phone number", @parent.phone].join)
 
     expect(page).not_to have_content("Answers to health questions")
   end

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -64,7 +64,7 @@ describe "Verbal consent" do
   def and_the_patients_status_is_consent_refused
     click_link @patient.full_name
 
-    relation = @parent.relationship_to(patient: @patient).label
+    relation = @patient.parent_relationships.first.label
     expect(page).to have_content("Consent refused")
     expect(page).to have_content("#{relation} refused to give consent.")
   end
@@ -73,7 +73,7 @@ describe "Verbal consent" do
     click_link @parent.full_name
 
     expect(page).to have_content(
-      ["Response date", Time.zone.today.to_fs(:long)].join
+      ["Response date", Date.current.to_fs(:long)].join
     )
     expect(page).to have_content(["Decision", "Consent refused"].join)
     expect(page).to have_content(["Response method", "By phone"].join)
@@ -90,7 +90,7 @@ describe "Verbal consent" do
 
     expect(page).to have_content(["Name", @parent.full_name].join)
     expect(page).to have_content(
-      ["Relationship", @parent.relationship_to(patient: @patient).label].join
+      ["Relationship", @patient.parent_relationships.first.label].join
     )
     expect(page).to have_content(["Email address", @parent.email].join)
     expect(page).to have_content(["Phone number", @parent.phone].join)

--- a/spec/lib/unscheduled_sessions_factory_spec.rb
+++ b/spec/lib/unscheduled_sessions_factory_spec.rb
@@ -13,7 +13,7 @@ describe UnscheduledSessionsFactory do
       it "creates missing unscheduled sessions" do
         expect { call }.to change(organisation.sessions, :count).by(1)
 
-        session = organisation.sessions.first
+        session = organisation.sessions.includes(:location, :programmes).first
         expect(session.location).to eq(location)
         expect(session.programmes).to eq([programme])
       end
@@ -25,7 +25,7 @@ describe UnscheduledSessionsFactory do
       it "creates missing unscheduled sessions" do
         expect { call }.to change(organisation.sessions, :count).by(1)
 
-        session = organisation.sessions.first
+        session = organisation.sessions.includes(:location, :programmes).first
         expect(session.location).to eq(location)
         expect(session.programmes).to eq([programme])
       end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -293,7 +293,8 @@ describe ClassImport do
           given_name: "Jimmy",
           family_name: "Smith",
           date_of_birth: Date.new(2010, 1, 2),
-          nhs_number: nil
+          nhs_number: nil,
+          parents: []
         )
       end
 
@@ -313,7 +314,10 @@ describe ClassImport do
 
         it "doesn't create an additional patient" do
           expect { process! }.to change(Parent, :count).by(4)
-          expect(parent.relationship_to(patient:)).to be_father
+
+          parent_relationship = patient.reload.parent_relationships.first
+          expect(parent_relationship.parent).to eq(parent)
+          expect(parent_relationship).to be_father
         end
       end
     end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -316,7 +316,7 @@ describe ClassImport do
           expect { process! }.to change(Parent, :count).by(4)
 
           parent_relationship = patient.reload.parent_relationships.first
-          expect(parent_relationship.parent).to eq(parent)
+          expect(parent_relationship.parent_id).to eq(parent.id)
           expect(parent_relationship).to be_father
         end
       end
@@ -351,7 +351,7 @@ describe ClassImport do
         )
 
         school_move = patient.school_moves.first
-        expect(school_move.school).to eq(session.location)
+        expect(school_move.school_id).to eq(session.location_id)
       end
 
       it "doesn't stage school changes" do

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -731,7 +731,7 @@ describe ConsentForm do
         ).by(1)
 
         school_move = patient.school_moves.first
-        expect(school_move.school).to eq(new_school)
+        expect(school_move.school_id).to eq(new_school.id)
       end
     end
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -243,7 +243,7 @@ describe ImmunisationImport do
 
         expect(immunisation_import.sessions.count).to eq(5)
 
-        session = immunisation_import.sessions.first
+        session = immunisation_import.sessions.includes(:session_dates).first
         expect(session.dates).to contain_exactly(Date.new(2024, 5, 14))
       end
 

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -28,11 +28,11 @@ describe Onboarding do
       expect(organisation.careplus_venue_code).to eq("EXAMPLE")
       expect(organisation.programmes).to contain_exactly(programme)
 
-      team1 = organisation.teams.find_by!(name: "Team 1")
+      team1 = organisation.teams.includes(:schools).find_by!(name: "Team 1")
       expect(team1.email).to eq("team-1@trust.nhs.uk")
       expect(team1.phone).to eq("07700 900816")
 
-      team2 = organisation.teams.find_by!(name: "Team 2")
+      team2 = organisation.teams.includes(:schools).find_by!(name: "Team 2")
       expect(team2.email).to eq("team-2@trust.nhs.uk")
       expect(team2.phone).to eq("07700 900817")
 

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -136,6 +136,8 @@ describe PatientSession do
 
     let(:patient_session) { create(:patient_session, programme:, patient:) }
 
+    before { patient_session.strict_loading!(false) }
+
     context "multiple consent given responses from different parents" do
       let(:parents) { create_list(:parent, 2) }
       let(:consents) do

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -2,7 +2,9 @@
 
 describe PatientSessionStats do
   describe "#to_h" do
-    subject(:to_h) { described_class.new(session.patient_sessions).to_h }
+    subject(:to_h) do
+      described_class.new(session.patient_sessions.preload_for_status).to_h
+    end
 
     let(:programme) { create(:programme) }
     let(:session) { create(:session, programme:) }

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -51,6 +51,8 @@ describe SessionNotification do
     let(:consent) { create(:consent, :given, patient:, programme:) }
     let(:current_user) { create(:user) }
 
+    before { patient_session.strict_loading!(false) }
+
     context "with a school reminder" do
       let(:type) { :school_reminder }
 

--- a/spec/models/triage_spec.rb
+++ b/spec/models/triage_spec.rb
@@ -73,14 +73,11 @@ describe Triage do
       let(:status) { :delay_vaccination }
 
       it "adds the patient to the generic clinic" do
-        expect { process! }.to change(
-          triage.patient.upcoming_sessions,
-          :count
-        ).by(1)
+        upcoming_sessions = triage.patient.upcoming_sessions.includes(:location)
 
-        expect(
-          triage.patient.upcoming_sessions.last.location
-        ).to be_generic_clinic
+        expect { process! }.to change(upcoming_sessions, :count).by(1)
+
+        expect(upcoming_sessions.last.location).to be_generic_clinic
       end
     end
   end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -43,22 +43,19 @@
 #
 
 describe VaccinationRecord do
-  subject(:vaccination_record) { create(:vaccination_record, programme:) }
-
-  let(:programme) { create(:programme) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  subject(:vaccination_record) { build(:vaccination_record) }
 
   describe "validations" do
     it { should validate_absence_of(:location_name) }
 
     context "for a generic clinic" do
       subject(:vaccination_record) do
-        build(
-          :vaccination_record,
-          programme:,
-          session: organisation.generic_clinic_session
-        )
+        build(:vaccination_record, programme:, session:)
       end
+
+      let(:programme) { create(:programme) }
+      let(:organisation) { create(:organisation, programmes: [programme]) }
+      let(:session) { organisation.generic_clinic_session }
 
       it { should validate_presence_of(:location_name) }
     end


### PR DESCRIPTION
This enables the Rails strict loading feature across the whole codebase while running in the development or test environments, allowing us to catch potential N+1 issues before they make it to production. I've also disabled strict loading in production so if any N+1 issues do make it through, it's going to lead to low performance rather than an unhandled exception.