### PR TITLE
Decouple vaccination records from patient sessions

### DIFF
--- a/app/components/app_patient_vaccination_table_component.html.erb
+++ b/app/components/app_patient_vaccination_table_component.html.erb
@@ -24,8 +24,11 @@
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Location</span>
-            <% location = vaccination_record.location %>
-            <%= ([location.name] + location.address_parts).join(", ") %>
+            <% if (location = vaccination_record.location) %>
+              <%= ([location.name] + location.address_parts).join(", ") %>
+            <% else %>
+              Unknown
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -255,10 +255,14 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   end
 
   def location_value
-    if @vaccination_record.location.generic_clinic?
-      @vaccination_record.location_name
+    if (location = @vaccination_record.location)
+      if location.generic_clinic?
+        @vaccination_record.location_name
+      else
+        location.name
+      end
     else
-      @vaccination_record.location.name
+      "Unknown"
     end
   end
 

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -42,12 +42,19 @@ module VaccinationMailerConcern
   end
 
   def parents_for_vaccination_mailer(vaccination_record)
-    patient_session = vaccination_record.patient_session
-    programme = vaccination_record.programme
-    patient = patient_session.patient
-
+    patient = vaccination_record.patient
     return [] unless patient.send_notifications?
 
+    patient_session =
+      PatientSession.find_by(
+        patient:,
+        session_id: vaccination_record.session_id
+      )
+    return [] if patient_session.nil?
+
+    patient_session.patient = patient
+
+    programme = vaccination_record.programme
     consents = patient_session.latest_consents(programme:)
 
     parents =

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -33,10 +33,10 @@ class DevController < ApplicationController
       SessionDate.where(session: sessions).destroy_all
       ConsentNotification.where(session: sessions).destroy_all
       SessionNotification.where(session: sessions).destroy_all
+      VaccinationRecord.where(session: sessions).destroy_all
 
       patient_sessions = PatientSession.where(session: sessions)
       GillickAssessment.where(patient_session: patient_sessions).destroy_all
-      VaccinationRecord.where(patient_session: patient_sessions).destroy_all
       PreScreening.where(patient_session: patient_sessions).destroy_all
       patient_sessions.destroy_all
 
@@ -49,6 +49,7 @@ class DevController < ApplicationController
       SchoolMoveLogEntry.where(patient: patients).destroy_all
       AccessLogEntry.where(patient: patients).destroy_all
       NotifyLogEntry.where(patient: patients).destroy_all
+      VaccinationRecord.where(patient: patients).destroy_all
 
       ConsentForm.where(organisation:).destroy_all
       Consent.where(organisation:).destroy_all

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -7,7 +7,6 @@ class DraftVaccinationRecordsController < ApplicationController
   skip_after_action :verify_policy_scoped
 
   before_action :set_draft_vaccination_record
-  before_action :set_patient_session
   before_action :set_patient
   before_action :set_session
   before_action :set_programme
@@ -156,16 +155,12 @@ class DraftVaccinationRecordsController < ApplicationController
       DraftVaccinationRecord.new(request_session: session, current_user:)
   end
 
-  def set_patient_session
-    @patient_session = @draft_vaccination_record.patient_session
-  end
-
   def set_patient
-    @patient = @patient_session.patient
+    @patient = @draft_vaccination_record.patient
   end
 
   def set_session
-    @session = @patient_session.session
+    @session = @draft_vaccination_record.session
   end
 
   def set_programme

--- a/app/controllers/import_issues_controller.rb
+++ b/app/controllers/import_issues_controller.rb
@@ -42,7 +42,6 @@ class ImportIssuesController < ApplicationController
         .includes(
           :batch,
           :location,
-          :patient_session,
           :performed_by_user,
           session: :location,
           patient: %i[gp_practice school],

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -35,8 +35,7 @@ class ProgrammesController < ApplicationController
           :session_dates,
           patient_sessions: [
             :gillick_assessments,
-            :vaccination_records,
-            { patient: [:triages, { consents: :parent }] }
+            { patient: [:triages, :vaccination_records, { consents: :parent }] }
           ]
         )
         .order("locations.name")

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -44,7 +44,6 @@ class RegisterAttendancesController < ApplicationController
     ps =
       @session.patient_sessions.preload_for_status.includes(
         :patient,
-        :vaccination_records,
         session: :session_dates,
         session_attendances: :session_date
       )

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -44,9 +44,8 @@ class SessionAttendancesController < ApplicationController
   def set_patient_session
     @patient_session =
       policy_scope(PatientSession)
-        .includes(:patient, :vaccination_records)
-        .eager_load(:session)
-        .preload(patient: %i[consents triages])
+        .eager_load(:patient, :session)
+        .preload(:vaccination_records, patient: %i[consents triages])
         .find_by!(
           session: {
             slug: params.fetch(:session_slug)

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -72,13 +72,11 @@ class VaccinationRecordsController < ApplicationController
           :location,
           :performed_by_user,
           :programme,
-          patient_session: {
-            patient: [
-              :gp_practice,
-              :school,
-              { consents: :parent, parent_relationships: :parent }
-            ]
-          },
+          patient: [
+            :gp_practice,
+            :school,
+            { consents: :parent, parent_relationships: :parent }
+          ],
           session: %i[session_dates],
           vaccine: :programme
         )
@@ -92,7 +90,7 @@ class VaccinationRecordsController < ApplicationController
 
   def set_vaccination_record
     @vaccination_record = vaccination_records.find(params[:id])
-    @patient = @vaccination_record.patient_session.patient
+    @patient = @vaccination_record.patient
     @session = @vaccination_record.session
   end
 

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -50,13 +50,14 @@ class VaccinateForm
       end
     end
 
+    draft_vaccination_record.batch_id = todays_batch&.id
     draft_vaccination_record.dose_sequence = dose_sequence
-    draft_vaccination_record.patient_session = patient_session
+    draft_vaccination_record.patient_id = patient_session.patient_id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user
     draft_vaccination_record.programme_id = programme_id
+    draft_vaccination_record.session_id = patient_session.session_id
     draft_vaccination_record.vaccine_id = vaccine_id
-    draft_vaccination_record.batch_id = todays_batch&.id
 
     draft_vaccination_record.save # rubocop:disable Rails/SaveBang
   end

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -7,7 +7,6 @@ class EmailDeliveryJob < NotifyDeliveryJob
     consent_form: nil,
     parent: nil,
     patient: nil,
-    patient_session: nil,
     programme: nil,
     sent_by: nil,
     session: nil,
@@ -27,7 +26,6 @@ class EmailDeliveryJob < NotifyDeliveryJob
         consent:,
         consent_form:,
         patient:,
-        patient_session:,
         programme:,
         vaccination_record:
       )
@@ -36,13 +34,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
 
     if (
          email_reply_to_id =
-           reply_to_id(
-             consent:,
-             consent_form:,
-             patient_session:,
-             session:,
-             vaccination_record:
-           )
+           reply_to_id(consent:, consent_form:, session:, vaccination_record:)
        )
       args[:email_reply_to_id] = email_reply_to_id
     end
@@ -58,7 +50,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
         nil
       end
 
