### PR TITLE
Fix flaky offline session report test

### DIFF
--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -638,7 +638,7 @@ describe Reports::OfflineSessionExporter do
 
       it "lists all the organisation users' emails" do
         emails = worksheet[1..].map { it.cells.first.value }
-        expect(emails).to eq vaccinators.map(&:email)
+        expect(emails).to match_array(vaccinators.map(&:email))
       end
 
       its(:state) { should eq "hidden" }
@@ -666,7 +666,7 @@ describe Reports::OfflineSessionExporter do
 
       it "lists all the batch numbers for the programme" do
         batch_numbers = worksheet[1..].map { it.cells.first.value }
-        expect(batch_numbers).to eq batches.map(&:name)
+        expect(batch_numbers).to match_array(batches.map(&:name))
       end
 
       its(:state) { should eq "hidden" }


### PR DESCRIPTION
This updates the test to use `match_array` instead of `eq` when comparing the values of the two arrays as the order of the arrays isn't relevant to the test, and isn't guaranteed.