### PR TITLE
Add deterministic recipient column

### DIFF
--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -66,6 +66,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
       parent:,
       patient:,
       recipient: email_address,
+      recipient_deterministic: email_address,
       sent_by:,
       template_id:,
       type: :email

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -53,6 +53,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
       parent:,
       patient:,
       recipient: phone_number,
+      recipient_deterministic: phone_number,
       sent_by:,
       template_id:,
       type: :sms

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -103,6 +103,7 @@ class ApplicationMailer < Mail::Notify::Mailer
         consent_form_id: mail.consent_form_id,
         patient_id: mail.patient_id,
         recipient:,
+        recipient_deterministic: recipient,
         sent_by_user_id: mail.sent_by_user_id,
         template_id: mail.template_id,
         type: :email

--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -4,17 +4,18 @@
 #
 # Table name: notify_log_entries
 #
-#  id              :bigint           not null, primary key
-#  delivery_status :integer          default("sending"), not null
-#  recipient       :string           not null
-#  type            :integer          not null
-#  created_at      :datetime         not null
-#  consent_form_id :bigint
-#  delivery_id     :uuid
-#  parent_id       :bigint
-#  patient_id      :bigint
-#  sent_by_user_id :bigint
-#  template_id     :uuid             not null
+#  id                      :bigint           not null, primary key
+#  delivery_status         :integer          default("sending"), not null
+#  recipient               :string           not null
+#  recipient_deterministic :string
+#  type                    :integer          not null
+#  created_at              :datetime         not null
+#  consent_form_id         :bigint
+#  delivery_id             :uuid
+#  parent_id               :bigint
+#  patient_id              :bigint
+#  sent_by_user_id         :bigint
+#  template_id             :uuid             not null
 #
 # Indexes
 #
@@ -54,6 +55,7 @@ class NotifyLogEntry < ApplicationRecord
   validates :recipient, presence: true
 
   encrypts :recipient
+  encrypts :recipient_deterministic, deterministic: true
 
   def title
     template_name&.to_s&.humanize.presence ||

--- a/app/models/parent.rb
+++ b/app/models/parent.rb
@@ -119,6 +119,9 @@ class Parent < ApplicationRecord
 
   def most_recent_notify_log_entry(type, recipient:)
     return nil if recipient.blank?
-    notify_log_entries.order(created_at: :desc).find_by(type:, recipient:)
+    notify_log_entries.order(created_at: :desc).find_by(
+      type:,
+      recipient_deterministic: recipient
+    )
   end
 end

--- a/db/migrate/20250127133639_add_recipient_deterministic_to_notify_log_entries.rb
+++ b/db/migrate/20250127133639_add_recipient_deterministic_to_notify_log_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRecipientDeterministicToNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notify_log_entries, :recipient_deterministic, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_21_112644) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_27_133639) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -473,6 +473,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_21_112644) do
     t.uuid "delivery_id"
     t.bigint "parent_id"
     t.integer "delivery_status", default: 0, null: false
+    t.string "recipient_deterministic"
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
     t.index ["delivery_id"], name: "index_notify_log_entries_on_delivery_id"
     t.index ["parent_id"], name: "index_notify_log_entries_on_parent_id"

--- a/lib/tasks/notify_log_entries.rake
+++ b/lib/tasks/notify_log_entries.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :notify_log_entries do
+  desc "Set the recipient_deterministic column from the recipient column."
+  task populate_deterministic_recipient: :environment do
+    NotifyLogEntry
+      .where(recipient_deterministic: nil)
+      .find_each do |entry|
+        entry.update!(receipient_deterministic: entry.recipient)
+      end
+  end
+end

--- a/spec/components/app_parent_summary_component_spec.rb
+++ b/spec/components/app_parent_summary_component_spec.rb
@@ -44,8 +44,6 @@ describe AppParentSummaryComponent do
           parent:,
           recipient: parent.email
         )
-
-        skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
       end
 
       it { should have_content("Email address does not exist") }
@@ -67,8 +65,6 @@ describe AppParentSummaryComponent do
           parent:,
           recipient: parent.phone
         )
-
-        skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
       end
 
       it { should have_content("Phone number does not exist") }

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -4,17 +4,18 @@
 #
 # Table name: notify_log_entries
 #
