### PR TITLE
Retry text delivery server errors

### DIFF
--- a/app/jobs/notify_delivery_job.rb
+++ b/app/jobs/notify_delivery_job.rb
@@ -3,6 +3,8 @@
 class NotifyDeliveryJob < ApplicationJob
   queue_as { Rails.configuration.action_mailer.deliver_later_queue_name }
 
+  retry_on Notifications::Client::ServerError, wait: :polynomially_longer
+
   def self.client
     @client ||=
       Notifications::Client.new(


### PR DESCRIPTION
If the text could not be delivered due to a server error, i.e. an issue with GOV.UK Notify, then we should keep trying to send these to avoid needing to manually re-send them via the Good Job dashboard.