### PR TITLE
Revert "Make NotifyLogEntry#recipient deterministic"

### DIFF
--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -53,7 +53,7 @@ class NotifyLogEntry < ApplicationRecord
   validates :template_id, presence: true
   validates :recipient, presence: true
 
-  encrypts :recipient, deterministic: true
+  encrypts :recipient
 
   def title
     template_name&.to_s&.humanize.presence ||

--- a/spec/components/app_parent_summary_component_spec.rb
+++ b/spec/components/app_parent_summary_component_spec.rb
@@ -44,6 +44,8 @@ describe AppParentSummaryComponent do
           parent:,
           recipient: parent.email
         )
+
+        skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
       end
 
       it { should have_content("Email address does not exist") }
@@ -65,6 +67,8 @@ describe AppParentSummaryComponent do
           parent:,
           recipient: parent.phone
         )
+
+        skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
       end
 
       it { should have_content("Phone number does not exist") }

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -151,6 +151,10 @@ describe Parent do
   describe "#email_delivery_status" do
     subject(:email_delivery_status) { parent.email_delivery_status }
 
+    before do
+      skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
+    end
+
     let(:parent) { create(:parent) }
 
     it { should be_nil }
@@ -221,6 +225,10 @@ describe Parent do
 
   describe "#sms_delivery_status" do
     subject(:sms_delivery_status) { parent.sms_delivery_status }
+
+    before do
+      skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
+    end
 
     let(:parent) { create(:parent) }
 


### PR DESCRIPTION
This reverts commit 61a8f29720c5cea8311d9d9056ea3da8166346ef.

This was added in #2882 but unfortunately this approach doesn't work because it breaks the previous encrypted values and we were seeing Sentry errors for it:

https://good-machine.sentry.io/issues/6250337106/

I'll have to find a backwards compatible way of converting this column to be deterministic.