-    patient ||= consent&.patient || patient_session&.patient
+    patient ||= consent&.patient
 
     NotifyLogEntry.create!(
       consent_form:,
@@ -72,23 +64,14 @@ class EmailDeliveryJob < NotifyDeliveryJob
     )
   end
 
-  def reply_to_id(
-    consent:,
-    consent_form:,
-    patient_session:,
-    session:,
-    vaccination_record:
-  )
-    team =
-      session&.team || patient_session&.team || consent_form&.team ||
-        vaccination_record&.team
+  def reply_to_id(consent:, consent_form:, session:, vaccination_record:)
+    team = session&.team || consent_form&.team || vaccination_record&.team
 
     return team.reply_to_id if team&.reply_to_id
 
     organisation =
-      session&.organisation || patient_session&.organisation ||
-        consent_form&.organisation || consent&.organisation ||
-        vaccination_record&.organisation
+      session&.organisation || consent_form&.organisation ||
+        consent&.organisation || vaccination_record&.organisation
 
     organisation.reply_to_id
   end

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -10,8 +10,12 @@ class SchoolSessionRemindersJob < ApplicationJob
       PatientSession
         .includes(
           :gillick_assessments,
-          :vaccination_records,
-          patient: [:parents, :triages, { consents: %i[parent patient] }]
+          patient: [
+            :parents,
+            :triages,
+            :vaccination_records,
+            { consents: %i[parent patient] }
+          ]
         )
         .eager_load(:session)
         .joins(:location)

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -7,7 +7,6 @@ class SMSDeliveryJob < NotifyDeliveryJob
     consent_form: nil,
     parent: nil,
     patient: nil,
-    patient_session: nil,
     programme: nil,
     sent_by: nil,
     session: nil,
@@ -27,7 +26,6 @@ class SMSDeliveryJob < NotifyDeliveryJob
         consent:,
         consent_form:,
         patient:,
-        patient_session:,
         programme:,
         vaccination_record:
       )
@@ -45,7 +43,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
         nil
       end
 
-    patient ||= consent&.patient || patient_session&.patient
+    patient ||= consent&.patient
 
     NotifyLogEntry.create!(
       consent_form:,

--- a/app/jobs/vaccination_confirmations_job.rb
+++ b/app/jobs/vaccination_confirmations_job.rb
@@ -15,7 +15,7 @@ class VaccinationConfirmationsJob < ApplicationJob
     academic_year = Date.current.academic_year
 
     VaccinationRecord
-      .includes(patient_session: { patient: { consents: :parent } })
+      .includes(patient: { consents: :parent })
       .kept
       .where("created_at >= ?", since)
       .where(confirmation_sent_at: nil)

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -7,29 +7,23 @@ class GovukNotifyPersonalisation
     consent: nil,
     consent_form: nil,
     patient: nil,
-    patient_session: nil,
     programme: nil,
     session: nil,
     vaccination_record: nil
   )
-    patient_session ||= vaccination_record&.patient_session
-
     @consent = consent
     @consent_form = consent_form
-    @patient = patient || consent&.patient || patient_session&.patient
+    @patient = patient || consent&.patient || vaccination_record&.patient
     @programme =
       programme || vaccination_record&.programme || consent_form&.programme ||
         consent&.programme
     @session =
       session || consent_form&.actual_upcoming_session ||
-        consent_form&.original_session || patient_session&.session
+        consent_form&.original_session || vaccination_record&.session
     @organisation =
-      session&.organisation || patient_session&.organisation ||
-        consent_form&.organisation || consent&.organisation ||
-        vaccination_record&.organisation
-    @team =
-      session&.team || patient_session&.team || consent_form&.team ||
-        vaccination_record&.team
+      session&.organisation || consent_form&.organisation ||
+        consent&.organisation || vaccination_record&.organisation
+    @team = session&.team || consent_form&.team || vaccination_record&.team
     @vaccination_record = vaccination_record
   end
 

--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -39,6 +39,9 @@ class PatientMerger
         patient_id: patient_to_keep.id
       )
       patient_to_destroy.triages.update_all(patient_id: patient_to_keep.id)
+      patient_to_destroy.vaccination_records.update_all(
+        patient_id: patient_to_keep.id
+      )
 
       patient_to_destroy.parent_relationships.find_each do |relationship|
         if patient_to_keep.parent_relationships.exists?(
@@ -61,9 +64,6 @@ class PatientMerger
             patient_session_id: existing_patient_session.id
           )
           patient_session.pre_screenings.update_all(
-            patient_session_id: existing_patient_session.id
-          )
-          patient_session.vaccination_records.update_all(
             patient_session_id: existing_patient_session.id
           )
         else

--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -74,8 +74,11 @@ class Reports::CareplusExporter
         .patient_sessions
         .includes(
           :location,
-          :vaccination_records,
-          patient: [:school, { consents: %i[parent patient] }]
+          patient: [
+            :school,
+            :vaccination_records,
+            { consents: %i[parent patient] }
+          ]
         )
         .where.not(vaccination_records: { id: nil })
         .merge(VaccinationRecord.administered)

--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -89,7 +89,9 @@ class DPSExportRow
   end
 
   def site_code
-    organisation.ods_code
+    # FIXME: If the vaccination record isn't attached to a session we don't have an organisation.
+    # https://trello.com/c/TxFJbYnh/1428-import-vaccinations-administered-by-someone-other-than-the-specific-sais-team-primary-source-false
+    organisation&.ods_code
   end
 
   def site_code_type_uri
@@ -186,10 +188,12 @@ class DPSExportRow
   end
 
   def location_code
-    location.urn.presence || location.ods_code
+    location&.urn.presence || location&.ods_code
   end
 
   def location_code_type_uri
+    return nil if location.nil?
+
     if location.urn.present?
       "https://fhir.hl7.org.uk/Id/urn-school-number"
     else

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -17,7 +17,8 @@ class DraftVaccinationRecord
   attribute :location_name, :string
   attribute :notes, :string
   attribute :outcome, :string
-  attribute :patient_session_id, :integer
+  attribute :patient_id, :integer
+  attribute :session_id, :integer
   attribute :performed_at, :datetime
   attribute :performed_by_family_name, :string
   attribute :performed_by_given_name, :string
@@ -118,19 +119,18 @@ class DraftVaccinationRecord
     vaccine.dose_volume_ml * 1 if vaccine.present?
   end
 
-  def patient_session
-    PatientSessionPolicy::Scope
-      .new(@current_user, PatientSession)
+  def patient
+    PatientPolicy::Scope
+      .new(@current_user, Patient)
       .resolve
-      .preload_for_status
-      .find_by(id: patient_session_id)
+      .find_by(id: patient_id)
   end
 
-  def patient_session=(value)
-    self.patient_session_id = value.id
+  def patient=(value)
+    self.patient_id = value.id
   end
 
-  delegate :location, :patient, :session, to: :patient_session, allow_nil: true
+  delegate :location, to: :session, allow_nil: true
 
   def performed_by_user
     User.find_by(id: performed_by_user_id)
@@ -151,11 +151,22 @@ class DraftVaccinationRecord
     self.programme_id = value.id
   end
 
