### PR TITLE
Validate date of birth in past

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -50,7 +50,11 @@ class ImmunisationImportRow
   validates :patient_nhs_number, length: { is: 10 }, allow_blank: true
   validates :patient_first_name, presence: true
   validates :patient_last_name, presence: true
-  validates :patient_date_of_birth, presence: true
+  validates :patient_date_of_birth,
+            presence: true,
+            comparison: {
+              less_than: -> { Date.current }
+            }
   validates :patient_gender_code, inclusion: { in: Patient.gender_codes.keys }
   validates :patient_postcode,
             postcode: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,7 +263,7 @@ en:
               equal_to: Enter an organisation code that matches the current organisation.
             patient_date_of_birth:
               blank: Enter a date of birth in the correct format.
-              inclusion: is not part of this programme
+              less_than: Enter a date of birth in the past.
             patient_first_name:
               blank: Enter a first name.
             patient_gender_code:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -248,6 +248,9 @@ describe ImmunisationImportRow do
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:patient_date_of_birth]).to eq(
+          ["Enter a date of birth in the past."]
+        )
       end
     end
 


### PR DESCRIPTION
When importing vaccination records we should validate that the date of birth for the patient is in the past, it doesn't make sense for the date to be in the future.

This validation was covered implicitly by the year group being in the programme which was removed to handle customising the year groups of the patients in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2780 so this is just a small amendment to that change to avoid a regression.