### PR TITLE
Link parents with notify log entries

### DIFF
--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -16,8 +16,9 @@ class EmailDeliveryJob < NotifyDeliveryJob
     template_id = GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name.to_sym]
     raise UnknownTemplate if template_id.nil?
 
-    email_address =
-      consent_form&.parent_email || consent&.parent&.email || parent&.email
+    parent ||= consent&.parent
+
+    email_address = consent_form&.parent_email || parent&.email
     return if email_address.nil?
 
     organisation =
@@ -59,6 +60,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
     NotifyLogEntry.create!(
       consent_form:,
       delivery_id:,
+      parent:,
       patient:,
       recipient: email_address,
       sent_by:,

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -16,8 +16,9 @@ class SMSDeliveryJob < NotifyDeliveryJob
     template_id = GOVUK_NOTIFY_SMS_TEMPLATES[template_name.to_sym]
     raise UnknownTemplate if template_id.nil?
 
-    phone_number =
-      consent_form&.parent_phone || consent&.parent&.phone || parent&.phone
+    parent ||= consent&.parent
+
+    phone_number = consent_form&.parent_phone || parent&.phone
     return if phone_number.nil?
 
     personalisation =
@@ -49,6 +50,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
     NotifyLogEntry.create!(
       consent_form:,
       delivery_id:,
+      parent:,
       patient:,
       recipient: phone_number,
       sent_by:,

--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  consent_form_id :bigint
 #  delivery_id     :uuid
+#  parent_id       :bigint
 #  patient_id      :bigint
 #  sent_by_user_id :bigint
 #  template_id     :uuid             not null
@@ -19,12 +20,14 @@
 #
 #  index_notify_log_entries_on_consent_form_id  (consent_form_id)
 #  index_notify_log_entries_on_delivery_id      (delivery_id)
+#  index_notify_log_entries_on_parent_id        (parent_id)
 #  index_notify_log_entries_on_patient_id       (patient_id)
 #  index_notify_log_entries_on_sent_by_user_id  (sent_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (consent_form_id => consent_forms.id)
+#  fk_rails_...  (parent_id => parents.id) ON DELETE => nullify
 #  fk_rails_...  (patient_id => patients.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #
@@ -35,6 +38,7 @@ class NotifyLogEntry < ApplicationRecord
 
   belongs_to :consent_form, optional: true
   belongs_to :patient, optional: true
+  belongs_to :parent, optional: true
 
   enum :type, { email: 0, sms: 1 }, validate: true
   enum :delivery_status,

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -24,11 +24,13 @@ class Parent < ApplicationRecord
   before_save :reset_unused_fields
 
   has_many :consents
+  has_many :notify_log_entries, dependent: :nullify
   has_many :parent_relationships
-  has_many :patients, through: :parent_relationships
 
   has_and_belongs_to_many :class_imports
   has_and_belongs_to_many :cohort_imports
+
+  has_many :patients, through: :parent_relationships
 
   enum :contact_method_type,
        { any: "any", other: "other", text: "text", voice: "voice" },

--- a/db/migrate/20250121112644_add_parent_to_notify_log_entries.rb
+++ b/db/migrate/20250121112644_add_parent_to_notify_log_entries.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddParentToNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :notify_log_entries,
+                  :parent,
+                  foreign_key: {
+                    on_delete: :nullify
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_16_093944) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_21_112644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -471,9 +471,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_16_093944) do
     t.bigint "patient_id"
     t.bigint "sent_by_user_id"
     t.uuid "delivery_id"
+    t.bigint "parent_id"
     t.integer "delivery_status", default: 0, null: false
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
     t.index ["delivery_id"], name: "index_notify_log_entries_on_delivery_id"
+    t.index ["parent_id"], name: "index_notify_log_entries_on_parent_id"
     t.index ["patient_id"], name: "index_notify_log_entries_on_patient_id"
     t.index ["sent_by_user_id"], name: "index_notify_log_entries_on_sent_by_user_id"
   end
@@ -829,6 +831,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_16_093944) do
   add_foreign_key "immunisation_imports_vaccination_records", "vaccination_records"
   add_foreign_key "locations", "teams"
   add_foreign_key "notify_log_entries", "consent_forms"
+  add_foreign_key "notify_log_entries", "parents", on_delete: :nullify
   add_foreign_key "notify_log_entries", "patients"
   add_foreign_key "notify_log_entries", "users", column: "sent_by_user_id"
   add_foreign_key "organisation_programmes", "organisations"

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  consent_form_id :bigint
 #  delivery_id     :uuid
+#  parent_id       :bigint
 #  patient_id      :bigint
 #  sent_by_user_id :bigint
 #  template_id     :uuid             not null
@@ -19,19 +20,20 @@
 #
 #  index_notify_log_entries_on_consent_form_id  (consent_form_id)
 #  index_notify_log_entries_on_delivery_id      (delivery_id)
+#  index_notify_log_entries_on_parent_id        (parent_id)
 #  index_notify_log_entries_on_patient_id       (patient_id)
 #  index_notify_log_entries_on_sent_by_user_id  (sent_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (consent_form_id => consent_forms.id)
+#  fk_rails_...  (parent_id => parents.id) ON DELETE => nullify
 #  fk_rails_...  (patient_id => patients.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #
 FactoryBot.define do
   factory :notify_log_entry do
     patient
-    consent_form
 
     trait :email do
       type { "email" }

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -92,6 +92,7 @@ describe EmailDeliveryJob do
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
       )
+      expect(notify_log_entry.parent).to eq(parent)
       expect(notify_log_entry.patient).to eq(patient)
       expect(notify_log_entry.sent_by).to eq(sent_by)
     end

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -84,6 +84,7 @@ describe SMSDeliveryJob do
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_SMS_TEMPLATES[template_name]
       )
+      expect(notify_log_entry.parent).to eq(parent)
       expect(notify_log_entry.patient).to eq(patient)
       expect(notify_log_entry.sent_by).to eq(sent_by)
     end

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -11,6 +11,7 @@
 #  created_at      :datetime         not null
 #  consent_form_id :bigint
 #  delivery_id     :uuid
+#  parent_id       :bigint
 #  patient_id      :bigint
 #  sent_by_user_id :bigint
 #  template_id     :uuid             not null
@@ -19,12 +20,14 @@
 #
 #  index_notify_log_entries_on_consent_form_id  (consent_form_id)
 #  index_notify_log_entries_on_delivery_id      (delivery_id)
+#  index_notify_log_entries_on_parent_id        (parent_id)
 #  index_notify_log_entries_on_patient_id       (patient_id)
 #  index_notify_log_entries_on_sent_by_user_id  (sent_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (consent_form_id => consent_forms.id)
+#  fk_rails_...  (parent_id => parents.id) ON DELETE => nullify
 #  fk_rails_...  (patient_id => patients.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #


### PR DESCRIPTION
This ensures that when recording a notify log entry, it's linked with the parent that the email or text message was sent to, allowing us to easily show the status of the messages to nurses.