+  def session
+    SessionPolicy::Scope
+      .new(@current_user, Session)
+      .resolve
+      .find_by(id: session_id)
+  end
+
+  def session=(value)
+    self.session_id = value.id
+  end
+
   def vaccination_record
     VaccinationRecordPolicy::Scope
       .new(@current_user, VaccinationRecord)
       .resolve
-      .includes(patient_session: { patient: { consents: :parent } })
+      .includes(patient: { consents: :parent })
       .find_by(id: editing_id)
   end
 

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -80,7 +80,6 @@ class ImmunisationImport < ApplicationRecord
     @vaccination_records_batch ||= Set.new
     @batches_batch ||= Set.new
     @patients_batch ||= Set.new
-    @patient_sessions_batch ||= Set.new
     @sessions_batch ||= Set.new
 
     @vaccination_records_batch.add(vaccination_record)
@@ -88,7 +87,6 @@ class ImmunisationImport < ApplicationRecord
       @batches_batch.add(vaccination_record.batch)
     end
     @patients_batch.add(vaccination_record.patient)
-    @patient_sessions_batch.add(vaccination_record.patient_session)
     @sessions_batch.add(vaccination_record.session)
 
     count_column_to_increment
@@ -107,7 +105,6 @@ class ImmunisationImport < ApplicationRecord
       [:vaccination_records, vaccination_records],
       [:batches, @batches_batch],
       [:patients, @patients_batch],
-      [:patient_sessions, @patient_sessions_batch],
       [:sessions, @sessions_batch]
     ].each do |association, collection|
       link_records_by_type(association, collection)

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -120,12 +120,13 @@ class ImmunisationImportRow
       dose_sequence:,
       location_name:,
       outcome:,
-      patient_session:,
+      patient:,
       performed_at:,
       performed_by_family_name:,
       performed_by_given_name:,
       performed_by_user:,
-      programme: @programme
+      programme: @programme,
+      session:
     }
 
     vaccination_record =
@@ -179,12 +180,6 @@ class ImmunisationImportRow
 
           session.session_dates.find_or_create_by!(value: date_of_vaccination)
         end
-  end
-
-  def patient_session
-    return unless valid?
-
-    @patient_session ||= PatientSession.find_or_create_by!(patient:, session:)
   end
 
   def location_name

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -397,7 +397,11 @@ class Patient < ApplicationRecord
 
   def clear_upcoming_sessions
     patient_sessions
-      .includes(:session_attendances)
+      .includes(
+        :gillick_assessments,
+        :session_attendances,
+        :vaccination_records
+      )
       .where(session: upcoming_sessions)
       .find_each(&:destroy_if_safe!)
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -75,6 +75,7 @@ class Patient < ApplicationRecord
   has_many :school_moves
   has_many :session_notifications
   has_many :triages
+  has_many :vaccination_records, -> { kept }
 
   has_many :parents, through: :parent_relationships
   has_many :gillick_assessments,
@@ -85,7 +86,6 @@ class Patient < ApplicationRecord
            through: :patient_sessions
   has_many :session_attendances, through: :patient_sessions
   has_many :sessions, through: :patient_sessions
-  has_many :vaccination_records, through: :patient_sessions
 
   has_many :upcoming_sessions,
            -> { upcoming },

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -38,8 +38,10 @@ class PatientSession < ApplicationRecord
 
   has_many :gillick_assessments, -> { order(:created_at) }
   has_many :pre_screenings, -> { order(:created_at) }
-  has_many :vaccination_records, -> { kept.order(:created_at) }
 
+  has_many :vaccination_records,
+           -> { kept.where(session_id: _1.session_id).order(:created_at) },
+           through: :patient
   has_many :session_notifications,
            -> { where(session_id: _1.session_id) },
            through: :patient

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -35,11 +35,13 @@ class Session < ApplicationRecord
   has_many :patient_sessions
   has_many :session_dates, -> { order(:value) }
   has_many :session_notifications
+  has_many :vaccination_records
 
   has_and_belongs_to_many :immunisation_imports
   has_and_belongs_to_many :programmes
 
   has_one :team, through: :location
+  has_many :gillick_assessments, through: :patient_sessions
   has_many :patients, through: :patient_sessions
   has_many :vaccines, through: :programmes
 

--- a/app/models/session_attendance.rb
+++ b/app/models/session_attendance.rb
@@ -27,5 +27,6 @@ class SessionAttendance < ApplicationRecord
   belongs_to :session_date
 
   has_one :session, through: :patient_session
+  has_one :patient, through: :patient_session
   has_one :location, through: :session
 end

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -81,7 +81,7 @@ class SessionNotification < ApplicationRecord
 
     if type == :school_reminder
       contacts.each do |consent|
-        params = { consent:, patient_session:, sent_by: current_user }
+        params = { consent:, session:, sent_by: current_user }
 
         EmailDeliveryJob.perform_later(:session_school_reminder, **params)
 
@@ -91,7 +91,7 @@ class SessionNotification < ApplicationRecord
       end
     else
       contacts.each do |parent|
-        params = { parent:, patient_session:, sent_by: current_user }
+        params = { parent:, patient:, session:, sent_by: current_user }
 
         EmailDeliveryJob.perform_later(:"session_#{type}", **params)
         SMSDeliveryJob.perform_later(:"session_#{type}", **params)

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -21,25 +21,28 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  batch_id                 :bigint
-#  patient_session_id       :bigint           not null
+#  patient_id               :bigint
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
+#  session_id               :bigint
 #
 # Indexes
 #
 #  index_vaccination_records_on_batch_id              (batch_id)
 #  index_vaccination_records_on_discarded_at          (discarded_at)
-#  index_vaccination_records_on_patient_session_id    (patient_session_id)
+#  index_vaccination_records_on_patient_id            (patient_id)
 #  index_vaccination_records_on_performed_by_user_id  (performed_by_user_id)
 #  index_vaccination_records_on_programme_id          (programme_id)
+#  index_vaccination_records_on_session_id            (session_id)
 #  index_vaccination_records_on_uuid                  (uuid) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (batch_id => batches.id)
-#  fk_rails_...  (patient_session_id => patient_sessions.id)
+#  fk_rails_...  (patient_id => patients.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_id => sessions.id)
 #
 class VaccinationRecord < ApplicationRecord
   include Discard::Model

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -49,7 +49,7 @@ class VaccinationRecord < ApplicationRecord
   include PendingChangesConcern
   include VaccinationRecordPerformedByConcern
 
-  audited associated_with: :patient_session
+  audited associated_with: :patient
 
   DELIVERY_SITE_SNOMED_CODES_AND_TERMS = {
     left_thigh: ["61396006", "Structure of left thigh (body structure)"],
@@ -74,15 +74,15 @@ class VaccinationRecord < ApplicationRecord
   }.with_indifferent_access
 
   belongs_to :batch, optional: true
-  belongs_to :patient_session
   belongs_to :performed_by_user, class_name: "User", optional: true
   belongs_to :programme
 
   has_and_belongs_to_many :dps_exports
   has_and_belongs_to_many :immunisation_imports
 