-#  id              :bigint           not null, primary key
-#  delivery_status :integer          default("sending"), not null
-#  recipient       :string           not null
-#  type            :integer          not null
-#  created_at      :datetime         not null
-#  consent_form_id :bigint
-#  delivery_id     :uuid
-#  parent_id       :bigint
-#  patient_id      :bigint
-#  sent_by_user_id :bigint
-#  template_id     :uuid             not null
+#  id                      :bigint           not null, primary key
+#  delivery_status         :integer          default("sending"), not null
+#  recipient               :string           not null
+#  recipient_deterministic :string
+#  type                    :integer          not null
+#  created_at              :datetime         not null
+#  consent_form_id         :bigint
+#  delivery_id             :uuid
+#  parent_id               :bigint
+#  patient_id              :bigint
+#  sent_by_user_id         :bigint
+#  template_id             :uuid             not null
 #
 # Indexes
 #
@@ -46,6 +47,8 @@ FactoryBot.define do
       recipient { Faker::PhoneNumber.phone_number }
       template_id { GOVUK_NOTIFY_SMS_TEMPLATES.values.sample }
     end
+
+    recipient_deterministic { recipient }
 
     delivery_id { SecureRandom.uuid }
     traits_for_enum :delivery_status

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -102,6 +102,7 @@ describe EmailDeliveryJob do
       expect(notify_log_entry).to be_email
       expect(notify_log_entry.delivery_id).to eq(response.id)
       expect(notify_log_entry.recipient).to eq("test@example.com")
+      expect(notify_log_entry.recipient_deterministic).to eq("test@example.com")
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
       )
@@ -161,6 +162,9 @@ describe EmailDeliveryJob do
         expect(notify_log_entry).to be_email
         expect(notify_log_entry.delivery_id).to eq(response.id)
         expect(notify_log_entry.recipient).to eq("test@example.com")
+        expect(notify_log_entry.recipient_deterministic).to eq(
+          "test@example.com"
+        )
         expect(notify_log_entry.template_id).to eq(
           GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
         )

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -81,6 +81,7 @@ describe SMSDeliveryJob do
       expect(notify_log_entry).to be_sms
       expect(notify_log_entry.delivery_id).to eq(response.id)
       expect(notify_log_entry.recipient).to eq("01234 567890")
+      expect(notify_log_entry.recipient_deterministic).to eq("01234 567890")
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_SMS_TEMPLATES[template_name]
       )
@@ -121,6 +122,7 @@ describe SMSDeliveryJob do
         expect(notify_log_entry).to be_sms
         expect(notify_log_entry.delivery_id).to eq(response.id)
         expect(notify_log_entry.recipient).to eq("01234 567890")
+        expect(notify_log_entry.recipient_deterministic).to eq("01234 567890")
         expect(notify_log_entry.template_id).to eq(
           GOVUK_NOTIFY_SMS_TEMPLATES[template_name]
         )

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -4,17 +4,18 @@
 #
 # Table name: notify_log_entries
 #
-#  id              :bigint           not null, primary key
-#  delivery_status :integer          default("sending"), not null
-#  recipient       :string           not null
-#  type            :integer          not null
-#  created_at      :datetime         not null
-#  consent_form_id :bigint
-#  delivery_id     :uuid
-#  parent_id       :bigint
-#  patient_id      :bigint
-#  sent_by_user_id :bigint
-#  template_id     :uuid             not null
+#  id                      :bigint           not null, primary key
+#  delivery_status         :integer          default("sending"), not null
+#  recipient               :string           not null
+#  recipient_deterministic :string
+#  type                    :integer          not null
+#  created_at              :datetime         not null
+#  consent_form_id         :bigint
+#  delivery_id             :uuid
+#  parent_id               :bigint
+#  patient_id              :bigint
+#  sent_by_user_id         :bigint
+#  template_id             :uuid             not null
 #
 # Indexes
 #

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -151,10 +151,6 @@ describe Parent do
   describe "#email_delivery_status" do
     subject(:email_delivery_status) { parent.email_delivery_status }
 
-    before do
-      skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
-    end
-
     let(:parent) { create(:parent) }
 
     it { should be_nil }
@@ -225,10 +221,6 @@ describe Parent do
 
   describe "#sms_delivery_status" do
     subject(:sms_delivery_status) { parent.sms_delivery_status }
-
-    before do
-      skip "https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2887"
-    end
 
     let(:parent) { create(:parent) }
 


### PR DESCRIPTION
This adds a new column `recipient_deterministic` to the `NotifyLogEntry` model with the intention of eventually replacing the `recipient` column. This is necessary to change the encryption configuration of the column from non-deterministic to deterministic which isn't backwards compatible.

This is the first step, to add the new column, backfill the values and start using this column. Once this is in production, we can start to remove the old `recipient` column, starting by making it nullable and stop writing to it, removing it from the list of Rails columns, and then removing and renaming the new column back to `recipient`.