### PR TITLE
Use GOV.UK Notify directly to send emails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,7 @@ Rails/UnknownEnv:
 
 RSpec/BeforeAfterAll:
   Exclude:
+    - spec/jobs/email_delivery_job_spec.rb
     - spec/jobs/sms_delivery_job_spec.rb
 
 RSpec/ContextWording:

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -13,21 +13,21 @@ module TriageMailerConcern
     params = { consent:, session:, sent_by: current_user }
 
     if vaccination_will_happen?(patient_session, consent)
-      TriageMailer.with(params).vaccination_will_happen.deliver_later
+      EmailDeliveryJob.perform_later(:triage_vaccination_will_happen, **params)
     elsif vaccination_wont_happen?(patient_session, consent)
-      TriageMailer.with(params).vaccination_wont_happen.deliver_later
+      EmailDeliveryJob.perform_later(:triage_vaccination_wont_happen, **params)
     elsif vaccination_at_clinic?(patient_session, consent)
-      TriageMailer.with(params).vaccination_at_clinic.deliver_later
+      EmailDeliveryJob.perform_later(:triage_vaccination_at_clinic, **params)
     elsif consent.triage_needed?
-      ConsentMailer.with(params).confirmation_triage.deliver_later
+      EmailDeliveryJob.perform_later(:consent_confirmation_triage, **params)
     elsif consent.response_refused?
-      ConsentMailer.with(params).confirmation_refused.deliver_later
+      EmailDeliveryJob.perform_later(:consent_confirmation_refused, **params)
 
       if consent.parent.phone_receive_updates
         SMSDeliveryJob.perform_later(:consent_confirmation_refused, **params)
       end
     elsif consent.response_given?
-      ConsentMailer.with(params).confirmation_given.deliver_later
+      EmailDeliveryJob.perform_later(:consent_confirmation_given, **params)
 
       if consent.parent.phone_receive_updates
         SMSDeliveryJob.perform_later(:consent_confirmation_given, **params)

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class EmailDeliveryJob < NotifyDeliveryJob
+  def perform(
+    template_name,
+    consent: nil,
+    consent_form: nil,
+    parent: nil,
+    patient: nil,
+    patient_session: nil,
+    programme: nil,
+    sent_by: nil,
+    session: nil,
+    vaccination_record: nil
+  )
+    template_id = GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name.to_sym]
+    raise UnknownTemplate if template_id.nil?
+
+    email_address =
+      consent_form&.parent_email || consent&.parent&.email || parent&.email
+    return if email_address.nil?
+
+    organisation =
+      session&.organisation || patient_session&.organisation ||
+        consent_form&.organisation || consent&.organisation ||
+        vaccination_record&.organisation
+
+    personalisation =
+      GovukNotifyPersonalisation.call(
+        session:,
+        consent:,
+        consent_form:,
+        patient:,
+        patient_session:,
+        programme:,
+        vaccination_record:
+      )
+
+    args = {
+      email_address:,
+      email_reply_to_id: organisation.reply_to_id,
+      personalisation:,
+      template_id:
+    }
+
+    delivery_id =
+      if self.class.send_via_notify?
+        self.class.client.send_email(**args).id
+      elsif self.class.send_via_test?
+        self.class.deliveries << args
+        SecureRandom.uuid
+      else
+        Rails.logger.info "Sending email to #{email_address} with template #{template_id}"
+        nil
+      end
+
+    patient ||= consent&.patient || patient_session&.patient
+
+    NotifyLogEntry.create!(
+      consent_form:,
+      delivery_id:,
+      patient:,
+      recipient: email_address,
+      sent_by:,
+      template_id:,
+      type: :email
+    )
+  end
+end

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -11,10 +11,9 @@ describe ConsentFormMailerConcern do
     end
 
     it "sends a confirmation email" do
-      expect { send_consent_form_confirmation }.to have_enqueued_mail(
-        ConsentMailer,
-        :confirmation_given
-      ).with(params: { consent_form: }, args: [])
+      expect { send_consent_form_confirmation }.to have_delivered_email(
+        :consent_confirmation_given
+      ).with(consent_form:)
     end
 
     it "sends a consent given text" do
