### PR TITLE
Improve email address and phone number normalisation

### DIFF
--- a/app/lib/email_address_normaliser.rb
+++ b/app/lib/email_address_normaliser.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EmailAddressNormaliser
+  def call(value)
+    value.blank? ? nil : value.downcase.strip
+  end
+end

--- a/app/lib/phone_number_normaliser.rb
+++ b/app/lib/phone_number_normaliser.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PhoneNumberNormaliser
+  def call(value)
+    Phonelib
+      .parse(value)
+      .then { it.country == "GB" ? it.national : it.international }
+  end
+end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -131,10 +131,9 @@ class ConsentForm < ApplicationRecord
 
   normalizes :given_name, with: -> { _1.strip }
   normalizes :family_name, with: -> { _1.strip }
-  normalizes :parent_phone,
-             with: -> { _1.blank? ? nil : _1.to_s.gsub(/\s/, "") }
-  normalizes :parent_email,
-             with: -> { _1.blank? ? nil : _1.to_s.downcase.strip }
+
+  normalizes :parent_email, with: EmailAddressNormaliser.new
+  normalizes :parent_phone, with: PhoneNumberNormaliser.new
 
   validates :programme, inclusion: { in: -> { _1.organisation.programmes } }
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -45,6 +45,9 @@ class Organisation < ApplicationRecord
 
   has_and_belongs_to_many :users
 
+  normalizes :email, with: EmailAddressNormaliser.new
+  normalizes :phone, with: PhoneNumberNormaliser.new
+
   validates :careplus_venue_code, presence: true
   validates :email, notify_safe_email: true
   validates :name, presence: true, uniqueness: true

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -40,13 +40,8 @@ class Parent < ApplicationRecord
   encrypts :email, :full_name, :phone, deterministic: true
   encrypts :contact_method_other_details
 
