### PR TITLE
Add ability to mark unmatched consent forms as invalid

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -112,7 +112,11 @@ class ConsentsController < ApplicationController
         @patient_session.triages.invalidate_all
       end
 
-      redirect_to session_patient_consent_path
+      redirect_to session_patient_consent_path,
+                  flash: {
+                    success:
+                      "Consent response from #{@consent.name} marked as invalid"
+                  }
     else
       render :invalidate, status: :unprocessable_entity
     end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -15,6 +15,7 @@
 #  family_name                         :text
 #  given_name                          :text
 #  health_answers                      :jsonb            not null
+#  invalidated_at                      :datetime
 #  nhs_number                          :string
 #  parent_contact_method_other_details :string
 #  parent_contact_method_type          :string

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -17,6 +17,7 @@
 #  health_answers                      :jsonb            not null
 #  invalidated_at                      :datetime
 #  nhs_number                          :string
+#  notes                               :text             default(""), not null
 #  parent_contact_method_other_details :string
 #  parent_contact_method_type          :string
 #  parent_email                        :string

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -64,6 +64,7 @@ class ConsentForm < ApplicationRecord
   include AddressConcern
   include AgeConcern
   include FullNameConcern
+  include Invalidatable
   include WizardStepConcern
 
   before_save :reset_unused_fields
@@ -170,6 +171,8 @@ class ConsentForm < ApplicationRecord
             if: :parent_relationship_other?
 
   validates :reason_notes, length: { maximum: 1000 }
+
+  validates :notes, presence: { if: :invalidated? }, length: { maximum: 1000 }
 
   normalizes :nhs_number, with: -> { _1.blank? ? nil : _1.gsub(/\s/, "") }
 

--- a/app/views/consent_forms/index.html.erb
+++ b/app/views/consent_forms/index.html.erb
@@ -24,10 +24,14 @@
                 row.with_cell(text: consent_form.parent_full_name)
                 row.with_cell do
                   tag.ul(class: "app-action-list") do
-                    match_link = link_to("Match with record", consent_form)
                     create_link = link_to("Create record", patient_consent_form_path(consent_form))
+                    invalidate_link = link_to("Mark as invalid", invalidate_consent_form_path(consent_form))
+                    match_link = link_to("Match with record", consent_form)
         
-                    links = [tag.li(class: "app-action-list__item") { match_link }]
+                    links = [
+                      tag.li(class: "app-action-list__item") { match_link },
+                      tag.li(class: "app-action-list__item") { invalidate_link },
+                    ]
         
                     if consent_form.nhs_number.present?
                       links << tag.li(class: "app-action-list__item") { create_link }

--- a/app/views/consent_forms/invalidate.html.erb
+++ b/app/views/consent_forms/invalidate.html.erb
@@ -1,19 +1,19 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_consent_path, name: "consent page") %>
+  <%= render AppBacklinkComponent.new(consent_form_path, name: "consent page") %>
 <% end %>
 
-<%= form_with model: @consent, url: invalidate_session_patient_consent_path, method: :post do |f| %>
+<%= form_with model: @consent_form, url: invalidate_consent_form_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
   <% page_title = "Mark response as invalid" %>
   <%= h1 page_title: do %>
     <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-      Consent response from <%= @consent.name %>
+      Consent response from <%= @consent_form.parent_full_name %>
     </span>
     <%= page_title %>
   <% end %>
 
-  <p class="nhsuk-body">This operation cannot be undone.</p>
+  <p class="nhsuk-body">The unmatched response will be hidden. This operation cannot be undone.</p>
 
   <%= f.govuk_text_area :notes, label: { text: "Notes", size: "m" } %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -47,7 +47,7 @@
           t("consent_forms.index.title_short"),
           consent_forms_path,
           request_path: request.path,
