### PR TITLE
Fix flaky manage attendance feature test

### DIFF
--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -94,7 +94,12 @@ describe "Manage attendance" do
   end
 
   def when_i_go_to_a_patient
-    click_link @session.reload.patients.last.full_name
+    click_link PatientSession
+                 .where
+                 .missing(:session_attendances)
+                 .find_by(session: @session)
+                 .patient
+                 .full_name
   end
 
   def then_the_patient_is_not_registered_yet


### PR DESCRIPTION
Instead of picking the last patient (which doesn't have a guaranteed order) we can pick the patient that will be left on the page, i.e. the patient that's missing attendance information.

This has been extracted from #2771.

Example failures:

- https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/12389409160/attempts/2
- https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/12389403286/attempts/2