### PR TITLE
Replace cohorts with organisations directly

### DIFF
--- a/app/components/app_patient_cohort_table_component.html.erb
+++ b/app/components/app_patient_cohort_table_component.html.erb
@@ -1,4 +1,4 @@
-<% if cohort %>
+<% if organisation %>
   <%= govuk_table(html_attributes: {
                     class: "nhsuk-table-responsive",
                   }) do |table| %>
@@ -13,12 +13,12 @@
       <% body.with_row do |row| %>
         <% row.with_cell do %>
           <span class="nhsuk-table-responsive__heading">Name</span>
-          <%= helpers.format_year_group(cohort.year_group) %>
+          <%= helpers.format_year_group(year_group) %>
         <% end %>
         <% row.with_cell do %>
           <span class="nhsuk-table-responsive__heading">Actions</span>
           <%= form_with model: @patient, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-            <%= f.hidden_field :cohort_id, value: "" %>
+            <%= f.hidden_field :organisation_id, value: "" %>
             <%= f.govuk_submit "Remove from cohort", class: "app-button--secondary-warning app-button--small" %>
           <% end %>
         <% end %>

--- a/app/components/app_patient_cohort_table_component.rb
+++ b/app/components/app_patient_cohort_table_component.rb
@@ -11,5 +11,5 @@ class AppPatientCohortTableComponent < ViewComponent::Base
 
   attr_reader :patient
 
-  delegate :cohort, to: :patient
+  delegate :organisation, :year_group, to: :patient
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -18,7 +18,7 @@ class ConsentsController < ApplicationController
         .patient_sessions
         .preload_for_status
         .preload(consents: %i[parent patient])
-        .eager_load(patient: :cohort)
+        .eager_load(:patient)
         .order_by_name
 
     tab_patient_sessions =

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -42,7 +42,7 @@ class DevController < ApplicationController
 
       sessions.destroy_all
 
-      patients = Patient.joins(:cohort).where(cohorts: { organisation: })
+      patients = organisation.patients
 
       SchoolMove.where(patient: patients).destroy_all
       SchoolMove.where(organisation:).destroy_all
@@ -54,7 +54,7 @@ class DevController < ApplicationController
       Consent.where(organisation:).destroy_all
       Triage.where(organisation:).destroy_all
 
-      patients.destroy_all
+      patients.includes(:parents).destroy_all
 
       Cohort.where(organisation:).destroy_all
       Batch.where(organisation:).destroy_all

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -56,7 +56,6 @@ class DevController < ApplicationController
 
       patients.includes(:parents).destroy_all
 
-      Cohort.where(organisation:).destroy_all
       Batch.where(organisation:).destroy_all
 
       UnscheduledSessionsFactory.new.call

--- a/app/controllers/import_issues_controller.rb
+++ b/app/controllers/import_issues_controller.rb
@@ -45,7 +45,7 @@ class ImportIssuesController < ApplicationController
           :patient_session,
           :performed_by_user,
           session: :location,
-          patient: %i[cohort gp_practice school],
+          patient: %i[gp_practice school],
           vaccine: :programme
         )
 
@@ -53,7 +53,7 @@ class ImportIssuesController < ApplicationController
       policy_scope(Patient)
         .with_pending_changes
         .distinct
-        .eager_load(:cohort, :gp_practice, :school)
+        .eager_load(:gp_practice, :school)
         .preload(:school_moves, :upcoming_sessions)
 
     @import_issues =

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -25,12 +25,7 @@ class PatientSessionsController < ApplicationController
         :session,
         :session_attendances,
         consents: %i[parent],