-          count: policy_scope(ConsentForm).unmatched.recorded.count
+          count: policy_scope(ConsentForm).unmatched.recorded.not_invalidated.count
         ) %>
 
         <%= render AppHeaderNavigationItemComponent.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -481,6 +481,9 @@ en:
             given_name:
               blank: Enter a first name
               too_long: Enter a first name that is less than 300 characters long
+            notes:
+              blank: Enter notes
+              too_long: Enter notes that are less than %{count} characters long
             parent_contact_method_type:
               inclusion: Choose a contact method
             parent_contact_method_other_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,9 @@ Rails.application.routes.draw do
       get "match/:patient_id", action: :edit_match, as: :match
       post "match/:patient_id", action: :update_match
 
+      get "invalidate", action: :edit_invalidate
+      post "invalidate", action: :update_invalidate
+
       get "patient", action: :new_patient
       post "patient", action: :create_patient
     end

--- a/db/migrate/20250114113856_add_invalidated_at_to_consent_forms.rb
+++ b/db/migrate/20250114113856_add_invalidated_at_to_consent_forms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddInvalidatedAtToConsentForms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :consent_forms, :invalidated_at, :datetime
+  end
+end

--- a/db/migrate/20250114150405_add_notes_to_consent_forms.rb
+++ b/db/migrate/20250114150405_add_notes_to_consent_forms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotesToConsentForms < ActiveRecord::Migration[8.0]
+  def change
+    add_column :consent_forms, :notes, :text, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_13_142937) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_14_113856) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -198,6 +198,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_13_142937) do
     t.string "preferred_family_name"
     t.integer "education_setting"
     t.string "nhs_number"
+    t.datetime "invalidated_at"
     t.index ["consent_id"], name: "index_consent_forms_on_consent_id"
     t.index ["location_id"], name: "index_consent_forms_on_location_id"
     t.index ["nhs_number"], name: "index_consent_forms_on_nhs_number"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_14_113856) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_14_150405) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -199,6 +199,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_14_113856) do
     t.integer "education_setting"
     t.string "nhs_number"
     t.datetime "invalidated_at"
+    t.text "notes", default: "", null: false
     t.index ["consent_id"], name: "index_consent_forms_on_consent_id"
     t.index ["location_id"], name: "index_consent_forms_on_location_id"
     t.index ["nhs_number"], name: "index_consent_forms_on_nhs_number"

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -15,6 +15,7 @@
 #  family_name                         :text
 #  given_name                          :text
 #  health_answers                      :jsonb            not null
+#  invalidated_at                      :datetime
 #  nhs_number                          :string
 #  parent_contact_method_other_details :string
 #  parent_contact_method_type          :string

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -111,6 +111,10 @@ FactoryBot.define do
       ]
     end
 
+    trait :invalidated do
+      invalidated_at { Time.current }
+    end
+
     trait :refused do
       response { :refused }
       reason { :personal_choice }

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -17,6 +17,7 @@
 #  health_answers                      :jsonb            not null
 #  invalidated_at                      :datetime
 #  nhs_number                          :string
+#  notes                               :text             default(""), not null
 #  parent_contact_method_other_details :string
 #  parent_contact_method_type          :string
 #  parent_email                        :string

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -108,6 +108,9 @@ describe "Invalidate consent" do
 
   def then_i_see_the_consent_has_been_invalidated
     expect(page).to have_content("Invalid")
+    expect(page).to have_content(
+      "Consent response from #{@parent.full_name} marked as invalid"
+    )
   end
 
   def and_i_cant_mark_as_invalid

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 describe "Parental consent manual matching" do
-  scenario "Consent isn't matched automatically so nurse matches it manually" do
-    given_the_app_is_setup
+  before { given_the_app_is_setup }
 
+  scenario "Consent isn't matched automatically so nurse matches it manually" do
     when_i_go_to_the_dashboard
     and_i_click_on_unmatched_consent_responses
     then_i_am_on_the_unmatched_responses_page
+    and_i_see_one_response
 
     when_i_choose_a_consent_response
     then_i_am_on_the_consent_matching_page
