### PR TITLE
Set node count to 3 in qa and test

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -66,6 +66,7 @@ environments:
       MAVIS__PDS__PERFORM_JOBS: false
       MAVIS__SPLUNK__ENABLED: false
   qa:
+    count: 3
     http:
       alias:
         - "qa.mavistesting.com"
@@ -80,6 +81,7 @@ environments:
       MAVIS__PDS__PERFORM_JOBS: false
       MAVIS__SPLUNK__ENABLED: false
   test:
+    count: 3
     http:
       alias:
         - "test.mavistesting.com"


### PR DESCRIPTION
We're testing this out ahead of rolling it out to production, in preparation for adding more SAIS teams.