-  normalizes :phone,
-             with: ->(phone) do
-               Phonelib
-                 .parse(phone)
-                 .then { |p| p.country == "GB" ? p.national : p.international }
-             end
-  normalizes :email, with: -> { _1.blank? ? nil : _1.to_s.downcase.strip }
+  normalizes :email, with: EmailAddressNormaliser.new
+  normalizes :phone, with: PhoneNumberNormaliser.new
 
   validates :phone,
             presence: {

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -29,6 +29,9 @@ class Team < ApplicationRecord
   has_many :community_clinics, -> { community_clinic }, class_name: "Location"
   has_many :schools, -> { school }, class_name: "Location"
 
+  normalizes :email, with: EmailAddressNormaliser.new
+  normalizes :phone, with: PhoneNumberNormaliser.new
+
   validates :name, presence: true, uniqueness: { scope: :organisation }
   validates :email, notify_safe_email: true
   validates :phone, presence: true, phone: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,8 @@ class User < ApplicationRecord
   encrypts :email, deterministic: true
   encrypts :family_name, :given_name
 
+  normalizes :email, with: EmailAddressNormaliser.new
+
   validates :family_name, :given_name, presence: true, length: { maximum: 255 }
 
   validates :email,

--- a/spec/components/app_consent_form_summary_component_spec.rb
+++ b/spec/components/app_consent_form_summary_component_spec.rb
@@ -8,7 +8,7 @@ describe AppConsentFormSummaryComponent do
       name: "Jane Smith",
       relationship: "Mum",
       contact: {
-        phone: "07987654321",
+        phone: "07987 654321",
         email: "jane@example.com"
       },
       response: {
@@ -24,7 +24,7 @@ describe AppConsentFormSummaryComponent do
 
   it { should have_text("Jane Smith") }
   it { should have_text("Mum") }
-  it { should have_text("07987654321") }
+  it { should have_text("07987 654321") }
   it { should have_text("jane@example.com") }
   it { should have_text("Consent refused (online)") }
   it { should have_text("1 March 2024 at 2:23pm") }

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -121,7 +121,7 @@ describe "Parental consent" do
   end
 
   def and_i_receive_a_text_confirming_that_my_child_wont_be_vaccinated
-    expect_text_to "07123456789", :consent_confirmation_refused
+    expect_text_to "07123 456789", :consent_confirmation_refused
   end
 
   def when_the_nurse_checks_the_consent_responses

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -136,7 +136,7 @@ describe "Parental consent" do
   end
 
   def and_i_get_a_confirmation_text
-    expect_text_to("07123456789", :consent_confirmation_given)
+    expect_text_to("07123 456789", :consent_confirmation_given)
   end
 
   def when_the_nurse_checks_the_consent_responses

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -85,6 +85,6 @@ describe "Verbal consent" do
   end
 
   def and_i_a_text_is_sent_to_the_parent_confirming_their_consent
-    expect_text_to("07987654321", :consent_confirmation_given)
+    expect_text_to("07987 654321", :consent_confirmation_given)
   end
 end

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -100,7 +100,7 @@ describe TextDeliveryJob do
 
       it "sends a text using GOV.UK Notify" do
         expect(notifications_client).to receive(:send_sms).with(
-          phone_number: "01234567890",
+          phone_number: "01234 567890",
           template_id: GOVUK_NOTIFY_TEXT_TEMPLATES[template_name],
           personalisation: an_instance_of(Hash)
         )
@@ -112,7 +112,7 @@ describe TextDeliveryJob do
 
         notify_log_entry = NotifyLogEntry.last
         expect(notify_log_entry).to be_sms
-        expect(notify_log_entry.recipient).to eq("01234567890")
+        expect(notify_log_entry.recipient).to eq("01234 567890")
         expect(notify_log_entry.template_id).to eq(
           GOVUK_NOTIFY_TEXT_TEMPLATES[template_name]
         )

--- a/spec/mailers/session_mailer_spec.rb
+++ b/spec/mailers/session_mailer_spec.rb
@@ -57,7 +57,7 @@ describe SessionMailer do
         :team,
         name: "SAIS organisation",
         email: "sais@example.com",
-        phone: "07987654321",
+        phone: "07987 654321",
         organisation:
       )
     end
@@ -89,7 +89,7 @@ describe SessionMailer do
 
       it { should include(team_name: "SAIS organisation") }
       it { should include(team_email: "sais@example.com") }
-      it { should include(team_phone: "07987654321") }
+      it { should include(team_phone: "07987 654321") }
     end
   end
 
@@ -108,7 +108,7 @@ describe SessionMailer do
         :team,
         name: "SAIS organisation",
         email: "sais@example.com",
-        phone: "07987654321",
+        phone: "07987 654321",
         organisation:
       )
     end
@@ -140,7 +140,7 @@ describe SessionMailer do
 
       it { should include(team_name: "SAIS organisation") }
       it { should include(team_email: "sais@example.com") }
-      it { should include(team_phone: "07987654321") }
+      it { should include(team_phone: "07987 654321") }
     end
   end
 end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -307,6 +307,9 @@ describe ConsentForm do
   it { should normalize(:family_name).from(" Smith ").to("Smith") }
   it { should normalize(:address_postcode).from(" SW111AA ").to("SW11 1AA") }
 
+  it_behaves_like "a model with a normalised email address", :parent_email
+  it_behaves_like "a model with a normalised phone number", :parent_phone
+
   describe "#full_name" do
     it "returns the full name as a string" do
       consent_form =
@@ -655,54 +658,6 @@ describe ConsentForm do
     it "summarises the consent form when consent is refused" do
       consent_form = build(:consent_form, response: "refused")
       expect(consent_form.summary_with_route).to eq("Consent refused (online)")