-  has_one :patient, through: :patient_session
-  has_one :session, through: :patient_session
+  belongs_to :patient
+  belongs_to :session, optional: true
+
   has_one :location, through: :session
   has_one :organisation, through: :session
   has_one :team, through: :session
@@ -132,8 +132,6 @@ class VaccinationRecord < ApplicationRecord
        validate: true
 
   encrypts :notes
-
-  validates :programme, inclusion: { in: -> { _1.patient_session.programmes } }
 
   validates :notes, length: { maximum: 1000 }
 

--- a/db/migrate/20250205132254_add_vaccination_record_references.rb
+++ b/db/migrate/20250205132254_add_vaccination_record_references.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class AddVaccinationRecordReferences < ActiveRecord::Migration[8.0]
+  def up
+    change_table :vaccination_records, bulk: true do |t|
+      t.references :patient, foreign_key: true
+      t.references :session, foreign_key: true
+      t.change_null :patient_session_id, null: true
+    end
+
+    VaccinationRecord.find_each do |vaccination_record|
+      patient_session =
+        PatientSession.find(vaccination_record.patient_session_id)
+      vaccination_record.update!(
+        patient_id: patient_session.patient_id,
+        session_id: patient_session.session_id
+      )
+    end
+
+    change_table :vaccination_records, bulk: true do |t|
+      t.change_null :patient_id, null: false # rubocop:disable Rails/NotNullColumn
+      t.remove_references :patient_session
+    end
+  end
+
+  def down
+    change_table :vaccination_records, bulk: true do |t|
+      t.references :patient_session, foreign_key: true
+      t.change_null :patient_id, null: true
+    end
+
+    VaccinationRecord.find_each do |vaccination_record|
+      patient_session =
+        PatientSession.find_by!(
+          patient_id: vaccination_record.patient_id,
+          session_id: vaccination_record.session_id
+        )
+      vaccination_record.update!(patient_session_id: patient_session.id)
+    end
+
+    change_table :vaccination_records, bulk: true do |t|
+      t.change_null :patient_session_id, null: true
+      t.remove_references :patient, :session
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_05_132254) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -742,7 +742,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
   end
 
   create_table "vaccination_records", force: :cascade do |t|
-    t.bigint "patient_session_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "delivery_site"
@@ -761,11 +760,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
     t.string "location_name"
     t.datetime "discarded_at"
     t.datetime "confirmation_sent_at"
+    t.bigint "patient_id"
+    t.bigint "session_id"
     t.index ["batch_id"], name: "index_vaccination_records_on_batch_id"
     t.index ["discarded_at"], name: "index_vaccination_records_on_discarded_at"
-    t.index ["patient_session_id"], name: "index_vaccination_records_on_patient_session_id"
+    t.index ["patient_id"], name: "index_vaccination_records_on_patient_id"
     t.index ["performed_by_user_id"], name: "index_vaccination_records_on_performed_by_user_id"
     t.index ["programme_id"], name: "index_vaccination_records_on_programme_id"
+    t.index ["session_id"], name: "index_vaccination_records_on_session_id"
     t.index ["uuid"], name: "index_vaccination_records_on_uuid", unique: true
   end
 
@@ -882,8 +884,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_01_201237) do
   add_foreign_key "triage", "programmes"
   add_foreign_key "triage", "users", column: "performed_by_user_id"
   add_foreign_key "vaccination_records", "batches"
-  add_foreign_key "vaccination_records", "patient_sessions"
+  add_foreign_key "vaccination_records", "patients"
   add_foreign_key "vaccination_records", "programmes"
+  add_foreign_key "vaccination_records", "sessions"
   add_foreign_key "vaccination_records", "users", column: "performed_by_user_id"
   add_foreign_key "vaccines", "programmes"
 end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -89,7 +89,8 @@ describe AppActivityLogComponent do
       create(
         :vaccination_record,
         programme:,
-        patient_session:,
+        patient:,
+        session:,
         performed_at: Time.zone.parse("2024-05-31 12:00"),
         performed_by: user,
         notes: "Some notes"
@@ -98,7 +99,8 @@ describe AppActivityLogComponent do
       create(
         :vaccination_record,
         programme:,
-        patient_session:,
+        patient:,
+        session:,
         performed_at: Time.zone.parse("2024-05-31 13:00"),
         performed_by: nil,
         notes: "Some notes",
@@ -183,7 +185,8 @@ describe AppActivityLogComponent do
         :vaccination_record,
         :not_administered,
         programme:,
-        patient_session:,
+        patient:,
+        session:,
         performed_at: Time.zone.local(2024, 5, 31, 13),
         performed_by: user,
         notes: "Some notes.",
@@ -204,7 +207,8 @@ describe AppActivityLogComponent do
         :vaccination_record,
         :discarded,
         programme:,
-        patient_session:,
+        patient:,
+        session:,
         performed_at: Time.zone.local(2024, 5, 31, 13),
         discarded_at: Time.zone.local(2024, 5, 31, 14),
         performed_by: user

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -67,7 +67,8 @@ describe AppOutcomeBannerComponent do
       let(:date) { Time.zone.now - 2.days }
       let(:patient_session) do
         create(:patient_session, :vaccinated).tap do |ps|
-          ps.vaccination_records.first.update(performed_at: date)
+          ps.strict_loading!(false)
+          ps.vaccination_records.first.update!(performed_at: date)
         end
       end
 

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -9,13 +9,13 @@ describe AppProgrammeSessionTableComponent do
   let(:location) { create(:school, name: "Waterloo Road") }
   let(:session) { create(:session, programme:, location:) }
   let(:sessions) { [session] + create_list(:session, 2, programme:) }
-  let(:patient_session) { create(:patient_session, session:) }
+  let(:patient) { create(:patient, session:) }
 
   before do
     create_list(:patient_session, 4, session:)
 
-    create(:consent, :given, programme:, patient: patient_session.patient)
-    create(:vaccination_record, programme:, patient_session:)
+    create(:consent, :given, programme:, patient:)
+    create(:vaccination_record, programme:, patient:, session:)
 
     sessions.each { _1.strict_loading!(false) }
   end

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -13,7 +13,6 @@ describe AppVaccinationRecordSummaryComponent do
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:session) { create(:session, programme:, location:, organisation:) }
   let(:patient) { create(:patient) }
-  let(:patient_session) { create(:patient_session, session:, patient:) }
   let(:vaccine) { programme.vaccines.first }
   let(:batch) do
     create(:batch, name: "ABC", expiry: Date.new(2026, 1, 1), vaccine:)
@@ -32,7 +31,8 @@ describe AppVaccinationRecordSummaryComponent do
       outcome:,
       batch:,
       vaccine:,
-      patient_session:,
+      patient:,
+      session:,
       delivery_method: :intramuscular,
       delivery_site: :left_arm_upper_position,
       notes:,

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -13,8 +13,7 @@ describe VaccinationMailerConcern do
     end
 
     vaccination_record.strict_loading!(false)
-    vaccination_record.patient_session.strict_loading!(false)
-    vaccination_record.patient_session.patient.strict_loading!(false)
+    vaccination_record.patient.strict_loading!(false)
   end
 
   let(:sample) { SampleClass.new(current_user:) }
@@ -28,10 +27,9 @@ describe VaccinationMailerConcern do
     let(:programme) { create(:programme) }
     let(:session) { create(:session, programme:) }
     let(:parent) { create(:parent) }
-    let(:patient) { create(:patient, parents: [parent]) }
-    let(:patient_session) { create(:patient_session, session:, patient:) }
+    let(:patient) { create(:patient, parents: [parent], session:) }
     let(:vaccination_record) do
-      create(:vaccination_record, programme:, patient_session:)
+      create(:vaccination_record, programme:, patient:, session:)
     end
 
     context "when the vaccination has taken place" do
@@ -58,7 +56,8 @@ describe VaccinationMailerConcern do
           :vaccination_record,
           :not_administered,
           programme:,
-          patient_session:
+          patient:,
+          session:
         )
       end
 
