### PR TITLE
Ensure patient merging works with audited and strict loading

### DIFF
--- a/app/controllers/patients/edit_controller.rb
+++ b/app/controllers/patients/edit_controller.rb
@@ -26,7 +26,10 @@ class Patients::EditController < ApplicationController
   end
 
   def update_nhs_number_merge
-    @existing_patient = policy_scope(Patient).find_by!(nhs_number:)
+    @existing_patient =
+      policy_scope(Patient).includes(parent_relationships: :parent).find_by!(
+        nhs_number:
+      )
 
     PatientMerger.call(to_keep: @existing_patient, to_destroy: @patient)
 

--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -95,7 +95,7 @@ class PatientMerger
       patient_to_destroy.cohort_imports.clear
       patient_to_destroy.immunisation_imports.clear
 
-      patient_to_destroy.destroy!
+      patient_to_destroy.reload.destroy!
     end
   end
 

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -3,11 +3,25 @@
 describe PatientMerger do
   describe "#call" do
     subject(:call) do
-      described_class.call(
-        to_keep: patient_to_keep.reload,
-        to_destroy: patient_to_destroy.reload
-      )
+      # Intentionally call this method as we would in a controller because
+      # we were finding bugs when called like this but not on its own.
+      Audited
+        .audit_class
+        .as_user(user) do
+          described_class.call(
+            to_keep:
+              Patient.includes(parent_relationships: :parent).find(
+                patient_to_keep.id
+              ),
+            to_destroy:
+              Patient.includes(parent_relationships: :parent).find(
+                patient_to_destroy.id
+              )
+          )
+        end
     end
+
+    let(:user) { create(:user) }
 
     let(:programme) { create(:programme) }
     let(:session) { create(:session, programme:) }


### PR DESCRIPTION
This updates the tests for the `PatientMerger` class (and the implementation of the class) to ensure that it works when called from a controller, with `audited` and with parents and parent relationships already pre-loaded.

https://good-machine.sentry.io/issues/6259221555/