### PR TITLE
Add SystmOne exporter

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -125,10 +125,10 @@ class Reports::SystmOneExporter
       patient.given_name, # Forename
       gender_code(patient.gender_code), # Gender
       patient.date_of_birth.to_fs(:uk_short),
-      patient.address_line_2, # House name
-      patient.address_line_1, # House number and road
-      patient.address_town, # Town
-      patient.address_postcode, # Postcode
+      patient.restricted? ? "" : patient.address_line_2, # House name
+      patient.restricted? ? "" : patient.address_line_1, # House number and road
+      patient.restricted? ? "" : patient.address_town, # Town
+      patient.restricted? ? "" : patient.address_postcode, # Postcode
       vaccination(vaccination_record), # Vaccination
       "", # Part
       vaccination_record.performed_at.to_date.to_fs(:uk_short), # Admin date

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -9,6 +9,15 @@ class Reports::SystmOneExporter
     }
   }.freeze
 
+  DELIVERY_SITE_MAPPINGS = {
+    left_arm_upper_position: "Left deltoid",
+    left_arm_lower_position: "Left anterior forearm",
+    left_thigh: "Left lateral thigh",
+    right_arm_upper_position: "Right deltoid",
+    right_arm_lower_position: "Right anterior forearm",
+    right_thigh: "Right lateral thigh"
+  }.with_indifferent_access.freeze
+
   def initialize(organisation:, programme:, start_date:, end_date:)
     @organisation = organisation
     @programme = programme
@@ -127,7 +136,7 @@ class Reports::SystmOneExporter
       vaccination_record.batch&.expiry&.to_fs(:uk_short), # Expiry date
       vaccination_record.dose_volume_ml, # Dose
       reason(vaccination_record), # Reason (not specified)
-      vaccination_record.delivery_site, # Site
+      site(vaccination_record), # Site
       vaccination_record.delivery_method, # Method
       vaccination_record.notes # Notes
     ]
@@ -158,5 +167,14 @@ class Reports::SystmOneExporter
     else
       "At Risk"
     end
+  end
+
+  # TODO: These mappings are valid for Hertforshire, but may not be correct for
+  #       other SAIS teams. We'll need to check these are correct with new SAIS
+  #       teams.
+  def site(vaccination_record)
+    return if vaccination_record.not_administered?
+
+    DELIVERY_SITE_MAPPINGS.fetch(vaccination_record.delivery_site)
   end
 end

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class Reports::SystmOneExporter
+  VACCINE_DOSE_MAPPINGS = {
+    "Gardasil 9" => {
+      "1" => "Y19a4",
+      "2" => "Y19a5",
+      "3" => "Y19a6"
+    }
+  }.freeze
+
   def initialize(organisation:, programme:, start_date:, end_date:)
     @organisation = organisation
     @programme = programme
@@ -129,8 +137,18 @@ class Reports::SystmOneExporter
     { male: "M", female: "F", not_specified: "U", not_known: "U" }[code.to_sym]
   end
 
+  # TODO: These mappings are valid for Hertforshire, but may not be correct for
+  #       other SAIS teams. We'll need to check these are correct with new SAIS
+  #       teams.
   def vaccination(vaccination_record)
-    "#{vaccination_record.vaccine.brand} dose #{vaccination_record.dose_sequence}"
+    return if vaccination_record.not_administered?
+
+    VACCINE_DOSE_MAPPINGS.dig(
+      vaccination_record.vaccine.brand,
+      vaccination_record.dose_sequence.to_s
+    ) ||
+      "#{vaccination_record.vaccine.brand} " \
+        "Part #{vaccination_record.dose_sequence}"
   end
 
   def reason(vaccination_record)

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -126,14 +126,7 @@ class Reports::SystmOneExporter
   end
 
   def gender_code(code)
