### PR TITLE
Update docker build step packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libpq-dev node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y build-essential git libpq-dev \
+      libyaml-dev node-gyp pkg-config python-is-python3 zlib1g-dev && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install JavaScript dependencies


### PR DESCRIPTION
It looks like `psych` and `charlock_holmes` depend on `libyaml-dev` and `zlib1g-dev` to build native extensions. It's unclear why the build worked before without them.

This is being added to the 1.2.0 release as a hotfix to ensure we can deploy successfully.