### PR TITLE
Fix specs that assume a specific patient age so they pass in 2025

### DIFF
--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 describe "Child record imports duplicates" do
+  around do |example|
+    # to ensure the age calculation stays correct
+    travel_to Time.zone.local(2024, 12, 1) do
+      example.run
+    end
+  end
+
   scenario "User reviews and selects between duplicate records" do
     given_i_am_signed_in
     and_an_hpv_programme_is_underway

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -193,7 +193,8 @@ describe "Patient sorting and filtering" do
   end
 
   def when_i_filter_by_dob
-    fill_in "Date of birth", with: "2011"
+    alex = Patient.find_by(given_name: "Alex")
+    fill_in "Date of birth", with: alex.date_of_birth.year
   end
 
   def then_i_see_patients_with_dob


### PR DESCRIPTION
The `main` branch is failing because two feature specs rely on being run in a given date range.