### PR TITLE
Handle invalid characters when encoding as UTF-8

### DIFF
--- a/config/initializers/i18n_nhs_design_system_date_interpolation.rb
+++ b/config/initializers/i18n_nhs_design_system_date_interpolation.rb
@@ -11,9 +11,12 @@ module I18n
       values[:count] = values[:count].to_fs(:long) if values[:count].is_a?(Date)
 
       # Convert any ISO-8859-1 values
-      values[:value] = values[:value].encode("UTF-8") if values[:value].is_a?(
-        String
-      )
+      values[:value] = values[:value].encode(
+        "UTF-8",
+        invalid: :replace,
+        undef: :replace,
+        replace: "?"
+      ) if values[:value].is_a?(String)
 
       # Call the original interpolate method with modified values
       super(locale, string, values)


### PR DESCRIPTION
This ensures that when importing a file with invalid characters that we try and encode as UTF-8, instead of raising an error we present the characters back to the user as `?`.

https://good-machine.sentry.io/issues/6202471696/

This adds a further improvement on top of https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2782 which is already merged in to `main`.