### PR TITLE
Add ability to edit vaccination record notes

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -179,10 +179,15 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
         end
       end
 
-      if @show_notes && @vaccination_record.notes.present?
+      if @show_notes
         summary_list.with_row do |row|
           row.with_key { "Notes" }
-          row.with_value { notes_value }
+
+          if @vaccination_record.notes.present?
+            row.with_value { notes_value }
+          else
+            row.with_value { "Not provided" }
+          end
         end
       end
     end

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -185,6 +185,16 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
 
           if @vaccination_record.notes.present?
             row.with_value { notes_value }
+
+            if (href = @change_links[:notes])
+              row.with_action(
+                text: "Change",
+                href:,
+                visually_hidden_text: "site"
+              )
+            end
+          elsif (href = @change_links[:notes])
+            row.with_value { link_to "Add notes", href }
           else
             row.with_value { "Not provided" }
           end

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -136,10 +136,11 @@ class DraftVaccinationRecordsController < ApplicationController
   def update_params
     permitted_attributes = {
       batch: %i[batch_id],
-      confirm: %i[notes],
+      confirm: @draft_vaccination_record.editing? ? [] : %i[notes],
       date_and_time: %i[performed_at],
       delivery: %i[delivery_site delivery_method],
       location: %i[location_name],
+      notes: %i[notes],
       outcome: %i[outcome],
       vaccine: %i[vaccine_id]
     }.fetch(current_step)

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -63,6 +63,8 @@ class VaccinationsController < ApplicationController
     if @vaccinate_form.save(draft_vaccination_record:)
       steps = draft_vaccination_record.wizard_steps
 
+      steps.delete(:notes) # this is on the confirmation page
+
       steps.delete(:date_and_time)
       steps.delete(:outcome) if draft_vaccination_record.administered?
       if draft_vaccination_record.delivery_method.present? &&

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -33,6 +33,7 @@ class DraftVaccinationRecord
 
   def wizard_steps
     [
+      :notes,
       :date_and_time,
       :outcome,
       (:delivery if administered?),

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -19,6 +19,7 @@
      delivery_method: wizard_path("delivery"),
      delivery_site: wizard_path("delivery"),
      location: @draft_vaccination_record.wizard_steps.include?(:location) ? wizard_path("location") : nil,
+     notes: wizard_path("notes"),
      outcome: wizard_path("outcome"),
      performed_at: wizard_path("date-and-time"),
      vaccine: wizard_path("vaccine"),

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -24,6 +24,8 @@
      vaccine: wizard_path("vaccine"),
    } %>
 
+<% show_notes = @draft_vaccination_record.editing? %>
+
 <% if @draft_vaccination_record.administered? %>
   <%= render AppCardComponent.new do |card| %>
     <% card.with_heading { "Vaccination details" } %>
@@ -31,7 +33,7 @@
           @draft_vaccination_record,
           current_user:,
           change_links:,
-          show_notes: false,
+          show_notes:,
         ) %>
   <% end %>
 <% else %>
@@ -40,7 +42,7 @@
           @draft_vaccination_record,
           current_user:,
           change_links:,
-          show_notes: false,
+          show_notes:,
         ) %>
   <% end %>
 <% end %>

--- a/app/views/draft_vaccination_records/notes.html.erb
+++ b/app/views/draft_vaccination_records/notes.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
+<% end %>
+
+<% content_for :page_title, "Notes" %>
+
+<%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_area :notes,
+                        caption: { text: @patient.full_name, size: "l" },
+                        label: { text: "Notes", tag: "h1", size: "l" },
+                        hint: { text: "For example, if the child had a reaction to the vaccine" } %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
+<% end %>

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -263,7 +263,12 @@ describe AppVaccinationRecordSummaryComponent do
     context "when the notes are not present" do
       let(:notes) { nil }
 
-      it { should_not have_css(".nhsuk-summary-list__row", text: "Notes") }
+      it do
+        expect(rendered).to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Notes\nNot provided"
+        )
+      end
     end
   end
 

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -42,6 +42,10 @@ describe "Edit vaccination record" do
     then_i_see_the_edit_vaccination_record_page
     and_i_should_see_the_updated_batch
 
+    when_i_click_change_notes
+    and_i_enter_some_notes
+    then_i_see_the_edit_vaccination_record_page
+
     when_i_click_on_save_changes
     then_the_parent_doesnt_receive_an_email
   end
@@ -441,6 +445,15 @@ describe "Edit vaccination record" do
 
   def and_i_should_see_the_updated_batch
     expect(page).to have_content("Batch ID#{@replacement_batch.name}")
+  end
+
+  def when_i_click_change_notes
+    click_on "Add notes"
+  end
+
+  def and_i_enter_some_notes
+    fill_in "Notes", with: "Some notes."
+    click_on "Continue"
   end
 
   def when_i_click_on_change_outcome


### PR DESCRIPTION
This adds the ability to edit the notes of a vaccination record after the record has been created, matching the designs in the prototype. This works by adding a new "notes" step which is only used when editing, rather than when first recording a vaccination.

## Screenshots

<img width="454" alt="Screenshot 2025-01-30 at 14 52 44" src="https://github.com/user-attachments/assets/61816f0c-20a3-4b40-bd34-6eadca0dabdb" />
<img width="789" alt="Screenshot 2025-01-30 at 15 04 58" src="https://github.com/user-attachments/assets/5d291301-5941-4c86-94db-d4b8f89455ee" />
<img width="800" alt="Screenshot 2025-01-30 at 14 52 55" src="https://github.com/user-attachments/assets/0125201c-756b-4670-b59e-38b657af5923" />
