### PR TITLE
Fix performing professionals dropdown in offline spreadsheets

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -60,7 +60,12 @@ class Reports::OfflineSessionExporter
     package.use_shared_strings = true
 
     workbook = package.workbook
-    workbook.add_worksheet(name: "Performing Professionals") do |sheet|
+    workbook.add_worksheet(
+      name: "Performing Professionals",
+      state: :hidden
+    ) do |sheet|
+      sheet.sheet_protection
+
       sheet.add_row(%w[EMAIL])
 
       performing_professional_email_values.each do |email|


### PR DESCRIPTION
In Excel spreadsheets when the list of available options for data validation is too large this can cause issues.

    https://stackoverflow.com/questions/16017403/maximum-drop-down-list-formula-length-in-excel

To avoid this we can move the list of options to another sheet, table or named range.

    https://contextures.com/xldataval11.html

This change moves the list of emails of the performing professionals to it's own sheet and adds a formula to use them as the source data for the data validation for the PERFORMING_PROFESSIONAL_EMAIL field of the offline spreadsheet.

[Fixes MAVIS-1800](https://trello.com/c/FZvpVCEk/1800-offline-spreadsheet-opens-with-errors-when-many-vaccinators-present-in-the-organisation?filter=offline)
