### PR TITLE
Ensure self-consent overrides parental consent

### DIFF
--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -54,7 +54,11 @@ module PatientSessionStatusConcern
     def consent_given?
       return false if no_consent?
 
-      latest_consents.all?(&:response_given?)
+      if !(self_consents = latest_consents.select(&:via_self_consent?)).empty?
+        self_consents.all?(&:response_given?)
+      else
+        latest_consents.all?(&:response_given?)
+      end
     end
 
     def consent_refused?


### PR DESCRIPTION
When calculating the overall status of a patient session, if consent has been given by the patient themselves via Gillick assessment, then it should override any refused or conflicting consent from the parents.

This fixes a bug where patients who had self-consenting were remaining in the "conflicting consent" status where they should instead have been in "safe to vaccinate".