### PR TITLE
Use `params.expect`

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -89,12 +89,7 @@ class BatchesController < ApplicationController
   end
 
   def batch_params
-    params.require(:batch).permit(
-      :name,
-      :"expiry(3i)",
-      :"expiry(2i)",
-      :"expiry(1i)"
-    )
+    params.expect(batch: %i[name expiry(3i) expiry(2i) expiry(1i)])
   end
 
   def expiry_validator

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -157,13 +157,13 @@ class ConsentsController < ApplicationController
   end
 
   def withdraw_params
-    params
-      .require(:consent)
-      .permit(:reason_for_refusal, :notes)
-      .merge(response: "refused", withdrawn_at: Time.current)
+    params.expect(consent: %i[reason_for_refusal notes]).merge(
+      response: "refused",
+      withdrawn_at: Time.current
+    )
   end
 
   def invalidate_params
-    params.require(:consent).permit(:notes).merge(invalidated_at: Time.current)
+    params.expect(consent: :notes).merge(invalidated_at: Time.current)
   end
 end

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -50,16 +50,15 @@ class GillickAssessmentsController < ApplicationController
   end
 
   def gillick_assessment_params
-    params
-      .require(:gillick_assessment)
-      .permit(
-        :knows_consequences,
-        :knows_delivery,
-        :knows_disease,
-        :knows_side_effects,
-        :knows_vaccination,
-        :notes
-      )
-      .merge(performed_by: current_user)
+    params.expect(
+      gillick_assessment: %i[
+        knows_consequences
+        knows_delivery
+        knows_disease
+        knows_side_effects
+        knows_vaccination
+        notes
+      ]
+    ).merge(performed_by: current_user)
   end
 end

--- a/app/controllers/offline_passwords_controller.rb
+++ b/app/controllers/offline_passwords_controller.rb
@@ -21,6 +21,6 @@ class OfflinePasswordsController < ApplicationController
   private
 
   def password_params
-    params.require(:offline_password).permit(:password, :password_confirmation)
+    params.expect(offline_password: %i[password password_confirmation])
   end
 end

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -81,8 +81,7 @@ class SessionAttendancesController < ApplicationController
 
   def session_attendance_params
     params
-      .require(:session_attendance)
+      .expect(session_attendance: :attending)
       .tap { |p| p[:attending] = nil if p[:attending] == "not_registered" }
-      .permit(:attending)
   end
 end

--- a/app/controllers/session_dates_controller.rb
+++ b/app/controllers/session_dates_controller.rb
@@ -45,8 +45,10 @@ class SessionDatesController < ApplicationController
   end
 
   def session_params
-    params.require(:session).permit(
-      session_dates_attributes: %i[id value _destroy]
+    params.expect(
+      session: {
+        session_dates_attributes: [%i[id value _destroy]]
+      }
     )
   end
 

--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -63,7 +63,7 @@ class Sessions::EditController < ApplicationController
   end
 
   def send_consent_requests_at_params
-    params.require(:session).permit(:send_consent_requests_at)
+    params.expect(session: :send_consent_requests_at)
   end
 
   def send_invitations_at_validator
@@ -76,10 +76,10 @@ class Sessions::EditController < ApplicationController
   end
 
   def send_invitations_at_params
-    params.require(:session).permit(:send_invitations_at)
+    params.expect(session: :send_invitations_at)
   end
 
   def weeks_before_consent_reminders_params
-    params.require(:session).permit(:weeks_before_consent_reminders)
+    params.expect(session: :weeks_before_consent_reminders)
   end
 end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -95,7 +95,7 @@ class TriagesController < ApplicationController
   end
 
   def triage_params
-    params.require(:triage).permit(:status, :notes)
+    params.expect(triage: %i[status notes])
   end
 
   def redirect_path

--- a/app/controllers/vaccination_reports_controller.rb
+++ b/app/controllers/vaccination_reports_controller.rb
@@ -59,9 +59,8 @@ class VaccinationReportsController < ApplicationController
   end
 
   def update_params
-    params
-      .require(:vaccination_report)
-      .permit(:date_from, :date_to, :file_format)
-      .merge(wizard_step: current_step)
+    params.expect(vaccination_report: %i[date_from date_to file_format]).merge(
+      wizard_step: current_step
+    )
   end
 end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -107,18 +107,20 @@ class VaccinationsController < ApplicationController
   private
 
   def vaccinate_form_params
-    params.require(:vaccinate_form).permit(
-      :administered,
-      :delivery_method,
-      :delivery_site,
-      :dose_sequence,
-      :feeling_well,
-      :knows_vaccination,
-      :no_allergies,
-      :not_already_had,
-      :pre_screening_notes,
-      :programme_id,
-      :vaccine_id
+    params.expect(
+      vaccinate_form: %i[
+        administered
+        delivery_method
+        delivery_site
+        dose_sequence
+        feeling_well
+        knows_vaccination
+        no_allergies
+        not_already_had
+        pre_screening_notes
+        programme_id
+        vaccine_id
+      ]
     )
   end
 


### PR DESCRIPTION
This changes any instance of `params.require(...).permit(...)` to use `params.expect(...)` instead which is new in Rails 8. There are number of uses of `params.fetch` remaining which we should look at replacing eventually but the behaviour is quite the same.