### PR TITLE
Only look for existing patients with an NHS number

### DIFF
--- a/app/controllers/patients/edit_controller.rb
+++ b/app/controllers/patients/edit_controller.rb
@@ -8,13 +8,16 @@ class Patients::EditController < ApplicationController
   end
 
   def update_nhs_number
-    @patient.nhs_number = nhs_number
+    @patient.nhs_number = nhs_number.presence
+
     redirect_to edit_patient_path(@patient) and return unless @patient.changed?
 
     @existing_patient =
-      policy_scope(Patient).includes(parent_relationships: :parent).find_by(
-        nhs_number:
-      )
+      if nhs_number.present?
+        policy_scope(Patient).includes(parent_relationships: :parent).find_by(
+          nhs_number:
+        )
+      end
 
     if @existing_patient
       render :nhs_number_merge

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -42,6 +42,24 @@ describe "Manage children" do
     then_i_see_the_merged_edit_child_record_page
   end
 
+  scenario "Removing an NHS number" do
+    given_patients_exist
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+    then_i_see_the_child
+
+    when_i_click_on_edit_child_record
+    then_i_see_the_edit_child_record_page
+
+    when_i_click_on_change_nhs_number
+    then_i_see_the_edit_nhs_number_page
+
+    when_i_enter_a_blank_nhs_number
+    then_i_see_the_edit_child_record_page
+    and_i_see_the_blank_nhs_number
+  end
+
   scenario "Removing a child from a cohort" do
     given_patients_exist
     and_the_patient_belongs_to_a_session
@@ -125,6 +143,8 @@ describe "Manage children" do
         family_name: "Doe",
         cohort: @organisation.cohorts.first
       )
+
+    create(:patient, organisation: @organisation, nhs_number: nil)
   end
 
   def and_the_patient_is_vaccinated
@@ -206,6 +226,11 @@ describe "Manage children" do
     click_on "Continue"
   end
 
+  def when_i_enter_a_blank_nhs_number
+    fill_in "What is the child’s NHS number?", with: ""
+    click_on "Continue"
+  end
+
   def and_i_enter_an_existing_nhs_number
     fill_in "What is the child’s NHS number?",
             with: @existing_patient.nhs_number
@@ -214,6 +239,10 @@ describe "Manage children" do
 
   def and_i_see_the_nhs_number
     expect(page).to have_content("123 ‍456 ‍7890")
+  end
+
+  def and_i_see_the_blank_nhs_number
+    expect(page).to have_content("NHS numberNot provided")
   end
 
   def then_i_see_the_merge_record_page


### PR DESCRIPTION
When editing the NHS number of the patient and trying to remove the NHS number, currently this ends up finding existing patients without NHS numbers and flagging them as existing patients, which isn't the correct behaviour. Instead, we should allow users to set the NHS number to a blank string without trying to merge with an existing patient.