### PR TITLE
Improve session slug string sequence generation

### DIFF
--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -34,7 +34,7 @@ FactoryBot.define do
       team { association(:team, organisation:) }
     end
 
-    sequence(:slug, &:to_s)
+    sequence(:slug) { |n| "session-#{n}" }
 
     academic_year { (date || Date.current).academic_year }
     programmes { [programme] }


### PR DESCRIPTION
This improves the session factory to generate session slugs with alphanumeric characters to make it clear that these are slugs and not integer IDs, avoiding any potential confusiong and making them more realistic.