### PR TITLE
Stage entire address as a pending change

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -59,7 +59,13 @@ class PatientImportRow
         existing_patient.registration = attributes.delete(:registration)
       end
 
+      if address_postcode.present? &&
+           address_postcode != existing_patient.address_postcode
+        attributes.merge!(address_line_1:, address_line_2:, address_town:)
+      end
+
       existing_patient.stage_changes(attributes)
+
       existing_patient
     else
       Patient.new(attributes.merge(home_educated: false))

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -139,6 +139,7 @@ describe ClassImportRow do
         create(
           :patient,
           address_postcode: "SW1A 1AA",
+          date_of_birth: Date.new(2010, 1, 1),
           family_name: "Smith",
           gender_code: "male",
           given_name: "Jimmy",
@@ -153,6 +154,28 @@ describe ClassImportRow do
       it "overwrites registration" do
         expect(patient.registration).to eq("8AB")
         expect(patient.pending_changes).not_to have_key("registration")
+      end
+
+      it "doesn't stage the address for changing" do
+        expect(patient.pending_changes).not_to have_key("address_line_1")
+        expect(patient.pending_changes).not_to have_key("address_line_2")
+        expect(patient.pending_changes).not_to have_key("address_town")
+        expect(patient.pending_changes).not_to have_key("address_postcode")
+      end
+
+      context "with a different postcode" do
+        before { existing_patient.update!(address_postcode: "SW1A 1AB") }
+
+        it "stages the entire address for changing" do
+          expect(patient.pending_changes).to match(
+            a_hash_including(
+              "address_line_1" => nil,
+              "address_line_2" => nil,
+              "address_town" => nil,
+              "address_postcode" => "SW1A 1AA"
+            )
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
If the postcode has changed, as this means the entire address is likely to be incorrect. Even if we don't have the other parts of the address (line 1, line 2 and town) we should blank those out as they will no longer be correct if the postcode has changed.