### PR TITLE
Record school move log entries 

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -46,6 +46,7 @@ class DevController < ApplicationController
 
       SchoolMove.where(patient: patients).destroy_all
       SchoolMove.where(organisation:).destroy_all
+      SchoolMoveLogEntry.where(patient: patients).destroy_all
       AccessLogEntry.where(patient: patients).destroy_all
       NotifyLogEntry.where(patient: patients).destroy_all
 

--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -13,12 +13,13 @@ class SchoolMovesController < ApplicationController
   end
 
   def show
-    @form = SchoolMoveForm.new(school_move: @school_move)
+    @form = SchoolMoveForm.new(current_user:, school_move: @school_move)
   end
 
   def update
     @form =
       SchoolMoveForm.new(
+        current_user:,
         school_move: @school_move,
         action: params.dig(:school_move_form, :action),
         move_to_school: params.dig(:school_move_form, :move_to_school)

--- a/app/forms/school_move_form.rb
+++ b/app/forms/school_move_form.rb
@@ -4,7 +4,7 @@ class SchoolMoveForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :school_move
+  attr_accessor :current_user, :school_move
 
   attribute :action, :string
   attribute :move_to_school, :boolean
@@ -21,7 +21,7 @@ class SchoolMoveForm
 
     case action
     when "confirm"
-      @school_move.confirm!(move_to_school:)
+      @school_move.confirm!(user: current_user, move_to_school:)
     when "ignore"
       @school_move.ignore!
     end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -68,6 +68,7 @@ class Patient < ApplicationRecord
   has_many :notify_log_entries
   has_many :parent_relationships
   has_many :patient_sessions
+  has_many :school_move_log_entries
   has_many :school_moves
   has_many :session_notifications
   has_many :triages

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -51,10 +51,11 @@ class SchoolMove < ApplicationRecord
               unless: -> { school.nil? }
             }
 
-  def confirm!(move_to_school: nil)
+  def confirm!(user: nil, move_to_school: nil)
     ActiveRecord::Base.transaction do
       update_patient!
       update_sessions!(move_to_school:)
+      create_log_entry!(user:, move_to_school:)
       SchoolMove.where(patient:).destroy_all if persisted?
     end
   end
@@ -107,6 +108,16 @@ class SchoolMove < ApplicationRecord
     return if session.nil?
 
     PatientSession.find_or_create_by!(patient:, session:)
+  end
+
+  def create_log_entry!(user:, move_to_school:)
+    SchoolMoveLogEntry.create!(
+      home_educated:,
+      move_to_school:,
+      patient:,
+      school:,
+      user:
+    )
   end
 
   def cohort

--- a/app/models/school_move_log_entry.rb
+++ b/app/models/school_move_log_entry.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: school_move_log_entries
+#
+#  id             :bigint           not null, primary key
+#  home_educated  :boolean
+#  move_to_school :boolean
+#  created_at     :datetime         not null
+#  patient_id     :bigint           not null
+#  school_id      :bigint
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_school_move_log_entries_on_patient_id  (patient_id)
+#  index_school_move_log_entries_on_school_id   (school_id)
+#  index_school_move_log_entries_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class SchoolMoveLogEntry < ApplicationRecord
+  include Schoolable
+
+  belongs_to :patient
+  belongs_to :user, optional: true
+end

--- a/db/migrate/20250122155821_create_school_move_log_entries.rb
+++ b/db/migrate/20250122155821_create_school_move_log_entries.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateSchoolMoveLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    create_table :school_move_log_entries do |t|
+      t.references :patient, foreign_key: true, null: false
+      t.references :user, foreign_key: true
+
+      t.references :school, foreign_key: { to_table: :locations }
+      t.boolean :home_educated
+
+      t.boolean :move_to_school
+
+      t.datetime :created_at, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -617,6 +617,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_27_133639) do
     t.index ["session_id", "programme_id"], name: "index_programmes_sessions_on_session_id_and_programme_id", unique: true
   end
 
+  create_table "school_move_log_entries", force: :cascade do |t|
+    t.bigint "patient_id", null: false
+    t.bigint "user_id"
+    t.bigint "school_id"
+    t.boolean "home_educated"
+    t.boolean "move_to_school"
+    t.datetime "created_at", null: false
+    t.index ["patient_id"], name: "index_school_move_log_entries_on_patient_id"
+    t.index ["school_id"], name: "index_school_move_log_entries_on_school_id"
+    t.index ["user_id"], name: "index_school_move_log_entries_on_user_id"
+  end
+
   create_table "school_moves", force: :cascade do |t|
     t.bigint "patient_id", null: false
     t.integer "source", null: false
