### PR TITLE
Allow creating patients from consent without NHS numbers

### DIFF
--- a/app/views/consent_forms/index.html.erb
+++ b/app/views/consent_forms/index.html.erb
@@ -24,19 +24,17 @@
                 row.with_cell(text: consent_form.parent_full_name)
                 row.with_cell do
                   tag.ul(class: "app-action-list") do
-                    match_link = link_to("Match with record", consent_form)
-                    create_link = link_to("Create record", patient_consent_form_path(consent_form))
-                    archive_link = link_to("Archive", archive_consent_form_path(consent_form))
-        
-                    links = [
-                      tag.li(class: "app-action-list__item") { match_link },
-                      if consent_form.nhs_number.present?
-                        tag.li(class: "app-action-list__item") { create_link }
+                    safe_join([
+                      tag.li(class: "app-action-list__item") do
+                        link_to("Match with record", consent_form_path(consent_form))
                       end,
-                      tag.li(class: "app-action-list__item") { archive_link },
-                    ].compact
-        
-                    safe_join(links)
+                      tag.li(class: "app-action-list__item") do
+                        link_to("Create record", patient_consent_form_path(consent_form))
+                      end,
+                      tag.li(class: "app-action-list__item") do
+                        link_to("Archive", archive_consent_form_path(consent_form))
+                      end,
+                    ])
                   end
                 end
               end


### PR DESCRIPTION
This makes it possible for a nurse to create a patient record from a consent form, even if the consent form was unable to be matched with patient record details in PDS.

The workaround currently would be to create a cohort record for that child and then manually match the consent response to that record.