### PR TITLE
Handle school move log entries when merging patients 

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -31,6 +31,10 @@ class PatientMerger
         end
       end
 
+      patient_to_destroy.school_move_log_entries.update_all(
+        patient_id: patient_to_keep.id
+      )
+
       patient_to_destroy.session_notifications.update_all(
         patient_id: patient_to_keep.id
       )

--- a/app/models/school_move_log_entry.rb
+++ b/app/models/school_move_log_entry.rb
@@ -18,6 +18,12 @@
 #  index_school_move_log_entries_on_school_id   (school_id)
 #  index_school_move_log_entries_on_user_id     (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class SchoolMoveLogEntry < ApplicationRecord
   include Schoolable
 

--- a/db/migrate/20250201201237_add_school_move_log_entries_foreign_keys.rb
+++ b/db/migrate/20250201201237_add_school_move_log_entries_foreign_keys.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddSchoolMoveLogEntriesForeignKeys < ActiveRecord::Migration[8.0]
+  def change
+    add_foreign_key :school_move_log_entries, :patients
+    add_foreign_key :school_move_log_entries, :users
+    add_foreign_key :school_move_log_entries, :locations, column: :school_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_31_153531) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -618,12 +618,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_31_153531) do
   end
 
   create_table "school_move_log_entries", force: :cascade do |t|
+    t.bigint "patient_id", null: false
+    t.bigint "user_id"
+    t.bigint "school_id"
     t.boolean "home_educated"
     t.boolean "move_to_school"
     t.datetime "created_at", null: false
-    t.bigint "school_id"
-    t.bigint "user_id"
-    t.bigint "patient_id", null: false
     t.index ["patient_id"], name: "index_school_move_log_entries_on_patient_id"
     t.index ["school_id"], name: "index_school_move_log_entries_on_school_id"
     t.index ["user_id"], name: "index_school_move_log_entries_on_user_id"
@@ -860,6 +860,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_31_153531) do
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
   add_foreign_key "programmes_sessions", "programmes"
   add_foreign_key "programmes_sessions", "sessions"
+  add_foreign_key "school_move_log_entries", "locations", column: "school_id"
+  add_foreign_key "school_move_log_entries", "patients"
+  add_foreign_key "school_move_log_entries", "users"
   add_foreign_key "school_moves", "locations", column: "school_id"
   add_foreign_key "school_moves", "organisations"
   add_foreign_key "school_moves", "patients"

--- a/spec/factories/school_move_log_entries.rb
+++ b/spec/factories/school_move_log_entries.rb
@@ -18,6 +18,12 @@
 #  index_school_move_log_entries_on_school_id   (school_id)
 #  index_school_move_log_entries_on_user_id     (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :school_move_log_entry do
     patient

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -28,7 +28,8 @@ describe GovukNotifyPersonalisation do
       :patient,
       given_name: "John",
       family_name: "Smith",
-      date_of_birth: Date.current - 13.years
+      date_of_birth: Date.new(2012, 2, 1),
+      year_group: 8
     )
   end
   let(:location) { create(:school, name: "Hogwarts") }
@@ -60,7 +61,7 @@ describe GovukNotifyPersonalisation do
         not_catch_up: "yes",
         organisation_privacy_notice_url: "https://example.com/privacy-notice",
         organisation_privacy_policy_url: "https://example.com/privacy-policy",
-        patient_date_of_birth: "30 January 2012",
+        patient_date_of_birth: "1 February 2012",
         programme_name: "HPV",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -45,6 +45,9 @@ describe PatientMerger do
     let(:school_move) do
       create(:school_move, :to_school, patient: patient_to_destroy)
     end
+    let(:school_move_log_entry) do
+      create(:school_move_log_entry, patient: patient_to_destroy)
+    end
     let(:duplicate_school_move) do
       create(:school_move, patient: patient_to_keep, school: school_move.school)
     end
@@ -115,6 +118,12 @@ describe PatientMerger do
 
     it "moves school moves" do
       expect { call }.to change { school_move.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves school move log entries" do
+      expect { call }.to change { school_move_log_entry.reload.patient }.to(
         patient_to_keep
       )
     end

--- a/spec/models/school_move_log_entry_spec.rb
+++ b/spec/models/school_move_log_entry_spec.rb
@@ -18,6 +18,12 @@
 #  index_school_move_log_entries_on_school_id   (school_id)
 #  index_school_move_log_entries_on_user_id     (user_id)
 #
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 describe SchoolMoveLogEntry do
   subject(:school_move_log_entry) { build(:school_move_log_entry) }
 


### PR DESCRIPTION
This reverts the change that was made in https://github.com/nhsuk/manage-vaccinations-in-schools/commit/6d8880d3c5b4810b7851614fdf30ce365a163f6e to remove these foreign keys to fix a bug where patients couldn't be merged due to the school move log entries existing.

Instead, we can handle the school move log entries by modifying the `patient_id` value, ensuring that the foreign keys continue to be valid. Removing the foreign keys means we can no longer rely on this model to generate activity logs which is one of the reason it was added.

It's true that it also prevents us from being able to delete any schools or users, but we already have this problem or more crucial models (like vaccination records, triage, sessions, etc) so when if we come to a situation where we need to handle that we should do it in a consistent way (likely by soft-deleting the foreign keyed model).