### PR TITLE
Fix bug where nurses can't sort with blank postcodes

### DIFF
--- a/app/controllers/concerns/patient_sorting_concern.rb
+++ b/app/controllers/concerns/patient_sorting_concern.rb
@@ -28,7 +28,11 @@ module PatientSortingConcern
     when "status"
       obj.try(:status) || "not_in_session"
     when "postcode"
-      obj.try(:address_postcode) || obj.patient.address_postcode
+      if obj.respond_to?(:address_postcode)
+        obj.address_postcode
+      else
+        obj.patient.address_postcode
+      end || ""
     when "year_group"
       [
         obj.try(:year_group) || obj.patient.year_group || "",
@@ -52,8 +56,13 @@ module PatientSortingConcern
     end
 
     if (postcode = params[:postcode]).present?
-      patients_or_patient_sessions.select! do
-        value = _1.try(:address_postcode) || _1.patient.address_postcode
+      patients_or_patient_sessions.select! do |obj|
+        value =
+          if obj.respond_to?(:address_postcode)
+            obj.address_postcode
+          else
+            obj.patient.address_postcode
+          end
         value&.downcase&.include?(postcode.downcase)
       end
     end

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -31,12 +31,7 @@ describe PatientSortingConcern do
     )
   end
   let(:casey) do
-    create(
-      :patient,
-      given_name: "Casey",
-      year_group: 10,
-      address_postcode: "SW3A 1AA"
-    )
+    create(:patient, given_name: "Casey", year_group: 10, address_postcode: nil)
   end
 
   let(:programme) { create(:programme) }
@@ -108,7 +103,7 @@ describe PatientSortingConcern do
       it "sorts patient sessions by name in ascending order" do
         controller.sort_patients!(patient_sessions)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
-          %w[Casey Blair Alex]
+          %w[Blair Alex Casey]
         )
       end
     end


### PR DESCRIPTION
This fixes a bug where if a user tries to sort on a table by postcode and some of the rows don't have a postcode, the sorting fails.

https://good-machine.sentry.io/issues/6164317867/