### PR TITLE
Validate batch numbers using separate worksheet(s)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :test do
       branch: "main"
   gem "capybara-screenshot"
   gem "cuprite"
+  gem "its"
   gem "rspec"
   gem "rspec-html-matchers"
   gem "rubyXL"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,8 @@ GEM
     irb (1.14.3)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    its (0.2.0)
+      rspec-core
     jaro_winkler (1.5.6)
     jmespath (1.6.2)
     jsbundling-rails (1.3.1)
@@ -736,6 +738,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   govuk_markdown
   hotwire-livereload
+  its
   jsbundling-rails
   jsonb_accessor
   jwt

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -13,6 +13,8 @@ class Reports::OfflineSessionExporter
     # stree-ignore
     Axlsx::Package
       .new { |package|
+        package.use_shared_strings = true
+
         add_vaccinations_sheet(package)
         add_reference_sheet package,
                             name: "Performing Professionals",
@@ -37,8 +39,6 @@ class Reports::OfflineSessionExporter
   delegate :location, :organisation, to: :session
 
   def add_vaccinations_sheet(package)
-    package.use_shared_strings = true
-
     workbook = package.workbook
 
     cached_styles = CachedStyles.new(workbook)
@@ -61,8 +61,6 @@ class Reports::OfflineSessionExporter
   end
 
   def add_reference_sheet(package, name:, values_name:, values:)
-    package.use_shared_strings = true
-
     workbook = package.workbook
     workbook.add_worksheet(name:, state: :hidden) do |sheet|
       sheet.sheet_protection
@@ -74,8 +72,6 @@ class Reports::OfflineSessionExporter
   end
 
   def add_batch_numbers_sheets(package)
-    package.use_shared_strings = true
-
     session.programmes.map do |programme|
       add_reference_sheet package,
                           name: "#{programme.type} Batch Numbers",

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -237,7 +237,7 @@ class Reports::OfflineSessionExporter
     )
     row[:performing_professional_email] = Cell.new(
       vaccination_record.performed_by_user&.email,
-      allowed_formula: "=#{performing_professionals_range}"
+      allowed_formula: performing_professionals_range
     )
     row[:batch_number] = Cell.new(
       batch&.name,
@@ -273,7 +273,7 @@ class Reports::OfflineSessionExporter
       allowed_values: vaccine_values_for_programme(programme)
     )
     row[:performing_professional_email] = Cell.new(
-      allowed_formula: "=#{performing_professionals_range}"
+      allowed_formula: performing_professionals_range
     )
     row[:batch_number] = Cell.new(
       allowed_values: batch_values_for_programme(programme)
@@ -321,7 +321,7 @@ class Reports::OfflineSessionExporter
 
   def performing_professionals_range
     count = performing_professional_email_values.count
-    "='Performing Professionals'!$A2:$A#{count + 1}"
+    "'Performing Professionals'!$A2:$A#{count + 1}"
   end
 
   def clinic_name_values
@@ -406,7 +406,7 @@ class Reports::OfflineSessionExporter
         if allowed_values.present?
           "\"#{allowed_values.join(", ")}\""
         elsif allowed_formula.present?
-          allowed_formula
+          "=#{allowed_formula}"
         end
 
       sheet.add_data_validation(

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -14,7 +14,10 @@ class Reports::OfflineSessionExporter
     Axlsx::Package
       .new { |package|
         add_vaccinations_sheet(package)
-        add_performing_professionals_sheet(package)
+        add_reference_sheet package,
+                            name: "Performing Professionals",
+                            values_name: "EMAIL",
+                            values: performing_professional_email_values
       }
       .to_stream
       .read
@@ -56,20 +59,17 @@ class Reports::OfflineSessionExporter
     end
   end
 
-  def add_performing_professionals_sheet(package)
+  def add_reference_sheet(package, name:, values_name:, values:)
     package.use_shared_strings = true
 
     workbook = package.workbook
-    workbook.add_worksheet(
-      name: "Performing Professionals",
-      state: :hidden
-    ) do |sheet|
+    workbook.add_worksheet(name:, state: :hidden) do |sheet|
       sheet.sheet_protection
 
-      sheet.add_row(%w[EMAIL])
+      sheet.add_row([values_name])
 
-      performing_professional_email_values.each do |email|
-        sheet.add_row([email])
+      values.each do |value|
+        sheet.add_row([value])
       end
     end
   end

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -13,14 +13,14 @@ describe Reports::OfflineSessionExporter do
   end
 
   def validation_formula(worksheet:, column_name:, row: 1)
-    column = worksheet[0].cells.find_index { _1.value == column_name.upcase }
+    column = worksheet[0].cells.find_index { it.value == column_name.upcase }
 
     # stree-ignore
     worksheet
       .data_validations
       .find { |validation|
         validation.sqref.any? do
-          _1.col_range.include?(column) && _1.row_range.include?(row)
+          it.col_range.include?(column) && it.row_range.include?(row)
         end
       }
       .formula1
@@ -342,7 +342,7 @@ describe Reports::OfflineSessionExporter do
 
     describe "performing professionals sheet" do
       subject(:worksheet) do
-        workbook.worksheets.find { _1.sheet_name == "Performing Professionals" }
+        workbook.worksheets.find { it.sheet_name == "Performing Professionals" }
       end
 
       let!(:vaccinators) { create_list(:user, 2, organisation:) }
@@ -357,7 +357,7 @@ describe Reports::OfflineSessionExporter do
       end
 
       it "lists all the organisation users' emails" do
-        emails = worksheet[1..].map { _1.cells.first.value }
+        emails = worksheet[1..].map { it.cells.first.value }
         expect(emails).to include(*vaccinators.map(&:email))
       end
 
@@ -367,7 +367,7 @@ describe Reports::OfflineSessionExporter do
 
     describe "batch numbers sheet" do
       subject(:worksheet) do
-        workbook.worksheets.find { _1.sheet_name == "hpv Batch Numbers" }
+        workbook.worksheets.find { it.sheet_name == "hpv Batch Numbers" }
       end
 
       let!(:batches) do
@@ -385,7 +385,7 @@ describe Reports::OfflineSessionExporter do
       end
 
       it "lists all the batch numbers for the programme" do
-        batch_numbers = worksheet[1..].map { _1.cells.first.value }
+        batch_numbers = worksheet[1..].map { it.cells.first.value }
         expect(batch_numbers).to include(*batches.map(&:name))
       end
 
@@ -622,7 +622,7 @@ describe Reports::OfflineSessionExporter do
 
     describe "performing professionals sheet" do
       subject(:worksheet) do
-        workbook.worksheets.find { _1.sheet_name == "Performing Professionals" }
+        workbook.worksheets.find { it.sheet_name == "Performing Professionals" }
       end
 
       let!(:vaccinators) { create_list(:user, 2, organisation:) }
@@ -637,7 +637,7 @@ describe Reports::OfflineSessionExporter do
       end
 
       it "lists all the organisation users' emails" do
-        emails = worksheet[1..].map { _1.cells.first.value }
+        emails = worksheet[1..].map { it.cells.first.value }
         expect(emails).to eq vaccinators.map(&:email)
       end
 
@@ -647,7 +647,7 @@ describe Reports::OfflineSessionExporter do
 
     describe "batch numbers sheet" do
       subject(:worksheet) do
-        workbook.worksheets.find { _1.sheet_name == "hpv Batch Numbers" }
+        workbook.worksheets.find { it.sheet_name == "hpv Batch Numbers" }
       end
 
       let!(:batches) do
@@ -665,7 +665,7 @@ describe Reports::OfflineSessionExporter do
       end
 
       it "lists all the batch numbers for the programme" do
-        batch_numbers = worksheet[1..].map { _1.cells.first.value }
+        batch_numbers = worksheet[1..].map { it.cells.first.value }
         expect(batch_numbers).to eq batches.map(&:name)
       end
 

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -324,6 +324,20 @@ describe Reports::OfflineSessionExporter do
 
         it { should eq "='Performing Professionals'!$A2:$A2" }
       end
+
+      describe "batch number" do
+        subject(:validation) do
+          create(
+            :batch,
+            name: "BATCH12345",
+            vaccine: programme.vaccines.active.first,
+            organisation:
+          )
+          validation_formula(worksheet:, column_name: "batch_number")
+        end
+
+        it { should eq "='hpv Batch Numbers'!$A2:$A2" }
+      end
     end
 
     describe "performing professionals sheet" do
@@ -345,6 +359,34 @@ describe Reports::OfflineSessionExporter do
       it "lists all the organisation users' emails" do
         emails = worksheet[1..].map { _1.cells.first.value }
         expect(emails).to eq vaccinators.map(&:email)
+      end
+
+      its(:state) { should eq "hidden" }
+      its(:sheet_protection) { should be_present }
+    end
+
+    describe "batch numbers sheet" do
+      subject(:worksheet) do
+        workbook.worksheets.find { _1.sheet_name == "hpv Batch Numbers" }
+      end
+
+      let!(:batches) do
+        create_list(
+          :batch,
+          2,
+          vaccine: programme.vaccines.active.first,
+          organisation:
+        )
+      end
+
+      before do
+        create(:patient, session:)
+        create(:batch, name: "OTHERBATCH", vaccine: create(:vaccine, :flu))
+      end
+
+      it "lists all the batch numbers for the programme" do
+        batch_numbers = worksheet[1..].map { _1.cells.first.value }
+        expect(batch_numbers).to eq batches.map(&:name)
       end
 
       its(:state) { should eq "hidden" }
@@ -562,6 +604,20 @@ describe Reports::OfflineSessionExporter do
 
         it { should eq "='Performing Professionals'!$A2:$A2" }
       end
+
+      describe "batch number" do
+        subject(:validation) do
+          create(
+            :batch,
+            name: "BATCH12345",
+            vaccine: programme.vaccines.active.first,
+            organisation:
+          )
+          validation_formula(worksheet:, column_name: "batch_number")
+        end
+
+        it { should eq "='hpv Batch Numbers'!$A2:$A2" }
+      end
     end
 
     describe "performing professionals sheet" do
@@ -583,6 +639,34 @@ describe Reports::OfflineSessionExporter do
       it "lists all the organisation users' emails" do
         emails = worksheet[1..].map { _1.cells.first.value }
         expect(emails).to eq vaccinators.map(&:email)
+      end
+
+      its(:state) { should eq "hidden" }
+      its(:sheet_protection) { should be_present }
+    end
+
+    describe "batch numbers sheet" do
+      subject(:worksheet) do
+        workbook.worksheets.find { _1.sheet_name == "hpv Batch Numbers" }
+      end
+
+      let!(:batches) do
+        create_list(
+          :batch,
+          2,
+          vaccine: programme.vaccines.active.first,
+          organisation:
+        )
+      end
+
+      before do
+        create(:patient, session:)
+        create(:batch, name: "OTHERBATCH", vaccine: create(:vaccine, :flu))
+      end
+
+      it "lists all the batch numbers for the programme" do
+        batch_numbers = worksheet[1..].map { _1.cells.first.value }
+        expect(batch_numbers).to eq batches.map(&:name)
       end
 
       its(:state) { should eq "hidden" }

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -36,13 +36,14 @@ describe Reports::OfflineSessionExporter do
   let(:session) { create(:session, location:, organisation:, programme:) }
 
   context "a school session" do
+    subject(:workbook) { RubyXL::Parser.parse_buffer(call) }
+
     let(:location) { create(:school, team:) }
 
     it { should_not be_blank }
 
     describe "headers" do
       subject(:headers) do
-        workbook = RubyXL::Parser.parse_buffer(call)
         sheet = workbook.worksheets[0]
         sheet[0].cells.map(&:value)
       end
@@ -92,10 +93,7 @@ describe Reports::OfflineSessionExporter do
     end
 
     describe "rows" do
-      subject(:rows) do
-        workbook = RubyXL::Parser.parse_buffer(call)
-        worksheet_to_hashes(workbook.worksheets[0])
-      end
+      subject(:rows) { worksheet_to_hashes(workbook.worksheets[0]) }
 
       let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
       let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
@@ -308,10 +306,7 @@ describe Reports::OfflineSessionExporter do
     end
 
     describe "cell validations" do
-      subject(:worksheet) do
-        workbook = RubyXL::Parser.parse_buffer(call)
-        workbook.worksheets[0]
-      end
+      subject(:worksheet) { workbook.worksheets[0] }
 
       before do
         # Without a patient no validation will be setup.
@@ -333,7 +328,6 @@ describe Reports::OfflineSessionExporter do
 
     describe "performing professionals sheet" do
       subject(:worksheet) do
-        workbook = RubyXL::Parser.parse_buffer(call)
         workbook.worksheets.find { _1.sheet_name == "Performing Professionals" }
       end
 
@@ -359,13 +353,14 @@ describe Reports::OfflineSessionExporter do
   end
 
   context "a clinic session" do
+    subject(:workbook) { RubyXL::Parser.parse_buffer(call) }
+
     let(:location) { create(:generic_clinic, team:) }
 
     it { should_not be_blank }
 
     describe "headers" do
       subject(:headers) do
-        workbook = RubyXL::Parser.parse_buffer(call)
         sheet = workbook.worksheets[0]
         sheet[0].cells.map(&:value)
       end
@@ -416,10 +411,7 @@ describe Reports::OfflineSessionExporter do
     end
 
     describe "rows" do
-      subject(:rows) do
-        workbook = RubyXL::Parser.parse_buffer(call)
-        worksheet_to_hashes(workbook.worksheets[0])
-      end
+      subject(:rows) { worksheet_to_hashes(workbook.worksheets[0]) }
 
       it { should be_empty }
 
@@ -552,7 +544,7 @@ describe Reports::OfflineSessionExporter do
     end
 
     describe "cell validations" do
-      subject(:workbook) { RubyXL::Parser.parse_buffer(call) }
+      subject(:worksheet) { workbook.worksheets[0] }
 
       before do
         create(:patient, session:)
@@ -560,7 +552,7 @@ describe Reports::OfflineSessionExporter do
       end
 
       describe "performing professional email" do
-        subject do
+        subject(:validation) do
           worksheet = workbook.worksheets[0]
           validation_formula(
             worksheet:,
@@ -574,7 +566,6 @@ describe Reports::OfflineSessionExporter do
 
     describe "performing professionals sheet" do
       subject(:worksheet) do
-        workbook = RubyXL::Parser.parse_buffer(call)
         workbook.worksheets.find { _1.sheet_name == "Performing Professionals" }
       end
 

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -358,7 +358,7 @@ describe Reports::OfflineSessionExporter do
 
       it "lists all the organisation users' emails" do
         emails = worksheet[1..].map { _1.cells.first.value }
-        expect(emails).to eq vaccinators.map(&:email)
+        expect(emails).to include(*vaccinators.map(&:email))
       end
 
       its(:state) { should eq "hidden" }
@@ -386,7 +386,7 @@ describe Reports::OfflineSessionExporter do
 
       it "lists all the batch numbers for the programme" do
         batch_numbers = worksheet[1..].map { _1.cells.first.value }
-        expect(batch_numbers).to eq batches.map(&:name)
+        expect(batch_numbers).to include(*batches.map(&:name))
       end
 
       its(:state) { should eq "hidden" }

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -322,7 +322,7 @@ describe Reports::OfflineSessionExporter do
           )
         end
 
-        it { should eq "=='Performing Professionals'!$A2:$A2" }
+        it { should eq "='Performing Professionals'!$A2:$A2" }
       end
     end
 
@@ -560,7 +560,7 @@ describe Reports::OfflineSessionExporter do
           )
         end
 
-        it { should eq "=='Performing Professionals'!$A2:$A2" }
+        it { should eq "='Performing Professionals'!$A2:$A2" }
       end
     end
 


### PR DESCRIPTION
This change to the offline spreadsheet protects against Excel's 256 char limit for validation values by putting batch numbers into a separate sheet and looking them up there. This builds on the work done for the performing professionals validations.

https://trello.com/c/PVjQ6E6B/1826-refactor-batch-ids-drop-down-in-offline-spreadsheet

Batch number drop-down:
![image](https://github.com/user-attachments/assets/f321ed06-24de-4665-8142-9a58211573cc)


New data validation for batch numbers:
![image](https://github.com/user-attachments/assets/bfb95a3d-1f8c-4fa5-a651-56628a19cb13)


New sheet added for the specific programme (normally this sheet is hidden):
![image](https://github.com/user-attachments/assets/a9ff99ee-d05d-4467-bdb1-4a445814f9e9)
