### PR TITLE
Include consent and session notifications when merging patients

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -11,8 +11,14 @@ class PatientMerger
       patient_to_destroy.access_log_entries.update_all(
         patient_id: patient_to_keep.id
       )
+      patient_to_destroy.consent_notifications.update_all(
+        patient_id: patient_to_keep.id
+      )
       patient_to_destroy.consents.update_all(patient_id: patient_to_keep.id)
       patient_to_destroy.notify_log_entries.update_all(
+        patient_id: patient_to_keep.id
+      )
+      patient_to_destroy.session_notifications.update_all(
         patient_id: patient_to_keep.id
       )
       patient_to_destroy.triages.update_all(patient_id: patient_to_keep.id)

--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -18,6 +18,7 @@ class PatientMerger
       patient_to_destroy.notify_log_entries.update_all(
         patient_id: patient_to_keep.id
       )
+      patient_to_destroy.school_moves.update_all(patient_id: patient_to_keep.id)
       patient_to_destroy.session_notifications.update_all(
         patient_id: patient_to_keep.id
       )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -19,6 +19,14 @@ describe PatientMerger do
       create(:access_log_entry, patient: patient_to_destroy)
     end
     let(:consent) { create(:consent, patient: patient_to_destroy, programme:) }
+    let(:consent_notification) do
+      create(
+        :consent_notification,
+        :request,
+        patient: patient_to_destroy,
+        programme:
+      )
+    end
     let(:gillick_assessment) do
       create(:gillick_assessment, :competent, patient_session:)
     end
@@ -30,6 +38,13 @@ describe PatientMerger do
     end
     let(:patient_session) do
       create(:patient_session, session:, patient: patient_to_destroy)
+    end
+    let(:session_notification) do
+      create(
+        :session_notification,
+        :school_reminder,
+        patient: patient_to_destroy
+      )
     end
     let(:triage) { create(:triage, patient: patient_to_destroy, programme:) }
     let(:vaccination_record) do
@@ -53,6 +68,12 @@ describe PatientMerger do
       expect { call }.to change { consent.reload.patient }.to(patient_to_keep)
     end
 
+    it "moves consent notifications" do
+      expect { call }.to change { consent_notification.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
     it "moves gillick assessments" do
       expect { call }.to change { gillick_assessment.reload.patient }.to(
         patient_to_keep
@@ -73,6 +94,12 @@ describe PatientMerger do
 
     it "moves patient sessions" do
       expect { call }.to change { patient_session.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves session notifications" do
+      expect { call }.to change { session_notification.reload.patient }.to(
         patient_to_keep
       )
     end

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -39,6 +39,9 @@ describe PatientMerger do
     let(:patient_session) do
       create(:patient_session, session:, patient: patient_to_destroy)
     end
+    let(:school_move) do
+      create(:school_move, :to_school, patient: patient_to_destroy)
+    end
     let(:session_notification) do
       create(
         :session_notification,
@@ -94,6 +97,12 @@ describe PatientMerger do
 
     it "moves patient sessions" do
       expect { call }.to change { patient_session.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves school moves" do
+      expect { call }.to change { school_move.reload.patient }.to(
         patient_to_keep
       )
     end


### PR DESCRIPTION
This fixes a bug where if a patient has a consent or session notification it is unable to be merged with another patient because the original patient cannot be destroyed (due to the foreign key constraints).

https://good-machine.sentry.io/issues/6157197172/