### PR TITLE
Upgrade Brakeman

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (6.2.2)
+    brakeman (7.0.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,6 +24,5 @@
       "note": "Programme names/types come from a limited set of enums."
     }
   ],
-  "updated": "2024-11-17 09:23:51 +0000",
-  "brakeman_version": "6.2.2"
+  "brakeman_version": "7.0.0"
 }


### PR DESCRIPTION
Version 7.0.0 was released on the 30th December with the main change being switching to the Prism Ruby parser made default in Ruby 3.4.

This also resolves a warning about Brakeman being out of date when running it locally.