### PR TITLE
Rename "Safe to vaccinate"

### DIFF
--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -46,8 +46,8 @@ en:
     triaged_ready_to_vaccinate:
       colour: purple
       text: Vaccinate
-      banner_title: Safe to vaccinate
-      banner_explanation: "%{nurse} decided that %{full_name} is safe to vaccinate."
+      banner_title: Ready for nurse
+      banner_explanation: "%{nurse} decided that %{full_name} is ready for the nurse."
     unable_to_vaccinate:
       colour: red
       text: Could not vaccinate

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -75,11 +75,11 @@ describe AppSimpleStatusBannerComponent do
     end
 
     it { should have_css(".app-card--purple") }
-    it { should have_css(".nhsuk-card__heading", text: "Safe to vaccinate") }
+    it { should have_css(".nhsuk-card__heading", text: "Ready for nurse") }
 
     it do
       expect(rendered).to have_text(
-        "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
+        "#{triage_nurse_name} decided that #{patient_name} is ready for the nurse"
       )
     end
 


### PR DESCRIPTION
This renames the "Safe to vaccinate" status after a triage to be "Ready for nurse" to match the naming we use when the patient is ready for the nurse after consent has been received and no triage was required.