### PR TITLE
Run bulk patient update job every 1 hour

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,7 +119,7 @@ Rails.application.configure do
   config.good_job.enable_cron = true
   config.good_job.cron = {
     bulk_update_patients_from_pds: {
-      cron: "every day at 00:00 and 8:00 and 12:00 and 18:00",
+      cron: "every hour",
       class: "BulkUpdatePatientsFromPDSJob",
       description: "Keep patient details up to date with PDS."
     },


### PR DESCRIPTION
The job only searches for patients that were updated >6 hours ago, so this divides the batch into more frequent, smaller batches.