### PR TITLE
Ignore restricted patients from sorting and filtering

### DIFF
--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -106,6 +106,17 @@ describe PatientSortingConcern do
           %w[Blair Alex Casey]
         )
       end
+
+      context "when a patient is restricted" do
+        before { blair.update!(restricted_at: Time.current) }
+
+        it "they are treated as though they have no postcode" do
+          controller.sort_patients!(patient_sessions)
+          expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
+            %w[Alex Casey Blair]
+          )
+        end
+      end
     end
 
     context "when sort parameter is missing" do
@@ -138,6 +149,15 @@ describe PatientSortingConcern do
         controller.filter_patients!(patient_sessions)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Blair")
+      end
+
+      context "when a patient is restricted" do
+        before { blair.update!(restricted_at: Time.current) }
+
+        it "excludes the patient from the result" do
+          controller.filter_patients!(patient_sessions)
+          expect(patient_sessions.size).to eq(0)
+        end
       end
     end
 

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -194,7 +194,7 @@ describe "Patient sorting and filtering" do
 
   def when_i_filter_by_dob
     alex = Patient.find_by(given_name: "Alex")
-    fill_in "Date of birth", with: alex.date_of_birth.year
+    fill_in "Date of birth", with: alex.date_of_birth.strftime("%d/%m/%Y")
   end
 
   def then_i_see_patients_with_dob


### PR DESCRIPTION
This prevents information about restricted patients being leaked inadvertently, as although the information itself was not shown, by using the sorting and filtering functionality it's possible to guess what the value might be.

Instead we now treat restricted patients as having no postcode for the purpose of filtering and sorting.