@@ -20,6 +21,21 @@ describe "Parental consent manual matching" do
 
     when_i_click_on_the_activity_log
     then_i_see_the_consent_was_matched_manually
+  end
+
+  scenario "Consent is marked as invalid" do
+    when_i_go_to_the_dashboard
+    and_i_click_on_unmatched_consent_responses
+    then_i_am_on_the_unmatched_responses_page
+    and_i_see_one_response
+
+    when_i_choose_to_mark_the_response_as_invalid
+    then_i_fill_in_the_notes
+    and_i_mark_the_response_as_invalid
+
+    then_i_am_on_the_unmatched_responses_page
+    and_i_see_the_marked_as_invalid_message
+    and_i_see_no_responses
   end
 
   def given_the_app_is_setup
@@ -36,7 +52,13 @@ describe "Parental consent manual matching" do
         programme: @programme
       )
     @consent_form =
-      create(:consent_form, :recorded, programme: @programme, session: @session)
+      create(
+        :consent_form,
+        :recorded,
+        programme: @programme,
+        session: @session,
+        parent_full_name: "John Smith"
+      )
     @patient = create(:patient, session: @session)
   end
 
@@ -51,6 +73,9 @@ describe "Parental consent manual matching" do
 
   def then_i_am_on_the_unmatched_responses_page
     expect(page).to have_content("Unmatched consent responses")
+  end
+
+  def and_i_see_one_response
     expect(page).to have_content("1 unmatched consent response")
   end
 
@@ -89,6 +114,30 @@ describe "Parental consent manual matching" do
   def then_i_see_the_consent_was_matched_manually
     expect(page).to have_content(
       "Consent response manually matched with child record"
+    )
+  end
+
+  def when_i_choose_to_mark_the_response_as_invalid
+    click_on "Mark as invalid"
+  end
+
+  def then_i_fill_in_the_notes
+    fill_in "Notes", with: "Some notes."
+  end
+
+  def and_i_mark_the_response_as_invalid
+    click_on "Mark as invalid"
+  end
+
+  def and_i_see_the_marked_as_invalid_message
+    expect(page).to have_content(
+      "Consent response from John Smith marked as invalid"
+    )
+  end
+
+  def and_i_see_no_responses
+    expect(page).to have_content(
+      "There are currently no unmatched consent responses."
     )
   end
 end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -15,6 +15,7 @@
 #  family_name                         :text
 #  given_name                          :text
 #  health_answers                      :jsonb            not null
+#  invalidated_at                      :datetime
 #  nhs_number                          :string
 #  parent_contact_method_other_details :string
 #  parent_contact_method_type          :string

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -17,6 +17,7 @@
 #  health_answers                      :jsonb            not null
 #  invalidated_at                      :datetime
 #  nhs_number                          :string
+#  notes                               :text             default(""), not null
 #  parent_contact_method_other_details :string
 #  parent_contact_method_type          :string
 #  parent_email                        :string


### PR DESCRIPTION
This adds some new functionality allowing nurses to mark unmatched consent forms as invalid, meaning that they will disappear from the list of unmatched consent responses reducing work for the SAIS team who need to look through the list.

We know that sometimes consent responses are provided for patients who aren't in the cohort, so the only action to take with these is to mark them as invalid. Although we will stop showing them on the page, we will continue to store the information internally so we can surface them later.

## Screenshots

<img width="1141" alt="Screenshot 2025-01-14 at 15 36 49" src="https://github.com/user-attachments/assets/9007a3e7-2abb-47e0-9d9e-2ded7e2db1c2" />
<img width="788" alt="Screenshot 2025-01-14 at 16 07 04" src="https://github.com/user-attachments/assets/de0343e2-e67b-4908-8c89-6d813b935c2c" />
<img width="796" alt="Screenshot 2025-01-14 at 16 07 10" src="https://github.com/user-attachments/assets/5eb6585c-6d1c-4526-bd87-8014899c21b7" />