@@ -77,7 +76,7 @@ describe VaccinationMailerConcern do
 
     context "when the consent was done through gillick assessment" do
       let(:vaccination_record) do
-        create(:vaccination_record, programme:, patient_session:)
+        create(:vaccination_record, programme:, patient:, session:)
       end
 
       context "when child wants parents to be notified" do

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -185,7 +185,8 @@ FactoryBot.define do
         create(
           :vaccination_record,
           :not_administered,
-          patient_session:,
+          patient: patient_session.patient,
+          session: patient_session.session,
           programme: evaluator.programme,
           performed_by: evaluator.user,
           location_name: evaluator.location_name,
@@ -224,7 +225,8 @@ FactoryBot.define do
         create(
           :vaccination_record,
           :not_administered,
-          patient_session:,
+          patient: patient_session.patient,
+          session: patient_session.session,
           programme: evaluator.programme,
           performed_by: evaluator.user,
           location_name: evaluator.location_name,
@@ -249,7 +251,8 @@ FactoryBot.define do
         create(
           :vaccination_record,
           :not_administered,
-          patient_session:,
+          patient: patient_session.patient,
+          session: patient_session.session,
           programme: evaluator.programme,
           performed_by: evaluator.user,
           outcome: :already_had
@@ -273,7 +276,8 @@ FactoryBot.define do
       after(:create) do |patient_session, evaluator|
         create(
           :vaccination_record,
-          patient_session:,
+          patient: patient_session.patient,
+          session: patient_session.session,
           programme: evaluator.programme,
           performed_by: evaluator.user,
           location_name: evaluator.location_name

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -58,10 +58,9 @@ FactoryBot.define do
 
     programme
 
-    session { association :session, programme:, organisation: }
     patient do
       association :patient,
-                  school: session.location.school? ? session.location : nil
+                  school: session&.location&.school? ? session.location : nil
     end
 
     delivery_site { "left_arm_upper_position" }

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -21,25 +21,28 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  batch_id                 :bigint
-#  patient_session_id       :bigint           not null
+#  patient_id               :bigint
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
+#  session_id               :bigint
 #
 # Indexes
 #
 #  index_vaccination_records_on_batch_id              (batch_id)
 #  index_vaccination_records_on_discarded_at          (discarded_at)
-#  index_vaccination_records_on_patient_session_id    (patient_session_id)
+#  index_vaccination_records_on_patient_id            (patient_id)
 #  index_vaccination_records_on_performed_by_user_id  (performed_by_user_id)
 #  index_vaccination_records_on_programme_id          (programme_id)
+#  index_vaccination_records_on_session_id            (session_id)
 #  index_vaccination_records_on_uuid                  (uuid) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (batch_id => batches.id)
-#  fk_rails_...  (patient_session_id => patient_sessions.id)
+#  fk_rails_...  (patient_id => patients.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_id => sessions.id)
 #
 FactoryBot.define do
   factory :vaccination_record do

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -51,26 +51,22 @@ FactoryBot.define do
         programme.organisations.first ||
           association(:organisation, programmes: [programme])
       end
-
-      session { association :session, programme:, organisation: }
-      patient do
-        association :patient,
-                    school: session.location.school? ? session.location : nil
+      vaccine do
+        programme.vaccines.active.first || association(:vaccine, programme:)
       end
     end
 
     programme
-    patient_session do
-      association :patient_session,
-                  programme:,
-                  patient:,
-                  session:,
-                  strategy: :create
+
+    session { association :session, programme:, organisation: }
+    patient do
+      association :patient,
+                  school: session.location.school? ? session.location : nil
     end
 
     delivery_site { "left_arm_upper_position" }
     delivery_method { "intramuscular" }
-    vaccine { programme.vaccines.active.first }
+
     batch do
       association :batch, organisation:, vaccine:, strategy: :create if vaccine
     end

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -134,7 +134,8 @@ describe "Delete vaccination record" do
       create(
         :vaccination_record,
         programme: @programme,
-        patient_session: @patient_session,
+        patient: @patient,
+        session: @session,
         batch:
       )
   end

--- a/spec/features/dev_reset_organisation_spec.rb
+++ b/spec/features/dev_reset_organisation_spec.rb
@@ -96,7 +96,7 @@ describe "Dev endpoint to reset a organisation" do
         .and(change(NotifyLogEntry, :count).by(-3))
         .and(change(Parent, :count).by(-4))
         .and(change(Patient, :count).by(-3))
-        .and(change(PatientSession, :count).by(-14))
+        .and(change(PatientSession, :count).by(-3))
         .and(change(Session, :count).by(-5))
         .and(change(VaccinationRecord, :count).by(-11))
     )

--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -60,7 +60,8 @@ describe "Download vaccination reports" do
     create(
       :vaccination_record,
       programme: @programme,
-      patient_session: @patient_session,
+      patient: @patient,
+      session: @session,
       batch:
     )
   end

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -276,6 +276,7 @@ describe "Edit vaccination record" do
         :consent_given_triage_not_needed,
         given_name: "John",
         family_name: "Smith",
+        organisation: @organisation,
         programme: @programme
       )
 
@@ -288,7 +289,8 @@ describe "Edit vaccination record" do
       create(
         :vaccination_record,
         batch: @original_batch,
-        patient_session: @patient_session,
+        patient: @patient,
+        session: @session,
         programme: @programme
       )
   end
@@ -298,7 +300,8 @@ describe "Edit vaccination record" do
       create(
         :vaccination_record,
         batch: @original_batch,
-        patient_session: @patient_session,
+        patient: @patient,
+        session: @session,
         performed_by_family_name: "Joy",
         performed_by_given_name: "Nurse",
         performed_by_user: nil,
@@ -312,7 +315,8 @@ describe "Edit vaccination record" do
         :vaccination_record,
         :not_administered,
         batch: @original_batch,
-        patient_session: @patient_session,
+        patient: @patient,
+        session: @session,
         programme: @programme
       )
   end

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -116,7 +116,8 @@ describe "Immunisation imports duplicates" do
         delivery_method: :nasal_spray,
         delivery_site: :nose,
         dose_sequence: 1,
-        patient_session: @patient_session,
+        patient: @already_vaccinated_patient,
+        session: @session,
         vaccine: @vaccine,
         performed_by_user: nil
       )
@@ -131,7 +132,8 @@ describe "Immunisation imports duplicates" do
         delivery_method: :nasal_spray,
         delivery_site: :left_arm_upper_position,
         dose_sequence: 1,
-        patient_session: @third_patient_session,
+        patient: @third_patient,
+        session: @session,
         vaccine: @other_vaccine,
         performed_by_user: nil
       )

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -5,6 +5,7 @@ describe "Manage children" do
 
   scenario "Viewing children" do
     given_patients_exist