-    case code
-    when "not_known"
-      "Not known"
-    when "not_specified"
-      "Not specified"
-    else
-      code.capitalize
-    end
+    { male: "M", female: "F", not_specified: "U", not_known: "U" }[code.to_sym]
   end
 
   def vaccination(vaccination_record)

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+class Reports::SystmOneExporter
+  def initialize(organisation:, programme:, start_date:, end_date:)
+    @organisation = organisation
+    @programme = programme
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def call
+    CSV.generate(headers:, write_headers: true) do |csv|
+      programme
+        .sessions
+        .where(organisation:)
+        .find_each do |session|
+          patient_sessions_for_session(session).each do |patient_session|
+            rows(patient_session:).each { |row| csv << row }
+          end
+        end
+    end
+  end
+
+  def self.call(*args, **kwargs)
+    new(*args, **kwargs).call
+  end
+
+  private_class_method :new
+
+  private
+
+  attr_reader :organisation, :programme, :start_date, :end_date
+
+  def headers
+    [
+      "Practice code",
+      "NHS number",
+      "Surname",
+      "Middle name",
+      "Forename",
+      "Gender",
+      "Date of Birth",
+      "House name",
+      "House number and road",
+      "Town",
+      "Postcode",
+      "Vaccination",
+      "Part",
+      "Admin date",
+      "Batch number",
+      "Expiry date",
+      "Dose",
+      "Reason",
+      "Site",
+      "Method",
+      "Notes"
+    ]
+  end
+
+  def patient_sessions_for_session(session)
+    scope =
+      session
+        .patient_sessions
+        .includes(
+          :location,
+          :vaccination_records,
+          consents: %i[parent patient],
+          patient: :school
+        )
+        .where.not(vaccination_records: { id: nil })
+        .merge(VaccinationRecord.administered)
+
+    if start_date.present?
+      scope =
+        scope.where(
+          "vaccination_records.created_at >= ?",
+          start_date.beginning_of_day
+        ).or(
+          scope.where(
+            "vaccination_records.updated_at >= ?",
+            start_date.beginning_of_day
+          )
+        )
+    end
+
+    if end_date.present?
+      scope =
+        scope.where(
+          "vaccination_records.created_at <= ?",
+          end_date.end_of_day
+        ).or(
+          scope.where(
+            "vaccination_records.updated_at <= ?",
+            end_date.end_of_day
+          )
+        )
+    end
+
+    scope
+  end
+
+  def rows(patient_session:)
+    patient = patient_session.patient
+    vaccination_records =
+      patient_session.vaccination_records.administered.order(:performed_at)
+
+    if vaccination_records.any?
+      vaccination_records.map do |vaccination_record|
+        existing_row(patient:, vaccination_record:)
+      end
+    end
+  end
+
+  def existing_row(patient:, vaccination_record:)
+    batch = vaccination_record.batch
+
+    [
+      organisation.ods_code, # Practice code
+      patient.nhs_number, # NHS number
+      patient.family_name, # Surname
+      "", # Middle name (not stored)
+      patient.given_name, # Forename
+      gender_code(patient.gender_code), # Gender
+      patient.date_of_birth.to_fs(:uk_short),
+      patient.address_line_2, # House name
+      patient.address_line_1, # House number and road
+      patient.address_town, # Town
+      patient.address_postcode, # Postcode
+      vaccination(vaccination_record), # Vaccination
+      "", # Part
+      vaccination_record.performed_at.to_date.to_fs(:uk_short), # Admin date
+      batch&.name, # Batch number
+      batch&.expiry&.to_fs(:uk_short), # Expiry date
+      vaccination_record.dose_volume_ml, # Dose
+      reason(vaccination_record), # Reason (not specified)
+      vaccination_record.delivery_site, # Site
+      vaccination_record.delivery_method, # Method
+      vaccination_record.notes # Notes
+    ]
+  end
+
+  def gender_code(code)
+    case code
+    when "not_known"
+      "Not known"
+    when "not_specified"
+      "Not specified"
+    else
+      code.capitalize
+    end
+  end
+
+  def vaccination(vaccination_record)
+    "#{vaccination_record.vaccine.brand} dose #{vaccination_record.dose_sequence}"
+  end
+
+  def reason(vaccination_record)
+    case vaccination_record.dose_sequence
+    when 1, nil
+      "Routine"
+    else
+      "At Risk"
+    end
+  end
+end

--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -9,11 +9,7 @@ class VaccinationReport
   end
 
   def self.file_formats(programme)
-    %w[careplus mavis].tap do
-      if Flipper.enabled?(:systm_one_exporter) && programme.hpv?
-        it << "systm_one"
-      end
-    end
+    %w[careplus mavis].tap { it << "systm_one" if programme.hpv? }
   end
 
   attribute :date_from, :date

--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -4,10 +4,16 @@ class VaccinationReport
   include RequestSessionPersistable
   include WizardStepConcern
 
-  FILE_FORMATS = %w[careplus mavis].freeze
-
   def self.request_session_key
     "vaccination_report"
