### PR TITLE
Update patient card to match latest designs

### DIFF
--- a/app/components/app_parent_summary_component.rb
+++ b/app/components/app_parent_summary_component.rb
@@ -1,41 +1,54 @@
 # frozen_string_literal: true
 
 class AppParentSummaryComponent < ViewComponent::Base
-  def initialize(parent_relationship:, change_links: {})
+  def initialize(
+    parent_relationship:,
+    change_links: {},
+    show_name_and_relationship: false
+  )
     super
 
     @parent_relationship = parent_relationship
     @parent = parent_relationship.parent
     @patient = parent_relationship.patient
+
     @change_links = change_links
+
+    @show_name_and_relationship = show_name_and_relationship
   end
 
   def call
     govuk_summary_list do |summary_list|
-      summary_list.with_row do |row|
-        row.with_key { "Name" }
+      if @show_name_and_relationship
+        summary_list.with_row do |row|
+          row.with_key { "Name" }
 
-        if @parent.full_name.present?
-          row.with_value { @parent.full_name }
-          if (href = @change_links[:name])
-            row.with_action(text: "Change", href:, visually_hidden_text: "name")
+          if @parent.full_name.present?
+            row.with_value { @parent.full_name }
+            if (href = @change_links[:name])
+              row.with_action(
+                text: "Change",
+                href:,
+                visually_hidden_text: "name"
+              )
+            end
+          elsif (href = @change_links[:name])
+            row.with_value { govuk_link_to("Add name", href) }
+          else
+            row.with_value { "Not provided" }
           end
-        elsif (href = @change_links[:name])
-          row.with_value { govuk_link_to("Add name", href) }
-        else
-          row.with_value { "Not provided" }
         end
-      end
 
-      summary_list.with_row do |row|
-        row.with_key { "Relationship" }
-        row.with_value { @parent_relationship.label }
-        if (href = @change_links[:relationship])
-          row.with_action(
-            text: "Change",
-            href:,
-            visually_hidden_text: "relationship"
-          )
+        summary_list.with_row do |row|
+          row.with_key { "Relationship" }
+          row.with_value { @parent_relationship.label }
+          if (href = @change_links[:relationship])
+            row.with_action(
+              text: "Change",
+              href:,
+              visually_hidden_text: "relationship"
+            )
+          end
         end
       end
 

--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -23,10 +23,17 @@ class AppPatientCardComponent < ViewComponent::Base
         ) %>
       <% end %>
 
-      <%= render AppPatientSummaryComponent.new(
-               patient,
-               show_parent_or_guardians: true
-             ) %>
+      <%= render AppPatientSummaryComponent.new(patient) %>
+
+      <% unless patient.restricted? %>
+        <% parent_relationships.each do |parent_relationship| %>
+          <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
+            <%= parent_relationship.label_with_parent %>
+          </h3>
+  
+          <%= render AppParentSummaryComponent.new(parent_relationship:) %>
+        <% end %>
+      <% end %>
 
       <%= content %>
     <% end %>
@@ -41,4 +48,6 @@ class AppPatientCardComponent < ViewComponent::Base
   private
 
   attr_reader :patient
+
+  delegate :parent_relationships, to: :patient
 end

--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -3,7 +3,7 @@
 class AppPatientCardComponent < ViewComponent::Base
   erb_template <<-ERB
     <%= render AppCardComponent.new do |card| %>
-      <% card.with_heading { "Child record" } %>
+      <% card.with_heading { "Child" } %>
       
       <% if @patient.date_of_death.present? %>
         <%= render AppNoticeStatusComponent.new(

--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 class AppPatientSummaryComponent < ViewComponent::Base
-  def initialize(patient, change_links: {}, show_parent_or_guardians: false)
+  def initialize(patient, change_links: {})
     super
 
     @patient = patient
     @change_links = change_links
-    @show_parent_or_guardians = show_parent_or_guardians
   end
 
   def call
@@ -64,15 +63,6 @@ class AppPatientSummaryComponent < ViewComponent::Base
         summary_list.with_row do |row|
           row.with_key { "GP surgery" }
           row.with_value { gp_practice.name }
-        end
-      end
-      if @show_parent_or_guardians && !@patient.restricted? &&
-           @patient.parent_relationships.present?
-        summary_list.with_row do |row|
-          row.with_key do
-            "Parent or guardian".pluralize(@patient.parent_relationships.count)
-          end
-          row.with_value { format_parent_or_guardians }
         end
       end
     end
@@ -141,10 +131,6 @@ class AppPatientSummaryComponent < ViewComponent::Base
       helpers.patient_year_group(@patient),
       @patient.year_group_changed? || @patient.registration_changed?
     )
-  end
-
-  def format_parent_or_guardians
-    helpers.patient_parents(@patient)
   end
 
   def highlight_if(value, condition)

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -31,7 +31,7 @@
 <% if (parent_relationship = @consent.parent_relationship).present? %>
   <%= render AppCardComponent.new do |card| %>
     <% card.with_heading { "Parent or guardian" } %>
-    <%= render AppParentSummaryComponent.new(parent_relationship:) %>
+    <%= render AppParentSummaryComponent.new(parent_relationship:, show_name_and_relationship: true) %>
   <% end %>
 <% end %>
 

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -32,7 +32,7 @@
                                                relationship: wizard_path("who"),
                                                email: wizard_path("parent-details"),
                                                phone: wizard_path("parent-details"),
-                                             }) %>
+                                             }, show_name_and_relationship: true) %>
   <% end %>
 <% end %>
 

