### PR TITLE
Reword consent form "Mark as invalid"

### DIFF
--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -45,21 +45,21 @@ class ConsentFormsController < ApplicationController
     redirect_to action: :index
   end
 
-  def edit_invalidate
-    render :invalidate, layout: "two_thirds"
+  def edit_archive
+    render :archive, layout: "two_thirds"
   end
 
-  def update_invalidate
-    @consent_form.assign_attributes(invalidate_params)
+  def update_archive
+    @consent_form.assign_attributes(archive_params)
 
     if @consent_form.save
       redirect_to consent_forms_path,
                   flash: {
                     success:
-                      "Consent response from #{@consent_form.parent_full_name} marked as invalid"
+                      "Consent response from #{@consent_form.parent_full_name} archived"
                   }
     else
-      render :invalidate, layout: "two_thirds", status: :unprocessable_entity
+      render :archive, layout: "two_thirds", status: :unprocessable_entity
     end
   end
 
@@ -99,7 +99,7 @@ class ConsentFormsController < ApplicationController
   private
 
   def consent_form_scope
-    policy_scope(ConsentForm).unmatched.recorded.not_invalidated
+    policy_scope(ConsentForm).unmatched.recorded.not_archived
   end
 
   def set_consent_form
@@ -110,7 +110,7 @@ class ConsentFormsController < ApplicationController
     @patient = policy_scope(Patient).find(params[:patient_id])
   end
 
-  def invalidate_params
-    params.expect(consent_form: :notes).merge(invalidated_at: Time.current)
+  def archive_params
+    params.expect(consent_form: :notes).merge(archived_at: Time.current)
   end
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -25,15 +25,14 @@
 #  fk_rails_...  (vaccine_id => vaccines.id)
 #
 class Batch < ApplicationRecord
+  include Archivable
+
   audited
 
   belongs_to :organisation
   belongs_to :vaccine
 
   scope :order_by_name_and_expiration, -> { order(expiry: :asc, name: :asc) }
-
-  scope :archived, -> { where.not(archived_at: nil) }
-  scope :not_archived, -> { where(archived_at: nil) }
 
   scope :expired, -> { where("expiry <= ?", Time.current) }
   scope :not_expired, -> { where("expiry > ?", Time.current) }
@@ -56,12 +55,4 @@ class Batch < ApplicationRecord
               less_than: -> { Date.current + 15.years }
             },
             unless: :archived?
-
-  def archived?
-    archived_at != nil
-  end
-
-  def archive!
-    update!(archived_at: Time.current) unless archived?
-  end
 end

--- a/app/models/concerns/archivable.rb
+++ b/app/models/concerns/archivable.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Archivable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :archived, -> { where.not(archived_at: nil) }
+    scope :not_archived, -> { where(archived_at: nil) }
+  end
+
+  def archived?
+    archived_at != nil
+  end
+
+  def archive!
+    update!(archived_at: Time.current) unless archived?
+  end
+end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -63,8 +63,8 @@
 class ConsentForm < ApplicationRecord
   include AddressConcern
   include AgeConcern
+  include Archivable
   include FullNameConcern
-  include Invalidatable
   include WizardStepConcern
 
   before_save :reset_unused_fields
@@ -172,7 +172,7 @@ class ConsentForm < ApplicationRecord
 
   validates :reason_notes, length: { maximum: 1000 }
 
-  validates :notes, presence: { if: :invalidated? }, length: { maximum: 1000 }
+  validates :notes, presence: { if: :archived? }, length: { maximum: 1000 }
 
   normalizes :nhs_number, with: -> { _1.blank? ? nil : _1.gsub(/\s/, "") }
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -9,13 +9,13 @@
 #  address_line_2                      :string
 #  address_postcode                    :string
 #  address_town                        :string
+#  archived_at                         :datetime
 #  contact_injection                   :boolean
 #  date_of_birth                       :date
 #  education_setting                   :integer
 #  family_name                         :text
 #  given_name                          :text
 #  health_answers                      :jsonb            not null
-#  invalidated_at                      :datetime
 #  nhs_number                          :string
 #  notes                               :text             default(""), not null
 #  parent_contact_method_other_details :string

--- a/app/views/consent_forms/archive.html.erb
+++ b/app/views/consent_forms/archive.html.erb
@@ -2,10 +2,10 @@
   <%= render AppBacklinkComponent.new(consent_form_path, name: "consent page") %>
 <% end %>
 
-<%= form_with model: @consent_form, url: invalidate_consent_form_path, method: :post do |f| %>
+<%= form_with model: @consent_form, url: archive_consent_form_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% page_title = "Mark response as invalid" %>
+  <% page_title = "Archive response" %>
   <%= h1 page_title: do %>
     <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
       Consent response from <%= @consent_form.parent_full_name %>
@@ -18,6 +18,6 @@
   <%= f.govuk_text_area :notes, label: { text: "Notes", size: "m" } %>
 
   <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Mark as invalid", warning: true %>
+    <%= f.govuk_submit "Archive response", warning: true %>
   </div>
 <% end %>

--- a/app/views/consent_forms/index.html.erb
+++ b/app/views/consent_forms/index.html.erb
@@ -24,18 +24,17 @@
                 row.with_cell(text: consent_form.parent_full_name)
                 row.with_cell do
                   tag.ul(class: "app-action-list") do
-                    create_link = link_to("Create record", patient_consent_form_path(consent_form))
-                    invalidate_link = link_to("Mark as invalid", invalidate_consent_form_path(consent_form))
                     match_link = link_to("Match with record", consent_form)
