### PR TITLE
Add patient_date_of_birth personalisation

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -50,6 +50,7 @@ class GovukNotifyPersonalisation
       organisation_privacy_policy_url:,
       outcome_administered:,
       outcome_not_administered:,
+      patient_date_of_birth:,
       programme_name:,
       reason_did_not_vaccinate:,
       reason_for_refusal:,
@@ -172,6 +173,10 @@ class GovukNotifyPersonalisation
   def outcome_not_administered
     return if vaccination_record.nil?
     vaccination_record.not_administered? ? "yes" : "no"
+  end
+
+  def patient_date_of_birth
+    patient&.date_of_birth&.to_fs(:long)
   end
 
   def programme_name

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -60,6 +60,7 @@ describe GovukNotifyPersonalisation do
         not_catch_up: "yes",
         organisation_privacy_notice_url: "https://example.com/privacy-notice",
         organisation_privacy_policy_url: "https://example.com/privacy-policy",
+        patient_date_of_birth: "30 January 2012",
         programme_name: "HPV",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",


### PR DESCRIPTION
This adds a new personalisation variable that is sent up to GOV.UK Notify when sending an email or text message, allowing the date of birth to be used in any templates.

We're not going to update the templates yet but this allows us to update them in the future without needing to make a code change at the time.