### PR TITLE
Decrease the number of good job threads to 1 in test

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -90,6 +90,7 @@ environments:
       SENTRY_ENVIRONMENT: test
       MAVIS__HOST: "test.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "test.mavistesting.com"
+      GOOD_JOB_MAX_THREADS: 1
   training:
     http:
       alias:


### PR DESCRIPTION
This will lead to 2x3x1 = 6 max threads instead of 2x3x5 = 30, which could in theory help with the PDS rate limit.