+    and_the_patient_belongs_to_a_session
     and_the_patient_is_vaccinated
 
     when_i_click_on_children

--- a/spec/jobs/clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/clinic_session_invitations_job_spec.rb
@@ -60,7 +60,8 @@ describe ClinicSessionInvitationsJob do
       before do
         create(
           :vaccination_record,
-          patient_session:,
+          patient:,
+          session:,
           programme:,
           location_name: "A clinic."
         )

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -34,7 +34,6 @@ describe EmailDeliveryJob do
         consent_form:,
         parent:,
         patient:,
-        patient_session:,
         programme:,
         sent_by:,
         vaccination_record:
@@ -55,7 +54,6 @@ describe EmailDeliveryJob do
     let(:consent) { nil }
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
-    let(:patient_session) { nil }
     let(:sent_by) { create(:user) }
     let(:vaccination_record) { nil }
 
@@ -65,7 +63,6 @@ describe EmailDeliveryJob do
         consent:,
         consent_form:,
         patient:,
-        patient_session:,
         programme:,
         vaccination_record:
       )

--- a/spec/jobs/patient_nhs_number_lookup_job_spec.rb
+++ b/spec/jobs/patient_nhs_number_lookup_job_spec.rb
@@ -73,7 +73,12 @@ describe PatientNHSNumberLookupJob do
       end
       let(:triage) { create(:triage, patient:, programme:) }
       let(:vaccination_record) do
-        create(:vaccination_record, patient_session:, programme:)
+        create(
+          :vaccination_record,
+          patient:,
+          session: patient_session.session,
+          programme:
+        )
       end
 
       context "when the existing patient is not already in the session" do

--- a/spec/jobs/school_session_reminders_job_spec.rb
+++ b/spec/jobs/school_session_reminders_job_spec.rb
@@ -58,7 +58,7 @@ describe SchoolSessionRemindersJob do
     end
 
     context "when already vaccinated" do
-      before { create(:vaccination_record, patient_session:, programme:) }
+      before { create(:vaccination_record, patient:, programme:) }
 
       it "doesn't send any notifications" do
         expect(SessionNotification).not_to receive(:create_and_send!)

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -34,7 +34,6 @@ describe SMSDeliveryJob do
         consent_form:,
         parent:,
         patient:,
-        patient_session:,
         programme:,
         sent_by:,
         vaccination_record:
@@ -48,7 +47,6 @@ describe SMSDeliveryJob do
     let(:consent) { nil }
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
-    let(:patient_session) { nil }
     let(:sent_by) { create(:user) }
     let(:vaccination_record) { nil }
 
@@ -58,7 +56,6 @@ describe SMSDeliveryJob do
         consent:,
         consent_form:,
         patient:,
-        patient_session:,
         programme:,
         vaccination_record:
       )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -74,7 +74,12 @@ describe PatientMerger do
     end
     let(:triage) { create(:triage, patient: patient_to_destroy, programme:) }
     let(:vaccination_record) do
-      create(:vaccination_record, patient_session:, programme:)
+      create(
+        :vaccination_record,
+        patient: patient_to_destroy,
+        session:,
+        programme:
+      )
     end
 
     it "destroys one of the patients" do

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -76,7 +76,8 @@ describe Reports::CareplusExporter do
       create(
         :vaccination_record,
         programme:,
-        patient_session:,
+        patient: patient_session.patient,
+        session: patient_session.session,
         performed_at: 2.weeks.ago
       )
 
@@ -107,17 +108,19 @@ describe Reports::CareplusExporter do
     let(:location) { create(:generic_clinic, organisation:) }
 
     it "includes clinic location details" do
-      patient_session =
-        create(
-          :patient_session,
-          :consent_given_triage_not_needed,
-          programme:,
-          session:
-        )
+      patient = create(:patient)
+      create(
+        :patient_session,
+        :consent_given_triage_not_needed,
+        programme:,
+        patient:,
+        session:
+      )
       create(
         :vaccination_record,
         programme:,
-        patient_session:,
+        patient:,
+        session:,
         location_name: "A clinic"
       )
 
@@ -132,11 +135,13 @@ describe Reports::CareplusExporter do
   end
 
   it "excludes vaccination records outside the date range" do
