### PR TITLE
Refactor how conflicting consent status is calculated

### DIFF
--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -54,8 +54,8 @@ module PatientSessionStatusConcern
     def consent_given?
       return false if no_consent?
 
-      if !(self_consents = latest_consents.select(&:via_self_consent?)).empty?
-        self_consents.all?(&:response_given?)
+      if latest_self_consents.present?
+        latest_self_consents.all?(&:response_given?)
       else
         latest_consents.all?(&:response_given?)
       end
@@ -70,8 +70,13 @@ module PatientSessionStatusConcern
     def consent_conflicts?
       return false if no_consent?
 
-      latest_consents.any?(&:response_refused?) &&
-        latest_consents.any?(&:response_given?)
+      if latest_self_consents.present?
+        latest_self_consents.any?(&:response_refused?) &&
+          latest_self_consents.any?(&:response_given?)
+      else
+        latest_consents.any?(&:response_refused?) &&
+          latest_consents.any?(&:response_given?)
+      end
     end
 
     def no_consent?

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -107,6 +107,10 @@ class PatientSession < ApplicationRecord
         .map { |_, consents| consents.max_by(&:created_at) }
   end
 
+  def latest_self_consents
+    @latest_self_consents ||= latest_consents.select(&:via_self_consent?)
+  end
+
   def latest_gillick_assessment
     @latest_gillick_assessment ||= gillick_assessments.max_by(&:updated_at)
   end

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -57,17 +57,28 @@ describe PatientSessionStats do
 
         create(:consent_form, :recorded, programme:, session:, consent_id: nil) # => unmatched response
         create(:consent_form, :draft, programme:, session:, consent_id: nil) # => still draft, should not be counted
+
+        create(:patient_session, :consent_conflicting, programme:, session:) # conflicting consent
+
+        gillick_patient =
+          create(
+            :patient_session,
+            :consent_conflicting,
+            programme:,
+            session:
+          ).patient
+        create(:consent, :self_consent, patient: gillick_patient, programme:) # conflicting consent with gillick
       end
 
       it "returns a hash of session stats" do
         expect(to_h).to eq(
-          could_not_vaccinate: 1,
+          could_not_vaccinate: 2,
           needing_triage: 2,
-          not_registered: 6,
-          vaccinate: 2,
+          not_registered: 8,
+          vaccinate: 3,
           vaccinated: 0,
-          with_conflicting_consent: 0,
-          with_consent_given: 4,
+          with_conflicting_consent: 1,
+          with_consent_given: 5,
           with_consent_refused: 1,
           without_a_response: 1
         )


### PR DESCRIPTION
This extends #2883 to ensure that when calculating the stats for a list of patient sessions we're correctly exclusing consent conflicted results when the consent has actually been given, via self-consent.