### PR TITLE
Show environment banner on staging environments

### DIFF
--- a/app/assets/stylesheets/_environment.scss
+++ b/app/assets/stylesheets/_environment.scss
@@ -1,0 +1,12 @@
+.app-environment {
+  @include nhsuk-responsive-padding(2, bottom);
+  @include nhsuk-responsive-padding(2, top);
+  @include nhsuk-typography-responsive(14);
+
+  .nhsuk-width-container {
+    align-items: baseline;
+    display: flex;
+    flex-wrap: wrap;
+    gap: nhsuk-spacing(1) nhsuk-spacing(2);
+  }
+}

--- a/app/assets/stylesheets/_tag.scss
+++ b/app/assets/stylesheets/_tag.scss
@@ -1,6 +1,0 @@
-.nhsuk-tag {
-  &--white {
-    font-weight: normal;
-    border-style: dashed;
-  }
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,6 +46,7 @@ $color_app-dark-orange: color.scale(
 @import "card";
 @import "count";
 @import "dev-tools";
+@import "environment";
 @import "file-upload";
 @import "globals";
 @import "header";
@@ -62,7 +63,6 @@ $color_app-dark-orange: color.scale(
 @import "summary-list";
 @import "table";
 @import "tabs";
-@import "tag";
 @import "typography";
 @import "utilities";
 

--- a/app/components/app_hosting_environment_component.rb
+++ b/app/components/app_hosting_environment_component.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class AppHostingEnvironmentComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <div class="app-environment nhsuk-tag--<%= colour %>">
+      <div class="nhsuk-width-container">
+        <strong class="nhsuk-tag nhsuk-tag--<%= colour %>">
+          <%= title %>
+        </strong>
+        <span><%= t("hosting_environment", name:) %></span>
+      </div>
+    </div>
+  ERB
+
+  def render?
+    !Rails.env.production?
+  end
+
+  ENVIRONMENT_COLOR = {
+    development: "white",
+    test: "red",
+    qa: "orange",
+    preview: "yellow",
+    training: "purple"
+  }.freeze
+
+  def title
+    environment.titleize
+  end
+
+  def name
+    return title if environment == "qa"
+
+    environment
+  end
+
+  def colour
+    ENVIRONMENT_COLOR[environment.to_sym]
+  end
+
+  def environment
+    ENV.fetch("SENTRY_ENVIRONMENT", "development")
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,85 +1,89 @@
-<header class="nhsuk-header app-header" role="banner" data-module="nhsuk-header">
-  <div class="nhsuk-header__container">
-    <div class="nhsuk-header__logo">
-      <a class="nhsuk-header__link nhsuk-header__link--service"
-        href="<%= @header_path %>"
-        aria-label="<%= @service_name %>">
-        <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
-          <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
-          <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
-        </svg>
-        <span class="nhsuk-header__service-name">
-          <%= @service_name %>
-        </span>
-      </a>
-    </div>
-    <% if @show_navigation %>
-      <div class="nhsuk-header__content app-header__content">
-        <div class="app-header__account">
-          <span class="app-header__account-item">
-            <svg class="app-header__account-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-              <path fill="currentColor" d="M8 0c4.4 0 8 3.6 8 8s-3.6 8-8 8-8-3.6-8-8 3.6-8 8-8Zm0 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm-1.5 9h3a2.5 2.5 0 0 1 2.5 2.5V14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1.5A2.5 2.5 0 0 1 6.5 10ZM8 9C6.368 9 5 7.684 5 6s1.316-3 3-3c1.632 0 3 1.316 3 3S9.632 9 8 9"></path>
-            </svg>
-            <%= current_user.full_name %> <%= (description = current_user.role_description) ? " (#{description})" : "" %>
+<header>
+  <%= render AppHostingEnvironmentComponent.new %>
+
+  <div class="nhsuk-header app-header" data-module="nhsuk-header">
+    <div class="nhsuk-header__container">
+      <div class="nhsuk-header__logo">
+        <a class="nhsuk-header__link nhsuk-header__link--service"
+           href="<%= @header_path %>"
+           aria-label="<%= @service_name %>">
+          <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
+            <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
+            <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+          </svg>
+          <span class="nhsuk-header__service-name">
+            <%= @service_name %>
           </span>
-          <% if Settings.cis2.enabled %>
-            <span class="app-header__account-item">
-              <%= button_to "Change role", user_cis2_omniauth_authorize_path, class: "app-header__account-button", params: { change_role: true } %>
-            </span>
-          <% end %>
-          <span class="app-header__account-item">
-            <%= button_to "Log out", logout_path,
-                          class: "app-header__account-button", method: :delete %>
-          </span>
-        </div>
+        </a>
       </div>
+      <% if @show_navigation %>
+        <div class="nhsuk-header__content app-header__content">
+          <div class="app-header__account">
+            <span class="app-header__account-item">
+              <svg class="app-header__account-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M8 0c4.4 0 8 3.6 8 8s-3.6 8-8 8-8-3.6-8-8 3.6-8 8-8Zm0 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1Zm-1.5 9h3a2.5 2.5 0 0 1 2.5 2.5V14a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1.5A2.5 2.5 0 0 1 6.5 10ZM8 9C6.368 9 5 7.684 5 6s1.316-3 3-3c1.632 0 3 1.316 3 3S9.632 9 8 9"></path>
+              </svg>
+              <%= current_user.full_name %> <%= (description = current_user.role_description) ? " (#{description})" : "" %>
+            </span>
+            <% if Settings.cis2.enabled %>
+              <span class="app-header__account-item">
+                <%= button_to "Change role", user_cis2_omniauth_authorize_path, class: "app-header__account-button", params: { change_role: true } %>
+              </span>
+            <% end %>
+            <span class="app-header__account-item">
+              <%= button_to "Log out", logout_path,
+                            class: "app-header__account-button", method: :delete %>
+            </span>
+          </div>
+        </div>
+      <% end %>
+    </div>
+
+    <% if @show_navigation %>
+      <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
+        <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
+          <%= render AppHeaderNavigationItemComponent.new(t("programmes.index.title"), programmes_path, request_path: request.path) %>
+          <%= render AppHeaderNavigationItemComponent.new(t("sessions.index.title"), sessions_path, request_path: request.path) %>
+          <%= render AppHeaderNavigationItemComponent.new(t("patients.index.title"), patients_path, request_path: request.path) %>
+
+          <%= render AppHeaderNavigationItemComponent.new(
+            t("consent_forms.index.title_short"),
+            consent_forms_path,
+            request_path: request.path,
+            count: policy_scope(ConsentForm).unmatched.recorded.not_archived.count
+          ) %>
+
+          <%= render AppHeaderNavigationItemComponent.new(
+            t("school_moves.index.title"),
+            school_moves_path,
+            request_path: request.path,
+            count: policy_scope(SchoolMove).count
+          ) %>
+
+          <% if policy(:notices).index? %>
+            <%= render AppHeaderNavigationItemComponent.new(
+              t("notices.index.title_short"),
+              notices_path,
+              request_path: request.path,
+              count: policy_scope(Patient).with_notice.count
+            ) %>
+          <% end %>
+
+          <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
+
+          <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>
+
+          <li class="nhsuk-mobile-menu-container">
+            <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
+              <span class="nhsuk-u-visually-hidden">Browse</span>
+              More
+              <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </button>
+          </li>
+        </ul>
+      </nav>
     <% end %>
   </div>
-
-  <% if @show_navigation %>
-    <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
-      <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
-        <%= render AppHeaderNavigationItemComponent.new(t("programmes.index.title"), programmes_path, request_path: request.path) %>
-        <%= render AppHeaderNavigationItemComponent.new(t("sessions.index.title"), sessions_path, request_path: request.path) %>
-        <%= render AppHeaderNavigationItemComponent.new(t("patients.index.title"), patients_path, request_path: request.path) %>
-
-        <%= render AppHeaderNavigationItemComponent.new(
-          t("consent_forms.index.title_short"),
-          consent_forms_path,
-          request_path: request.path,
-          count: policy_scope(ConsentForm).unmatched.recorded.not_archived.count
-        ) %>
-
-        <%= render AppHeaderNavigationItemComponent.new(
-          t("school_moves.index.title"),
-          school_moves_path,
-          request_path: request.path,
-          count: policy_scope(SchoolMove).count
-        ) %>
-
-        <% if policy(:notices).index? %>
-          <%= render AppHeaderNavigationItemComponent.new(
-            t("notices.index.title_short"),
-            notices_path,
-            request_path: request.path,
-            count: policy_scope(Patient).with_notice.count
-          ) %>
-        <% end %>
-
-        <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
-
-        <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>
-
-        <li class="nhsuk-mobile-menu-container">
-          <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
-            <span class="nhsuk-u-visually-hidden">Browse</span>
-            More
-            <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-            </svg>
-          </button>
-        </li>
-      </ul>
-    </nav>
-  <% end %>
 </header>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -29,6 +29,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "ODS"
   inflect.acronym "OpenID"
   inflect.acronym "PDS"
+  inflect.acronym "QA"
 
   inflect.irregular "batch", "batches"
   inflect.irregular "child", "children"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -723,6 +723,7 @@ en:
         other: Why are they refusing to give consent?
         personal_choice: Why are they refusing to give consent?
         will_be_vaccinated_elsewhere: Where will their child get their vaccination?
+  hosting_environment: This is a %{name} environment. Do not use it to make clinical decisions.
   imports:
     index:
       title: Imports


### PR DESCRIPTION
Styles and markup for an `AppHostingEnvironmentComponent` that renders a banner above the header on all staging environments, giving an environment’s name and assigned colour, default to staging/grey if this cannot be determined.

- Largely inspired by what was used on Apply, meaning parts of this are likely incorrect; do we use `HOSTING_ENVIRONMENT_NAME` variable? If not, where can I get the named environment?
- Do we also have an Heroku review environment that needs to be accounted for?
- Does it need any tests?

Also deleted the custom styling for white tags as we don’t use that anymore. 

## Banners

![Development banner.](https://github.com/user-attachments/assets/847743e6-d6c0-40e9-b926-c470a39358d8)
![Staging banner.](https://github.com/user-attachments/assets/30bdf437-5970-4272-9c9d-7e87549aca26)
![Test banner.](https://github.com/user-attachments/assets/47a22b1f-8564-4995-8c5f-72411f9e4dea)
![QA banner.](https://github.com/user-attachments/assets/6778eb19-639f-491f-8c6a-54a39e69bce2)
![Preview banner.](https://github.com/user-attachments/assets/00267080-4718-41e6-a766-ebcd3f554663)
![Training banner.](https://github.com/user-attachments/assets/fa8b6eea-606f-440b-b2bf-ac959155d235)
