### PR TITLE
Bump number of containers from 2 to 3

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -28,7 +28,7 @@ image:
 platform: linux/x86_64
 cpu: 1024 # Number of CPU units for the task.
 memory: 2048 # Amount of memory in MiB used by the task.
-count: 2 # Number of tasks that should be running in your service.
+count: 3 # Number of tasks that should be running in your service.
 exec: true # Enable running commands in your container.
 network:
   connect: true # Enable Service Connect for intra-environment traffic between services.
@@ -66,7 +66,6 @@ environments:
       MAVIS__PDS__PERFORM_JOBS: false
       MAVIS__SPLUNK__ENABLED: false
   qa:
-    count: 3
     http:
       alias:
         - "qa.mavistesting.com"
@@ -81,7 +80,6 @@ environments:
       MAVIS__PDS__PERFORM_JOBS: false
       MAVIS__SPLUNK__ENABLED: false
   test:
-    count: 3
     http:
       alias:
         - "test.mavistesting.com"


### PR DESCRIPTION
We are increasing the total capacity of the service to better support new teams that are joining next week.

This was previously https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2906 but it was closed by accident as we needed to get it into the hotfix branch.

https://github.com/nhsuk/manage-vaccinations-in-schools/pull/2909 was the hotfix branch equivalent.