### PR TITLE
Align Careplus report date filtering with Mavis report logic

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -85,16 +85,26 @@ class Reports::CareplusExporter
     if start_date.present?
       scope =
         scope.where(
-          "vaccination_records.performed_at >= ?",
+          "vaccination_records.created_at >= ?",
           start_date.beginning_of_day
+        ).or(
+          scope.where(
+            "vaccination_records.updated_at >= ?",
+            start_date.beginning_of_day
+          )
         )
     end
 
     if end_date.present?
       scope =
         scope.where(
-          "vaccination_records.performed_at <= ?",
+          "vaccination_records.created_at <= ?",
           end_date.end_of_day
+        ).or(
+          scope.where(
+            "vaccination_records.updated_at <= ?",
+            end_date.end_of_day
+          )
         )
     end
 

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -137,6 +137,8 @@ describe Reports::CareplusExporter do
       :vaccination_record,
       programme:,
       patient_session:,
+      created_at: 2.months.ago,
+      updated_at: 2.months.ago,
       performed_at: 2.months.ago
     )
 
@@ -148,6 +150,20 @@ describe Reports::CareplusExporter do
     create(:vaccination_record, :not_administered, programme:, patient_session:)
 
     expect(data_rows.first).to be_nil
+  end
+
+  it "includes vaccination records updated within the date range" do
+    patient_session = create(:patient_session, session:)
+    create(
+      :vaccination_record,
+      programme:,
+      patient_session:,
+      created_at: 2.months.ago,
+      updated_at: 1.day.ago,
+      performed_at: 2.months.ago
+    )
+
+    expect(data_rows.first).not_to be_nil
   end
 
   context "with a session in a different organisation" do


### PR DESCRIPTION
This change ensures the Careplus report behaves like the Mavis report by filtering vaccination records based on their _technical dates_ (creation or last update) rather than the actual vaccination date. Specifically, any record whose creation or last update date falls within the specified date range is returned, regardless of when the vaccination itself was administered.

This primarily impacts records that were uploaded to Mavis on a different day than the actual vaccination (where the creation date is later than the vaccination date). Records added on the same day as the vaccination should remain unaffected.

[Fixes MAVIS-1804](https://trello.com/c/QY3Gmfs8/1804-fix-the-date-filtering-inconsistencies-between-the-careplus-and-mavis-reports)