### PR TITLE
Add `delivery_status` column to `notify_log_entries`

### DIFF
--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -5,6 +5,7 @@
 # Table name: notify_log_entries
 #
 #  id              :bigint           not null, primary key
+#  delivery_status :integer          default("sending"), not null
 #  recipient       :string           not null
 #  type            :integer          not null
 #  created_at      :datetime         not null
@@ -35,6 +36,14 @@ class NotifyLogEntry < ApplicationRecord
   belongs_to :patient, optional: true
 
   enum :type, { email: 0, sms: 1 }, validate: true
+  enum :delivery_status,
+       {
+         sending: 0,
+         delivered: 1,
+         permanent_failure: 2,
+         temporary_failure: 3,
+         technical_failure: 4
+       }
 
   validates :template_id, presence: true
   validates :recipient, presence: true

--- a/db/migrate/20250116090241_add_delivery_status_to_notify_log_entries.rb
+++ b/db/migrate/20250116090241_add_delivery_status_to_notify_log_entries.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDeliveryStatusToNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notify_log_entries,
+               :delivery_status,
+               :integer,
+               null: false,
+               default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_15_123804) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_16_090241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -471,6 +471,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_15_123804) do
     t.bigint "patient_id"
     t.bigint "sent_by_user_id"
     t.uuid "delivery_id"
+    t.integer "delivery_status", default: 0, null: false
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
     t.index ["patient_id"], name: "index_notify_log_entries_on_patient_id"
     t.index ["sent_by_user_id"], name: "index_notify_log_entries_on_sent_by_user_id"

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -5,6 +5,7 @@
 # Table name: notify_log_entries
 #
 #  id              :bigint           not null, primary key
+#  delivery_status :integer          default("sending"), not null
 #  recipient       :string           not null
 #  type            :integer          not null
 #  created_at      :datetime         not null
@@ -31,8 +32,6 @@ FactoryBot.define do
     patient
     consent_form
 
-    delivery_id { SecureRandom.uuid }
-
     trait :email do
       type { "email" }
       recipient { Faker::Internet.email }
@@ -44,5 +43,8 @@ FactoryBot.define do
       recipient { Faker::PhoneNumber.phone_number }
       template_id { GOVUK_NOTIFY_TEXT_TEMPLATES.values.sample }
     end
+
+    delivery_id { SecureRandom.uuid }
+    traits_for_enum :delivery_status
   end
 end

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -5,6 +5,7 @@
 # Table name: notify_log_entries
 #
 #  id              :bigint           not null, primary key
+#  delivery_status :integer          default("sending"), not null
 #  recipient       :string           not null
 #  type            :integer          not null
 #  created_at      :datetime         not null


### PR DESCRIPTION
This adds a new enum integer column to `notify_log_entries` that we can use to track the status of a message delivery. This commit just adds the column, but the next steps will be to integrate with the GOV.UK Notify callback mechanism to ensure this value is accurate. This will allow us to display this information to the user either via the UI or in a report.