### PR TITLE
Only consider triage status if consent is given

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -56,9 +56,12 @@ class DraftConsentsController < ApplicationController
 
     ActiveRecord::Base.transaction do
       @triage&.save! if @draft_consent.response_given?
+
       @consent.parent&.save!
       @consent.save!
     end
+
+    set_patient_session # reload with new consents
 
     send_triage_confirmation(@patient_session, @consent)
 

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -30,7 +30,7 @@ module PatientSessionStatusConcern
           "unable_to_vaccinate"
         elsif triage_keep_in_triage?
           "triaged_kept_in_triage"
-        elsif triage_ready_to_vaccinate?
+        elsif consent_given? && triage_ready_to_vaccinate?
           "triaged_ready_to_vaccinate"
         elsif triage_do_not_vaccinate?
           "triaged_do_not_vaccinate"

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -275,6 +275,8 @@ FactoryBot.define do
     end
 
     trait :triage_ready_to_vaccinate do
+      consent_given_triage_needed
+
       triages do
         [
           association(

--- a/spec/features/triage_then_parenal_consent_refused_spec.rb
+++ b/spec/features/triage_then_parenal_consent_refused_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+describe "Triage" do
+  scenario "Nurse triages a patient and then consent is refused" do
+    stub_pds_search_to_return_no_patients
+
+    given_a_programme_with_a_running_session
+
+    when_i_go_to_the_patient_that_needs_triage
+    and_i_record_that_they_are_safe_to_vaccinate
+    then_i_see_the_patient_is_ready
+
+    when_i_go_to_the_consent_form_as_a_parent
+    and_i_refuse_consent
+    then_i_see_the_confirmation_page
+
+    when_i_wait_for_background_jobs_to_complete
+    and_i_go_to_the_patient_with_conflicting_consent
+    then_i_see_the_patient_is_not_safe_to_vaccinate
+  end
+
+  def given_a_programme_with_a_running_session
+    @programme = create(:programme, :hpv)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [@programme])
+
+    @session =
+      create(
+        :session,
+        :scheduled,
+        organisation: @organisation,
+        programme: @programme
+      )
+
+    @patient =
+      create(
+        :patient_session,
+        :consent_given_triage_needed,
+        programme: @programme,
+        session: @session
+      ).patient
+  end
+
+  def when_i_go_to_the_patient_that_needs_triage
+    sign_in @organisation.users.first
+    visit session_triage_tab_path(@session, tab: "needed")
+    click_link @patient.full_name
+  end
+
+  def and_i_record_that_they_are_safe_to_vaccinate
+    choose "Yes, it’s safe to vaccinate"
+    click_on "Save triage"
+  end
+
+  def then_i_see_the_patient_is_ready
+    click_on @patient.full_name
+    expect(page).to have_content("Safe to vaccinate")
+  end
+
+  def when_i_go_to_the_consent_form_as_a_parent
+    visit start_parent_interface_consent_forms_path(@session, @programme)
+  end
+
+  def and_i_refuse_consent
+    click_on "Start now"
+
+    expect(page).to have_content("What is your child’s name?")
+    fill_in "First name", with: @patient.given_name
+    fill_in "Last name", with: @patient.family_name
+    choose "No" # Do they use a different name in school?
+    click_on "Continue"
+
+    expect(page).to have_content("What is your child’s date of birth?")
+    fill_in "Day", with: @patient.date_of_birth.day
+    fill_in "Month", with: @patient.date_of_birth.month
+    fill_in "Year", with: @patient.date_of_birth.year
+    click_on "Continue"
+
+    expect(page).to have_content("Confirm your child’s school")
+    choose "Yes, they go to this school"
+    click_on "Continue"
+
+    expect(page).to have_content("About you")
+    fill_in "Your name", with: "Jane #{@patient.family_name}"
+    choose "Mum" # Your relationship to the child
+    fill_in "Email address", with: "jane@example.com"
+    fill_in "Phone number", with: "07123456789"
+    check "Tick this box if you’d like to get updates by text message"
+    click_on "Continue"
+
+    expect(page).to have_content("Phone contact method")
+    choose "I do not have specific needs"
+    click_on "Continue"
+
+    expect(page).to have_content("Do you agree")
+    choose "No"
+    click_on "Continue"
+
+    expect(page).to have_content("Why are you refusing to give consent?")
+    choose "Medical reasons"
+    click_on "Continue"
+
+    expect(page).to have_content(
+      "What medical reasons prevent your child from being vaccinated?"
+    )
+    fill_in "Give details", with: "They have a weakened immune system"
+    click_on "Continue"
+
+    click_on "Confirm"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content(
+      "Your child will not get an HPV vaccination at school"
+    )
+  end
+
+  def when_i_wait_for_background_jobs_to_complete
+    perform_enqueued_jobs
+  end
+
+  def and_i_go_to_the_patient_with_conflicting_consent
+    visit session_consents_tab_path(@session, tab: "conflicts")
+    click_on @patient.full_name
+  end
+
+  def then_i_see_the_patient_is_not_safe_to_vaccinate
+    expect(page).to have_content("Conflicting consent")
+  end
+end

--- a/spec/models/concerns/patient_session_status_concern_spec.rb
+++ b/spec/models/concerns/patient_session_status_concern_spec.rb
@@ -65,7 +65,7 @@ describe PatientSessionStatusConcern do
 
     include_examples "it supports the status",
                      :triaged_ready_to_vaccinate,
-                     conditions: [:triage_ready_to_vaccinate]
+                     conditions: %i[consent_given triage_ready_to_vaccinate]
 
     include_examples "it supports the status",
                      :triaged_do_not_vaccinate,


### PR DESCRIPTION
When calculating the overall status of a patient session, we should only consider the status of the `latest_triage` if the consent is given.

This is to handle a scenario where consent was given, then the nurse triaged the patient, and then consent was refused. Currently, the status of the patient would remain "ready to vaccinate" whereas instead the status should reflect the fact that consent has been withdrawn (even though the patient was triaged at one point).