-        patient: [
-          :cohort,
-          :gp_practice,
-          :school,
-          { parent_relationships: :parent }
-        ],
+        patient: [:gp_practice, :school, { parent_relationships: :parent }],
         triages: :performed_by,
         vaccination_records: {
           vaccine: :programme

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -49,18 +49,18 @@ class PatientsController < ApplicationController
   end
 
   def update
-    old_cohort = @patient.cohort
+    old_organisation = @patient.organisation
 
-    cohort_id = params.dig(:patient, :cohort_id).presence
+    organisation_id = params.dig(:patient, :organisation_id).presence
 
     ActiveRecord::Base.transaction do
-      @patient.update!(cohort_id:)
+      @patient.update!(organisation_id:)
 
-      if cohort_id.nil?
+      if organisation_id.nil?
         @patient
           .patient_sessions
           .includes(:session_attendances)
-          .where(session: old_cohort.organisation.sessions)
+          .where(session: old_organisation.sessions)
           .find_each(&:destroy_if_safe!)
       end
     end
@@ -76,8 +76,7 @@ class PatientsController < ApplicationController
 
     redirect_to path,
                 flash: {
-                  success:
-                    "#{@patient.full_name} removed from #{helpers.format_year_group(old_cohort.year_group)} cohort"
+                  success: "#{@patient.full_name} removed from cohort"
                 }
   end
 
@@ -88,9 +87,9 @@ class PatientsController < ApplicationController
       policy_scope(Patient).includes(
         :gillick_assessments,
         :gp_practice,
+        :organisation,
         :school,
         :triages,
-        cohort: :organisation,
         consents: %i[parent patient],
         parent_relationships: :parent,
         patient_sessions: %i[location session_attendances],

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -50,7 +50,7 @@ class ProgrammesController < ApplicationController
     patient_sessions =
       PatientSession
         .where(patient: patients, session: sessions)
-        .eager_load(:session, patient: :cohort)
+        .eager_load(:session, :patient)
         .preload_for_status
         .order_by_name
         .to_a

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -15,10 +15,7 @@ class ProgrammesController < ApplicationController
   end
 
   def show
-    patients =
-      policy_scope(Patient).where(
-        cohort: policy_scope(Cohort).for_year_groups(@programme.year_groups)
-      )
+    patients = policy_scope(Patient).in_programme(@programme)
 
     @patients_count = patients.count
     @vaccinations_count = policy_scope(VaccinationRecord).count
@@ -47,10 +44,7 @@ class ProgrammesController < ApplicationController
   end
 
   def patients
-    cohorts = policy_scope(Cohort).for_year_groups(@programme.year_groups)
-
-    patients = policy_scope(Patient).where(cohort: cohorts).not_deceased
-
+    patients = policy_scope(Patient).in_programme(@programme).not_deceased
     sessions = policy_scope(Session).has_programme(@programme)
 
     patient_sessions =

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -18,7 +18,7 @@ class TriagesController < ApplicationController
       @session
         .patient_sessions
         .preload_for_status
-        .eager_load(patient: :cohort)
+        .eager_load(:patient)
         .order_by_name
 
     @current_tab = TAB_PATHS[:triage][params[:tab]]

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -75,19 +75,9 @@ class VaccinationRecordsController < ApplicationController
           # TODO: avoid duplicate here by using one or the other everywhere
           patient_session: {
             consents: :parent,
-            patient: [
-              :cohort,
-              :gp_practice,
-              :school,
-              { parent_relationships: :parent }
-            ]
+            patient: [:gp_practice, :school, { parent_relationships: :parent }]
           },
-          patient: [
-            :cohort,
-            :gp_practice,
-            :school,
-            { parent_relationships: :parent }
-          ],
+          patient: [:gp_practice, :school, { parent_relationships: :parent }],
           session: %i[session_dates],
           vaccine: :programme
         )

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -23,7 +23,7 @@ class VaccinationsController < ApplicationController
       @session
         .patient_sessions
         .preload_for_status
-        .eager_load(patient: :cohort)
+        .eager_load(:patient)
         .order_by_name
 
     grouped_patient_sessions =

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -127,7 +127,7 @@ class Reports::OfflineSessionExporter
   def patient_sessions
     session
       .patient_sessions
-      .eager_load(patient: %i[cohort school])
+      .eager_load(patient: :school)
       .preload(
         consents: [:parent, { patient: :parent_relationships }],
         gillick_assessments: :performed_by,

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -95,7 +95,7 @@ class Reports::ProgrammeVaccinationsExporter
           patient_session: {
             consents: [:parent, { patient: :parent_relationships }],
             gillick_assessments: :performed_by,
-            patient: %i[cohort gp_practice school],
+            patient: %i[gp_practice school],
             triages: :performed_by
           }
         )

--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -28,10 +28,10 @@ class Cohort < ApplicationRecord
 
   scope :for_year_groups,
         ->(year_groups, academic_year: nil) do
-          academic_year ||= Date.current.academic_year
-
           birth_academic_years =
-            year_groups.map { |year_group| academic_year - year_group - 5 }
+            year_groups.map do |year_group|
+              year_group.to_birth_academic_year(academic_year:)
+            end
 
           where(birth_academic_year: birth_academic_years)
         end

--- a/app/models/concerns/year_group_concern.rb
+++ b/app/models/concerns/year_group_concern.rb
@@ -4,12 +4,7 @@ module YearGroupConcern
   extend ActiveSupport::Concern
 
   def year_group
-    return nil if birth_academic_year.nil?
-
-    # Children normally start school the September after their 4th birthday.
-    # https://www.gov.uk/schools-admissions/school-starting-age
-
-    Date.current.academic_year - (birth_academic_year + 5)
+    birth_academic_year&.to_year_group
   end
 
   def year_group_changed?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -34,6 +34,7 @@ class Organisation < ApplicationRecord
   has_many :consents
   has_many :locations
   has_many :organisation_programmes
+  has_many :patients
   has_many :sessions
   has_many :teams
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -29,7 +29,6 @@ class Organisation < ApplicationRecord
 
   has_many :batches
   has_many :cohort_imports
-  has_many :cohorts
   has_many :consent_forms
   has_many :consents
   has_many :locations

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -64,6 +64,7 @@ class Patient < ApplicationRecord
 
   belongs_to :cohort, optional: true
   belongs_to :gp_practice, class_name: "Location", optional: true
+  belongs_to :organisation, optional: true
 
   has_many :access_log_entries
   has_many :consent_notifications
@@ -369,12 +370,9 @@ class Patient < ApplicationRecord
 
   def self.from_consent_form(consent_form)
     birth_academic_year = consent_form.date_of_birth.academic_year
+    organisation = consent_form.organisation
 
-    cohort =
-      Cohort.find_or_create_by!(
-        birth_academic_year:,
-        organisation: consent_form.organisation
-      )
+    cohort = Cohort.find_or_create_by!(birth_academic_year:, organisation:)
 
     new(
       address_line_1: consent_form.address_line_1,
@@ -382,15 +380,16 @@ class Patient < ApplicationRecord
       address_postcode: consent_form.address_postcode,
       address_town: consent_form.address_town,
       birth_academic_year:,
+      cohort:,
       date_of_birth: consent_form.date_of_birth,
       family_name: consent_form.family_name,
       given_name: consent_form.given_name,
+      home_educated: consent_form.home_educated,
       nhs_number: consent_form.nhs_number,
+      organisation:,
       preferred_family_name: consent_form.preferred_family_name,
       preferred_given_name: consent_form.preferred_given_name,
-      school: consent_form.school,
-      home_educated: consent_form.home_educated,
-      cohort:
+      school: consent_form.school
     )
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -62,7 +62,6 @@ class Patient < ApplicationRecord
 
   audited
 
-  belongs_to :cohort, optional: true
   belongs_to :gp_practice, class_name: "Location", optional: true
   belongs_to :organisation, optional: true
 
@@ -354,24 +353,18 @@ class Patient < ApplicationRecord
   end
 
   def self.from_consent_form(consent_form)
-    birth_academic_year = consent_form.date_of_birth.academic_year
-    organisation = consent_form.organisation
-
-    cohort = Cohort.find_or_create_by!(birth_academic_year:, organisation:)
-
     new(
       address_line_1: consent_form.address_line_1,
       address_line_2: consent_form.address_line_2,
       address_postcode: consent_form.address_postcode,
       address_town: consent_form.address_town,
-      birth_academic_year:,
-      cohort:,
+      birth_academic_year: consent_form.date_of_birth.academic_year,
       date_of_birth: consent_form.date_of_birth,
       family_name: consent_form.family_name,
       given_name: consent_form.given_name,
       home_educated: consent_form.home_educated,
       nhs_number: consent_form.nhs_number,
-      organisation:,
+      organisation: consent_form.organisation,
       preferred_family_name: consent_form.preferred_family_name,
       preferred_given_name: consent_form.preferred_given_name,
       school: consent_form.school

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -339,7 +339,7 @@ class Patient < ApplicationRecord
     school_move =
       if school
         SchoolMove.new(patient: self, school:)
-      elsif (organisation = cohort&.organisation)
+      elsif organisation
         SchoolMove.new(patient: self, home_educated:, organisation:)
       end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -29,6 +29,7 @@
 #  updated_at                :datetime         not null
 #  cohort_id                 :bigint
 #  gp_practice_id            :bigint
+#  organisation_id           :bigint
 #  school_id                 :bigint
 #
 # Indexes
@@ -40,12 +41,14 @@
 #  index_patients_on_names_family_first   (family_name,given_name)
 #  index_patients_on_names_given_first    (given_name,family_name)
 #  index_patients_on_nhs_number           (nhs_number) UNIQUE
+#  index_patients_on_organisation_id      (organisation_id)
 #  index_patients_on_school_id            (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (cohort_id => cohorts.id)
 #  fk_rails_...  (gp_practice_id => locations.id)
+#  fk_rails_...  (organisation_id => organisations.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 class Patient < ApplicationRecord

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -120,6 +120,11 @@ class Patient < ApplicationRecord
           end
         end
 
+  scope :in_programme,
+        ->(programme) do
+          where(birth_academic_year: programme.birth_academic_years)
+        end
+
   scope :with_pending_changes, -> { where.not(pending_changes: {}) }
 
   scope :search_by_name,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -120,11 +120,6 @@ class Patient < ApplicationRecord
           end
         end
 
-  scope :in_pending_cohorts,
-        ->(cohorts) do
-          where("pending_changes->>'cohort_id' IN (?)", cohorts.pluck(:id))
-        end
-
   scope :with_pending_changes, -> { where.not(pending_changes: {}) }
 
   scope :search_by_name,
@@ -144,21 +139,6 @@ class Patient < ApplicationRecord
               query:
             )
           end
-        end
-
-  scope :in_organisation,
-        ->(organisation) do
-          cohort_ids = organisation.cohorts.ids
-          school_ids = organisation.schools.ids
-
-          school_moves =
-            SchoolMove.where(school_id: school_ids).or(
-              SchoolMove.where(organisation:)
-            )
-
-          where(cohort_id: cohort_ids).or(where(school_id: school_ids)).or(
-            where(school_moves.for_patient.arel.exists)
-          )
         end
 
   validates :given_name, :family_name, :date_of_birth, presence: true

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -181,7 +181,7 @@ class PatientImportRow
   def birth_academic_year
     if (year_group = @data["CHILD_YEAR_GROUP"]).present?
       begin
-        Date.current.academic_year - Integer(year_group) - 5
+        Integer(year_group).to_birth_academic_year
       rescue ArgumentError, TypeError
         nil
       end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -49,6 +49,10 @@ class Programme < ApplicationRecord
     YEAR_GROUPS_BY_TYPE.fetch(type)
   end
 
+  def birth_academic_years
+    year_groups.map(&:to_birth_academic_year)
+  end
+
   def to_param
     type
   end

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -41,8 +41,6 @@ class SchoolMove < ApplicationRecord
        prefix: true,
        validate: true
 
-  scope :for_patient, -> { where("patient_id = patients.id") }
-
   validates :organisation,
             presence: {
               if: -> { school.nil? }

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -95,7 +95,12 @@ class SchoolMove < ApplicationRecord
   end
 
   def update_patient!
-    patient.update!(school:, home_educated:, cohort:)
+    patient.update!(
+      cohort:,
+      home_educated:,
+      organisation: school&.organisation || organisation,
+      school:
+    )
   end
 
   def update_sessions!(move_to_school: nil)

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -94,7 +94,6 @@ class SchoolMove < ApplicationRecord
 
   def update_patient!
     patient.update!(
-      cohort:,
       home_educated:,
       organisation: school&.organisation || organisation,
       school:
@@ -120,12 +119,6 @@ class SchoolMove < ApplicationRecord
       patient:,
       school:,
       user:
-    )
-  end
-
-  def cohort
-    (school&.organisation || organisation)&.cohorts&.find_or_create_by!(
-      birth_academic_year: patient.birth_academic_year
     )
   end
 

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -4,9 +4,17 @@ class PatientPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       organisation = user.selected_organisation
+
       return scope.none if organisation.nil?
 
-      scope.in_organisation(organisation)
+      school_moves =
+        SchoolMove.where(organisation:).or(
+          SchoolMove.where(school: organisation.schools)
+        )
+
+      scope.where(organisation:).or(
+        scope.where(school_moves.where("patient_id = patients.id").arel.exists)
+      )
     end
   end
 end

--- a/app/policies/school_move_policy.rb
+++ b/app/policies/school_move_policy.rb
@@ -9,7 +9,7 @@ class SchoolMovePolicy < ApplicationPolicy
       scope
         .where(school: organisation.schools)
         .or(scope.where(organisation:))
-        .or(scope.where(patient: Patient.in_organisation(organisation)))
+        .or(scope.where(patient: organisation.patients))
     end
   end
 end

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -14,11 +14,11 @@
 <%= govuk_button_link_to "Import child records", new_programme_cohort_import_path(@programme), class: "app-button--secondary" %>
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
-  <% @cohorts.each do |cohort| %>
+  <% @patient_count_by_birth_academic_year.each do |birth_academic_year, patient_count| %>
     <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
-      <%= render AppCardComponent.new(link_to: cohort.patient_count > 0 ? programme_cohort_path(@programme, cohort) : nil) do |card| %>
-        <% card.with_heading { format_year_group(cohort.year_group) } %>
-        <% card.with_description { t("children", count: cohort.patient_count) } %>
+      <%= render AppCardComponent.new(link_to: patient_count > 0 ? programme_cohort_path(@programme, birth_academic_year) : nil) do |card| %>
+        <% card.with_heading { format_year_group(birth_academic_year.to_year_group) } %>
+        <% card.with_description { t("children", count: patient_count) } %>
       <% end %>
     </li>
   <% end %>

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -6,7 +6,7 @@
                                         ]) %>
 <% end %>
 
