### PR TITLE
Show patient flags without a feature flag

### DIFF
--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -5,24 +5,22 @@ class AppPatientCardComponent < ViewComponent::Base
     <%= render AppCardComponent.new do |card| %>
       <% card.with_heading { "Child record" } %>
       
-      <% if Flipper.enabled?(:"v1.2.0") %>
-        <% if @patient.date_of_death.present? %>
-          <%= render AppNoticeStatusComponent.new(
-            text: "Record updated with child’s date of death"
-          ) %>
-        <% end %>
-        
-        <% if @patient.invalidated? %>
-          <%= render AppNoticeStatusComponent.new(
-            text: "Record flagged as invalid"
-          ) %>
-        <% end %>
-        
-        <% if @patient.restricted? %>
-          <%= render AppNoticeStatusComponent.new(
-            text: "Record flagged as sensitive"
-          ) %>
-        <% end %>
+      <% if @patient.date_of_death.present? %>
+        <%= render AppNoticeStatusComponent.new(
+          text: "Record updated with child’s date of death"
+        ) %>
+      <% end %>
+      
+      <% if @patient.invalidated? %>
+        <%= render AppNoticeStatusComponent.new(
+          text: "Record flagged as invalid"
+        ) %>
+      <% end %>
+      
+      <% if @patient.restricted? %>
+        <%= render AppNoticeStatusComponent.new(
+          text: "Record flagged as sensitive"
+        ) %>
       <% end %>
 
       <%= render AppPatientSummaryComponent.new(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ end
 Faker::Config.locale = "en-GB"
 
 def set_feature_flags
-  %i[dev_tools mesh_jobs cis2 v1.2.0].each do |feature_flag|
+  %i[dev_tools mesh_jobs cis2].each do |feature_flag|
     Flipper.add(feature_flag) unless Flipper.exist?(feature_flag)
   end
 end

--- a/spec/components/app_patient_card_component_spec.rb
+++ b/spec/components/app_patient_card_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AppPatientCardComponent do
-  subject(:rendered) { render_inline(component) }
+  subject { render_inline(component) }
 
   let(:component) { described_class.new(patient) }
 
@@ -16,49 +16,18 @@ describe AppPatientCardComponent do
   context "with a deceased patient" do
     let(:patient) { create(:patient, :deceased) }
 
-    context "with feature flag enabled" do
-      before { Flipper.enable(:"v1.2.0") }
-      after { Flipper.enable(:"v1.2.0") }
-
-      it { should have_content("Record updated with child’s date of death") }
-    end
-
-    context "without feature flag enabled" do
-      it do
-        expect(rendered).not_to have_content(
-          "Record updated with child’s date of death"
-        )
-      end
-    end
+    it { should have_content("Record updated with child’s date of death") }
   end
 
   context "with an invalidated patient" do
     let(:patient) { create(:patient, :invalidated) }
 
-    context "with feature flag enabled" do
-      before { Flipper.enable(:"v1.2.0") }
-      after { Flipper.enable(:"v1.2.0") }
-
-      it { should have_content("Record flagged as invalid") }
-    end
-
-    context "without feature flag enabled" do
-      it { should_not have_content("Record flagged as invalid") }
-    end
+    it { should have_content("Record flagged as invalid") }
   end
 
   context "with a restricted patient" do
     let(:patient) { create(:patient, :restricted) }
 
-    context "with feature flag enabled" do
-      before { Flipper.enable(:"v1.2.0") }
-      after { Flipper.enable(:"v1.2.0") }
-
-      it { should have_content("Record flagged as sensitive") }
-    end
-
-    context "without feature flag enabled" do
-      it { should_not have_content("Record flagged as sensitive") }
-    end
+    it { should have_content("Record flagged as sensitive") }
   end
 end


### PR DESCRIPTION
This is in scope for the 1.1.1 release, so we can remove the feature flag, merge in to `main` and then it's ready for the testers.

https://trello.com/c/vBFF9W7B/1723-show-on-a-childs-record-that-they-have-a-flag