### PR TITLE
Increase interval between PDS jobs

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -25,7 +25,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
 
           PatientUpdateFromPDSJob.set(
             priority: 50,
-            wait: 0.5 * index
+            wait: 2 * index
           ).perform_later(patient)
         end
     end

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -172,12 +172,10 @@ module CSVImportable
         # should reduce the risk of this.
 
         if patient.nhs_number.nil?
-          PatientNHSNumberLookupJob.set(wait: 0.5 * index).perform_later(
-            patient
-          )
+          PatientNHSNumberLookupJob.set(wait: 2 * index).perform_later(patient)
         else
           PatientUpdateFromPDSJob.set(
-            wait: 0.5 * index,
+            wait: 2 * index,
             queue: :imports
           ).perform_later(patient)
         end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,7 +119,7 @@ Rails.application.configure do
   config.good_job.enable_cron = true
   config.good_job.cron = {
     bulk_update_patients_from_pds: {
-      cron: "every day at 00:00 and 8:00 and 12:00 and 18:00",
+      cron: "every day at 6:00 and 18:00",
       class: "BulkUpdatePatientsFromPDSJob",
       description: "Keep patient details up to date with PDS."
     },


### PR DESCRIPTION
We're still seeing the issue in production where the PDS jobs get stuck in a state where none of them can process successfully. Running some experiments by queueing the jobs manually via a Rails console suggests a 2 second interval between the jobs is handled much better, although it means that it'll take ~11 hours to process all the patients.