-<%= h1 format_year_group(@cohort.year_group) %>
+<%= h1 format_year_group(@birth_academic_year.to_year_group) %>
 
 <%= render AppPatientTableComponent.new(@patients, current_user:, count: @pagy.count) %>
 

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -28,7 +28,7 @@
 
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Children</span>
-            <%= policy_scope(Patient).where(cohort: policy_scope(Cohort).for_year_groups(programme.year_groups)).count %>
+            <%= policy_scope(Patient).in_programme(programme).count %>
           <% end %>
 
           <% row.with_cell do %>

--- a/db/migrate/20241219115056_add_organisation_to_patients.rb
+++ b/db/migrate/20241219115056_add_organisation_to_patients.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddOrganisationToPatients < ActiveRecord::Migration[8.0]
+  def up
+    add_reference :patients, :organisation, foreign_key: true
+    Patient
+      .eager_load(:cohort)
+      .find_each do |patient|
+        patient.update_column(:organisation_id, patient.cohort&.organisation)
+      end
+  end
+
+  def down
+    remove_reference :patients, :organisation
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -580,6 +580,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
     t.datetime "updated_from_pds_at"
     t.bigint "gp_practice_id"
     t.integer "birth_academic_year", null: false
+    t.bigint "organisation_id"
     t.index ["cohort_id"], name: "index_patients_on_cohort_id"
     t.index ["family_name", "given_name"], name: "index_patients_on_names_family_first"
     t.index ["family_name"], name: "index_patients_on_family_name_trigram", opclass: :gin_trgm_ops, using: :gin
