### PR TITLE
Allow community clinic ODS codes to be optional 

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -62,7 +62,6 @@ class Location < ApplicationRecord
   validates :urn, uniqueness: true, allow_nil: true
 
   with_options if: :clinic? do
-    validates :ods_code, presence: true
     validates :team, presence: true
   end
 

--- a/config/onboarding/coventry-model-office.yaml
+++ b/config/onboarding/coventry-model-office.yaml
@@ -122,32 +122,25 @@ schools:
     - 125781
     - 145486
 
-# !IMPORTANT! The ODS codes of these clinics are not correct.
-
 clinics:
   generic:
     - name: Jepson House
       address_line_1: 4 Manor Court Avenue
       address_town: Nuneaton
       address_postcode: CV11 5HX
-      ods_code: CV115HX
     - name: Locke House
       address_line_1: The Railings Woodside Park
       address_town: Rugby
       address_postcode: CV21 2AW
-      ods_code: CV212AW
     - name: Woodloes House
       address_line_1: Woodloes Avenue South
       address_town: Warwick
       address_postcode: CV34 5XN
-      ods_code: CV345XN
     - name: Alcester Clinic
       address_line_1: Fields Park Drive
       address_town: Warwickshire
       address_postcode: B49 6QR
-      ods_code: B496QR
     - name: City Of Coventry Health Centre
       address_line_1: 2 Stoney Stanton Road
       address_town: Coventry
       address_postcode: CV1 4FS
-      ods_code: CV14FS

--- a/config/onboarding/coventry-production.yaml
+++ b/config/onboarding/coventry-production.yaml
@@ -165,4 +165,3 @@ clinics:
       address_line_1: Smithford Way
       address_town: Coventry
       address_postcode: CV1 1FY
-      ods_code: RYG99CL

--- a/config/onboarding/hertfordshire-training-with-sessions.yaml
+++ b/config/onboarding/hertfordshire-training-with-sessions.yaml
@@ -50,12 +50,9 @@ schools:
     - 145051
     - 146369
 
-# !IMPORTANT! The ODS codes of these clinics are not correct.
-
 clinics:
   generic:
     - name: North Cambridgeshire Hospital
       address_line_1: Churchill Road
       address_town: Wisbech
       address_postcode: PE13 3AB
-      ods_code: PE133AB2

--- a/config/onboarding/hertfordshire-training.yaml
+++ b/config/onboarding/hertfordshire-training.yaml
@@ -50,12 +50,9 @@ schools:
     # - 145051
     # - 146369
 
-# !IMPORTANT! The ODS codes of these clinics are not correct.
-
 clinics:
   generic:
     - name: North Cambridgeshire Hospital
       address_line_1: Churchill Road
       address_town: Wisbech
       address_postcode: PE13 3AB
-      ods_code: PE133AB

--- a/spec/fixtures/files/onboarding/valid.yaml
+++ b/spec/fixtures/files/onboarding/valid.yaml
@@ -26,7 +26,7 @@ clinics:
   team_1:
     - name: 10 Downing Street
       address_postcode: SW1A 1AA
-      ods_code: SW1A10
+      # ods_code intentionally not provided
   team_2:
     - name: 11 Downing Street
       address_postcode: SW1A 1AA

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -56,7 +56,7 @@ describe Location do
       it { should_not validate_presence_of(:gias_establishment_number) }
       it { should_not validate_presence_of(:gias_local_authority_code) }
 
-      it { should validate_presence_of(:ods_code) }
+      it { should_not validate_presence_of(:ods_code) }
       it { should validate_uniqueness_of(:ods_code).ignoring_case_sensitivity }
 
       it { should_not validate_presence_of(:urn) }

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -39,7 +39,7 @@ describe Onboarding do
       expect(team1.schools).to contain_exactly(school1, school2)
       expect(team2.schools).to contain_exactly(school3, school4)
 
-      clinic1 = team1.community_clinics.find_by!(ods_code: "SW1A10")
+      clinic1 = team1.community_clinics.find_by!(ods_code: nil)
       expect(clinic1.name).to eq("10 Downing Street")
       expect(clinic1.address_postcode).to eq("SW1A 1AA")
 


### PR DESCRIPTION
When onboarding Coventry we became aware that not all of the community clinics will have an ODS code, so we need to allow these to be optional. When optional, we would use the ODS code of the organisation when sending data downstream.