-    end
-  end
-
-  describe "#parent_phone=" do
-    subject(:normalised_parent_phone) do
-      build(:consent_form, parent_phone: phone).parent_phone
-    end
-
-    context "with non-numeric characters" do
-      let(:phone) { "01234 567890" }
-
-      it { should eq("01234567890") }
-    end
-
-    context "when nil" do
-      let(:phone) { nil }
-
-      it { should be_nil }
-    end
-
-    context "when blank" do
-      let(:phone) { "" }
-
-      it { should be_nil }
-    end
-  end
-
-  describe "#parent_email=" do
-    subject(:normalised_parent_email) do
-      build(:consent_form, parent_email: email).parent_email
-    end
-
-    context "with whitespace and capitalised letters" do
-      let(:email) { "  joHn@doe.com " }
-
-      it { should eq("john@doe.com") }
-    end
-
-    context "when nil" do
-      let(:email) { nil }
-
-      it { should be_nil }
-    end
-
-    context "when blank" do
-      let(:email) { "" }
-
-      it { should be_nil }
     end
   end
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -40,6 +40,9 @@ describe Organisation do
 
   it { should normalize(:ods_code).from(" r1a ").to("R1A") }
 
+  it_behaves_like "a model with a normalised email address"
+  it_behaves_like "a model with a normalised phone number"
+
   describe "#community_clinics" do
     let(:clinic_locations) { create_list(:community_clinic, 3, organisation:) }
 

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -32,13 +32,8 @@ describe Parent do
     end
   end
 
-  it { should normalize(:email).from("  joHn@doe.com ").to("john@doe.com") }
-  it { should normalize(:email).from("").to(nil) }
-
-  it { should normalize(:phone).from(" 01234 567890 ").to("01234 567890") }
-  it { should normalize(:phone).from("1234567890").to("01234 567890") } # leading zero lost by Excel, say
-  it { should normalize(:phone).from("+35361234567").to("+353 61 234 567") }
-  it { should normalize(:phone).from("").to(nil) }
+  it_behaves_like "a model with a normalised email address"
+  it_behaves_like "a model with a normalised phone number"
 
   describe "#contactable?" do
     subject(:contactable?) { parent.contactable? }

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -25,6 +25,9 @@
 describe Team do
   subject(:team) { build(:team) }
 
+  it_behaves_like "a model with a normalised email address"
+  it_behaves_like "a model with a normalised phone number"
+
   describe "validations" do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:email) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,8 @@
 describe User do
   subject(:user) { build(:user) }
 
+  it_behaves_like "a model with a normalised email address"
+
   describe "validations" do
     it { should validate_presence_of(:given_name) }
     it { should validate_presence_of(:family_name) }

--- a/spec/support/shared_examples/a_model_with_a_normalised_email_address.rb
+++ b/spec/support/shared_examples/a_model_with_a_normalised_email_address.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+shared_examples_for "a model with a normalised email address" do |column = :email|
+  it { should normalize(column).from(nil).to(nil) }
+  it { should normalize(column).from("").to(nil) }
+
+  it do
+    expect(subject).to normalize(column).from("  joHn@doe.com ").to(
+      "john@doe.com"
+    )
+  end
+end

--- a/spec/support/shared_examples/a_model_with_a_normalised_phone_number.rb
+++ b/spec/support/shared_examples/a_model_with_a_normalised_phone_number.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+shared_examples_for "a model with a normalised phone number" do |column = :phone|
+  it { should normalize(column).from(nil).to(nil) }
+  it { should normalize(column).from("").to(nil) }
+
+  it do
+    expect(subject).to normalize(column).from("  01234567890 ").to(
+      "01234 567890"
+    )
+  end
+
+  it { should normalize(column).from("1234567890").to("01234 567890") }
+
+  it do
+    expect(subject).to normalize(column).from("+441234567890").to(
+      "01234 567890"
+    )
+  end
+
+  it do
+    expect(subject).to normalize(column).from("0033123456789").to(
+      "+33 1 23 45 67 89"
+    )
+  end
+end


### PR DESCRIPTION
This improves how the email addresses and phone numbers are normalised to make it easier to perform string comparisons on the values to match up consent form email addresses and phone numbers with parent email addresses and phone numbers. This is necessary to support the work to match failed email/phone number attempts in Notify with consent forms, where don't have a reference to the parent or patient instance.

The existing email addresses and phone numbers that weren't previously normalised won't be updated by this. We may choose not to modify those existing values and only apply this going forward, or we can add a Rake task to fix those not normalised values later.