### PR TITLE
Add GILLICK_NOTIFY_PARENTS column to report

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -58,6 +58,7 @@ class Reports::ProgrammeVaccinationsExporter
       GILLICK_ASSESSMENT_DATE
       GILLICK_ASSESSED_BY
       GILLICK_ASSESSMENT_NOTES
+      GILLICK_NOTIFY_PARENTS
       VACCINATED
       DATE_OF_VACCINATION
       TIME_OF_VACCINATION
@@ -167,6 +168,7 @@ class Reports::ProgrammeVaccinationsExporter
       gillick_assessment&.updated_at&.to_date&.iso8601 || "",
       gillick_assessment&.performed_by&.full_name || "",
       gillick_assessment&.notes || "",
+      gillick_notify_parents(gillick_assessment:, consents:),
       vaccinated(vaccination_record:),
       vaccination_record.performed_at.to_date.iso8601,
       vaccination_record.performed_at.strftime("%H:%M:%S"),
@@ -199,6 +201,16 @@ class Reports::ProgrammeVaccinationsExporter
       "02" # Number present but not traced
     else
       "03" # Trace required
+    end
+  end
+
+  def gillick_notify_parents(gillick_assessment:, consents:)
+    return "" if gillick_assessment.nil?
+
+    if (consent = consents.find(&:via_self_consent?))
+      consent.notify_parents ? "Y" : "N"
+    else
+      ""
     end
   end
 

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -56,6 +56,7 @@ describe Reports::ProgrammeVaccinationsExporter do
           GILLICK_ASSESSMENT_DATE
           GILLICK_ASSESSED_BY
           GILLICK_ASSESSMENT_NOTES
+          GILLICK_NOTIFY_PARENTS
           VACCINATED
           DATE_OF_VACCINATION
           TIME_OF_VACCINATION
@@ -129,6 +130,7 @@ describe Reports::ProgrammeVaccinationsExporter do
               "GILLICK_ASSESSED_BY" => "",
               "GILLICK_ASSESSMENT_DATE" => "",
               "GILLICK_ASSESSMENT_NOTES" => "",
+              "GILLICK_NOTIFY_PARENTS" => "",
               "GILLICK_STATUS" => "",
               "GP_NAME" => "",
               "GP_ORGANISATION_CODE" => "",
@@ -256,6 +258,7 @@ describe Reports::ProgrammeVaccinationsExporter do
               "GILLICK_ASSESSED_BY" => "",
               "GILLICK_ASSESSMENT_DATE" => "",
               "GILLICK_ASSESSMENT_NOTES" => "",
+              "GILLICK_NOTIFY_PARENTS" => "",
               "GILLICK_STATUS" => "",
               "GP_NAME" => "",
               "GP_ORGANISATION_CODE" => "",
@@ -386,6 +389,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       let(:patient_session) do
         create(:patient_session, :vaccinated, programme:, session:)
       end
+      let(:patient) { patient_session.patient }
 
       before do
         performed_by = create(:user, given_name: "Test", family_name: "Nurse")
@@ -404,8 +408,41 @@ describe Reports::ProgrammeVaccinationsExporter do
           "GILLICK_ASSESSED_BY" => "Test Nurse",
           "GILLICK_ASSESSMENT_DATE" => "2024-01-01",
           "GILLICK_ASSESSMENT_NOTES" => "Assessed as Gillick competent",
+          "GILLICK_NOTIFY_PARENTS" => "",
           "GILLICK_STATUS" => "Gillick competent"
         )
+      end
+
+      context "when child doesn't want parents to be informed" do
+        before do
+          create(
+            :consent,
+            :self_consent,
+            patient:,
+            programme:,
+            notify_parents: false
+          )
+        end
+
+        it "includes the information" do
+          expect(rows.first.to_hash).to include("GILLICK_NOTIFY_PARENTS" => "N")
+        end
+      end
+
+      context "when child wants parents to be informed" do
+        before do
+          create(
+            :consent,
+            :self_consent,
+            patient:,
+            programme:,
+            notify_parents: true
+          )
+        end
+
+        it "includes the information" do
+          expect(rows.first.to_hash).to include("GILLICK_NOTIFY_PARENTS" => "Y")
+        end
       end
     end
 


### PR DESCRIPTION
This adds a new column to the programme vaccinations CSV report which captures whether the child wants their parent to be informed about the vaccination.