### PR TITLE
Add counts to navigation bar items

### DIFF
--- a/app/assets/stylesheets/_count.scss
+++ b/app/assets/stylesheets/_count.scss
@@ -1,11 +1,19 @@
 .app-count {
   @include nhsuk-font(16);
 
-  background-color: rgba($color_nhsuk-grey-4, 0.5);
+  background-color: color.scale(
+    color.scale($nhsuk-link-color, $lightness: -50%),
+    $alpha: -60%
+  );
   border-radius: nhsuk-spacing(3);
+  color: $color_nhsuk-white;
   display: inline-block;
   min-width: nhsuk-spacing(5);
   padding-left: nhsuk-spacing(2);
   padding-right: nhsuk-spacing(2);
   text-align: center;
+
+  :focus & {
+    background-color: color.scale($nhsuk-focus-text-color, $alpha: -40%);
+  }
 }

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -8,6 +8,23 @@
   }
 }
 
+.app-header__navigation-item--current {
+  box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-border-color;
+  .nhsuk-header__drop-down & {
+    box-shadow: inset $nhsuk-focus-width 0 $nhsuk-link-color;
+  }
+}
+.app-header__navigation-item--with-count {
+  .app-count {
+    @include nhsuk-font(14, $line-height: 1);
+    margin-left: 6px;
+    min-width: nhsuk-spacing(4);
+    padding-bottom: 3px;
+    padding-top: 5px;
+    text-decoration: none;
+  }
+}
+
 .app-header__account {
   border-radius: $nhsuk-border-radius;
   display: flex;
@@ -18,7 +35,7 @@
 
 .app-header__account-item {
   align-items: start;
-  background-color: shade($nhsuk-link-color, 20%);
+  background-color: color.scale($nhsuk-link-color, $lightness: -20%);
   color: $color_nhsuk-white;
   display: inline-flex;
   flex-grow: 1;
@@ -73,20 +90,5 @@
   &:focus,
   &:active {
     text-decoration: none;
-  }
-}
-
-.app-header {
-  .nhsuk-header__search-form {
-    margin-top: 0;
-  }
-
-  .nhsuk-header__navigation-link[aria-current]:not(:focus):not(:active) {
-    text-decoration: none;
-    border-bottom: nhsuk-spacing(1) solid $nhsuk-border-color;
-
-    .nhsuk-header__drop-down & {
-      border-bottom-color: transparent;
-    }
   }
 }

--- a/app/components/app_header_navigation_item_component.rb
+++ b/app/components/app_header_navigation_item_component.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 class AppHeaderNavigationItemComponent < ViewComponent::Base
-  erb_template <<-ERB
-    <li class="nhsuk-header__navigation-item">
-      <%= link_to @title, @path,
-                  class: "nhsuk-header__navigation-link",
-                  aria: { current: current? ? "true" : nil } %>
-    </li>
-  ERB
-
   def initialize(title, path, request_path:)
     super
 
@@ -17,7 +9,27 @@ class AppHeaderNavigationItemComponent < ViewComponent::Base
     @request_path = request_path
   end
 
+  def call
+    tag.li(class: classes) do
+      link_to(
+        @title,
+        @path,
+        class: "nhsuk-header__navigation-link",
+        aria: {
+          current: current? ? "true" : nil
+        }
+      )
+    end
+  end
+
   def current?
     @request_path.starts_with?(@path)
+  end
+
+  def classes
+    [
+      "nhsuk-header__navigation-item",
+      ("app-header__navigation-item--current" if current?)
+    ].compact.join(" ")
   end
 end

--- a/app/components/app_header_navigation_item_component.rb
+++ b/app/components/app_header_navigation_item_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AppHeaderNavigationItemComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <li class="nhsuk-header__navigation-item">
+      <%= link_to @title, @path,
+                  class: "nhsuk-header__navigation-link",
+                  aria: { current: current? ? "true" : nil } %>
+    </li>
+  ERB
+
+  def initialize(title, path, request_path:)
+    super
+
+    @title = title
+    @path = path
+    @request_path = request_path
+  end
+
+  def current?
+    @request_path.starts_with?(@path)
+  end
+end

--- a/app/components/app_header_navigation_item_component.rb
+++ b/app/components/app_header_navigation_item_component.rb
@@ -1,24 +1,24 @@
 # frozen_string_literal: true
 
 class AppHeaderNavigationItemComponent < ViewComponent::Base
-  def initialize(title, path, request_path:)
+  def initialize(title, path, request_path:, count: nil)
     super
 
     @title = title
     @path = path
     @request_path = request_path
+    @count = count
   end
 
   def call
     tag.li(class: classes) do
       link_to(
-        @title,
         @path,
         class: "nhsuk-header__navigation-link",
         aria: {
           current: current? ? "true" : nil
         }
-      )
+      ) { safe_join([@title, count_tag], " ") }
     end
   end
 