@@ -848,6 +860,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_27_133639) do
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
   add_foreign_key "programmes_sessions", "programmes"
   add_foreign_key "programmes_sessions", "sessions"
+  add_foreign_key "school_move_log_entries", "locations", column: "school_id"
+  add_foreign_key "school_move_log_entries", "patients"
+  add_foreign_key "school_move_log_entries", "users"
   add_foreign_key "school_moves", "locations", column: "school_id"
   add_foreign_key "school_moves", "organisations"
   add_foreign_key "school_moves", "patients"

--- a/spec/factories/school_move_log_entries.rb
+++ b/spec/factories/school_move_log_entries.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: school_move_log_entries
+#
+#  id             :bigint           not null, primary key
+#  home_educated  :boolean
+#  move_to_school :boolean
+#  created_at     :datetime         not null
+#  patient_id     :bigint           not null
+#  school_id      :bigint
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_school_move_log_entries_on_patient_id  (patient_id)
+#  index_school_move_log_entries_on_school_id   (school_id)
+#  index_school_move_log_entries_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+FactoryBot.define do
+  factory :school_move_log_entry do
+    patient
+    user
+
+    home_educated { nil }
+    school
+
+    trait :home_educated do
+      home_educated { true }
+      school { nil }
+    end
+
+    trait :unknown_school do
+      home_educated { false }
+      school { nil }
+    end
+  end
+end

--- a/spec/models/school_move_log_entry_spec.rb
+++ b/spec/models/school_move_log_entry_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: school_move_log_entries
+#
+#  id             :bigint           not null, primary key
+#  home_educated  :boolean
+#  move_to_school :boolean
+#  created_at     :datetime         not null
+#  patient_id     :bigint           not null
+#  school_id      :bigint
+#  user_id        :bigint
+#
+# Indexes
+#
+#  index_school_move_log_entries_on_patient_id  (patient_id)
+#  index_school_move_log_entries_on_school_id   (school_id)
+#  index_school_move_log_entries_on_user_id     (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#  fk_rails_...  (user_id => users.id)
+#
+describe SchoolMoveLogEntry do
+  subject(:school_move_log_entry) { build(:school_move_log_entry) }
+
+  it { should be_valid }
+end

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -49,13 +49,30 @@ describe SchoolMove do
   end
 
   describe "#confirm!" do
-    subject(:confirm!) { school_move.confirm!(move_to_school:) }
+    subject(:confirm!) { school_move.confirm!(user:, move_to_school:) }
 
+    let(:user) { create(:user) }
     let(:move_to_school) { nil }
 
     let(:programme) { create(:programme) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
     let(:generic_clinic_session) { organisation.generic_clinic_session }
+
+    shared_examples "creates a log entry" do
+      it "creates a log entry" do
+        expect { confirm! }.to change(
+          patient.school_move_log_entries,
+          :count
+        ).by(1)
+
+        expect(SchoolMoveLogEntry.last).to have_attributes(
+          move_to_school:,
+          school: school_move.school,
+          home_educated: school_move.home_educated,
+          user:
+        )
+      end
+    end
 
     shared_examples "sets the patient school" do
       it "sets the patient school" do
@@ -175,6 +192,7 @@ describe SchoolMove do
           )
         end
 
+        include_examples "creates a log entry"
         include_examples "sets the patient cohort"
         include_examples "sets the patient school"
         include_examples "adds the patient to the new school session"
@@ -197,6 +215,7 @@ describe SchoolMove do
           )
         end
 
+        include_examples "creates a log entry"
         include_examples "sets the patient cohort"
         include_examples "sets the patient school"
         include_examples "adds the patient to the new school session"
@@ -213,6 +232,7 @@ describe SchoolMove do
           create(:session, :closed, location: school, organisation:, programme:)
         end
 
+        include_examples "creates a log entry"
         include_examples "sets the patient cohort"
         include_examples "sets the patient school"
         include_examples "adds the patient to the community clinics"
@@ -224,6 +244,7 @@ describe SchoolMove do
           create(:school_move, :to_home_educated, organisation:, patient:)
         end
 
+        include_examples "creates a log entry"
         include_examples "sets the patient cohort"
         include_examples "sets the patient to home-schooled"
         include_examples "adds the patient to the community clinics"
@@ -252,6 +273,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
@@ -275,6 +297,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
@@ -298,6 +321,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
@@ -310,6 +334,7 @@ describe SchoolMove do
             create(:school_move, :to_home_educated, organisation:, patient:)
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
@@ -336,6 +361,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "changes the patient cohort"
           include_examples "removes the patient from the old school session"
@@ -360,6 +386,7 @@ describe SchoolMove do
             new_organisation.generic_clinic_session
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "changes the patient cohort"
           include_examples "removes the patient from the old school session"