@@ -27,10 +26,9 @@ describe ConsentFormMailerConcern do
       before { consent_form.contact_injection = true }
 
       it "sends an injection confirmation email" do
-        expect { send_consent_form_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_injection
-        ).with(params: { consent_form: }, args: [])
+        expect { send_consent_form_confirmation }.to have_delivered_email(
+          :consent_confirmation_injection
+        ).with(consent_form:)
       end
 
       it "doesn't send a text" do
@@ -42,10 +40,9 @@ describe ConsentFormMailerConcern do
       before { consent_form.response = :refused }
 
       it "sends an confirmation refused email" do
-        expect { send_consent_form_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_refused
-        ).with(params: { consent_form: }, args: [])
+        expect { send_consent_form_confirmation }.to have_delivered_email(
+          :consent_confirmation_refused
+        ).with(consent_form:)
       end
 
       it "sends a consent refused text" do
@@ -59,10 +56,9 @@ describe ConsentFormMailerConcern do
       before { consent_form.health_answers.last.response = "yes" }
 
       it "sends an confirmation needs triage email" do
-        expect { send_consent_form_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_triage
-        ).with(params: { consent_form: }, args: [])
+        expect { send_consent_form_confirmation }.to have_delivered_email(
+          :consent_confirmation_triage
+        ).with(consent_form:)
       end
 
       it "doesn't send a text" do
@@ -85,10 +81,9 @@ describe ConsentFormMailerConcern do
       end
 
       it "sends an confirmation needs triage email" do
-        expect { send_consent_form_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_clinic
-        ).with(params: { consent_form: }, args: [])
+        expect { send_consent_form_confirmation }.to have_delivered_email(
+          :consent_confirmation_clinic
+        ).with(consent_form:)
       end
 
       it "doesn't send a text" do

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -32,10 +32,9 @@ describe TriageMailerConcern do
       end
 
       it "sends an email saying triage was needed and vaccination will happen" do
