### PR TITLE
Show details from consent form if available

### DIFF
--- a/app/components/app_consent_patient_summary_component.rb
+++ b/app/components/app_consent_patient_summary_component.rb
@@ -11,31 +11,37 @@ class AppConsentPatientSummaryComponent < ViewComponent::Base
     govuk_summary_list do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Full name" }
-        row.with_value { patient.full_name }
+        row.with_value { consent_form_or_patient.full_name }
       end
 
       summary_list.with_row do |row|
         row.with_key { "Date of birth" }
-        row.with_value { patient.date_of_birth.to_fs(:long) }
+        row.with_value { consent_form_or_patient.date_of_birth.to_fs(:long) }
       end
 
-      if !consent.restricted? && (consent_form = consent.consent_form)
+      unless restricted?
         summary_list.with_row do |row|
           row.with_key { "Home address" }
-          row.with_value { helpers.format_address_multi_line(consent_form) }
+          row.with_value do
+            helpers.format_address_multi_line(consent_form_or_patient)
+          end
         end
       end
 
       summary_list.with_row do |row|
         row.with_key { "School" }
-        row.with_value { helpers.patient_school(patient) }
+        row.with_value { helpers.patient_school(consent_form_or_patient) }
       end
     end
   end
 
   private
 
-  attr_reader :consent
+  def consent_form_or_patient
+    @consent.consent_form || @consent.patient
+  end
 
-  delegate :patient, to: :consent
+  def restricted?
+    @consent.patient.restricted?
+  end
 end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -97,8 +97,6 @@ class Consent < ApplicationRecord
             presence: true,
             unless: -> { via_self_consent? || via_website? }
 
-  delegate :restricted?, to: :patient
-
   def name
     via_self_consent? ? patient.full_name : parent.label
   end

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -282,8 +282,6 @@ class DraftConsent
     false
   end
 
-  delegate :restricted?, to: :patient
-
   def consent_form
     nil
   end

--- a/spec/components/app_consent_patient_summary_component_spec.rb
+++ b/spec/components/app_consent_patient_summary_component_spec.rb
@@ -15,39 +15,63 @@ describe AppConsentPatientSummaryComponent do
   let(:session) do
     create(:session, programme:, organisation:, location: school)
   end
-  let(:consent_form) do
-    create(:consent_form, address_postcode: "SW1A 1AA", session:)
+  let(:consent_form) { nil }
+  let(:patient) { create(:patient) }
+
+  context "with a consent form" do
+    let(:consent_form) do
+      create(
+        :consent_form,
+        address_postcode: "SW1A 1AA",
+        date_of_birth: Date.new(2000, 1, 1),
+        given_name: "John",
+        family_name: "Doe",
+        session:
+      )
+    end
+
+    it { should have_content("Full name") }
+    it { should have_content("John Doe") }
+
+    it { should have_content("Date of birth") }
+    it { should have_content("1 January 2000") }
+
+    it { should have_content("Home address") }
+    it { should have_content("SW1A 1AA") }
+
+    it { should have_content("School") }
+    it { should have_content("Waterloo Road") }
   end
 
-  let(:restricted) { false }
-  let(:patient) do
-    create(
-      :patient,
-      given_name: "John",
-      family_name: "Doe",
-      date_of_birth: Date.new(2000, 1, 1),
-      school:,
-      organisation:,
-      restricted_at: restricted ? Time.current : nil
-    )
+  context "without a consent form" do
+    let(:patient) do
+      create(
+        :patient,
+        given_name: "John",
+        family_name: "Doe",
+        date_of_birth: Date.new(2000, 1, 1),
+        address_postcode: "SW1A 1AA",
+        school:,
+        organisation:
+      )
+    end
+
+    it { should have_content("Full name") }
+    it { should have_content("John Doe") }
+
+    it { should have_content("Date of birth") }
+    it { should have_content("1 January 2000") }
+
+    it { should have_content("Home address") }
+    it { should have_content("SW1A 1AA") }
+
+    it { should have_content("School") }
+    it { should have_content("Waterloo Road") }
   end
-
-  it { should have_content("Full name") }
-  it { should have_content("John Doe") }
-
-  it { should have_content("Date of birth") }
-  it { should have_content("1 January 2000") }
-
-  it { should have_content("Home address") }
-  it { should have_content("SW1A 1AA") }
-
-  it { should have_content("School") }
-  it { should have_content("Waterloo Road") }
 
   context "with a restricted patient" do
-    let(:restricted) { true }
+    let(:patient) { create(:patient, :restricted) }
 
     it { should_not have_content("Home address") }
-    it { should_not have_content("SW1A 1AA") }
   end
 end


### PR DESCRIPTION
If the consent form is attached to a consent (because it came from a parent), we should be showing the response from the parent, rather than the details of the patient that was eventually linked to the consent.