### PR TITLE
Update unmatched consent responses table design

### DIFF
--- a/app/views/consent_forms/index.html.erb
+++ b/app/views/consent_forms/index.html.erb
@@ -1,42 +1,48 @@
 <%= h1 t(".title"), size: "xl" %>
 
-<%= render AppCardComponent.new do |card|
-      card.with_heading { pluralize(@pagy.count, "consent response") }
-    
-      govuk_table(classes: "nhsuk-u-margin-0") do |table|
-        table.with_head do |head|
-          head.with_row do |row|
-            row.with_cell(text: "Response date", html_attributes: { "data-col": "date" })
-            row.with_cell(text: "Child", html_attributes: { "data-col": "child" })
-            row.with_cell(text: "Parent or guardian", html_attributes: { "data-col": "parent" })
-            row.with_cell(text: "Action", html_attributes: { "no-sort": true })
+<% if @consent_forms.any? %>
+  <div class="nhsuk-table__panel-with-heading-tab">
+    <h3 class="nhsuk-table__heading-tab">
+      <%= pluralize(@pagy.count, "unmatched consent response") %>
+    </h3>
+
+    <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table|
+          table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(text: "Response date", html_attributes: { "data-col": "date" })
+              row.with_cell(text: "Child", html_attributes: { "data-col": "child" })
+              row.with_cell(text: "Parent or guardian", html_attributes: { "data-col": "parent" })
+              row.with_cell(text: "Action", html_attributes: { "no-sort": true })
+            end
           end
-        end
-    
-        table.with_body do |body|
-          @consent_forms.each do |consent_form|
-            body.with_row do |row|
-              row.with_cell(text: consent_form.recorded_at.to_date.to_fs(:long))
-              row.with_cell(text: consent_form.full_name)
-              row.with_cell(text: consent_form.parent_full_name)
-              row.with_cell do
-                tag.ul(class: "app-action-list") do
-                  match_link = link_to("Match with record", consent_form)
-                  create_link = link_to("Create record", patient_consent_form_path(consent_form))
-    
-                  links = [tag.li(class: "app-action-list__item") { match_link }]
-    
-                  if consent_form.nhs_number.present?
-                    links << tag.li(class: "app-action-list__item") { create_link }
+        
+          table.with_body do |body|
+            @consent_forms.each do |consent_form|
+              body.with_row do |row|
+                row.with_cell(text: consent_form.recorded_at.to_date.to_fs(:long))
+                row.with_cell(text: consent_form.full_name)
+                row.with_cell(text: consent_form.parent_full_name)
+                row.with_cell do
+                  tag.ul(class: "app-action-list") do
+                    match_link = link_to("Match with record", consent_form)
+                    create_link = link_to("Create record", patient_consent_form_path(consent_form))
+        
+                    links = [tag.li(class: "app-action-list__item") { match_link }]
+        
+                    if consent_form.nhs_number.present?
+                      links << tag.li(class: "app-action-list__item") { create_link }
+                    end
+        
+                    safe_join(links)
                   end
-    
-                  safe_join(links)
                 end
               end
             end
           end
-        end
-      end
-    end %>
+        end %>
+  </div>
 
-<%= govuk_pagination(pagy: @pagy) %>
+  <%= govuk_pagination(pagy: @pagy) %>
+<% else %>
+  <p class="nhsuk-body">There are currently no unmatched consent responses.</p>
+<% end %>

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -151,7 +151,9 @@ describe "Parental consent create patient" do
   end
 
   def and_the_unmatched_consent_responses_page_is_empty
-    expect(page).to have_content("0 consent responses")
+    expect(page).to have_content(
+      "There are currently no unmatched consent responses."
+    )
   end
 
   def when_they_check_triage

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -51,7 +51,7 @@ describe "Parental consent manual matching" do
 
   def then_i_am_on_the_unmatched_responses_page
     expect(page).to have_content("Unmatched consent responses")
-    expect(page).to have_content("1 consent response")
+    expect(page).to have_content("1 unmatched consent response")
   end
 
   def when_i_choose_a_consent_response


### PR DESCRIPTION
This updates the design of unmatched consent responses table to match the latest designs in the prototype with the blue bar at the top of the table showing the total number of unmatched consent responses.

This was spotted by the testers when testing #2808 so we can include this as part of that change in 1.3.0.

## Screenshots

<img width="1154" alt="Screenshot 2025-01-14 at 16 16 59" src="https://github.com/user-attachments/assets/baec9178-f08e-4713-b2d7-04f645b110d9" />