+                    create_link = link_to("Create record", patient_consent_form_path(consent_form))
+                    archive_link = link_to("Archive", archive_consent_form_path(consent_form))
         
                     links = [
                       tag.li(class: "app-action-list__item") { match_link },
-                      tag.li(class: "app-action-list__item") { invalidate_link },
-                    ]
-        
-                    if consent_form.nhs_number.present?
-                      links << tag.li(class: "app-action-list__item") { create_link }
-                    end
+                      if consent_form.nhs_number.present?
+                        tag.li(class: "app-action-list__item") { create_link }
+                      end,
+                      tag.li(class: "app-action-list__item") { archive_link },
+                    ].compact
         
                     safe_join(links)
                   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -47,7 +47,7 @@
           t("consent_forms.index.title_short"),
           consent_forms_path,
           request_path: request.path,
-          count: policy_scope(ConsentForm).unmatched.recorded.not_invalidated.count
+          count: policy_scope(ConsentForm).unmatched.recorded.not_archived.count
         ) %>
 
         <%= render AppHeaderNavigationItemComponent.new(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,8 +93,8 @@ Rails.application.routes.draw do
       get "match/:patient_id", action: :edit_match, as: :match
       post "match/:patient_id", action: :update_match
 
-      get "invalidate", action: :edit_invalidate
-      post "invalidate", action: :update_invalidate
+      get "archive", action: :edit_archive
+      post "archive", action: :update_archive
 
       get "patient", action: :new_patient
       post "patient", action: :create_patient

--- a/db/migrate/20250115123804_rename_consent_form_invalidated_at_to_archived_at.rb
+++ b/db/migrate/20250115123804_rename_consent_form_invalidated_at_to_archived_at.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameConsentFormInvalidatedAtToArchivedAt < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :consent_forms, :invalidated_at, :archived_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_14_150405) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_15_123804) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -198,7 +198,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_14_150405) do
     t.string "preferred_family_name"
     t.integer "education_setting"
     t.string "nhs_number"
-    t.datetime "invalidated_at"
+    t.datetime "archived_at"
     t.text "notes", default: "", null: false
     t.index ["consent_id"], name: "index_consent_forms_on_consent_id"
     t.index ["location_id"], name: "index_consent_forms_on_location_id"

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -111,8 +111,8 @@ FactoryBot.define do
       ]
     end
 
-    trait :invalidated do
-      invalidated_at { Time.current }
+    trait :archived do
+      archived_at { Time.current }
     end
 
     trait :refused do

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -9,13 +9,13 @@
 #  address_line_2                      :string
 #  address_postcode                    :string
 #  address_town                        :string
+#  archived_at                         :datetime
 #  contact_injection                   :boolean
 #  date_of_birth                       :date
 #  education_setting                   :integer
 #  family_name                         :text
 #  given_name                          :text
 #  health_answers                      :jsonb            not null
-#  invalidated_at                      :datetime
 #  nhs_number                          :string
 #  notes                               :text             default(""), not null
 #  parent_contact_method_other_details :string

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -29,12 +29,12 @@ describe "Parental consent manual matching" do
     then_i_am_on_the_unmatched_responses_page
     and_i_see_one_response
 
-    when_i_choose_to_mark_the_response_as_invalid
+    when_i_choose_to_archive_the_response
     then_i_fill_in_the_notes
-    and_i_mark_the_response_as_invalid
+    and_i_archive_the_response
 
     then_i_am_on_the_unmatched_responses_page
-    and_i_see_the_marked_as_invalid_message
+    and_i_see_the_archived_message
     and_i_see_no_responses
   end
 
@@ -117,22 +117,20 @@ describe "Parental consent manual matching" do
     )
   end
 
-  def when_i_choose_to_mark_the_response_as_invalid
-    click_on "Mark as invalid"
+  def when_i_choose_to_archive_the_response
+    click_on "Archive"
   end
 
   def then_i_fill_in_the_notes
     fill_in "Notes", with: "Some notes."
   end
 
-  def and_i_mark_the_response_as_invalid
-    click_on "Mark as invalid"
+  def and_i_archive_the_response
+    click_on "Archive response"
   end
 
-  def and_i_see_the_marked_as_invalid_message
-    expect(page).to have_content(
-      "Consent response from John Smith marked as invalid"
-    )
+  def and_i_see_the_archived_message
+    expect(page).to have_content("Consent response from John Smith archived")
   end
 
   def and_i_see_no_responses

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -9,13 +9,13 @@
 #  address_line_2                      :string
 #  address_postcode                    :string
 #  address_town                        :string
+#  archived_at                         :datetime
 #  contact_injection                   :boolean
 #  date_of_birth                       :date
 #  education_setting                   :integer
 #  family_name                         :text
 #  given_name                          :text
 #  health_answers                      :jsonb            not null
-#  invalidated_at                      :datetime
 #  nhs_number                          :string
 #  notes                               :text             default(""), not null
 #  parent_contact_method_other_details :string


### PR DESCRIPTION
We'd like to change the wording around invalidating consent forms to instead refer to archiving consent forms.

This improves upon #2846 and will be included in 1.3.0 as part of that feature.

## Screenshots

![Screenshot 2025-01-15 at 12 47 40](https://github.com/user-attachments/assets/c804a6c8-1869-4e32-89ed-8202e5d2dfb5)
![Screenshot 2025-01-15 at 12 47 44](https://github.com/user-attachments/assets/f6cee5c4-b889-4dc3-9a9a-f06a1d5d7323)
![Screenshot 2025-01-15 at 12 47 52](https://github.com/user-attachments/assets/bc277218-ad01-4d6d-aa02-ab37e41e3277)