-    patient_session = create(:patient_session, session:)
+    patient = create(:patient_session, session:).patient
+
     create(
       :vaccination_record,
       programme:,
-      patient_session:,
+      patient:,
+      session:,
       created_at: 2.months.ago,
       updated_at: 2.months.ago,
       performed_at: 2.months.ago
@@ -146,18 +151,27 @@ describe Reports::CareplusExporter do
   end
 
   it "excludes not administered vaccination records" do
-    patient_session = create(:patient_session, session:)
-    create(:vaccination_record, :not_administered, programme:, patient_session:)
+    patient = create(:patient_session, session:).patient
+
+    create(
+      :vaccination_record,
+      :not_administered,
+      programme:,
+      patient:,
+      session:
+    )
 
     expect(data_rows.first).to be_nil
   end
 
   it "includes vaccination records updated within the date range" do
-    patient_session = create(:patient_session, session:)
+    patient = create(:patient_session, session:).patient
+
     create(
       :vaccination_record,
       programme:,
-      patient_session:,
+      patient:,
+      session:,
       created_at: 2.months.ago,
       updated_at: 1.day.ago,
       performed_at: 2.months.ago
@@ -170,8 +184,7 @@ describe Reports::CareplusExporter do
     let(:session) { create(:session, programme:, location:) }
 
     it "excludes the vaccination record" do
-      patient_session = create(:patient_session, session:)
-      create(:vaccination_record, programme:, patient_session:)
+      create(:vaccination_record, programme:, session:)
 
       expect(data_rows.first).to be_nil
     end

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -161,12 +161,15 @@ describe Reports::OfflineSessionExporter do
       end
 
       context "with a vaccinated patient" do
+        before { create(:patient_session, patient:, session:) }
+
         let!(:vaccination_record) do
           create(
             :vaccination_record,
             performed_at:,
             batch:,
-            patient_session:,
+            patient:,
+            session:,
             programme:,
             performed_by: user,
             notes: "Some notes."
@@ -245,11 +248,14 @@ describe Reports::OfflineSessionExporter do
       end
 
       context "with a patient who couldn't be vaccinated" do
+        before { create(:patient_session, patient:, session:) }
+
         let!(:vaccination_record) do
           create(
             :vaccination_record,
             :not_administered,
-            patient_session:,
+            patient:,
+            session:,
             programme:,
             performed_at:,
             performed_by: user,
@@ -513,22 +519,23 @@ describe Reports::OfflineSessionExporter do
             school: create(:school, urn: "123456", name: "Waterloo Road")
           )
         end
-        let(:patient_session) { create(:patient_session, patient:, session:) }
         let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
         let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
-
         let!(:vaccination_record) do
           create(
             :vaccination_record,
             performed_at:,
             batch:,
-            patient_session:,
+            patient:,
+            session:,
             programme:,
             location_name: "A Clinic",
             performed_by: user,
             notes: "Some notes."
           )
         end
+
+        before { create(:patient_session, patient:, session:) }
 
         it "adds a row to fill in" do
           expect(rows.count).to eq(1)

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -90,8 +90,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       it { should be_empty }
 
       context "with a vaccinated patient" do
-        let(:patient) { create(:patient, year_group: 8) }
-        let(:patient_session) { create(:patient_session, patient:, session:) }
+        let(:patient) { create(:patient, year_group: 8, session:) }
         let(:batch) do
           create(
             :batch,
@@ -105,7 +104,8 @@ describe Reports::ProgrammeVaccinationsExporter do
           create(
             :vaccination_record,
             batch:,
-            patient_session:,
+            patient:,
+            session:,
             performed_at:,
             created_at: performed_at,
             updated_at: performed_at,
@@ -173,13 +173,14 @@ describe Reports::ProgrammeVaccinationsExporter do
       end
 
       context "with a vaccinated patient outside the date range" do
-        let(:patient_session) { create(:patient_session, session:) }
+        let(:patient) { create(:patient_session, session:).patient }
         let(:start_date) { Date.current }
 
         before do
           create(
             :vaccination_record,
-            patient_session:,
+            patient:,
+            session:,
             created_at: 1.day.ago,
             updated_at: 1.day.ago,
             programme:,
@@ -191,13 +192,14 @@ describe Reports::ProgrammeVaccinationsExporter do
       end
 
       context "with a vaccinated patient that was updated in the date range" do
-        let(:patient_session) { create(:patient_session, session:) }
+        let(:patient) { create(:patient_session, session:).patient }
         let(:start_date) { 1.day.ago }
 
         before do
           create(
             :vaccination_record,
-            patient_session:,
+            patient:,
+            session:,
             created_at: 10.days.ago,
             updated_at: Time.current,
             programme:,
@@ -219,8 +221,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       it { should be_empty }
 
       context "with a vaccinated patient" do
-        let(:patient) { create(:patient, year_group: 8) }
-        let(:patient_session) { create(:patient_session, patient:, session:) }
+        let(:patient) { create(:patient, year_group: 8, session:) }
         let(:batch) do
           create(
             :batch,
@@ -235,7 +236,8 @@ describe Reports::ProgrammeVaccinationsExporter do
             :vaccination_record,
             performed_at:,
             batch:,
-            patient_session:,
+            patient:,
+            session:,
             programme:,
             location_name: "A Clinic",
             performed_by: user

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -14,7 +14,6 @@ describe DPSExportRow do
     create(:patient, date_of_birth: Date.new(2012, 12, 29), school:)
   end
   let(:session) { create(:session, organisation:, programme:, location:) }
-  let(:patient_session) { create(:patient_session, patient:, session:) }
   let(:performed_by) { create(:user, family_name: "Doe", given_name: "Jane") }
   let(:performed_by_given_name) { nil }
   let(:performed_by_family_name) { nil }
@@ -29,11 +28,12 @@ describe DPSExportRow do
       delivery_site: :left_arm_upper_position,
       dose_sequence: 1,
       location_name:,
-      patient_session:,
+      patient:,
       performed_at: Time.zone.local(2024, 6, 12, 11, 28, 31),
       performed_by:,
       performed_by_given_name:,
       performed_by_family_name:,
+      session:,
       uuid: "ea4860a5-6d97-4f31-b640-f5c50f43bfd2",
       vaccine:
     )

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -12,8 +12,9 @@ describe DraftVaccinationRecord do
   let(:request_session) { {} }
   let(:current_user) { organisation.users.first }
 
-  let(:patient_session) { create(:patient_session, programme:) }
   let(:programme) { create(:programme, :hpv) }
+  let(:session) { create(:session, programme:) }
+  let(:patient) { create(:patient, session:) }
   let(:vaccine) { programme.vaccines.first }
   let(:batch) { create(:batch, vaccine:) }
 
@@ -26,8 +27,9 @@ describe DraftVaccinationRecord do
       dose_sequence: 1,
       notes: "Some notes.",
       outcome: "administered",
-      patient_session_id: patient_session.id,
+      patient_id: patient.id,
       programme_id: programme.id,
+      session_id: session.id,
       vaccine_id: vaccine.id
     }
   end
@@ -35,8 +37,9 @@ describe DraftVaccinationRecord do
   let(:valid_not_administered_attributes) do
     {
       notes: "Some notes.",
-      patient_session_id: patient_session.id,
+      patient_id: patient.id,
       programme_id: programme.id,
+      session_id: session.id,
       outcome: "unwell"
     }
   end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -758,22 +758,6 @@ describe ImmunisationImportRow do
     end
   end
 
-  describe "#patient_session" do
-    subject(:patient_session) { immunisation_import_row.patient_session }
-
-    context "without data" do
-      let(:data) { {} }
-
-      it { should be_nil }
-    end
-
-    context "with valid data" do
-      let(:data) { valid_data }
-
-      it { should_not be_nil }
-    end
-  end
-
   describe "#location_name" do
     subject(:location_name) { immunisation_import_row.location_name }
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -140,7 +140,6 @@ describe ImmunisationImport do
           .and change(immunisation_import.vaccination_records, :count).by(11)
           .and change(immunisation_import.patients, :count).by(11)
           .and change(immunisation_import.sessions, :count).by(3)
-          .and change(immunisation_import.patient_sessions, :count).by(11)
           .and change(immunisation_import.batches, :count).by(4)
 
         # Second import should not duplicate the vaccination records if they're
@@ -202,7 +201,6 @@ describe ImmunisationImport do
           .and change(immunisation_import.vaccination_records, :count).by(11)
           .and change(immunisation_import.patients, :count).by(10)
           .and change(immunisation_import.sessions, :count).by(5)
-          .and change(immunisation_import.patient_sessions, :count).by(11)
           .and change(immunisation_import.batches, :count).by(9)
 
         # Second import should not duplicate the vaccination records if they're

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -257,6 +257,8 @@ describe PatientSession do
     subject(:safe_to_destroy?) { patient_session.safe_to_destroy? }
 
     let(:patient_session) { create(:patient_session, programme:) }
+    let(:patient) { patient_session.patient }
+    let(:session) { patient_session.session }
 
     context "when safe to destroy" do
       it { should be true }
@@ -269,7 +271,7 @@ describe PatientSession do
 
     context "when unsafe to destroy" do
       it "is unsafe with vaccination records" do
-        create(:vaccination_record, programme:, patient_session:)
+        create(:vaccination_record, programme:, patient:, session:)
         expect(safe_to_destroy?).to be false
       end
 
@@ -285,7 +287,7 @@ describe PatientSession do
 
       it "is unsafe with mixed conditions" do
         create(:session_attendance, :absent, patient_session:)
-        create(:vaccination_record, programme:, patient_session:)
+        create(:vaccination_record, programme:, patient:, session:)
         expect(safe_to_destroy?).to be false
       end
     end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -30,9 +30,10 @@ describe PatientSession do
   it { should have_many(:gillick_assessments).order(:created_at) }
 
   it do
-    expect(patient_session).to have_many(:vaccination_records).conditions(
-      discarded_at: nil
-    ).order(:created_at)
+    expect(patient_session).to have_many(:vaccination_records)
+      .through(:patient)
+      .conditions(discarded_at: nil, session_id: patient_session.session_id)
+      .order(:created_at)
   end
 
   describe "#triages" do

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -396,13 +396,7 @@ describe SchoolMove do
       end
 
       context "and already vaccinated" do
-        before do
-          create(
-            :vaccination_record,
-            programme:,
-            patient_session: patient.patient_sessions.first
-          )
-        end
+        before { create(:vaccination_record, programme:, patient:, session:) }
 
         context "to a school with a scheduled session" do
           let(:school_move) do
@@ -713,7 +707,8 @@ describe SchoolMove do
           create(
             :vaccination_record,
             programme:,
-            patient_session: patient.patient_sessions.first,
+            patient:,
+            session: generic_clinic_session,
             location_name: "A clinic"
           )
         end
@@ -1029,7 +1024,8 @@ describe SchoolMove do
           create(
             :vaccination_record,
             programme:,
-            patient_session: patient.patient_sessions.first,
+            patient:,
+            session: generic_clinic_session,
             location_name: "A clinic"
           )
         end

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -71,13 +71,13 @@ describe SessionNotification do
       it "enqueues an email per parent who gave consent" do
         expect { create_and_send! }.to have_delivered_email(
           :session_school_reminder
-        ).with(consent:, patient_session:, sent_by: current_user)
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_delivered_sms(
           :session_school_reminder
-        ).with(consent:, patient_session:, sent_by: current_user)
+        ).with(consent:, session:, sent_by: current_user)
       end
 
       context "when parent doesn't want to receive updates by text" do
@@ -107,11 +107,13 @@ describe SessionNotification do
           :session_clinic_initial_invitation
         ).with(
           parent: parents.first,
-          patient_session:,
+          patient:,
+          session:,
           sent_by: current_user
         ).and have_delivered_email(:session_clinic_initial_invitation).with(
                 parent: parents.second,
-                patient_session:,
+                patient:,
+                session:,
                 sent_by: current_user
               )
       end
@@ -121,11 +123,13 @@ describe SessionNotification do
           :session_clinic_initial_invitation
         ).with(
           parent: parents.first,
-          patient_session:,
+          patient:,
+          session:,
           sent_by: current_user
         ).and have_delivered_sms(:session_clinic_initial_invitation).with(
                 parent: parents.second,
-                patient_session:,
+                patient:,
+                session:,
                 sent_by: current_user
               )
       end
@@ -138,7 +142,7 @@ describe SessionNotification do
         it "still enqueues a text" do
           expect { create_and_send! }.to have_delivered_sms(
             :session_clinic_initial_invitation
-          ).with(parent:, patient_session:, sent_by: current_user)
+          ).with(parent:, patient:, session:, sent_by: current_user)
         end
       end
     end
@@ -161,11 +165,13 @@ describe SessionNotification do
           :session_clinic_subsequent_invitation
         ).with(
           parent: parents.first,
-          patient_session:,
+          patient:,
+          session:,
           sent_by: current_user
         ).and have_delivered_email(:session_clinic_subsequent_invitation).with(
                 parent: parents.second,
-                patient_session:,
+                patient:,
+                session:,
                 sent_by: current_user
               )
       end
@@ -175,11 +181,13 @@ describe SessionNotification do
           :session_clinic_subsequent_invitation
         ).with(
           parent: parents.first,
-          patient_session:,
+          patient:,
+          session:,
           sent_by: current_user
         ).and have_delivered_sms(:session_clinic_subsequent_invitation).with(
                 parent: parents.second,
-                patient_session:,
+                patient:,
+                session:,
                 sent_by: current_user
               )
       end