+  end
+
+  def self.file_formats(programme)
+    %w[careplus mavis].tap do
+      if Flipper.enabled?(:systm_one_exporter) && programme.hpv?
+        it << "systm_one"
+      end
+    end
   end
 
   attribute :date_from, :date
@@ -20,7 +26,10 @@ class VaccinationReport
   end
 
   on_wizard_step :file_format, exact: true do
-    validates :file_format, inclusion: { in: FILE_FORMATS }
+    validates :file_format,
+              inclusion: {
+                in: -> { VaccinationReport.file_formats(it.programme) }
+              }
   end
 
   def programme
@@ -57,7 +66,8 @@ class VaccinationReport
   def exporter_class
     {
       careplus: Reports::CareplusExporter,
-      mavis: Reports::ProgrammeVaccinationsExporter
+      mavis: Reports::ProgrammeVaccinationsExporter,
+      systm_one: Reports::SystmOneExporter
     }.fetch(file_format.to_sym)
   end
 

--- a/app/views/vaccination_reports/file_format.html.erb
+++ b/app/views/vaccination_reports/file_format.html.erb
@@ -8,7 +8,7 @@
 <%= form_with model: @vaccination_report, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_collection_radio_buttons :file_format, VaccinationReport::FILE_FORMATS, :itself, legend: { text: title, size: "l", tag: "h1" }, caption: { text: @programme.name } %>
+  <%= f.govuk_collection_radio_buttons :file_format, VaccinationReport.file_formats(@programme), :itself, legend: { text: title, size: "l", tag: "h1" }, caption: { text: @programme.name } %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -21,3 +21,4 @@ en:
         file_format_options:
           careplus: CarePlus
           mavis: CSV
+          systm_one: SystmOne

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ end
 Faker::Config.locale = "en-GB"
 
 def set_feature_flags
-  %i[dev_tools mesh_jobs cis2].each do |feature_flag|
+  %i[dev_tools mesh_jobs cis2 systm_one_export].each do |feature_flag|
     Flipper.add(feature_flag) unless Flipper.exist?(feature_flag)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@ end
 Faker::Config.locale = "en-GB"
 
 def set_feature_flags
-  %i[dev_tools mesh_jobs cis2 systm_one_export].each do |feature_flag|
+  %i[dev_tools mesh_jobs cis2].each do |feature_flag|
     Flipper.add(feature_flag) unless Flipper.exist?(feature_flag)
   end
 end

--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -34,7 +34,6 @@ describe "Download vaccination reports" do
   scenario "Download in SystmOne format" do
     given_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
-    and_systm_one_export_is_enabled
 
     when_i_go_to_the_programme
     and_i_click_on_download_vaccination_report
@@ -47,8 +46,8 @@ describe "Download vaccination reports" do
     then_i_download_a_systm_one_file
   end
 
-  scenario "SystmOne disabled" do
-    given_an_hpv_programme_is_underway
+  scenario "Programme is not HPV" do
+    given_a_menacwy_programme_is_underway
     and_an_administered_vaccination_record_exists
 
     when_i_go_to_the_programme
@@ -81,6 +80,27 @@ describe "Download vaccination reports" do
       create(:patient_session, patient: @patient, session: @session)
   end
 
+  def given_a_menacwy_programme_is_underway
+    @organisation = create(:organisation, :with_one_nurse)
+    @programme = create(:programme, :menacwy, organisations: [@organisation])
+
+    @session =
+      create(:session, organisation: @organisation, programmes: [@programme])
+
+    @patient =
+      create(
+        :patient,
+        :triage_ready_to_vaccinate,
+        given_name: "John",
+        family_name: "Smith",
+        programmes: [@programme],
+        organisation: @organisation
+      )
+
+    @patient_session =
+      create(:patient_session, patient: @patient, session: @session)
+  end
+
   def and_an_administered_vaccination_record_exists
     vaccine = @programme.vaccines.first
 
@@ -93,10 +113,6 @@ describe "Download vaccination reports" do
       session: @session,
       batch:
     )
-  end
-
-  def and_systm_one_export_is_enabled
-    Flipper.enable(:systm_one_exporter)
   end
 
   def when_i_go_to_the_programme

--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -31,6 +31,35 @@ describe "Download vaccination reports" do
     then_i_download_a_mavis_file
   end
 
