### PR TITLE
Fix sort/filter not working on attendances page

### DIFF
--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -56,6 +56,7 @@ class RegisterAttendancesController < ApplicationController
         .where
         .missing(:session_attendances)
         .or(ps.where.not(session_attendances: { session_date: @session_date }))
+        .to_a
   end
 
   def set_patient


### PR DESCRIPTION
This fixes a bug that was inadvertently introduced in ddbd6b96507cbf86388754fa72843c72adcc605d where users could no longer sort and filter on the register attendances page. This was happening because we try and call `select!` on an `ActiveRecord::AssociationRelation` which doesn't have such a method, instead we have to first convert the list of patients to an array.

https://good-machine.sentry.io/issues/6161232701