### PR TITLE
Calculate `Consent#responded_at` from consent form

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -118,7 +118,7 @@ class Consent < ApplicationRecord
   end
 
   def responded_at
-    invalidated_at || withdrawn_at || created_at
+    invalidated_at || withdrawn_at || consent_form&.recorded_at || created_at
   end
 
   def triage_needed?

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -70,6 +70,35 @@ describe Consent do
     end
   end
 
+  describe "#responded_at" do
+    subject(:responded_at) { consent.responded_at }
+
+    context "with a consent form" do
+      let(:consent) do
+        build(
+          :consent,
+          created_at: Time.current,
+          consent_form:
+            build(:consent_form, recorded_at: Time.zone.local(2024, 12, 20, 12))
+        )
+      end
+
+      it { should eq(Time.zone.local(2024, 12, 20, 12)) }
+    end
+
+    context "without a consent form" do
+      let(:consent) do
+        build(
+          :consent,
+          created_at: Time.zone.local(2024, 12, 20, 12),
+          consent_form: nil
+        )
+      end
+
+      it { should eq(Time.zone.local(2024, 12, 20, 12)) }
+    end
+  end
+
   describe "#from_consent_form!" do
     describe "the created consent object" do
       subject(:consent) do


### PR DESCRIPTION
If the consent is linked to a consent form we should get the `responded_at` date/time from when the consent form was submitted, not when it was linked with the patient.

This has been spotted as a bug and the testers would like it included as part of the work to fix inconsistent data between the consent and the consent form (https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2772).

https://trello.com/c/2yk5lEkG/1769-linked-patient-details-shown-on-consent-response-page-instead-of-consent-form-responses