@@ -587,6 +588,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
     t.index ["given_name"], name: "index_patients_on_given_name_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["gp_practice_id"], name: "index_patients_on_gp_practice_id"
     t.index ["nhs_number"], name: "index_patients_on_nhs_number", unique: true
+    t.index ["organisation_id"], name: "index_patients_on_organisation_id"
     t.index ["school_id"], name: "index_patients_on_school_id"
   end
 
@@ -856,6 +858,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
   add_foreign_key "patients", "cohorts"
   add_foreign_key "patients", "locations", column: "gp_practice_id"
   add_foreign_key "patients", "locations", column: "school_id"
+  add_foreign_key "patients", "organisations"
   add_foreign_key "pre_screenings", "patient_sessions"
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
   add_foreign_key "programmes_sessions", "programmes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -260,7 +260,7 @@ def create_imports(user, organisation)
 end
 
 def create_school_moves(organisation)
-  patients = Patient.in_organisation(organisation).sample(10)
+  patients = Patient.where(organisation:).sample(10)
 
   patients.each do |patient|
     if [true, false].sample

--- a/lib/core_ext/integer/year_group.rb
+++ b/lib/core_ext/integer/year_group.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Integer
+  def to_year_group(academic_year: nil)
+    # Children normally start school the September after their 4th birthday.
+    # https://www.gov.uk/schools-admissions/school-starting-age
+
+    (academic_year || Date.current.academic_year) - self - 5
+  end
+
+  alias_method :to_birth_academic_year, :to_year_group
+end