+  scenario "Download in SystmOne format" do
+    given_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+    and_systm_one_export_is_enabled
+
+    when_i_go_to_the_programme
+    and_i_click_on_download_vaccination_report
+    then_i_see_the_dates_page
+
+    when_i_enter_some_dates
+    then_i_see_the_file_format_page
+
+    when_i_choose_systm_one
+    then_i_download_a_systm_one_file
+  end
+
+  scenario "SystmOne disabled" do
+    given_an_hpv_programme_is_underway
+    and_an_administered_vaccination_record_exists
+
+    when_i_go_to_the_programme
+    and_i_click_on_download_vaccination_report
+    then_i_see_the_dates_page
+
+    when_i_enter_some_dates
+    then_i_see_the_file_format_page
+    and_systm_one_export_is_disabled
+  end
+
   def given_an_hpv_programme_is_underway
     @organisation = create(:organisation, :with_one_nurse)
     @programme = create(:programme, :hpv, organisations: [@organisation])
@@ -64,6 +93,10 @@ describe "Download vaccination reports" do
       session: @session,
       batch:
     )
+  end
+
+  def and_systm_one_export_is_enabled
+    Flipper.enable(:systm_one_exporter)
   end
 
   def when_i_go_to_the_programme
@@ -109,6 +142,11 @@ describe "Download vaccination reports" do
     click_on "Continue"
   end
 
+  def when_i_choose_systm_one
+    choose "SystmOne"
+    click_on "Continue"
+  end
+
   def then_i_download_a_careplus_file
     expect(page.status_code).to eq(200)
 
@@ -123,5 +161,17 @@ describe "Download vaccination reports" do
     expect(page).to have_content(
       "ORGANISATION_CODE,SCHOOL_URN,SCHOOL_NAME,CARE_SETTING,CLINIC_NAME,PERSON_FORENAME,PERSON_SURNAME"
     )
+  end
+
+  def then_i_download_a_systm_one_file
+    expect(page.status_code).to eq(200)
+
+    expect(page).to have_content(
+      "Practice code,NHS number,Surname,Middle name,Forename,Gender,Date of Birth,House name,House number and road,Town"
+    )
+  end
+
+  def and_systm_one_export_is_disabled
+    expect(page).not_to have_selector("SystmOne")
   end
 end

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+describe Reports::SystmOneExporter do
+  subject(:parsed_csv) { CSV.parse(csv, headers: true) }
+
+  let(:csv) do
+    described_class.call(
+      organisation:,
+      programme:,
+      start_date: 1.month.ago.to_date,
+      end_date: Date.current
+    )
+  end
+  let(:programme) { create(:programme, :hpv) }
+  let(:organisation) do
+    create(:organisation, ods_code: "ABC123", programmes: [programme])
+  end
+  let(:location) { create(:school) }
+  let(:session) { create(:session, organisation:, programme:, location:) }
+  let(:headers) { parsed_csv.headers }
+
+  it "includes the patient and vaccination details" do
+    patient_session = create(:patient_session, session:)
+    vaccination_record =
+      create(
+        :vaccination_record,
+        programme:,
+        patient_session:,
+        performed_at: 2.weeks.ago
+      )
+
+    expect(parsed_csv.first.to_h).to eq(
+      {
+        "Practice code" => "ABC123",
+        "NHS number" => vaccination_record.patient.nhs_number,
+        "Surname" => vaccination_record.patient.family_name,
+        "Middle name" => "",
+        "Forename" => vaccination_record.patient.given_name,
+        "Gender" => "Not known",
+        "Date of Birth" =>
+          vaccination_record.patient.date_of_birth.strftime("%d/%m/%Y"),
+        "House name" => vaccination_record.patient.address_line_2,
+        "House number and road" => vaccination_record.patient.address_line_1,
+        "Town" => vaccination_record.patient.address_town,
+        "Postcode" => vaccination_record.patient.address_postcode,
+        "Vaccination" => "Gardasil 9 dose 1",
+        "Part" => "",
+        "Admin date" =>
+          vaccination_record.performed_at.to_date.strftime("%d/%m/%Y"),
+        "Batch number" => vaccination_record.batch.name,
+        "Expiry date" => vaccination_record.batch.expiry.strftime("%d/%m/%Y"),
+        "Dose" => vaccination_record.dose_volume_ml.to_s,
+        "Reason" => "Routine",
+        "Site" => vaccination_record.delivery_site,
+        "Method" => vaccination_record.delivery_method,
+        "Notes" => vaccination_record.notes
+      }
+    )
+  end
+
+  context "no vaccination details" do
+    before { create(:patient_session, session:) }
+
+    it { should be_empty }
+  end
+
+  context "with vaccination records outside the date range" do
+    before do
+      patient_session = create(:patient_session, session:)
+      create(
+        :vaccination_record,
+        programme:,
+        patient_session:,
+        created_at: 2.months.ago,
+        updated_at: 2.months.ago,
+        performed_at: 2.months.ago
+      )
+    end
+
+    it { should be_empty }
+  end
+
+  context "with vaccination records that haven't been administered" do
+    before do
+      patient_session = create(:patient_session, session:)
+      create(
+        :vaccination_record,
+        :not_administered,
+        programme:,
+        patient_session:
+      )
+    end
+
+    it { should be_empty }
+  end
+
+  context "with vaccination records updated within the date range do" do
+    before do
+      patient_session = create(:patient_session, session:)
+      create(
+        :vaccination_record,
+        programme:,
+        patient_session:,
+        created_at: 2.months.ago,
+        updated_at: 1.day.ago,
+        performed_at: 2.months.ago
+      )
+    end
+
+    it { should_not be_empty }
+  end
+
+  context "with a session in a different organisation" do
+    before do
+      session = create(:session, programme:, location:)
+      patient_session = create(:patient_session, session:)
+      create(:vaccination_record, programme:, patient_session:)
+    end
+
+    it { should be_empty }
+  end
+end

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -152,4 +152,41 @@ describe Reports::SystmOneExporter do
       it { should eq "U" }
     end
   end
