### PR TITLE
Ensure `subsequent_session_dates_offered_message` is present

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -221,7 +221,7 @@ class GovukNotifyPersonalisation
 
   def subsequent_session_dates_offered_message
     dates = session.today_or_future_dates.drop(1)
-    return if dates.empty?
+    return "" if dates.empty?
 
     "If they’re not seen, they’ll be offered the vaccination on #{
       dates.map { _1.to_fs(:short_day_of_week) }.to_sentence

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -64,6 +64,7 @@ describe GovukNotifyPersonalisation do
         programme_name: "HPV",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",
+        subsequent_session_dates_offered_message: "",
         team_email: "organisation@example.com",
         team_name: "Organisation",
         team_phone: "01234 567890",

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -35,6 +35,7 @@ describe SessionMailer do
           :parent_full_name,
           :short_patient_name,
           :short_patient_name_apos,
+          :subsequent_session_dates_offered_message,
           :team_email,
           :team_name,
           :team_phone,


### PR DESCRIPTION
This is an optional personalisation variable that we send to GOV.UK Notify and is used in the session reminder emails. Previously we were not sending this variable when not present, but that was causing a bug where the emails couldn't be sent as GOV.UK Notify would raise a client bad request error when the template variable was missing. Instead we can send it to GOV.UK Notify as a blank string.

https://good-machine.sentry.io/issues/5805756718/?environment=production&project=4505625073876992