--- a/spec/components/app_patient_cohort_table_component_spec.rb
+++ b/spec/components/app_patient_cohort_table_component_spec.rb
@@ -6,14 +6,13 @@ describe AppPatientCohortTableComponent do
   let(:component) { described_class.new(patient) }
 
   context "without a cohort" do
-    let(:patient) { create(:patient, cohort: nil) }
+    let(:patient) { create(:patient, organisation: nil) }
 
     it { should have_content("No cohorts") }
   end
 
   context "with a cohort" do
-    let(:cohort) { create(:cohort, year_group: 8) }
-    let(:patient) { create(:patient, cohort:) }
+    let(:patient) { create(:patient, year_group: 8) }
 
     it { should have_content("Year 8") }
     it { should have_content("Remove from cohort") }

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -68,7 +68,7 @@ describe AppPatientTableComponent do
   end
 
   context "with a patient not in the cohort" do
-    before { patients.first.update!(cohort_id: nil) }
+    before { patients.first.update!(organisation: nil) }
 
     it "doesn't render a link" do
       expect(rendered).not_to have_link("John Smith")

--- a/spec/factories/cohorts.rb
+++ b/spec/factories/cohorts.rb
@@ -25,6 +25,6 @@ FactoryBot.define do
 
     organisation
 
-    birth_academic_year { Date.current.academic_year - year_group - 5 }
+    birth_academic_year { year_group.to_birth_academic_year }
   end
 end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -63,15 +63,15 @@ FactoryBot.define do
       performed_by { association(:user) }
       programme { session&.programmes&.first }
       session { nil }
-      organisation do
-        session&.organisation ||
-          association(:organisation, programmes: [programme].compact)
-      end
       year_group { nil }
       location_name { nil }
       in_attendance { false }
     end
 
