### PR TITLE
Replace recipient_deterministic with recipient

### DIFF
--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -57,6 +57,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
       delivery_id:,
       parent:,
       patient:,
+      recipient: email_address,
       recipient_deterministic: email_address,
       sent_by:,
       template_id:,

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -50,6 +50,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
       delivery_id:,
       parent:,
       patient:,
+      recipient: phone_number,
       recipient_deterministic: phone_number,
       sent_by:,
       template_id:,

--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  delivery_status         :integer          default("sending"), not null
+#  recipient               :string
 #  recipient_deterministic :string
 #  type                    :integer          not null
 #  created_at              :datetime         not null
@@ -35,7 +36,6 @@ class NotifyLogEntry < ApplicationRecord
   include Sendable
 
   self.inheritance_column = nil
-  self.ignored_columns = ["recipient"]
 
   belongs_to :consent_form, optional: true
   belongs_to :patient, optional: true
@@ -54,6 +54,7 @@ class NotifyLogEntry < ApplicationRecord
   validates :recipient_deterministic, presence: true
   validates :template_id, presence: true
 
+  encrypts :recipient, deterministic: true
   encrypts :recipient_deterministic, deterministic: true
 
   def title

--- a/db/migrate/20250128111046_remove_recipient_from_notify_log_entries.rb
+++ b/db/migrate/20250128111046_remove_recipient_from_notify_log_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRecipientFromNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :notify_log_entries, :recipient, :string, null: false
+  end
+end

--- a/db/migrate/20250128111223_add_recipient_to_notify_log_entries.rb
+++ b/db/migrate/20250128111223_add_recipient_to_notify_log_entries.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRecipientToNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notify_log_entries, :recipient, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -454,7 +454,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_10_092331) do
   create_table "notify_log_entries", force: :cascade do |t|
     t.integer "type", null: false
     t.uuid "template_id", null: false
-    t.string "recipient"
     t.datetime "created_at", null: false
     t.bigint "consent_form_id"
     t.bigint "patient_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -462,6 +462,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_10_092331) do
     t.bigint "parent_id"
     t.integer "delivery_status", default: 0, null: false
     t.string "recipient_deterministic"
+    t.string "recipient"
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
     t.index ["delivery_id"], name: "index_notify_log_entries_on_delivery_id"
     t.index ["parent_id"], name: "index_notify_log_entries_on_parent_id"

--- a/lib/tasks/notify_log_entries.rake
+++ b/lib/tasks/notify_log_entries.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :notify_log_entries do
+  desc "Set the recipient column from the recipient_deterministic column."
+  task populate_recipient: :environment do
+    NotifyLogEntry
+      .where(recipient: nil)
+      .find_each do |entry|
+        entry.update_column(:recipient, entry.recipient_deterministic)
+      end
+  end
+end

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  delivery_status         :integer          default("sending"), not null
+#  recipient               :string
 #  recipient_deterministic :string
 #  type                    :integer          not null
 #  created_at              :datetime         not null
@@ -33,8 +34,6 @@
 #
 FactoryBot.define do
   factory :notify_log_entry do
-    transient { recipient { nil } }
-
     patient
 
     trait :email do

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -98,6 +98,7 @@ describe EmailDeliveryJob do
       notify_log_entry = NotifyLogEntry.last
       expect(notify_log_entry).to be_email
       expect(notify_log_entry.delivery_id).to eq(response.id)
+      expect(notify_log_entry.recipient).to eq("test@example.com")
       expect(notify_log_entry.recipient_deterministic).to eq("test@example.com")
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
@@ -157,6 +158,7 @@ describe EmailDeliveryJob do
         notify_log_entry = NotifyLogEntry.last
         expect(notify_log_entry).to be_email
         expect(notify_log_entry.delivery_id).to eq(response.id)
+        expect(notify_log_entry.recipient).to eq("test@example.com")
         expect(notify_log_entry.recipient_deterministic).to eq(
           "test@example.com"
         )

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -77,6 +77,7 @@ describe SMSDeliveryJob do
       notify_log_entry = NotifyLogEntry.last
       expect(notify_log_entry).to be_sms
       expect(notify_log_entry.delivery_id).to eq(response.id)
+      expect(notify_log_entry.recipient).to eq("01234 567890")
       expect(notify_log_entry.recipient_deterministic).to eq("01234 567890")
       expect(notify_log_entry.template_id).to eq(
         GOVUK_NOTIFY_SMS_TEMPLATES[template_name]
@@ -117,6 +118,7 @@ describe SMSDeliveryJob do
         notify_log_entry = NotifyLogEntry.last
         expect(notify_log_entry).to be_sms
         expect(notify_log_entry.delivery_id).to eq(response.id)
+        expect(notify_log_entry.recipient).to eq("01234 567890")
         expect(notify_log_entry.recipient_deterministic).to eq("01234 567890")
         expect(notify_log_entry.template_id).to eq(
           GOVUK_NOTIFY_SMS_TEMPLATES[template_name]

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  delivery_status         :integer          default("sending"), not null
+#  recipient               :string
 #  recipient_deterministic :string
 #  type                    :integer          not null
 #  created_at              :datetime         not null


### PR DESCRIPTION
This follows on from https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2899 to support replacing the `recipient_deterministic` column with the `recipient` column.

This stage removes the old `recipient` column and replaces it with a new deterministic `recipient` column and starts writing to it. The next stage will be to stop writing to the `recipient_deterministic` column so it can eventually be removed.