### PR TITLE
Ensure duplicate school moves are removed when merging

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -18,7 +18,19 @@ class PatientMerger
       patient_to_destroy.notify_log_entries.update_all(
         patient_id: patient_to_keep.id
       )
-      patient_to_destroy.school_moves.update_all(patient_id: patient_to_keep.id)
+
+      patient_to_destroy.school_moves.find_each do |school_move|
+        if patient_to_keep.school_moves.exists?(
+             home_educated: school_move.home_educated,
+             organisation_id: school_move.organisation_id,
+             school_id: school_move.school_id
+           )
+          school_move.destroy!
+        else
+          school_move.update!(patient: patient_to_keep)
+        end
+      end
+
       patient_to_destroy.session_notifications.update_all(
         patient_id: patient_to_keep.id
       )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -45,6 +45,9 @@ describe PatientMerger do
     let(:school_move) do
       create(:school_move, :to_school, patient: patient_to_destroy)
     end
+    let(:duplicate_school_move) do
+      create(:school_move, patient: patient_to_keep, school: school_move.school)
+    end
     let(:session_notification) do
       create(
         :session_notification,
@@ -114,6 +117,11 @@ describe PatientMerger do
       expect { call }.to change { school_move.reload.patient }.to(
         patient_to_keep
       )
+    end
+
+    it "deletes duplicate school moves" do
+      expect { call }.not_to change(duplicate_school_move, :patient)
+      expect { school_move.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
     it "moves session notifications" do


### PR DESCRIPTION
When merging patients it's possible to end up with duplicate school moves (if both the patient to keep and patient to destroy had the same school move). This results in a database error on the unique constraints, so we should handle this by deleting one of the school moves.