@@ -29,7 +29,21 @@ class AppHeaderNavigationItemComponent < ViewComponent::Base
   def classes
     [
       "nhsuk-header__navigation-item",
-      ("app-header__navigation-item--current" if current?)
+      ("app-header__navigation-item--current" if current?),
+      ("app-header__navigation-item--with-count" if show_count?)
     ].compact.join(" ")
+  end
+
+  def show_count?
+    @count != nil
+  end
+
+  def count_tag
+    return "" unless show_count?
+
+    tag.span(class: "app-count") do
+      tag.span("(", class: "nhsuk-u-visually-hidden") + @count.to_s +
+        tag.span(")", class: "nhsuk-u-visually-hidden")
+    end
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -106,6 +106,8 @@ class Patient < ApplicationRecord
   scope :not_restricted, -> { where(restricted_at: nil) }
   scope :restricted, -> { where.not(restricted_at: nil) }
 
+  scope :with_notice, -> { deceased.or(restricted).or(invalidated) }
+
   scope :unvaccinated_for,
         ->(programmes:) do
           includes(:vaccination_records).reject do |patient|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,9 @@ class User < ApplicationRecord
 
   def selected_organisation
     @selected_organisation ||=
-      Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
+      if cis2_info.present?
+        Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
+      end
   end
 
   def requires_email_and_password?

--- a/app/policies/consent_form_policy.rb
+++ b/app/policies/consent_form_policy.rb
@@ -3,7 +3,10 @@
 class ConsentFormPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.where(organisation: user.selected_organisation)
+      organisation = user.selected_organisation
+      return scope.none if organisation.nil?
+
+      scope.where(organisation:)
     end
   end
 end

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -3,7 +3,10 @@
 class PatientPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.in_organisation(user.selected_organisation)
+      organisation = user.selected_organisation
+      return scope.none if organisation.nil?
+
+      scope.in_organisation(organisation)
     end
   end
 end

--- a/app/policies/school_move_policy.rb
+++ b/app/policies/school_move_policy.rb
@@ -4,6 +4,7 @@ class SchoolMovePolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       organisation = user.selected_organisation
+      return scope.none if organisation.nil?
 
       scope
         .where(school: organisation.schools)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -39,58 +39,19 @@
   <% if @show_navigation %>
     <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
       <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
-        <li class="nhsuk-header__navigation-item">
-          <%= link_to t("programmes.index.title"), programmes_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(programmes_path) ?
-                        "true" : nil } %>
-        </li>
-        <li class="nhsuk-header__navigation-item">
-          <%= link_to t("sessions.index.title"), sessions_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(sessions_path) ?
-                        "true" : nil } %>
-        </li>
-        <li class="nhsuk-header__navigation-item">
-          <%= link_to t("patients.index.title"), patients_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(patients_path) ?
-                        "true" : nil } %>
-        </li>
-        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-          <%= link_to t("vaccines.index.title"), vaccines_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(vaccines_path) ?
-                        "true" : nil } %>
-        </li>
-        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-          <%= link_to t("consent_forms.index.title_short"), consent_forms_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(consent_forms_path) ?
-                        "true" : nil } %>
-        </li>
-        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-          <%= link_to t("school_moves.index.title"), school_moves_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(school_moves_path) ?
-                        "true" : nil } %>
-        </li>
+        <%= render AppHeaderNavigationItemComponent.new(t("programmes.index.title"), programmes_path, request_path: request.path) %>
+        <%= render AppHeaderNavigationItemComponent.new(t("sessions.index.title"), sessions_path, request_path: request.path) %>
+        <%= render AppHeaderNavigationItemComponent.new(t("patients.index.title"), patients_path, request_path: request.path) %>
+        <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
+        <%= render AppHeaderNavigationItemComponent.new(t("consent_forms.index.title_short"), consent_forms_path, request_path: request.path) %>
+        <%= render AppHeaderNavigationItemComponent.new(t("school_moves.index.title"), school_moves_path, request_path: request.path) %>
 
         <% if policy(:notices).index? %>