-        expect { send_triage_confirmation }.to have_enqueued_mail(
-          TriageMailer,
-          :vaccination_will_happen
-        ).with(params: { consent:, session:, sent_by: current_user }, args: [])
+        expect { send_triage_confirmation }.to have_delivered_email(
+          :triage_vaccination_will_happen
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "doesn't send a text message" do
@@ -49,10 +48,9 @@ describe TriageMailerConcern do
       end
 
       it "sends an email saying triage was needed but vaccination won't happen" do
-        expect { send_triage_confirmation }.to have_enqueued_mail(
-          TriageMailer,
-          :vaccination_wont_happen
-        ).with(params: { consent:, session:, sent_by: current_user }, args: [])
+        expect { send_triage_confirmation }.to have_delivered_email(
+          :triage_vaccination_wont_happen
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "doesn't send a text message" do
@@ -64,10 +62,9 @@ describe TriageMailerConcern do
       let(:patient_session) { create(:patient_session, :delay_vaccination) }
 
       it "sends an email saying triage was needed but vaccination won't happen" do
-        expect { send_triage_confirmation }.to have_enqueued_mail(
-          TriageMailer,
-          :vaccination_at_clinic
-        ).with(params: { consent:, session:, sent_by: current_user }, args: [])
+        expect { send_triage_confirmation }.to have_delivered_email(
+          :triage_vaccination_at_clinic
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "doesn't send a text message" do
@@ -81,10 +78,9 @@ describe TriageMailerConcern do
       end
 
       it "sends an email saying vaccination will happen" do
-        expect { send_triage_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_given
-        ).with(params: { consent:, session:, sent_by: current_user }, args: [])
+        expect { send_triage_confirmation }.to have_delivered_email(
+          :consent_confirmation_given
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "sends a text message" do
@@ -100,10 +96,9 @@ describe TriageMailerConcern do
       end
 
       it "sends an email saying triage is required" do
-        expect { send_triage_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_triage
-        ).with(params: { consent:, session:, sent_by: current_user }, args: [])
+        expect { send_triage_confirmation }.to have_delivered_email(
+          :consent_confirmation_triage
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "doesn't send a text message" do
@@ -115,7 +110,7 @@ describe TriageMailerConcern do
       let(:patient_session) { create(:patient_session, :consent_not_provided) }
 
       it "doesn't send an email" do
-        expect { send_triage_confirmation }.not_to have_enqueued_email
+        expect { send_triage_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do
@@ -136,7 +131,7 @@ describe TriageMailerConcern do
       end
 
       it "doesn't send an email" do
-        expect { send_triage_confirmation }.not_to have_enqueued_email
+        expect { send_triage_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do
@@ -148,10 +143,9 @@ describe TriageMailerConcern do
       let(:patient_session) { create(:patient_session, :consent_refused) }
 
       it "sends an email confirming they've refused consent" do
-        expect { send_triage_confirmation }.to have_enqueued_mail(
-          ConsentMailer,
-          :confirmation_refused
-        ).with(params: { consent:, session:, sent_by: current_user }, args: [])
+        expect { send_triage_confirmation }.to have_delivered_email(
+          :consent_confirmation_refused
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "sends a text message" do
@@ -166,7 +160,7 @@ describe TriageMailerConcern do
       let(:patient_session) { create(:patient_session, patient:) }
 
       it "doesn't send an email" do
-        expect { send_triage_confirmation }.not_to have_enqueued_email
+        expect { send_triage_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do
@@ -179,7 +173,7 @@ describe TriageMailerConcern do
       let(:patient_session) { create(:patient_session, patient:) }
 
       it "doesn't send an email" do
-        expect { send_triage_confirmation }.not_to have_enqueued_email
+        expect { send_triage_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do
@@ -192,7 +186,7 @@ describe TriageMailerConcern do
       let(:patient_session) { create(:patient_session, patient:) }
 
       it "doesn't send an email" do
-        expect { send_triage_confirmation }.not_to have_enqueued_email
+        expect { send_triage_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -37,17 +37,9 @@ describe VaccinationMailerConcern do
       before { create(:consent, :given, patient:, programme:) }
 
       it "sends an email" do
-        expect { send_vaccination_confirmation }.to have_enqueued_mail(
-          VaccinationMailer,
-          :confirmation_administered
-        ).with(
-          params: {
-            parent:,
-            vaccination_record:,
-            sent_by: current_user
-          },
-          args: []
-        )
+        expect { send_vaccination_confirmation }.to have_delivered_email(
+          :vaccination_confirmation_administered
+        ).with(parent:, vaccination_record:, sent_by: current_user)
       end
 
       it "sends a text message" do
@@ -70,17 +62,9 @@ describe VaccinationMailerConcern do
       end
 
       it "sends an email" do
-        expect { send_vaccination_confirmation }.to have_enqueued_mail(
-          VaccinationMailer,
-          :confirmation_not_administered
-        ).with(
-          params: {
-            parent:,
-            vaccination_record:,
-            sent_by: current_user
-          },
-          args: []
-        )
+        expect { send_vaccination_confirmation }.to have_delivered_email(
+          :vaccination_confirmation_not_administered
+        ).with(parent:, vaccination_record:, sent_by: current_user)
       end
 
       it "sends a text message" do
@@ -108,17 +92,9 @@ describe VaccinationMailerConcern do
         end
 
         it "sends an email" do
-          expect { send_vaccination_confirmation }.to have_enqueued_mail(
-            VaccinationMailer,
-            :confirmation_administered
-          ).with(
-            params: {
-              parent:,
-              vaccination_record:,
-              sent_by: current_user
-            },
-            args: []
-          )
+          expect { send_vaccination_confirmation }.to have_delivered_email(
+            :vaccination_confirmation_administered
+          ).with(parent:, vaccination_record:, sent_by: current_user)
         end
 
         it "sends a text message" do
@@ -132,7 +108,7 @@ describe VaccinationMailerConcern do
         before { create(:consent, :given, :self_consent, patient:, programme:) }
 
         it "doesn't send an email" do
-          expect { send_vaccination_confirmation }.not_to have_enqueued_mail
+          expect { send_vaccination_confirmation }.not_to have_delivered_email
         end
 
         it "doesn't send a text message" do
@@ -145,7 +121,7 @@ describe VaccinationMailerConcern do
       let(:patient) { create(:patient, :deceased) }
 
       it "doesn't send an email" do
-        expect { send_vaccination_confirmation }.not_to have_enqueued_email
+        expect { send_vaccination_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do
@@ -157,7 +133,7 @@ describe VaccinationMailerConcern do
       let(:patient) { create(:patient, :invalidated) }
 
       it "doesn't send an email" do
-        expect { send_vaccination_confirmation }.not_to have_enqueued_email
+        expect { send_vaccination_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do
@@ -169,7 +145,7 @@ describe VaccinationMailerConcern do
       let(:patient) { create(:patient, :restricted) }
 
       it "doesn't send an email" do
-        expect { send_vaccination_confirmation }.not_to have_enqueued_email
+        expect { send_vaccination_confirmation }.not_to have_delivered_email
       end
 
       it "doesn't send a text message" do

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -220,7 +220,7 @@ describe "Delete vaccination record" do
   end
 
   def and_the_parent_doesnt_receives_an_email
-    expect(sent_emails).to be_empty
+    expect(email_deliveries).to be_empty
   end
 
   def then_i_cant_click_on_delete_vaccination_record

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -489,7 +489,7 @@ describe "Edit vaccination record" do
   end
 
   def then_the_parent_doesnt_receive_an_email
-    expect(sent_emails).to be_empty
+    expect(email_deliveries).to be_empty
   end
 
   alias_method :and_the_parent_doesnt_receive_an_email,

--- a/spec/features/scheduled_consent_requests_spec.rb
+++ b/spec/features/scheduled_consent_requests_spec.rb
@@ -109,7 +109,7 @@ describe "Scheduled consent requests" do
   def then_no_consent_requests_have_been_sent
     SchoolConsentRequestsJob.perform_now
 
-    expect(sent_emails).to be_empty
+    expect(email_deliveries).to be_empty
     expect(sms_deliveries).to be_empty
   end
 

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+describe EmailDeliveryJob do
+  before(:all) do
+    Rails.configuration.action_mailer.delivery_method = :notify
+    Rails.configuration.action_mailer.notify_settings = { api_key: "abc" }
+  end
+
+  after(:all) { Rails.configuration.action_mailer.delivery_method = :test }
+
+  let(:response) do
+    instance_double(
+      Notifications::Client::ResponseNotification,
+      id: SecureRandom.uuid
+    )
+  end
+  let(:notifications_client) { instance_double(Notifications::Client) }
+
+  before do
+    allow(Notifications::Client).to receive(:new).with("abc").and_return(
+      notifications_client
+    )
+    allow(notifications_client).to receive(:send_email).and_return(response)
+  end
+
+  after { described_class.instance_variable_set("@client", nil) }
+
+  describe "#perform_now" do
+    subject(:perform_now) do
+      described_class.perform_now(
+        template_name,
+        session:,
+        consent:,
+        consent_form:,
+        parent:,
+        patient:,
+        patient_session:,
+        programme:,
+        sent_by:,
+        vaccination_record:
+      )
+    end
+
+    let(:template_name) { GOVUK_NOTIFY_EMAIL_TEMPLATES.keys.first }
+    let(:programme) { create(:programme) }
+    let(:organisation) do
+      create(
+        :organisation,
+        reply_to_id: "54bf1d28-8851-43f2-893d-1853f43a50cd",
+        programmes: [programme]
+      )
+    end
+    let(:session) { create(:session, programme:, organisation:) }
+    let(:parent) { create(:parent, email: "test@example.com") }
+    let(:consent) { nil }
+    let(:consent_form) { nil }
+    let(:patient) { create(:patient) }
+    let(:patient_session) { nil }
+    let(:sent_by) { create(:user) }
+    let(:vaccination_record) { nil }
+
+    it "generates personalisation" do
+      expect(GovukNotifyPersonalisation).to receive(:call).with(
+        session:,
+        consent:,
+        consent_form:,
+        patient:,
+        patient_session:,
+        programme:,
+        vaccination_record:
+      )
+      perform_now
+    end
+
+    it "sends a text using GOV.UK Notify" do
+      expect(notifications_client).to receive(:send_email).with(
+        email_address: "test@example.com",
+        email_reply_to_id: "54bf1d28-8851-43f2-893d-1853f43a50cd",
+        personalisation: an_instance_of(Hash),
+        template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+      )
+      perform_now
+    end
+
+    it "creates a log entry" do
+      expect { perform_now }.to change(NotifyLogEntry, :count).by(1)
+
+      notify_log_entry = NotifyLogEntry.last
+      expect(notify_log_entry).to be_email
+      expect(notify_log_entry.delivery_id).to eq(response.id)
+      expect(notify_log_entry.recipient).to eq("test@example.com")
+      expect(notify_log_entry.template_id).to eq(
+        GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+      )
+      expect(notify_log_entry.patient).to eq(patient)
+      expect(notify_log_entry.sent_by).to eq(sent_by)
+    end
+
+    context "when the parent doesn't have an email address" do
+      let(:parent) { create(:parent, email: nil) }
+
+      it "doesn't send a text" do
+        expect(notifications_client).not_to receive(:send_email)
+        perform_now
+      end
+    end
+
+    context "with a consent form" do
+      let(:consent_form) do
+        create(
+          :consent_form,
+          programme:,
+          session:,
+          parent_email: "test@example.com"
+        )
+      end
+      let(:parent) { nil }
+      let(:patient) { nil }
+
+      it "sends a text using GOV.UK Notify" do
+        expect(notifications_client).to receive(:send_email).with(
+          email_address: "test@example.com",
+          email_reply_to_id: "54bf1d28-8851-43f2-893d-1853f43a50cd",
+          personalisation: an_instance_of(Hash),
+          template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+        )
+        perform_now
+      end
+
+      it "creates a log entry" do
+        expect { perform_now }.to change(NotifyLogEntry, :count).by(1)
+
+        notify_log_entry = NotifyLogEntry.last
+        expect(notify_log_entry).to be_email
+        expect(notify_log_entry.delivery_id).to eq(response.id)
+        expect(notify_log_entry.recipient).to eq("test@example.com")
+        expect(notify_log_entry.template_id).to eq(
+          GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+        )
+        expect(notify_log_entry.consent_form).to eq(consent_form)
+      end
+
+      context "when the parent doesn't have a phone number" do
+        let(:consent_form) do
+          create(:consent_form, programme:, session:, parent_email: nil)
+        end
+
+        it "doesn't send a text" do
+          expect(notifications_client).not_to receive(:send_email)
+          perform_now
+        end
+      end
+    end
+  end
+
+  describe "#perform_later" do
+    subject(:perform_later) do
+      described_class.perform_later(GOVUK_NOTIFY_EMAIL_TEMPLATES.keys.first)
+    end
+
+    it "uses the mailer queue" do
+      expect { perform_later }.to have_enqueued_job(described_class).on_queue(
+        :mailer
+      )
+    end
+  end
+end

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -73,27 +73,20 @@ describe ConsentNotification do
       end
 
       it "enqueues an email per parent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          ConsentMailer,
-          :school_request
+        expect { create_and_send! }.to have_delivered_email(
+          :consent_school_request
         ).with(
-          params: {
-            parent: parents.first,
-            patient:,
-            programme:,
-            session:,
-            sent_by: current_user
-          },
-          args: []
-        ).and have_enqueued_mail(ConsentMailer, :school_request).with(
-                params: {
-                  parent: parents.second,
-                  patient:,
-                  programme:,
-                  session:,
-                  sent_by: current_user
-                },
-                args: []
+          parent: parents.first,
+          patient:,
+          programme:,
+          session:,
+          sent_by: current_user
+        ).and have_delivered_email(:consent_school_request).with(
+                parent: parents.second,
+                patient:,
+                programme:,
+                session:,
+                sent_by: current_user
               )
       end
 
@@ -143,27 +136,20 @@ describe ConsentNotification do
       end
 
       it "enqueues an email per parent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          ConsentMailer,
-          :clinic_request
+        expect { create_and_send! }.to have_delivered_email(
+          :consent_clinic_request
         ).with(
-          params: {
-            parent: parents.first,
-            patient:,
-            programme:,
-            session:,
-            sent_by: current_user
-          },
-          args: []
-        ).and have_enqueued_mail(ConsentMailer, :clinic_request).with(
-                params: {
-                  parent: parents.second,
-                  patient:,
-                  programme:,
-                  session:,
-                  sent_by: current_user
-                },
-                args: []
+          parent: parents.first,
+          patient:,
+          programme:,
+          session:,
+          sent_by: current_user
+        ).and have_delivered_email(:consent_clinic_request).with(
+                parent: parents.second,
+                patient:,
+                programme:,
+                session:,
+                sent_by: current_user
               )
       end
 
@@ -212,27 +198,20 @@ describe ConsentNotification do
       end
 
       it "enqueues an email per parent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          ConsentMailer,
-          :school_initial_reminder
+        expect { create_and_send! }.to have_delivered_email(
+          :consent_school_initial_reminder
         ).with(
-          params: {
-            parent: parents.first,
-            patient:,
-            programme:,
-            session:,
-            sent_by: current_user
-          },
-          args: []
-        ).and have_enqueued_mail(ConsentMailer, :school_initial_reminder).with(
-                params: {
-                  parent: parents.second,
-                  patient:,
-                  programme:,
-                  session:,
-                  sent_by: current_user
-                },
-                args: []
+          parent: parents.first,
+          patient:,
+          programme:,
+          session:,
+          sent_by: current_user
+        ).and have_delivered_email(:consent_school_initial_reminder).with(
+                parent: parents.second,
+                patient:,
+                programme:,
+                session:,
+                sent_by: current_user
               )
       end
 
@@ -281,30 +260,20 @@ describe ConsentNotification do
       end
 
       it "enqueues an email per parent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          ConsentMailer,
-          :school_subsequent_reminder
+        expect { create_and_send! }.to have_delivered_email(
+          :consent_school_subsequent_reminder
         ).with(
-          params: {
-            parent: parents.first,
-            patient:,
-            programme:,
-            session:,
-            sent_by: current_user
-          },
-          args: []
-        ).and have_enqueued_mail(
-                ConsentMailer,
-                :school_subsequent_reminder
-              ).with(
-                params: {
-                  parent: parents.second,
-                  patient:,
-                  programme:,
-                  session:,
-                  sent_by: current_user
-                },
-                args: []
+          parent: parents.first,
+          patient:,
+          programme:,
+          session:,
+          sent_by: current_user
+        ).and have_delivered_email(:consent_school_subsequent_reminder).with(
+                parent: parents.second,
+                patient:,
+                programme:,
+                session:,
+                sent_by: current_user
               )
       end
 

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -69,17 +69,9 @@ describe SessionNotification do
       end
 
       it "enqueues an email per parent who gave consent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          SessionMailer,
-          :school_reminder
-        ).with(
-          params: {
-            consent:,
-            patient_session:,
-            sent_by: current_user
-          },
-          args: []
-        )
+        expect { create_and_send! }.to have_delivered_email(
+          :session_school_reminder
+        ).with(consent:, patient_session:, sent_by: current_user)
       end
 
       it "enqueues a text per parent" do
@@ -111,26 +103,16 @@ describe SessionNotification do
       end
 
       it "enqueues an email per parent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          SessionMailer,
-          :clinic_initial_invitation
+        expect { create_and_send! }.to have_delivered_email(
+          :session_clinic_initial_invitation
         ).with(
-          params: {
-            parent: parents.first,
-            patient_session:,
-            sent_by: current_user
-          },
-          args: []
-        ).and have_enqueued_mail(
-                SessionMailer,
-                :clinic_initial_invitation
-              ).with(
-                params: {
-                  parent: parents.second,
-                  patient_session:,
-                  sent_by: current_user
-                },
-                args: []
+          parent: parents.first,
+          patient_session:,
+          sent_by: current_user
+        ).and have_delivered_email(:session_clinic_initial_invitation).with(
+                parent: parents.second,
+                patient_session:,
+                sent_by: current_user
               )
       end
 
@@ -175,26 +157,16 @@ describe SessionNotification do
       end
 
       it "enqueues an email per parent" do
-        expect { create_and_send! }.to have_enqueued_mail(
-          SessionMailer,
-          :clinic_subsequent_invitation
+        expect { create_and_send! }.to have_delivered_email(
+          :session_clinic_subsequent_invitation
         ).with(
-          params: {
-            parent: parents.first,
-            patient_session:,
-            sent_by: current_user
-          },
-          args: []
-        ).and have_enqueued_mail(
-                SessionMailer,
-                :clinic_subsequent_invitation
-              ).with(
-                params: {
-                  parent: parents.second,
-                  patient_session:,
-                  sent_by: current_user
-                },
-                args: []
+          parent: parents.first,
+          patient_session:,
+          sent_by: current_user
+        ).and have_delivered_email(:session_clinic_subsequent_invitation).with(
+                parent: parents.second,
+                patient_session:,
+                sent_by: current_user
               )
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -202,7 +202,7 @@ RSpec.configure do |config|
   config.after(:each, :js) { WebMock.disable_net_connect! }
 
   config.before do
-    ActionMailer::Base.deliveries.clear
+    EmailDeliveryJob.deliveries.clear
     SMSDeliveryJob.deliveries.clear
   end
 

--- a/spec/support/email_expectations.rb
+++ b/spec/support/email_expectations.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 module EmailExpectations
-  def expect_email_to(to, template_name, nth = :first)
+  def expect_email_to(email_address, template_name, nth = :first)
     template_id = GOVUK_NOTIFY_EMAIL_TEMPLATES.fetch(template_name)
 
     email =
       if nth == :any
-        sent_emails.find do |e|
-          e.to.include?(to) && e.template_id == template_id
+        email_deliveries.find do
+          it[:email_address] == email_address && it[:template_id] == template_id
         end
       else
-        sent_emails.send(nth)
+        email_deliveries.send(nth)
       end
 
     expect(email).not_to be_nil
-    expect(email.to).to eq([to])
-    expect(email.template_id).to eq(template_id)
+    expect(email[:email_address]).to eq(email_address)
+    expect(email[:template_id]).to eq(template_id)
   end
 
-  def sent_emails
+  def email_deliveries
     perform_enqueued_jobs
 
-    ActionMailer::Base.deliveries
+    EmailDeliveryJob.deliveries
   end
 end

--- a/spec/support/matchers/have_delivered_email.rb
+++ b/spec/support/matchers/have_delivered_email.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.matcher :have_delivered_email do |template_name = nil|
+  supports_block_expectations
+
+  chain :with do |params|
+    @params = params
+  end
+
+  match do |actual|
+    expect { actual.call }.to have_enqueued_job(EmailDeliveryJob).with(
+      *[template_name].compact,
+      **(@params || {})
+    )
+  end
+
+  match_when_negated do |actual|
+    expect { actual.call }.not_to have_enqueued_job(EmailDeliveryJob).with(
+      *[template_name].compact,
+      **(@params || {})
+    )
+  end
+end


### PR DESCRIPTION
This adds a new job, similar to the `SMSDeliveryJob` that allows us to send emails using GOV.UK Notify directly rather than going via `ActionMailer`. Using the API directly allows us to record the delivery message ID, which we can then use to get the status of the receipt later on and present this information to users.

By switching to this job we get automatic retry behaviour on GOV.UK Notify server errors, and tracking of message IDs.