+    organisation do
+      session&.organisation ||
+        association(:organisation, programmes: [programme].compact)
+    end
     cohort { Cohort.find_or_create_by!(birth_academic_year:, organisation:) }
 
     nhs_number do

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
     end
 
     organisation do
-      session&.organisation ||
+      session&.organisation || school&.organisation ||
         association(:organisation, programmes: [programme].compact)
     end
     cohort { Cohort.find_or_create_by!(birth_academic_year:, organisation:) }

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -72,11 +72,6 @@ FactoryBot.define do
       session&.organisation || school&.organisation ||
         association(:organisation, programmes: [programme].compact)
     end
-    cohort do
-      if organisation
-        Cohort.find_or_create_by!(birth_academic_year:, organisation:)
-      end
-    end
 
     nhs_number do
       # Prevents duplicate NHS numbers by sequencing and appending a check

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -72,7 +72,11 @@ FactoryBot.define do
       session&.organisation || school&.organisation ||
         association(:organisation, programmes: [programme].compact)
     end
-    cohort { Cohort.find_or_create_by!(birth_academic_year:, organisation:) }
+    cohort do
+      if organisation
+        Cohort.find_or_create_by!(birth_academic_year:, organisation:)
+      end
+    end
 
     nhs_number do
       # Prevents duplicate NHS numbers by sequencing and appending a check

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -29,6 +29,7 @@
 #  updated_at                :datetime         not null
 #  cohort_id                 :bigint
 #  gp_practice_id            :bigint
+#  organisation_id           :bigint
 #  school_id                 :bigint
 #
 # Indexes
@@ -40,12 +41,14 @@
 #  index_patients_on_names_family_first   (family_name,given_name)
 #  index_patients_on_names_given_first    (given_name,family_name)
 #  index_patients_on_nhs_number           (nhs_number) UNIQUE
+#  index_patients_on_organisation_id      (organisation_id)
 #  index_patients_on_school_id            (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (cohort_id => cohorts.id)
 #  fk_rails_...  (gp_practice_id => locations.id)
+#  fk_rails_...  (organisation_id => organisations.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 

--- a/spec/features/dev_reset_organisation_spec.rb
+++ b/spec/features/dev_reset_organisation_spec.rb
@@ -40,8 +40,7 @@ describe "Dev endpoint to reset a organisation" do
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
 
-    @patients =
-      @organisation.cohorts.includes(patients: :parents).flat_map(&:patients)
+    @patients = @organisation.patients.includes(:parents)
 
     expect(@patients.size).to eq(3)
     expect(@patients.flat_map(&:parents).size).to eq(3)
@@ -91,9 +90,8 @@ describe "Dev endpoint to reset a organisation" do
 
   def then_all_associated_data_is_deleted_when_i_reset_the_organisation
     expect { visit "/reset/r1l" }.to(
-      change(Cohort, :count)
-        .by(-2)
-        .and(change(CohortImport, :count).by(-1))
+      change(CohortImport, :count)
+        .by(-1)
         .and(change(ImmunisationImport, :count).by(-1))
         .and(change(NotifyLogEntry, :count).by(-3))
         .and(change(Parent, :count).by(-4))

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -123,7 +123,7 @@ describe "Manage children" do
         :patient,
         given_name: "Jane",
         family_name: "Doe",
-        cohort: @organisation.cohorts.first
+        organisation: @organisation
       )
   end
 

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -52,14 +52,8 @@ describe "Manage children" do
     and_i_see_the_cohort
 
     when_i_click_on_remove_from_cohort
-    then_i_see_the_child
-    and_i_see_a_removed_from_cohort_message
-    and_no_longer_see_the_cohort
-
-    when_i_click_on_children
-    and_i_click_on_a_child_who_is_only_in_the_cohort
-    when_i_click_on_remove_from_cohort
     then_i_see_the_children
+    and_i_see_a_removed_from_cohort_message
   end
 
   scenario "Viewing important notices" do
@@ -240,12 +234,7 @@ describe "Manage children" do
   end
 
   def and_i_see_a_removed_from_cohort_message
-    expect(page).to have_content(/removed from Year ([0-9]+) cohort/)
-  end
-
-  def and_no_longer_see_the_cohort
-    expect(page).to have_content("No cohorts")
-    expect(page).to have_content("No sessions")
+    expect(page).to have_content("removed from cohort")
   end
 
   def when_i_go_to_the_dashboard
@@ -298,9 +287,5 @@ describe "Manage children" do
     expect(page).to have_content("Notices (1)")
     expect(page).to have_content(@restricted_patient.full_name)
     expect(page).to have_content("Record flagged as sensitive")
