### PR TITLE
Handle consent label without a relationship

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -130,7 +130,11 @@ class Consent < ApplicationRecord
   end
 
   def who_responded
-    via_self_consent? ? "Child (Gillick competent)" : parent_relationship.label
+    if via_self_consent?
+      "Child (Gillick competent)"
+    else
+      (parent_relationship || parent).label
+    end
   end
 
   def health_answers_require_follow_up?


### PR DESCRIPTION
When displaying the label for a consent response, sometimes the `parent_relationship` will be `nil`. This can happen if an ops task manually removes the relationship, or if a patient is merged. Currently when trying to view this patient we will see a server error whereas we should instead display the name of the parent even if the relationship no longer exists.

This will also be relevant in the future where we will give the ability for nurses to remove parental contacts, but might still want a record of the consent.

https://good-machine.sentry.io/issues/6254607593/