### PR TITLE
Link text delivery with GOV.UK Notify IDs

### DIFF
--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -9,9 +9,10 @@
 #  type            :integer          not null
 #  created_at      :datetime         not null
 #  consent_form_id :bigint
+#  delivery_id     :uuid
 #  patient_id      :bigint
 #  sent_by_user_id :bigint
-#  template_id     :string           not null
+#  template_id     :uuid             not null
 #
 # Indexes
 #

--- a/db/migrate/20250113142937_add_delivery_id_to_notify_log_entries.rb
+++ b/db/migrate/20250113142937_add_delivery_id_to_notify_log_entries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddDeliveryIdToNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def up
+    change_table :notify_log_entries, bulk: true do |t|
+      t.uuid :delivery_id
+      t.change :template_id, :uuid, null: false, using: "template_id::uuid"
+    end
+  end
+
+  def down
+    change_table :notify_log_entries, bulk: true do |t|
+      t.change :template_id, :string, null: false
+      t.remove :delivery_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_18_155027) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_13_142937) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -462,12 +462,13 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_18_155027) do
 
   create_table "notify_log_entries", force: :cascade do |t|
     t.integer "type", null: false
-    t.string "template_id", null: false
+    t.uuid "template_id", null: false
     t.string "recipient", null: false
     t.datetime "created_at", null: false
     t.bigint "consent_form_id"
     t.bigint "patient_id"
     t.bigint "sent_by_user_id"
+    t.uuid "delivery_id"
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
     t.index ["patient_id"], name: "index_notify_log_entries_on_patient_id"
     t.index ["sent_by_user_id"], name: "index_notify_log_entries_on_sent_by_user_id"

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -9,9 +9,10 @@
 #  type            :integer          not null
 #  created_at      :datetime         not null
 #  consent_form_id :bigint
+#  delivery_id     :uuid
 #  patient_id      :bigint
 #  sent_by_user_id :bigint
-#  template_id     :string           not null
+#  template_id     :uuid             not null
 #
 # Indexes
 #
@@ -29,6 +30,8 @@ FactoryBot.define do
   factory :notify_log_entry do
     patient
     consent_form
+
+    delivery_id { SecureRandom.uuid }
 
     trait :email do
       type { "email" }

--- a/spec/jobs/text_delivery_job_spec.rb
+++ b/spec/jobs/text_delivery_job_spec.rb
@@ -8,16 +8,22 @@ describe TextDeliveryJob do
 
   after(:all) { Rails.configuration.action_mailer.delivery_method = :test }
 
+  let(:response) do
+    instance_double(
+      Notifications::Client::ResponseNotification,
+      id: SecureRandom.uuid
+    )
+  end
+  let(:notifications_client) { instance_double(Notifications::Client) }
+
   before do
     allow(Notifications::Client).to receive(:new).with("abc").and_return(
       notifications_client
     )
-    allow(notifications_client).to receive(:send_sms)
+    allow(notifications_client).to receive(:send_sms).and_return(response)
   end
 
   after { described_class.instance_variable_set("@client", nil) }
-
-  let(:notifications_client) { instance_double(Notifications::Client) }
 
   describe "#perform_now" do
     subject(:perform_now) do
@@ -74,6 +80,7 @@ describe TextDeliveryJob do
 
       notify_log_entry = NotifyLogEntry.last
       expect(notify_log_entry).to be_sms
+      expect(notify_log_entry.delivery_id).to eq(response.id)
       expect(notify_log_entry.recipient).to eq("01234 567890")
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_TEXT_TEMPLATES[template_name]
@@ -112,6 +119,7 @@ describe TextDeliveryJob do
 
         notify_log_entry = NotifyLogEntry.last
         expect(notify_log_entry).to be_sms
+        expect(notify_log_entry.delivery_id).to eq(response.id)
         expect(notify_log_entry.recipient).to eq("01234 567890")
         expect(notify_log_entry.template_id).to eq(
           GOVUK_NOTIFY_TEXT_TEMPLATES[template_name]

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -9,9 +9,10 @@
 #  type            :integer          not null
 #  created_at      :datetime         not null
 #  consent_form_id :bigint
+#  delivery_id     :uuid
 #  patient_id      :bigint
 #  sent_by_user_id :bigint
-#  template_id     :string           not null
+#  template_id     :uuid             not null
 #
 # Indexes
 #


### PR DESCRIPTION
This ensures that when sending a text message we store the ID of the message returned to us from GOV.UK Notify. This allows us to link up text message delivery failures with the original delivery request that triggered the response, allowing for this to be shown to users in the future.