@@ -393,6 +420,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
@@ -415,6 +443,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
@@ -437,6 +466,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
@@ -448,6 +478,7 @@ describe SchoolMove do
             create(:school_move, :to_home_educated, organisation:, patient:)
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
@@ -473,6 +504,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "changes the patient cohort"
           include_examples "keeps the patient in the old school session"
@@ -496,6 +528,7 @@ describe SchoolMove do
             new_organisation.generic_clinic_session
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "changes the patient cohort"
           include_examples "keeps the patient in the old school session"
@@ -526,6 +559,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -555,6 +589,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -584,6 +619,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -605,6 +641,7 @@ describe SchoolMove do
             expect { confirm! }.not_to(change { patient.reload.home_educated })
           end
 
+          include_examples "creates a log entry"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -629,6 +666,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "changes the patient cohort"
           include_examples "removes the patient from the community clinics"
@@ -663,6 +701,7 @@ describe SchoolMove do
             expect { confirm! }.not_to(change { patient.reload.home_educated })
           end
 
+          include_examples "creates a log entry"
           include_examples "changes the patient cohort"
           include_examples "adds the patient to the community clinics"
           include_examples "destroys the school move"
@@ -695,6 +734,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -717,6 +757,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -739,6 +780,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -778,6 +820,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -809,6 +852,7 @@ describe SchoolMove do
             expect { confirm! }.not_to(change { patient.reload.home_educated })
           end
 
+          include_examples "creates a log entry"
           include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -838,6 +882,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -845,6 +890,7 @@ describe SchoolMove do
           context "when the user asks to move the patient to the new school" do
             let(:move_to_school) { true }
 
+            include_examples "creates a log entry"
             include_examples "removes the patient from the community clinics"
             include_examples "adds the patient to the new school session"
           end
@@ -866,6 +912,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -873,6 +920,7 @@ describe SchoolMove do
           context "when the user asks to move the patient to the new school" do
             let(:move_to_school) { true }
 
+            include_examples "creates a log entry"
             include_examples "removes the patient from the community clinics"
             include_examples "adds the patient to the new school session"
           end
@@ -894,6 +942,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -901,6 +950,7 @@ describe SchoolMove do
           context "when the user asks to move the patient to the new school" do
             let(:move_to_school) { true }
 
+            include_examples "creates a log entry"
             include_examples "keeps the patient in the community clinics"
           end
         end
@@ -910,6 +960,7 @@ describe SchoolMove do
             create(:school_move, :to_home_educated, organisation:, patient:)
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -934,6 +985,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "changes the patient cohort"
           include_examples "removes the patient from the community clinics"
@@ -964,6 +1016,7 @@ describe SchoolMove do
             new_organisation.generic_clinic_session
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "changes the patient cohort"
           include_examples "adds the patient to the community clinics"
@@ -997,6 +1050,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -1018,6 +1072,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -1039,6 +1094,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -1049,6 +1105,7 @@ describe SchoolMove do
             create(:school_move, :to_home_educated, organisation:, patient:)
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
@@ -1073,6 +1130,7 @@ describe SchoolMove do
             )
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient school"
           include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -1100,6 +1158,7 @@ describe SchoolMove do
             create(:organisation, programmes: [programme])
           end
 
+          include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
           include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
@@ -1129,6 +1188,10 @@ describe SchoolMove do
         expect { school_move.reload }.to raise_error(
           ActiveRecord::RecordNotFound
         )
+      end
+
+      it "doesn't create a log entry" do
+        expect { ignore! }.not_to change(SchoolMoveLogEntry, :count)
       end
     end
 


### PR DESCRIPTION
This creates a new model that will be used to capture when a school move is confirmed, by which user and outcome of the school move. I've only added columns to capture the minimum we need to answer questions not available in our existing audit logs, but this could be extended in the future.

The model has been created using a similar pattern to other actions that we log, specifically the `NotifyLogEntry` and `AccessLogEntry`. It might be time to consider if we can build a more generic way of recording actions taken in the service. For now, the approach taken in this commit will allow us to answer the question of why a number of patients have ended up in the community clinic when there are still school sessions scheduled.

We already record database changes using the `audited` Gem, but this doesn't always allow us to record actions taken in the service, particular ones that aren't able to be determined by looking just at the database changes, for example access logs, school moves or patient merges. This is why it's been necessary to record these actions in separate tables.

This updates the `confirm!` method on the `SchoolMove` model to record an entry in the school move log when a school move is confirmed. This acts in parallel with our existing audit logs that are based on database changes, allowing us to track missing information such as whether the user asked for the patient to remain in the community clinic or not.