+
+  describe "Vaccination field" do
+    subject { csv_row["Vaccination"] }
+
+    let(:vaccination_record) do
+      create(
+        :vaccination_record,
+        programme:,
+        patient:,
+        session:,
+        performed_at: 2.weeks.ago,
+        vaccine:,
+        dose_sequence:
+      )
+    end
+
+    context "HPV Gardasil 9 dose 2" do
+      let(:vaccine) { Vaccine.find_by(brand: "Gardasil 9") }
+      let(:dose_sequence) { 2 }
+
+      it { should eq "Y19a5" }
+    end
+
+    context "HPV Gardasil 9 dose 3" do
+      let(:vaccine) { Vaccine.find_by(brand: "Gardasil 9") }
+      let(:dose_sequence) { 3 }
+
+      it { should eq "Y19a6" }
+    end
+
+    context "unknown vaccine and no dose sequence" do
+      let(:vaccine) { create(:vaccine, :fluad_tetra) }
+      let(:dose_sequence) { 1 }
+
+      it { should eq "Fluad Tetra - aQIV Part 1" }
+    end
+  end
 end

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -54,7 +54,7 @@ describe Reports::SystmOneExporter do
         "Expiry date" => vaccination_record.batch.expiry.strftime("%d/%m/%Y"),
         "Dose" => vaccination_record.dose_volume_ml.to_s,
         "Reason" => "Routine",
-        "Site" => vaccination_record.delivery_site,
+        "Site" => "Left deltoid",
         "Method" => vaccination_record.delivery_method,
         "Notes" => vaccination_record.notes
       }
@@ -187,6 +187,27 @@ describe Reports::SystmOneExporter do
       let(:dose_sequence) { 1 }
 
       it { should eq "Fluad Tetra - aQIV Part 1" }
+    end
+  end
+
+  describe "Site field" do
+    subject { csv_row["Site"] }
+
+    let(:vaccination_record) do
+      create(
+        :vaccination_record,
+        programme:,
+        patient:,
+        session:,
+        performed_at: 2.weeks.ago,
+        delivery_site:
+      )
+    end
+
+    context "left arm lower position" do
+      let(:delivery_site) { "left_arm_lower_position" }
+
+      it { should eq "Left anterior forearm" }
     end
   end
 end

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -130,4 +130,26 @@ describe Reports::SystmOneExporter do
 
     it { should be_blank }
   end
