### PR TITLE
Prevent consecutive statuses appearing inline

### DIFF
--- a/app/assets/stylesheets/_status.scss
+++ b/app/assets/stylesheets/_status.scss
@@ -1,6 +1,6 @@
 .app-status {
   align-items: center;
-  display: inline-flex;
+  display: flex;
   font-weight: bold;
   gap: nhsuk-spacing(1);
 


### PR DESCRIPTION
Using `inline-flex` for `.app-status` means several consecutive status items can appear inline, when they should appear stacked. Using `inline-flex` also adds unwanted spacing when this component appears in a table cell, which upcoming design changes may require.

## Before

<img width="722" alt="Inline flow" src="https://github.com/user-attachments/assets/256a1668-7491-4460-bb9c-ad5452dcf09c" />

## After

<img width="722" alt="Block flow" src="https://github.com/user-attachments/assets/3cfaa221-e535-4a60-8407-77d852f99a9e" />
