### PR TITLE
Increase wait time between PDS jobs

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -25,7 +25,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
 
           PatientUpdateFromPDSJob.set(
             priority: 50,
-            wait: 0.21 * index
+            wait: 0.5 * index
           ).perform_later(patient)
         end
     end

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -172,12 +172,12 @@ module CSVImportable
         # should reduce the risk of this.
 
         if patient.nhs_number.nil?
-          PatientNHSNumberLookupJob.set(wait: 0.21 * index).perform_later(
+          PatientNHSNumberLookupJob.set(wait: 0.5 * index).perform_later(
             patient
           )
         else
           PatientUpdateFromPDSJob.set(
-            wait: 0.21 * index,
+            wait: 0.5 * index,
             queue: :imports
           ).perform_later(patient)
         end


### PR DESCRIPTION
We're seeing a problem in production where the queues for PDS jobs gets full with jobs that are not succeeding, likely related to the rate limit.

Some potentially related issues:

- https://github.com/bensheldon/good_job/issues/838
- https://github.com/bensheldon/good_job/issues/1278
- https://github.com/bensheldon/good_job/issues/1353

This wait time was added to artifically slow down the queues and prevent them from needing to be retried, so increasing this wait time should reduce the changes of the jobs ending up in this stuck state.

This is a temporary measure until we can either move away from Good Job or resolve the underlyling issue which is still not 100% clear.