### PR TITLE
Remove foreign keys from school moves log entries

### DIFF
--- a/app/models/school_move_log_entry.rb
+++ b/app/models/school_move_log_entry.rb
@@ -18,12 +18,6 @@
 #  index_school_move_log_entries_on_school_id   (school_id)
 #  index_school_move_log_entries_on_user_id     (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (school_id => locations.id)
-#  fk_rails_...  (user_id => users.id)
-#
 class SchoolMoveLogEntry < ApplicationRecord
   include Schoolable
 

--- a/db/migrate/20250131153531_remove_school_move_log_entries_foreign_keys.rb
+++ b/db/migrate/20250131153531_remove_school_move_log_entries_foreign_keys.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveSchoolMoveLogEntriesForeignKeys < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :school_move_log_entries, :patients
+    remove_foreign_key :school_move_log_entries, :users
+    remove_foreign_key :school_move_log_entries, :schools, to_table: :locations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_27_133639) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_31_153531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -618,12 +618,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_27_133639) do
   end
 
   create_table "school_move_log_entries", force: :cascade do |t|
-    t.bigint "patient_id", null: false
-    t.bigint "user_id"
-    t.bigint "school_id"
     t.boolean "home_educated"
     t.boolean "move_to_school"
     t.datetime "created_at", null: false
+    t.bigint "school_id"
+    t.bigint "user_id"
+    t.bigint "patient_id", null: false
     t.index ["patient_id"], name: "index_school_move_log_entries_on_patient_id"
     t.index ["school_id"], name: "index_school_move_log_entries_on_school_id"
     t.index ["user_id"], name: "index_school_move_log_entries_on_user_id"
@@ -860,9 +860,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_27_133639) do
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
   add_foreign_key "programmes_sessions", "programmes"
   add_foreign_key "programmes_sessions", "sessions"
-  add_foreign_key "school_move_log_entries", "locations", column: "school_id"
-  add_foreign_key "school_move_log_entries", "patients"
-  add_foreign_key "school_move_log_entries", "users"
   add_foreign_key "school_moves", "locations", column: "school_id"
   add_foreign_key "school_moves", "organisations"
   add_foreign_key "school_moves", "patients"

--- a/spec/factories/school_move_log_entries.rb
+++ b/spec/factories/school_move_log_entries.rb
@@ -18,12 +18,6 @@
 #  index_school_move_log_entries_on_school_id   (school_id)
 #  index_school_move_log_entries_on_user_id     (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (school_id => locations.id)
-#  fk_rails_...  (user_id => users.id)
-#
 FactoryBot.define do
   factory :school_move_log_entry do
     patient

--- a/spec/models/school_move_log_entry_spec.rb
+++ b/spec/models/school_move_log_entry_spec.rb
@@ -18,12 +18,6 @@
 #  index_school_move_log_entries_on_school_id   (school_id)
 #  index_school_move_log_entries_on_user_id     (user_id)
 #
-# Foreign Keys
-#
-#  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (school_id => locations.id)
-#  fk_rails_...  (user_id => users.id)
-#
 describe SchoolMoveLogEntry do
   subject(:school_move_log_entry) { build(:school_move_log_entry) }
 


### PR DESCRIPTION
This record is intended to be used as part of an activity log, and any of it's associated entities may be removed without affecting the activity log trail. For example, a patient record could be removed when merging with another patient record in the case of duplication.

This very issue was blocking a bug fix for [MAVIS-1877](https://trello.com/c/f1FEuzMF/) because when merging the patients the `school_move_log_entries` record generated as part of the import was triggering a foreign key constraint error.

![image](https://github.com/user-attachments/assets/06b64ec7-d60a-4ec5-8473-4f22a5c81379)

This is a follow-up to the #2880