-  end
-
-  def and_i_click_on_a_child_who_is_only_in_the_cohort
-    click_on "Jane Doe"
   end
 end

--- a/spec/features/patient_search_spec.rb
+++ b/spec/features/patient_search_spec.rb
@@ -27,11 +27,8 @@ describe "Patient search" do
   end
 
   def given_that_i_am_signed_in
-    @organisation = create(:organisation, :with_one_nurse)
-    @user = @organisation.users.first
-    cohort = create(:cohort, organisation: @organisation)
+    organisation = create(:organisation, :with_one_nurse)
 
-    # Create test patients with various names
     [
       %w[Aaron Smith],
       %w[Aardvark Jones],
@@ -39,18 +36,18 @@ describe "Patient search" do
       %w[Cassidy Wilson],
       %w[Bob Taylor]
     ].each do |(given_name, family_name)|
-      create(:patient, given_name:, family_name:, cohort:)
+      create(:patient, given_name:, family_name:, organisation:)
     end
 
     create(
       :patient,
       given_name: "Salvor",
       family_name: "Hardin",
-      cohort:,
+      organisation:,
       nhs_number: nil
     )
 
-    sign_in @user
+    sign_in organisation.users.first
   end
 
   def when_i_visit_the_patients_page

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -118,7 +118,6 @@ describe ClassImportRow do
 
     it do
       expect(patient).to have_attributes(
-        cohort: nil,
         date_of_birth: Date.new(2010, 1, 1),
         gender_code: "not_known",
         home_educated: false,

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -357,9 +357,10 @@ describe ClassImport do
       it "doesn't stage school changes" do
         expect { process! }.not_to change(patient, :pending_changes)
         expect(patient.pending_changes.keys).not_to include(
-          :school_id,
           :cohort_id,
-          :home_educated
+          :home_educated,
+          :organisation_id,
+          :school_id
         )
       end
     end

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -164,7 +164,6 @@ describe ClassImport do
         .to change(class_import, :processed_at).from(nil)
         .and change(class_import.patients, :count).by(4)
         .and change(class_import.parents, :count).by(5)
-        .and change(organisation.cohorts, :count).by(2)
 
       expect(Patient.first).to have_attributes(
         nhs_number: "1234567890",

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -143,7 +143,6 @@ describe CohortImportRow do
 
     it do
       expect(patient).to have_attributes(
-        cohort: nil,
         date_of_birth: Date.new(2010, 1, 1),
         gender_code: "male",
         home_educated: false,

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -185,7 +185,6 @@ describe CohortImport do
         .to change(cohort_import, :processed_at).from(nil)
         .and change(cohort_import.patients, :count).by(3)
         .and change(cohort_import.parents, :count).by(3)
-        .and change(organisation.cohorts, :count).by(2)
 
       expect(Patient.first).to have_attributes(
         nhs_number: "1234567890",

--- a/spec/models/concerns/pending_changes_concern_spec.rb
+++ b/spec/models/concerns/pending_changes_concern_spec.rb
@@ -12,7 +12,6 @@ describe PendingChangesConcern do
   let(:model) do
     model_class.create!(
       address_postcode: "",
-      cohort_id: create(:cohort).id,
       date_of_birth: Date.current,
       birth_academic_year: 2000,
       given_name: "John",

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -605,17 +605,17 @@ describe ImmunisationImportRow do
       end
     end
 
-    describe "#cohort" do
-      subject(:cohort) { patient.cohort }
+    describe "#organisation" do
+      subject(:cohort) { patient.organisation }
 
       let(:data) { valid_data }
 
       it { should be_nil }
 
-      context "with an existing patient in a cohort" do
-        let(:patient) { create(:patient, nhs_number:, cohort: create(:cohort)) }
+      context "with an existing patient in the cohort" do
+        let(:patient) { create(:patient, nhs_number:) }
 
-        it { should eq(patient.cohort) }
+        it { should eq(patient.organisation) }
       end
     end
   end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -67,69 +67,6 @@ describe Patient do
 
       it { should eq([patient_a, patient_b, patient_c]) }
     end
-
-    describe "#in_organisation" do
-      subject(:scope) { described_class.in_organisation(organisation) }
-
-      let(:organisation) { create(:organisation) }
-      let(:another_organisation) { create(:organisation) }
-      let(:school) { create(:school, organisation:) }
-      let(:user) { create(:user, organisation:) }
-
-      let(:patient_in_school) { create(:patient, school:) }
-      let(:patient_in_cohort) { create(:patient, organisation:) }
-      let(:patient_not_in_organisation) { create(:patient) }
-
-      it { should include(patient_in_school) }
-      it { should include(patient_in_cohort) }
-      it { should_not include(patient_not_in_organisation) }
-
-      context "when the patient not in the org but pending joining the cohort" do
-        let(:patient_with_move_in_cohort) { create(:patient) }
-        let(:patient_with_move_in_another_cohort) { create(:patient) }
-
-        before do
-          create(
-            :school_move,
-            :to_home_educated,
-            patient: patient_with_move_in_cohort,
-            organisation:
-          )
-          create(
-            :school_move,
-            :to_home_educated,
-            patient: patient_with_move_in_another_cohort,
-            organisation: another_organisation
-          )
-        end
-
-        it { should include(patient_with_move_in_cohort) }
-        it { should_not include(patient_with_move_in_another_cohort) }
-      end
-
-      context "when the patient not in the org but pending joining the school" do
-        let(:patient_with_move_in_school) { create(:patient) }
-        let(:patient_with_move_in_another_school) { create(:patient) }
-
-        before do
-          create(
-            :school_move,
-            :to_school,
-            patient: patient_with_move_in_school,
-            school:
-          )
-          create(
-            :school_move,
-            :to_school,
-            patient: patient_with_move_in_another_school,
-            school: create(:school, organisation: another_organisation)
-          )
-        end
-
-        it { should include(patient_with_move_in_school) }
-        it { should_not include(patient_with_move_in_another_school) }
-      end
-    end
   end
 
   describe "validations" do

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -29,6 +29,7 @@
 #  updated_at                :datetime         not null
 #  cohort_id                 :bigint
 #  gp_practice_id            :bigint
+#  organisation_id           :bigint
 #  school_id                 :bigint
 #
 # Indexes
@@ -40,12 +41,14 @@
 #  index_patients_on_names_family_first   (family_name,given_name)
 #  index_patients_on_names_given_first    (given_name,family_name)
 #  index_patients_on_nhs_number           (nhs_number) UNIQUE
+#  index_patients_on_organisation_id      (organisation_id)
 #  index_patients_on_school_id            (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (cohort_id => cohorts.id)
 #  fk_rails_...  (gp_practice_id => locations.id)
+#  fk_rails_...  (organisation_id => organisations.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -90,21 +90,21 @@ describe SchoolMove do
 
     shared_examples "sets the patient cohort" do
       it "sets the patient cohort" do
-        expect { confirm! }.to change(patient, :cohort).from(nil)
-        expect(patient.cohort.organisation).to eq(organisation)
+        expect { confirm! }.to change(patient, :organisation).from(nil)
+        expect(patient.organisation).to eq(organisation)
       end
     end
 
     shared_examples "keeps the patient cohort" do
       it "keeps the patient cohort" do
-        expect { confirm! }.not_to change(patient, :cohort)
+        expect { confirm! }.not_to change(patient, :organisation)
       end
     end
 
     shared_examples "changes the patient cohort" do
       it "changes the patient cohort" do
-        expect { confirm! }.to change(patient, :cohort)
-        expect(patient.cohort.organisation).to eq(new_organisation)
+        expect { confirm! }.to change(patient, :organisation)
+        expect(patient.organisation).to eq(new_organisation)
       end
     end
 
@@ -174,7 +174,7 @@ describe SchoolMove do
     end
 
     context "with a patient in no sessions" do
-      let(:patient) { create(:patient, cohort: nil) }
+      let(:patient) { create(:patient, organisation: nil) }
 
       context "to a school with a scheduled session" do
         let(:school_move) do

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -6,19 +6,13 @@ describe PatientPolicy do
 
     let(:organisation) { create(:organisation) }
     let(:another_organisation) { create(:organisation) }
-    let(:cohort) { create(:cohort, organisation:) }
-    let(:cohort_for_another_organisation) do
-      create(:cohort, organisation: another_organisation)
-    end
     let(:school) { create(:school, organisation:) }
     let(:user) { create(:user, organisation:) }
 
-    let(:patient_in_school) { create(:patient, school:) }
-    let(:patient_in_cohort) { create(:patient, cohort:) }
+    let(:patient_in_organisation) { create(:patient, organisation:) }
     let(:patient_not_in_organisation) { create(:patient) }
 
-    it { should include(patient_in_school) }
-    it { should include(patient_in_cohort) }
+    it { should include(patient_in_organisation) }
     it { should_not include(patient_not_in_organisation) }
 
     context "when the patient not in the org but pending joining the cohort" do


### PR DESCRIPTION
Following on from #2780 each patient now has a specific year group they belong to, so we don't need the cohort model which at the moment is just a duplicate of this information. Instead we can have a direct link between patients and organisations, simplifying quite a bit of the code related to cohorting.

See individual commits for more details, the business logic is the same before and after. This will allow us to remove the `Cohort` model entirely and simplify our database structure.