@@ -192,7 +200,7 @@ describe SessionNotification do
         it "still enqueues a text" do
           expect { create_and_send! }.to have_delivered_sms(
             :session_clinic_subsequent_invitation
-          ).with(parent:, patient_session:, sent_by: current_user)
+          ).with(parent:, patient:, session:, sent_by: current_user)
         end
       end
     end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -21,25 +21,28 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  batch_id                 :bigint
-#  patient_session_id       :bigint           not null
+#  patient_id               :bigint
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
+#  session_id               :bigint
 #
 # Indexes
 #
 #  index_vaccination_records_on_batch_id              (batch_id)
 #  index_vaccination_records_on_discarded_at          (discarded_at)
-#  index_vaccination_records_on_patient_session_id    (patient_session_id)
+#  index_vaccination_records_on_patient_id            (patient_id)
 #  index_vaccination_records_on_performed_by_user_id  (performed_by_user_id)
 #  index_vaccination_records_on_programme_id          (programme_id)
+#  index_vaccination_records_on_session_id            (session_id)
 #  index_vaccination_records_on_uuid                  (uuid) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (batch_id => batches.id)
-#  fk_rails_...  (patient_session_id => patient_sessions.id)
+#  fk_rails_...  (patient_id => patients.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_id => sessions.id)
 #
 
 describe VaccinationRecord do

--- a/spec/policies/session_attendance_policy_spec.rb
+++ b/spec/policies/session_attendance_policy_spec.rb
@@ -8,7 +8,8 @@ describe SessionAttendancePolicy do
   let(:programme) { create(:programme) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:session) { create(:session, organisation:, programme:) }
-  let(:patient_session) { create(:patient_session, session:) }
+  let(:patient) { create(:patient) }
+  let(:patient_session) { create(:patient_session, patient:, session:) }
 
   shared_examples "allow if not yet seen by nurse" do
     context "with a new session attendance" do
@@ -23,7 +24,8 @@ describe SessionAttendancePolicy do
       before do
         create(
           :vaccination_record,
-          patient_session:,
+          patient:,
+          session:,
           programme:,
           performed_at: Time.current
         )
@@ -38,7 +40,8 @@ describe SessionAttendancePolicy do
       before do
         create(
           :vaccination_record,
-          patient_session:,
+          patient:,
+          session:,
           programme:,
           performed_at: Time.zone.yesterday
         )


### PR DESCRIPTION
Depends on #2939 

We need to decouple vaccination records from sessions, so they can exist outside of a session. To do this we need to add references to the patient and the location that we currently get from the patient session reference.

Decoupling vaccination records from sessions is necessary to support doubles where patients can be vaccinated outside of a session managed by Mavis (for example in A&E or a pharmacy before travelling abroad). We need to be able to import these records and allow them to be visible across all organisations as appropriate.

The migration adds to this PR is not backwards compatible with the code running before this PR, but it can be rolled back in combination with deploying the old code.