-          <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-            <%= link_to "Notices", notices_path,
-                        class: "nhsuk-header__navigation-link",
-                        aria: { current: request.path.start_with?(notices_path) ?
-                          "true" : nil } %>
-          </li>
+          <%= render AppHeaderNavigationItemComponent.new(t("notices.index.title_short"), notices_path, request_path: request.path) %>
         <% end %>
 
-        <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
-          <%= link_to t("organisations.show.title"), organisation_path,
-                      class: "nhsuk-header__navigation-link",
-                      aria: { current: request.path.start_with?(organisation_path) ?
-                        "true" : nil } %>
-        </li>
+        <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>
+
         <li class="nhsuk-mobile-menu-container">
           <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
             <span class="nhsuk-u-visually-hidden">Browse</span>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -43,11 +43,28 @@
         <%= render AppHeaderNavigationItemComponent.new(t("sessions.index.title"), sessions_path, request_path: request.path) %>
         <%= render AppHeaderNavigationItemComponent.new(t("patients.index.title"), patients_path, request_path: request.path) %>
         <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
-        <%= render AppHeaderNavigationItemComponent.new(t("consent_forms.index.title_short"), consent_forms_path, request_path: request.path) %>
-        <%= render AppHeaderNavigationItemComponent.new(t("school_moves.index.title"), school_moves_path, request_path: request.path) %>
+
+        <%= render AppHeaderNavigationItemComponent.new(
+          t("consent_forms.index.title_short"),
+          consent_forms_path,
+          request_path: request.path,
+          count: policy_scope(ConsentForm).unmatched.recorded.count
+        ) %>
+
+        <%= render AppHeaderNavigationItemComponent.new(
+          t("school_moves.index.title"),
+          school_moves_path,
+          request_path: request.path,
+          count: policy_scope(SchoolMove).count
+        ) %>
 
         <% if policy(:notices).index? %>
-          <%= render AppHeaderNavigationItemComponent.new(t("notices.index.title_short"), notices_path, request_path: request.path) %>
+          <%= render AppHeaderNavigationItemComponent.new(
+            t("notices.index.title_short"),
+            notices_path,
+            request_path: request.path,
+            count: policy_scope(Patient).with_notice.count
+          ) %>
         <% end %>
 
         <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -729,6 +729,7 @@ en:
   notices:
     index:
       title: Important notices
+      title_short: Notices
       no_results: There are currently no important notices.
   mailers:
     consent_form_mailer:

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -106,6 +106,7 @@ describe "Import class lists - Moving patients" do
   end
 
   def then_i_should_see_the_school_moves
+    expect(page).to have_content("School moves (4)")
     expect(page).to have_content("4 school moves")
   end
 

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -283,16 +283,19 @@ describe "Manage children" do
   end
 
   def then_i_see_the_notice_of_date_of_death
+    expect(page).to have_content("Notices (1)")
     expect(page).to have_content(@deceased_patient.full_name)
     expect(page).to have_content("Record updated with child’s date of death")
   end
 
   def then_i_see_the_notice_of_invalid
+    expect(page).to have_content("Notices (1)")
     expect(page).to have_content(@invalidated_patient.full_name)
     expect(page).to have_content("Record flagged as invalid")
   end
 
   def then_i_see_the_notice_of_sensitive
+    expect(page).to have_content("Notices (1)")
     expect(page).to have_content(@restricted_patient.full_name)
     expect(page).to have_content("Record flagged as sensitive")
   end

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -277,6 +277,7 @@ describe "Parental consent school" do
   end
 
   def then_the_nurse_should_see_one_move
+    expect(page).to have_content("School moves (1)")
     expect(page).to have_content("1 school move")
   end
 

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -120,6 +120,7 @@ describe "Parental consent create patient" do
     sign_in @organisation.users.first
     visit "/dashboard"
 
+    expect(page).to have_content("Responses (1)")
     click_on "Responses", match: :first
   end
 


### PR DESCRIPTION
This adds counts to the navigation bar for the consent form responses, important notices and school moves items so hopefully given some indication that there's action to be taken in those pages.

## Screenshot

![Screenshot 2025-01-06 at 09 09 24](https://github.com/user-attachments/assets/a092a504-7ffd-4b32-99db-b1626c7805f4)
