### PR TITLE
Avoid duplicate `DATE_OF_BIRTH` errors

### DIFF
--- a/app/models/cohort.rb
+++ b/app/models/cohort.rb
@@ -35,4 +35,6 @@ class Cohort < ApplicationRecord
 
           where(birth_academic_year: birth_academic_years)
         end
+
+  validates :birth_academic_year, comparison: { greater_than_or_equal_to: 1990 }
 end

--- a/app/models/concerns/year_group_concern.rb
+++ b/app/models/concerns/year_group_concern.rb
@@ -3,13 +3,6 @@
 module YearGroupConcern
   extend ActiveSupport::Concern
 
-  included do
-    validates :birth_academic_year,
-              comparison: {
-                greater_than_or_equal_to: 1990
-              }
-  end
-
   def year_group
     return nil if birth_academic_year.nil?
 

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -51,7 +51,6 @@ class ImmunisationImportRow
   validates :patient_first_name, presence: true
   validates :patient_last_name, presence: true
   validates :patient_date_of_birth,
-            presence: true,
             comparison: {
               less_than: -> { Date.current }
             }

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -166,6 +166,8 @@ class Patient < ApplicationRecord
 
   validate :gp_practice_is_correct_type
 
+  validates :birth_academic_year, comparison: { greater_than_or_equal_to: 1990 }
+
   encrypts :preferred_family_name,
            :preferred_given_name,
            :address_postcode,

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -5,6 +5,11 @@ class PatientImportRow
   include YearGroupConcern
 
   validates :date_of_birth, presence: true
+  validates :birth_academic_year,
+            comparison: {
+              greater_than_or_equal_to: 1990
+            },
+            if: :date_of_birth
   validates :existing_patients, length: { maximum: 1 }
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
         parent_2_relationship: <code>PARENT_2_RELATIONSHIP</code>
         preferred_family_name: <code>CHILD_PREFERRED_LAST_NAME</code>
         preferred_given_name: <code>CHILD_PREFERRED_FIRST_NAME</code>
+        year_group: <code>CHILD_YEAR_GROUP</code>
       cohort_import_row:
         address_line_1: <code>CHILD_ADDRESS_LINE_1</code>
         address_line_2: <code>CHILD_ADDRESS_LINE_2</code>
@@ -44,6 +45,7 @@ en:
         preferred_family_name: <code>CHILD_PREFERRED_LAST_NAME</code>
         preferred_given_name: <code>CHILD_PREFERRED_FIRST_NAME</code>
         school_urn: <code>CHILD_SCHOOL_URN</code>
+        year_group: <code>CHILD_YEAR_GROUP</code>
       immunisation_import_row:
         administered: <code>VACCINATED</code>
         batch_expiry_date: <code>BATCH_EXPIRY_DATE</code>

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -52,13 +52,10 @@ describe ClassImportRow do
 
       it "is invalid" do
         expect(class_import_row).to be_invalid
-        expect(class_import_row.errors.size).to eq(2)
+        expect(class_import_row.errors.size).to eq(1)
         expect(class_import_row.errors[:date_of_birth]).to contain_exactly(
           "is required but missing"
         )
-        expect(
-          class_import_row.errors[:birth_academic_year]
-        ).to contain_exactly("is required but missing")
       end
     end
   end

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -70,13 +70,10 @@ describe CohortImportRow do
 
       it "is invalid" do
         expect(cohort_import_row).to be_invalid
-        expect(cohort_import_row.errors.size).to eq(2)
+        expect(cohort_import_row.errors.size).to eq(1)
         expect(cohort_import_row.errors[:date_of_birth]).to contain_exactly(
           "is required but missing"
         )
-        expect(
-          cohort_import_row.errors[:birth_academic_year]
-        ).to contain_exactly("is required but missing")
       end
     end
   end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -85,6 +85,9 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row.errors[:organisation_code]).to eq(
           ["Enter an organisation code that matches the current organisation."]
         )
+        expect(immunisation_import_row.errors[:patient_date_of_birth]).to eq(
+          ["Enter a date of birth in the correct format."]
+        )
         expect(immunisation_import_row.errors[:patient_gender_code]).to eq(
           ["Enter a gender or gender code."]
         )


### PR DESCRIPTION
This fixes a few minor visual issues spotted by the testers when testing https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2780 where if the date of birth is missing the same error will appear twice for each row, and similarly an issue where the year group wouldn't render correctly.

This fixes are already in place for a future release (in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2783 and https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2784), however including them now makes the testing easier and avoids needing to record additional defects.

## Screenshots

![{CFD5D2F8-A8E7-40F1-B323-45361B94AB3A}](https://github.com/user-attachments/assets/c2cec1ef-2f5f-42c6-adc6-89b333c68282)
![{9A759A33-DF06-4FCC-9F59-9B9C8FF22271}](https://github.com/user-attachments/assets/6e022805-4ab5-4452-8363-e90d8e9c7227)
