### PR TITLE
Remove recipient_deterministic column

### DIFF
--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -36,7 +36,6 @@ class NotifyLogEntry < ApplicationRecord
   include Sendable
 
   self.inheritance_column = nil
-  self.ignored_columns = ["recipient_deterministic"]
 
   belongs_to :consent_form, optional: true
   belongs_to :patient, optional: true

--- a/db/migrate/20250128112422_remove_recipient_deterministic_from_notify_log_entries.rb
+++ b/db/migrate/20250128112422_remove_recipient_deterministic_from_notify_log_entries.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveRecipientDeterministicFromNotifyLogEntries < ActiveRecord::Migration[
+  8.0
+]
+  def change
+    remove_column :notify_log_entries, :recipient_deterministic, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -474,7 +474,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_07_163053) do
     t.uuid "delivery_id"
     t.integer "delivery_status", default: 0, null: false
     t.bigint "parent_id"
-    t.string "recipient_deterministic"
     t.string "recipient", null: false
     t.integer "programme_ids", default: [], null: false, array: true
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"


### PR DESCRIPTION
This column can be safely removed after version 2.1.0 is deployed as we will no longer being using this column anywhere. In version 2.1.0 it's marked as ignored anyway.