### PR TITLE
Show health answers from latest consents

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -69,7 +69,7 @@
 <% if display_health_questions? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "All answers to health questions" } %>
-    <%= render AppHealthQuestionsComponent.new(consents: patient_session.consents) %>
+    <%= render AppHealthQuestionsComponent.new(consents: patient_session.latest_consents) %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
This avoids showing health answers for consents that have been invalidated or overridden by a newer consent response from the same person.