### PR TITLE
Refactor AppOutcomeBannerComponent

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -21,7 +21,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
 
   def rows
     data =
-      if @patient_session.vaccinated?
+      if vaccination_record&.administered?
         [
           ["Vaccine", vaccine_summary],
           ["Site", vaccination_record.human_enum_name(:delivery_site)],
@@ -47,7 +47,15 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def vaccination_record
-    @vaccination_record ||= @patient_session.latest_vaccination_record
+    @vaccination_record ||=
+      if @patient_session.vaccinated?
+        @patient_session
+          .vaccination_records
+          .select(&:administered?)
+          .max_by(&:created_at)
+      else
+        @patient_session.latest_vaccination_record
+      end
   end
 
   def triage


### PR DESCRIPTION
This refactors the component to correctly handle the situation where a patient was vaccinated in a session, and then a not administered vaccination record was recorded _after_ the administered vaccination record.

In reality this situation won't happen, but it can happen during training, so we should update the component to handle this and avoid presenting users with an internal server error.

https://good-machine.sentry.io/issues/6202199115/