+
+  describe "Gender field" do
+    subject { csv_row["Gender"] }
+
+    context "gender_code is male" do
+      let(:patient) { create(:patient, gender_code: :male) }
+
+      it { should eq "M" }
+    end
+
+    context "gender_code is female" do
+      let(:patient) { create(:patient, gender_code: :female) }
+
+      it { should eq "F" }
+    end
+
+    context "gender_code is not specified" do
+      let(:patient) { create(:patient, gender_code: :not_specified) }
+
+      it { should eq "U" }
+    end
+  end
 end

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -34,7 +34,7 @@ describe Reports::SystmOneExporter do
   it "includes the patient and vaccination details" do
     expect(parsed_csv.first.to_h).to eq(
       {
-        "Practice code" => "ABC123",
+        "Practice code" => location.urn,
         "NHS number" => vaccination_record.patient.nhs_number,
         "Surname" => vaccination_record.patient.family_name,
         "Middle name" => "",
@@ -129,6 +129,16 @@ describe Reports::SystmOneExporter do
     end
 
     it { should be_blank }
+  end
+
+  describe "Practice code field" do
+    subject { csv_row["Practice code"] }
+
+    context "location is a gp clinic" do
+      let(:location) { create(:gp_practice) }
+
+      it { should eq location.ods_code }
+    end
   end
 
   describe "Gender field" do

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -220,4 +220,19 @@ describe Reports::SystmOneExporter do
       it { should eq "Left anterior forearm" }
     end
   end
+
+  describe "address fields" do
+    context "patient is restricted" do
+      let(:patient) { create(:patient, :restricted) }
+
+      it "does not include address details" do
+        expect(csv_row.to_h).to include(
+          "House name" => "",
+          "House number and road" => "",
+          "Town" => "",
+          "Postcode" => ""
+        )
+      end
+    end
+  end
 end

--- a/spec/models/vaccination_report_spec.rb
+++ b/spec/models/vaccination_report_spec.rb
@@ -4,25 +4,13 @@ describe VaccinationReport do
   describe "file_formats" do
     subject { described_class.file_formats(programme) }
 
-    context "when hpv and feature is disabled" do
-      before { Flipper.disable(:systm_one_exporter) }
-
-      let(:programme) { create(:programme, :hpv) }
-
-      it { should eq(%w[careplus mavis]) }
-    end
-
-    context "when hpv and feature is enabled" do
-      before { Flipper.enable(:systm_one_exporter) }
-
+    context "when programme is hpv" do
       let(:programme) { create(:programme, :hpv) }
 
       it { should eq(%w[careplus mavis systm_one]) }
     end
 
-    context "when menacwy and feature is enabled" do
-      before { Flipper.enable(:systm_one_exporter) }
-
+    context "when programme is menacwy" do
       let(:programme) { create(:programme, :menacwy) }
 
       it { should eq(%w[careplus mavis]) }

--- a/spec/models/vaccination_report_spec.rb
+++ b/spec/models/vaccination_report_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe VaccinationReport do
+  describe "file_formats" do
+    subject { described_class.file_formats(programme) }
+
+    context "when hpv and feature is disabled" do
+      before { Flipper.disable(:systm_one_exporter) }
+
+      let(:programme) { create(:programme, :hpv) }
+
+      it { should eq(%w[careplus mavis]) }
+    end
+
+    context "when hpv and feature is enabled" do
+      before { Flipper.enable(:systm_one_exporter) }
+
+      let(:programme) { create(:programme, :hpv) }
+
+      it { should eq(%w[careplus mavis systm_one]) }
+    end
+
+    context "when menacwy and feature is enabled" do
+      before { Flipper.enable(:systm_one_exporter) }
+
+      let(:programme) { create(:programme, :menacwy) }
+
+      it { should eq(%w[careplus mavis]) }
+    end
+  end
+end


### PR DESCRIPTION
The exporter has been tested and confirmed working by Hertfordshire. It's hidden behind a feature flag for the time being, and only available on HPV programmes.

![image](https://github.com/user-attachments/assets/d28e31e3-722d-4c46-a92c-0ca0007651b8)

Worth noting the current export format is fairly bespoke to Hertfordshire's needs, and there are a few areas we'll need to review for new teams or even new vaccines:

-  **vaccination field** - This maps from the vaccine brand and dose sequence to a code. We only have mappings for "Gardasil 9" at the moment, and we don't even know if maybe these codes change depending on provider.
- **practice code** - The URN or ODS code of where the vaccination was performed. Hertfordshire has only defined how to do this for vaccinations in schools (URN) or in GP practices (ODS code), we've just assumed that for clinics this is also the ODS code, but this may be wrong.
- **site** - The delivery site of the vaccination. These value may be bespoke to Hertfordshire, we don't know if other SAIS teams will need these to be customised.