### PR TITLE
Add controller to handle GOV.UK Notify callbacks 

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class NotificationsController < ActionController::API
+  include ActionController::HttpAuthentication::Token::ControllerMethods
+
+  before_action :authenticate
+
+  def create
+    delivery_id = params.require(:id)
+    delivery_status = params.require(:status).underscore
+
+    if (notify_log_entry = NotifyLogEntry.find_by(delivery_id:))
+      notify_log_entry.update!(delivery_status:)
+      head :no_content
+    else
+      head :not_found
+    end
+  end
+
+  private
+
+  def authenticate
+    authenticate_or_request_with_http_token do |token, _options|
+      ActiveSupport::SecurityUtils.secure_compare(
+        token,
+        Settings.govuk_notify.callback_bearer_token
+      )
+    end
+  end
+end

--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_notify_log_entries_on_consent_form_id  (consent_form_id)
+#  index_notify_log_entries_on_delivery_id      (delivery_id)
 #  index_notify_log_entries_on_patient_id       (patient_id)
 #  index_notify_log_entries_on_sent_by_user_id  (sent_by_user_id)
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
 
   resources :notices, only: :index
 
+  resources :notifications, only: :create
+
   resources :patients, only: %i[index show edit update] do
     post "", action: :index, on: :collection
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,6 +24,7 @@ govuk_notify:
   test_key: <%= Rails.application.credentials.govuk_notify&.test_key %>
   team_key: <%= Rails.application.credentials.govuk_notify&.team_key %>
   live_key: <%= Rails.application.credentials.govuk_notify&.live_key %>
+  callback_bearer_token: <%= Rails.application.credentials.govuk_notify&.callback_bearer_token %>
 
 mesh:
   base_url: "https://msg.intspineservices.nhs.uk"

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -11,6 +11,7 @@ cis2:
 govuk_notify:
   enabled: false
   mode: test
+  callback_bearer_token: dev-bearer-token
 
 mesh:
   base_url: https://localhost:8700

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -7,6 +7,9 @@ cis2:
   issuer: "http://localhost:4000/test/oidc"
   client_id: "31337.apps.national"
 
+govuk_notify:
+  callback_bearer_token: test-bearer-token
+
 mesh:
   base_url: https://localhost:8700
   disable_ssl_verification: true

--- a/db/migrate/20250116093944_add_index_on_notify_log_entries_delivery_id.rb
+++ b/db/migrate/20250116093944_add_index_on_notify_log_entries_delivery_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexOnNotifyLogEntriesDeliveryId < ActiveRecord::Migration[8.0]
+  def change
+    add_index :notify_log_entries, :delivery_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_16_090241) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_16_093944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -473,6 +473,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_16_090241) do
     t.uuid "delivery_id"
     t.integer "delivery_status", default: 0, null: false
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
+    t.index ["delivery_id"], name: "index_notify_log_entries_on_delivery_id"
     t.index ["patient_id"], name: "index_notify_log_entries_on_patient_id"
     t.index ["sent_by_user_id"], name: "index_notify_log_entries_on_sent_by_user_id"
   end

--- a/spec/controllers/notifications_controller_spec.rb
+++ b/spec/controllers/notifications_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe NotificationsController do
+  describe "POST create" do
+    let(:notify_log_entry) { create(:notify_log_entry, :email) }
+
+    before { request.headers["Authorization"] = "Bearer #{bearer_token}" }
+
+    context "with an invalid bearer token" do
+      let(:bearer_token) { "invalid-bearer-token" }
+
+      it "doesn't update the status" do
+        params = { id: notify_log_entry.delivery_id, status: "delivered" }
+        post :create, params:, format: :json
+
+        expect(response).to have_http_status(:unauthorized)
+        expect(notify_log_entry.reload.delivery_status).to eq("sending")
+      end
+    end
+
+    shared_examples "handles the status" do |notify_status, model_status|
+      context "with a valid bearer token" do
+        let(:bearer_token) { "test-bearer-token" } # matches settings/test.yml
+
+        it "handles the #{notify_status} status" do
+          params = { id: notify_log_entry.delivery_id, status: notify_status }
+          post :create, params:, format: :json
+
+          expect(response).to have_http_status(:no_content)
+          expect(notify_log_entry.reload.delivery_status).to eq(model_status)
+        end
+      end
+    end
+
+    include_examples "handles the status", "delivered", "delivered"
+
+    include_examples "handles the status",
+                     "permanent-failure",
+                     "permanent_failure"
+
+    include_examples "handles the status",
+                     "temporary-failure",
+                     "temporary_failure"
+
+    include_examples "handles the status",
+                     "technical-failure",
+                     "technical_failure"
+  end
+end

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_notify_log_entries_on_consent_form_id  (consent_form_id)
+#  index_notify_log_entries_on_delivery_id      (delivery_id)
 #  index_notify_log_entries_on_patient_id       (patient_id)
 #  index_notify_log_entries_on_sent_by_user_id  (sent_by_user_id)
 #

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -18,6 +18,7 @@
 # Indexes
 #
 #  index_notify_log_entries_on_consent_form_id  (consent_form_id)
+#  index_notify_log_entries_on_delivery_id      (delivery_id)
 #  index_notify_log_entries_on_patient_id       (patient_id)
 #  index_notify_log_entries_on_sent_by_user_id  (sent_by_user_id)
 #


### PR DESCRIPTION
This adds a controller which handles GOV.UK Notify callbacks, updating the status of the entry in the log which we can then use to display to the user.

Once deployed, the next step will be to configure this in GOV.UK Notify so that we start to receive callbacks for every email and text sent. This will require setting a bearer token, which I'll add in a separate PR.