### PR TITLE
Ensure patients with pre-screenings can be merged

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -44,6 +44,9 @@ class PatientMerger
           patient_session.gillick_assessments.update_all(
             patient_session_id: existing_patient_session.id
           )
+          patient_session.pre_screenings.update_all(
+            patient_session_id: existing_patient_session.id
+          )
           patient_session.vaccination_records.update_all(
             patient_session_id: existing_patient_session.id
           )

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -33,6 +33,8 @@ class PreScreening < ApplicationRecord
              class_name: "User",
              foreign_key: :performed_by_user_id
 
+  has_one :patient, through: :patient_session
+
   encrypts :notes
 
   validates :knows_vaccination,

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -39,6 +39,9 @@ describe PatientMerger do
     let(:patient_session) do
       create(:patient_session, session:, patient: patient_to_destroy)
     end
+    let(:pre_screening) do
+      create(:pre_screening, :allows_vaccination, patient_session:)
+    end
     let(:school_move) do
       create(:school_move, :to_school, patient: patient_to_destroy)
     end
@@ -97,6 +100,12 @@ describe PatientMerger do
 
     it "moves patient sessions" do
       expect { call }.to change { patient_session.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves pre-screenings" do
+      expect { call }.to change { pre_screening.reload.patient }.to(
         patient_to_keep
       )
     end


### PR DESCRIPTION
This fixes an issue where patients with a pre-screening record cannot be merged with another using the `PatientMerger` class as the old patient record cannot be deleted due to the foreign key persisting and not being updated to refer to the new patient.