### PR TITLE
Don't pass GOV.UK Notify reply-to if nil

### DIFF
--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -82,6 +82,19 @@ describe EmailDeliveryJob do
       perform_now
     end
 
+    context "without a reply-to id" do
+      let(:organisation) { create(:organisation, programmes: [programme]) }
+
+      it "sends a text using GOV.UK Notify" do
+        expect(notifications_client).to receive(:send_email).with(
+          email_address: "test@example.com",
+          personalisation: an_instance_of(Hash),
+          template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+        )
+        perform_now
+      end
+    end
+
     it "creates a log entry" do
       expect { perform_now }.to change(NotifyLogEntry, :count).by(1)
 
@@ -126,6 +139,19 @@ describe EmailDeliveryJob do
           template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
         )
         perform_now
+      end
+
+      context "without a reply-to id" do
+        let(:organisation) { create(:organisation, programmes: [programme]) }
+
+        it "sends a text using GOV.UK Notify" do
+          expect(notifications_client).to receive(:send_email).with(
+            email_address: "test@example.com",
+            personalisation: an_instance_of(Hash),
+            template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
+          )
+          perform_now
+        end
       end
 
       it "creates a log entry" do


### PR DESCRIPTION
This updates the `EmailDeliveryJob` to ensure that we don't pass a reply-to UUID if the value is `nil`, as this results in an error when making the call to GOV.UK Notify.