### PR TITLE
Remove patient invalidating when editing NHS number

### DIFF
--- a/app/controllers/patients/edit_controller.rb
+++ b/app/controllers/patients/edit_controller.rb
@@ -16,9 +16,13 @@ class Patients::EditController < ApplicationController
         nhs_number:
       )
 
-    if @existing_patient
-      render :nhs_number_merge
-    elsif @patient.save
+    render :nhs_number_merge and return if @existing_patient
+
+    @patient.invalidated_at = nil
+
+    if @patient.save
+      PatientUpdateFromPDSJob.perform_later(@patient)
+
       redirect_to edit_patient_path(@patient)
     else
       render :nhs_number, status: :unprocessable_entity

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -42,6 +42,25 @@ describe "Manage children" do
     then_i_see_the_merged_edit_child_record_page
   end
 
+  scenario "Adding an NHS number to an invalidated patient" do
+    given_an_invalidated_patient_exists
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+    then_i_see_the_child
+
+    when_i_click_on_edit_child_record
+    then_i_see_the_edit_child_record_page
+
+    when_i_click_on_change_nhs_number
+    then_i_see_the_edit_nhs_number_page
+
+    when_i_enter_an_nhs_number
+    then_i_see_the_edit_child_record_page
+    and_i_see_the_nhs_number
+    and_the_patient_is_no_longer_invalidated
+  end
+
   scenario "Removing a child from a cohort" do
     given_patients_exist
     and_the_patient_belongs_to_a_session
@@ -118,6 +137,17 @@ describe "Manage children" do
         given_name: "Jane",
         family_name: "Doe",
         organisation: @organisation
+      )
+  end
+
+  def given_an_invalidated_patient_exists
+    @patient =
+      create(
+        :patient,
+        :invalidated,
+        organisation: @organisation,
+        given_name: "John",
+        family_name: "Smith"
       )
   end
 
@@ -208,6 +238,10 @@ describe "Manage children" do
 
   def and_i_see_the_nhs_number
     expect(page).to have_content("123 ‍456 ‍7890")
+  end
+
+  def and_the_patient_is_no_longer_invalidated
+    expect(@patient.reload).not_to be_invalidated
   end
 
   def then_i_see_the_merge_record_page


### PR DESCRIPTION
When assigning the NHS number to a patient manually, we should make sure it's no longer marked as invalid and trigger a new job to fetch the latest information from PDS. This allows us to correct the NHS number of a patient that is marked as invalid due to the old NHS number not existing.