--- a/spec/components/app_parent_summary_component_spec.rb
+++ b/spec/components/app_parent_summary_component_spec.rb
@@ -11,11 +11,23 @@ describe AppParentSummaryComponent do
     create(:parent_relationship, :father, parent:, patient:)
   end
 
-  it { should have_content("Name") }
-  it { should have_content("John Smith") }
+  it { should_not have_content("Name") }
+  it { should_not have_content("Relationship") }
 
-  it { should have_content("Relationship") }
-  it { should have_content("Dad") }
+  context "when showing name and relationship" do
+    let(:component) do
+      described_class.new(
+        parent_relationship:,
+        show_name_and_relationship: true
+      )
+    end
+
+    it { should have_content("Name") }
+    it { should have_content("John Smith") }
+
+    it { should have_content("Relationship") }
+    it { should have_content("Dad") }
+  end
 
   context "with an email address" do
     let(:parent) { create(:parent, email: "test@example.com") }
@@ -41,7 +53,13 @@ describe AppParentSummaryComponent do
   it { should_not have_content("Change") }
 
   context "with change links" do
-    let(:component) { described_class.new(parent_relationship:, change_links:) }
+    let(:component) do
+      described_class.new(
+        parent_relationship:,
+        change_links:,
+        show_name_and_relationship: true
+      )
+    end
 
     let(:change_links) do
       {

--- a/spec/components/app_patient_card_component_spec.rb
+++ b/spec/components/app_patient_card_component_spec.rb
@@ -3,7 +3,11 @@
 describe AppPatientCardComponent do
   subject { render_inline(component) }
 
-  let(:component) { described_class.new(patient) }
+  let(:component) do
+    described_class.new(
+      Patient.includes(parent_relationships: :parent).find(patient.id)
+    )
+  end
 
   let(:patient) { create(:patient) }
 
@@ -29,5 +33,23 @@ describe AppPatientCardComponent do
     let(:patient) { create(:patient, :restricted) }
 
     it { should have_content("Record flagged as sensitive") }
+
+    context "with parents" do
+      let(:parent) { create(:parent, full_name: "Jenny Smith") }
+
+      before { create(:parent_relationship, :mother, patient:, parent:) }
+
+      it { should_not have_content("Jenny Smith") }
+      it { should_not have_content("Mum") }
+    end
+  end
+
+  context "with parents" do
+    let(:parent) { create(:parent, full_name: "Jenny Smith") }
+
+    before { create(:parent_relationship, :mother, patient:, parent:) }
+
+    it { should have_content("Jenny Smith") }
+    it { should have_content("Mum") }
   end
 end

--- a/spec/components/app_patient_card_component_spec.rb
+++ b/spec/components/app_patient_card_component_spec.rb
@@ -7,7 +7,7 @@ describe AppPatientCardComponent do
 
   let(:patient) { create(:patient) }
 
-  it { should have_content("Child record") }
+  it { should have_content("Child") }
 
   it { should have_content("Full name") }
   it { should have_content("Date of birth") }

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -36,7 +36,7 @@ describe AppPatientPageComponent do
       )
     end
 
-    it { should have_css(".nhsuk-card__heading", text: "Child record") }
+    it { should have_css(".nhsuk-card__heading", text: "Child") }
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should_not have_css(".nhsuk-card__heading", text: "Triage notes") }
 
@@ -79,7 +79,7 @@ describe AppPatientPageComponent do
       )
     end
 
-    it { should have_css(".nhsuk-card__heading", text: "Child record") }
+    it { should have_css(".nhsuk-card__heading", text: "Child") }
     it { should have_css(".nhsuk-card__heading", text: "Consent") }
     it { should have_css(".nhsuk-card__heading", text: "Triage notes") }
 

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -77,31 +77,6 @@ describe AppPatientSummaryComponent do
     it { should have_content("Waterloo GP") }
   end
 
-  context "when showing parents or guardians" do
-    let(:component) do
-      described_class.new(patient.reload, show_parent_or_guardians: true)
-    end
-
-    before do
-      create(
-        :parent_relationship,
-        :father,
-        patient:,
-        parent: build(:parent, full_name: "Mark Doe")
-      )
-    end
-
-    it { should have_content("Parent or guardian") }
-    it { should have_content("Mark Doe (Dad)") }
-
-    context "when the patient is restricted" do
-      let(:restricted) { true }
-
-      it { should_not have_content("Parent or guardian") }
-      it { should_not have_content("Mark Doe (Dad)") }
-    end
-  end
-
   it { should_not have_css(".app-highlight") }
 
   context "with pending changes" do

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -186,7 +186,7 @@ describe "Immunisation imports" do
 
   def then_i_should_see_the_vaccination_record
     expect(page).to have_content("Chyna Pickle")
-    expect(page).to have_content("Child record")
+    expect(page).to have_content("Child")
     expect(page).to have_content("Full nameChyna Pickle")
     expect(page).to have_content("Vaccination details")
     expect(page).to have_content("OutcomeVaccinated")


### PR DESCRIPTION
This updates the patient card used in a number of pages to match the latest designs in the prototype. Specifically this replaces how the parents are shown to instead have them in their own summary list with a heading.

## Screenshots

### Before

![Screenshot 2025-01-23 at 10 58 27](https://github.com/user-attachments/assets/ef7c671e-8bab-40b9-a4c5-2f4f4dfa41fb)

### After

![Screenshot 2025-01-23 at 10 58 16](https://github.com/user-attachments/assets/3f735e02-2afa-4424-8661-71aaab8ce692)
