### PR TITLE
Filter triage and consents by programme

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -14,8 +14,13 @@ class AppConsentComponent < ViewComponent::Base
   delegate :patient, to: :patient_session
   delegate :session, to: :patient_session
 
+  def programme
+    patient_session.programmes.first # TODO: handle multiple programmes
+  end
+
   def consents
-    @consents ||= patient_session.consents.sort_by(&:created_at).reverse
+    @consents ||=
+      patient_session.consents(programme:).sort_by(&:created_at).reverse
   end
 
   def latest_consent_request

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -48,14 +48,10 @@ class AppOutcomeBannerComponent < ViewComponent::Base
 
   def vaccination_record
     @vaccination_record ||=
-      if @patient_session.vaccinated?
-        @patient_session
-          .vaccination_records
-          .select(&:administered?)
-          .max_by(&:created_at)
-      else
-        @patient_session.latest_vaccination_record
-      end
+      @patient_session
+        .vaccination_records
+        .tap { it.select(&:administered?) if @patient_session.vaccinated? }
+        .last
   end
 
   def triage

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -50,12 +50,13 @@ class AppOutcomeBannerComponent < ViewComponent::Base
     @vaccination_record ||=
       @patient_session
         .vaccination_records
+        .select { it.programme_id == programme.id }
         .tap { it.select(&:administered?) if @patient_session.vaccinated? }
         .last
   end
 
   def triage
-    @triage ||= @patient_session.latest_triage
+    @triage ||= @patient_session.latest_triage(programme:)
   end
 
   def show_location?
@@ -121,5 +122,9 @@ class AppOutcomeBannerComponent < ViewComponent::Base
 
   def colour
     I18n.t("patient_session_statuses.#{status}.colour")
+  end
+
+  def programme
+    @patient_session.programmes.first # TODO: handle multiple programmes
   end
 end

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -15,7 +15,7 @@
 <% if display_gillick_assessment_card? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Gillick assessment" } %>
-    <% if (gillick_assessment = patient_session.latest_gillick_assessment) %>
+    <% if (gillick_assessment = patient_session.gillick_assessments.last) %>
       <% if gillick_assessment.gillick_competent? %>
         <p class="app-status app-status--aqua-green">
           <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -69,14 +69,14 @@
 <% if display_health_questions? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "All answers to health questions" } %>
-    <%= render AppHealthQuestionsComponent.new(consents: patient_session.latest_consents) %>
+    <%= render AppHealthQuestionsComponent.new(consents: patient_session.latest_consents(programme:)) %>
   <% end %>
 <% end %>
 
-<% if patient_session.triages.any? %>
+<% if patient_session.triages(programme:).any? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Triage notes" } %>
-    <%= render AppTriageNotesComponent.new(patient_session:) %>
+    <%= render AppTriageNotesComponent.new(patient_session:, programme:) %>
   <% end %>
 <% end %>
 

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -25,8 +25,12 @@ class AppPatientPageComponent < ViewComponent::Base
 
   delegate :patient, :session, to: :patient_session
 
+  def programme
+    patient_session.programmes.first # TODO: handle multiple programmes
+  end
+
   def display_health_questions?
-    patient_session.consents.any?(&:response_given?)
+    patient_session.latest_consents(programme:).any?(&:response_given?)
   end
 
   def display_gillick_assessment_card?

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -30,14 +30,11 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def display_gillick_assessment_card?
-    gillick_assessment_can_be_recorded? || gillick_assessment_recorded?
+    patient_session.gillick_assessments.present? ||
+      gillick_assessment_can_be_recorded?
   end
 
   def gillick_assessment_can_be_recorded?
     patient_session.session.today? && helpers.policy(GillickAssessment).new?
-  end
-
-  def gillick_assessment_recorded?
-    patient_session.latest_gillick_assessment.present?
   end
 end

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -75,7 +75,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       helpers.patient_year_group(patient)
     when :reason
       patient_session
-        .consents
+        .consents(programme: @programme)
         .map { |c| c.human_enum_name(:reason_for_refusal) }
         .uniq
         .join("<br />")

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -11,14 +11,6 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   private
 
-  def most_recent_triage
-    @most_recent_triage ||= @patient_session.latest_triage
-  end
-
-  def most_recent_vaccination
-    @most_recent_vaccination ||= @patient_session.latest_vaccination_record
-  end
-
   def who_refused
     @patient_session
       .consents
@@ -33,8 +25,8 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def nurse
     most_recent_event = [
-      most_recent_triage,
-      most_recent_vaccination
+      @patient_session.latest_triage,
+      @patient_session.vaccination_records.last
     ].compact.max_by(&:created_at)
 
     most_recent_event&.performed_by&.full_name

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -13,7 +13,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def who_refused
     @patient_session
-      .latest_consents
+      .latest_consents(programme:)
       .select(&:response_refused?)
       .map(&:who_responded)
       .last
@@ -24,10 +24,12 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   end
 
   def nurse
-    (@patient_session.triages + @patient_session.vaccination_records)
-      .max_by(&:updated_at)
-      &.performed_by
-      &.full_name
+    (
+      @patient_session.triages(programme:) +
+        @patient_session.vaccination_records.select do
+          it.programme_id == programme.id
+        end
+    ).max_by(&:updated_at)&.performed_by&.full_name
   end
 
   def heading
@@ -36,5 +38,9 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def colour
     I18n.t("patient_session_statuses.#{status}.colour")
+  end
+
+  def programme
+    @patient_session.programmes.first # TODO: handle multiple programmes
   end
 end

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -13,7 +13,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   def who_refused
     @patient_session
-      .consents
+      .latest_consents
       .select(&:response_refused?)
       .map(&:who_responded)
       .last
@@ -24,12 +24,10 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   end
 
   def nurse
-    most_recent_event = [
-      @patient_session.latest_triage,
-      @patient_session.vaccination_records.last
-    ].compact.max_by(&:created_at)
-
-    most_recent_event&.performed_by&.full_name
+    (@patient_session.triages + @patient_session.vaccination_records)
+      .max_by(&:updated_at)
+      &.performed_by
+      &.full_name
   end
 
   def heading

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -14,7 +14,7 @@ class AppTriageFormComponent < ViewComponent::Base
     @triage =
       triage ||
         Triage.new.tap do |t|
-          if (latest_triage = patient_session.latest_triage)
+          if (latest_triage = patient_session.latest_triage(programme:))
             t.status = latest_triage.status
           end
         end
@@ -24,6 +24,10 @@ class AppTriageFormComponent < ViewComponent::Base
   end
 
   private
+
+  def programme
+    @patient_session.programmes.first # TODO: handle multiple programmes
+  end
 
   def fieldset_options
     text = "Is it safe to vaccinate #{@patient_session.patient.given_name}?"

--- a/app/components/app_triage_notes_component.rb
+++ b/app/components/app_triage_notes_component.rb
@@ -11,17 +11,18 @@ class AppTriageNotesComponent < ViewComponent::Base
     <% end %>
   ERB
 
-  def initialize(patient_session:)
+  def initialize(patient_session:, programme:)
     super
 
     @patient_session = patient_session
+    @programme = programme
   end
 
   def render?
     events.present?
   end
 
-  private
+  delegate :patient, :session, to: :@patient_session
 
   def events
     @events ||=
@@ -29,8 +30,9 @@ class AppTriageNotesComponent < ViewComponent::Base
   end
 
   def triage_events
-    @patient_session
+    patient
       .triages
+      .where(programme: @programme)
       .includes(:performed_by)
       .map do |triage|
         {

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -43,11 +43,12 @@ module VaccinationMailerConcern
 
   def parents_for_vaccination_mailer(vaccination_record)
     patient_session = vaccination_record.patient_session
+    programme = vaccination_record.programme
     patient = patient_session.patient
 
     return [] unless patient.send_notifications?
 
-    consents = patient_session.latest_consents
+    consents = patient_session.latest_consents(programme:)
 
     parents =
       if consents.any?(&:via_self_consent?)

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -17,7 +17,7 @@ class ConsentsController < ApplicationController
       @session
         .patient_sessions
         .preload_for_status
-        .preload(consents: %i[parent patient])
+        .preload(patient: { consents: %i[parent patient] })
         .eager_load(:patient)
         .order_by_name
 
@@ -90,7 +90,10 @@ class ConsentsController < ApplicationController
     if @consent.valid?
       ActiveRecord::Base.transaction do
         @consent.save!
-        @patient_session.triages.invalidate_all
+        @patient
+          .triages
+          .where(programme_id: @consent.programme_id)
+          .invalidate_all
       end
 
       redirect_to session_patient_consent_path
@@ -109,7 +112,10 @@ class ConsentsController < ApplicationController
     if @consent.valid?
       ActiveRecord::Base.transaction do
         @consent.save!
-        @patient_session.triages.invalidate_all
+        @patient
+          .triages
+          .where(programme_id: @consent.programme_id)
+          .invalidate_all
       end
 
       redirect_to session_patient_consent_path,
@@ -147,7 +153,7 @@ class ConsentsController < ApplicationController
 
   def set_consent
     @consent =
-      @patient_session
+      @patient
         .consents
         .includes(:consent_form, :parent, patient: :parent_relationships)
         .find(params[:id])

--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -169,7 +169,9 @@ class DraftConsentsController < ApplicationController
     @parent_options =
       (
         @patient.parent_relationships.includes(:parent) +
-          @patient_session.consents.filter_map(&:parent_relationship)
+          @patient_session.consents(programme: @programme).filter_map(
+            &:parent_relationship
+          )
       ).compact.uniq.sort_by(&:label)
   end
 

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -45,7 +45,7 @@ class GillickAssessmentsController < ApplicationController
 
   def set_gillick_assessment
     @gillick_assessment =
-      authorize @patient_session.latest_gillick_assessment&.dup ||
+      authorize @patient_session.gillick_assessments.last&.dup ||
                   @patient_session.gillick_assessments.build
   end
 

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -22,11 +22,18 @@ class PatientSessionsController < ApplicationController
       policy_scope(PatientSession).includes(
         :gillick_assessments,
         :location,
+        :programmes,
         :session,
         :session_attendances,
-        consents: %i[parent],
-        patient: [:gp_practice, :school, { parent_relationships: :parent }],
-        triages: :performed_by,
+        patient: [
+          :gp_practice,
+          :school,
+          {
+            consents: %i[parent],
+            parent_relationships: :parent,
+            triages: :performed_by
+          }
+        ],
         vaccination_records: {
           vaccine: :programme
         }

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -35,9 +35,8 @@ class ProgrammesController < ApplicationController
           :session_dates,
           patient_sessions: [
             :gillick_assessments,
-            :triages,
             :vaccination_records,
-            { consents: :parent }
+            { patient: [:triages, { consents: :parent }] }
           ]
         )
         .order("locations.name")

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -45,8 +45,6 @@ class RegisterAttendancesController < ApplicationController
       @session.patient_sessions.preload_for_status.includes(
         :patient,
         :vaccination_records,
-        :triages,
-        consents: :parent,
         session: :session_dates,
         session_attendances: :session_date
       )
@@ -68,6 +66,7 @@ class RegisterAttendancesController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session = @patient.patient_sessions.find_by!(session: @session)
+    @patient_session =
+      @patient.patient_sessions.preload_for_status.find_by!(session: @session)
   end
 end

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -46,7 +46,7 @@ class SessionAttendancesController < ApplicationController
       policy_scope(PatientSession)
         .includes(:patient, :vaccination_records)
         .eager_load(:session)
-        .preload(:consents, :triages)
+        .preload(patient: %i[consents triages])
         .find_by!(
           session: {
             slug: params.fetch(:session_slug)

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -48,7 +48,10 @@ class TriagesController < ApplicationController
     if @triage.save(context: :consent)
       @triage.process!
 
-      @patient.consents.each { send_triage_confirmation(@patient_session, _1) }
+      @patient_session
+        .reload
+        .latest_consents(programme: @triage.programme)
+        .each { send_triage_confirmation(@patient_session, it) }
 
       flash[:success] = {
         heading: "Triage outcome updated for",
@@ -80,7 +83,8 @@ class TriagesController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session = @patient.patient_sessions.find_by!(session: @session)
+    @patient_session =
+      @patient.patient_sessions.preload_for_status.find_by!(session: @session)
   end
 
   def set_triage

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -73,8 +73,11 @@ class VaccinationRecordsController < ApplicationController
           :performed_by_user,
           :programme,
           patient_session: {
-            consents: :parent,
-            patient: [:gp_practice, :school, { parent_relationships: :parent }]
+            patient: [
+              :gp_practice,
+              :school,
+              { consents: :parent, parent_relationships: :parent }
+            ]
           },
           session: %i[session_dates],
           vaccine: :programme

--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -10,10 +10,9 @@ class ClinicSessionInvitationsJob < ApplicationJob
         .includes(
           :programmes,
           patient_sessions: [
-            :consents,
             :session_notifications,
             :vaccination_records,
-            { patient: :parents }
+            { patient: %i[consents parents] }
           ]
         )
         .preload(:session_dates)

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -10,10 +10,8 @@ class SchoolSessionRemindersJob < ApplicationJob
       PatientSession
         .includes(
           :gillick_assessments,
-          :triages,
           :vaccination_records,
-          consents: %i[parent patient],
-          patient: :parents
+          patient: [:parents, :triages, { consents: %i[parent patient] }]
         )
         .eager_load(:session)
         .joins(:location)

--- a/app/jobs/vaccination_confirmations_job.rb
+++ b/app/jobs/vaccination_confirmations_job.rb
@@ -15,7 +15,7 @@ class VaccinationConfirmationsJob < ApplicationJob
     academic_year = Date.current.academic_year
 
     VaccinationRecord
-      .includes(patient_session: { consents: :parent })
+      .includes(patient_session: { patient: { consents: :parent } })
       .kept
       .where("created_at >= ?", since)
       .where(confirmation_sent_at: nil)

--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -75,8 +75,7 @@ class Reports::CareplusExporter
         .includes(
           :location,
           :vaccination_records,
-          consents: %i[parent patient],
-          patient: :school
+          patient: [:school, { consents: %i[parent patient] }]
         )
         .where.not(vaccination_records: { id: nil })
         .merge(VaccinationRecord.administered)
@@ -122,6 +121,7 @@ class Reports::CareplusExporter
 
   def existing_row(patient:, patient_session:, vaccination_records:)
     first_vaccination = vaccination_records.first
+    programme = first_vaccination.programme
 
     [
       patient.nhs_number,
@@ -129,7 +129,7 @@ class Reports::CareplusExporter
       patient.given_name,
       patient.date_of_birth.strftime("%d/%m/%Y"),
       patient.address_line_1,
-      patient_session.latest_consents.first&.name || "",
+      patient_session.latest_consents(programme:).first&.name || "",
       99, # Ethnicity, 99 is "Not known"
       first_vaccination.performed_at.strftime("%d/%m/%Y"),
       first_vaccination.performed_at.strftime("%H:%M"),

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -176,7 +176,7 @@ class Reports::OfflineSessionExporter
 
   def add_patient_cells(row, patient_session:)
     consents = patient_session.latest_consents
-    gillick_assessment = patient_session.latest_gillick_assessment
+    gillick_assessment = patient_session.gillick_assessments.last
     patient = patient_session.patient
     triage = patient_session.latest_triage
 

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -129,9 +129,12 @@ class Reports::OfflineSessionExporter
       .patient_sessions
       .eager_load(patient: :school)
       .preload(
-        consents: [:parent, { patient: :parent_relationships }],
+        :programmes,
+        patient: {
+          consents: [:parent, { patient: :parent_relationships }],
+          triages: :performed_by
+        },
         gillick_assessments: :performed_by,
-        triages: :performed_by,
         vaccination_records: %i[batch performed_by_user vaccine]
       )
       .order_by_name
@@ -160,25 +163,27 @@ class Reports::OfflineSessionExporter
     if vaccination_records.any?
       vaccination_records.map do |vaccination_record|
         Row.new(columns, style: row_style) do |row|
-          add_patient_cells(row, patient_session:)
+          programme = vaccination_record.programme
+          add_patient_cells(row, patient_session:, programme:)
           add_existing_row_cells(row, vaccination_record:)
         end
       end
     else
       session.programmes.map do |programme|
         Row.new(columns, style: row_style) do |row|
-          add_patient_cells(row, patient_session:)
+          add_patient_cells(row, patient_session:, programme:)
           add_new_row_cells(row, programme:)
         end
       end
     end
   end
 
-  def add_patient_cells(row, patient_session:)
-    consents = patient_session.latest_consents
+  def add_patient_cells(row, patient_session:, programme:)
     gillick_assessment = patient_session.gillick_assessments.last
     patient = patient_session.patient
-    triage = patient_session.latest_triage
+
+    consents = patient_session.latest_consents(programme:)
+    triage = patient_session.latest_triage(programme:)
 
     row[:organisation_code] = organisation.ods_code
     row[:school_urn] = school_urn(location:, patient:)

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -94,10 +94,15 @@ class Reports::ProgrammeVaccinationsExporter
           :programme,
           :vaccine,
           patient_session: {
-            consents: [:parent, { patient: :parent_relationships }],
-            gillick_assessments: :performed_by,
-            patient: %i[gp_practice school],
-            triages: :performed_by
+            patient: [
+              :gp_practice,
+              :school,
+              {
+                consents: [:parent, { patient: :parent_relationships }],
+                triages: :performed_by
+              }
+            ],
+            gillick_assessments: :performed_by
           }
         )
 
@@ -132,12 +137,13 @@ class Reports::ProgrammeVaccinationsExporter
 
   def row(vaccination_record:)
     patient_session = vaccination_record.patient_session
-    consents = patient_session.latest_consents
     gillick_assessment = patient_session.gillick_assessments.last
     patient = patient_session.patient
-    triage = patient_session.latest_triage
     location = vaccination_record.location
     programme = vaccination_record.programme
+
+    consents = patient_session.latest_consents(programme:)
+    triage = patient_session.latest_triage(programme:)
 
     [
       organisation.ods_code,

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -133,7 +133,7 @@ class Reports::ProgrammeVaccinationsExporter
   def row(vaccination_record:)
     patient_session = vaccination_record.patient_session
     consents = patient_session.latest_consents
-    gillick_assessment = patient_session.latest_gillick_assessment
+    gillick_assessment = patient_session.gillick_assessments.last
     patient = patient_session.patient
     triage = patient_session.latest_triage
     location = vaccination_record.location

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -54,8 +54,8 @@ module PatientSessionStatusConcern
     def consent_given?
       return false if no_consent?
 
-      if latest_self_consents.present?
-        latest_self_consents.all?(&:response_given?)
+      if (self_consents = latest_consents.select(&:via_self_consent?)).present?
+        self_consents.all?(&:response_given?)
       else
         latest_consents.all?(&:response_given?)
       end
@@ -70,9 +70,9 @@ module PatientSessionStatusConcern
     def consent_conflicts?
       return false if no_consent?
 
-      if latest_self_consents.present?
-        latest_self_consents.any?(&:response_refused?) &&
-          latest_self_consents.any?(&:response_given?)
+      if (self_consents = latest_consents.select(&:via_self_consent?)).present?
+        self_consents.any?(&:response_refused?) &&
+          self_consents.any?(&:response_given?)
       else
         latest_consents.any?(&:response_refused?) &&
           latest_consents.any?(&:response_given?)

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -117,8 +117,10 @@ module PatientSessionStatusConcern
     end
 
     def vaccination_can_be_delayed?
-      latest_vaccination_record&.not_administered? &&
-        latest_vaccination_record.retryable_reason?
+      if (vaccination_record = vaccination_records.last)
+        vaccination_record.not_administered? &&
+          vaccination_record.retryable_reason?
+      end
     end
 
     def next_step

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -149,7 +149,9 @@ class DraftConsent
     else
       self.parent =
         patient.parents.find_by(id: value) ||
-          Parent.where(consents: patient_session.consents).find_by(id: value)
+          Parent.where(consents: patient_session.consents(programme:)).find_by(
+            id: value
+          )
     end
   end
 

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -155,7 +155,7 @@ class DraftVaccinationRecord
     VaccinationRecordPolicy::Scope
       .new(@current_user, VaccinationRecord)
       .resolve
-      .includes(patient_session: { consents: :parent })
+      .includes(patient_session: { patient: { consents: :parent } })
       .find_by(id: editing_id)
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -76,8 +76,6 @@ class Patient < ApplicationRecord
   has_many :session_notifications
   has_many :triages
 
-  has_one :latest_triage, -> { order(created_at: :desc) }, class_name: "Triage"
-
   has_many :parents, through: :parent_relationships
   has_many :gillick_assessments,
            -> { order(:created_at) },

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -110,10 +110,6 @@ class PatientSession < ApplicationRecord
         .map { |_, consents| consents.max_by(&:created_at) }
   end
 
-  def latest_self_consents
-    @latest_self_consents ||= latest_consents.select(&:via_self_consent?)
-  end
-
   def latest_triage
     @latest_triage ||= triages.reject(&:invalidated?).max_by(&:updated_at)
   end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -38,7 +38,7 @@ class PatientSession < ApplicationRecord
 
   has_many :gillick_assessments, -> { order(:created_at) }
   has_many :pre_screenings, -> { order(:created_at) }
-  has_many :vaccination_records, -> { kept }
+  has_many :vaccination_records, -> { kept.order(:created_at) }
 
   # TODO: Only fetch consents and triages for the relevant programme.
   has_many :consents, through: :patient
@@ -117,10 +117,6 @@ class PatientSession < ApplicationRecord
 
   def latest_triage
     @latest_triage ||= triages.reject(&:invalidated?).max_by(&:updated_at)
-  end
-
-  def latest_vaccination_record
-    @latest_vaccination_record ||= vaccination_records.max_by(&:created_at)
   end
 
   def todays_attendance

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -83,7 +83,10 @@ class PatientSession < ApplicationRecord
         end
 
   delegate :send_notifications?, to: :patient
-  delegate :gillick_competent?, to: :latest_gillick_assessment, allow_nil: true
+
+  def gillick_competent?
+    gillick_assessments.last&.gillick_competent? || false
+  end
 
   def able_to_vaccinate?
     !unable_to_vaccinate?
@@ -109,10 +112,6 @@ class PatientSession < ApplicationRecord
 
   def latest_self_consents
     @latest_self_consents ||= latest_consents.select(&:via_self_consent?)
-  end
-
-  def latest_gillick_assessment
-    @latest_gillick_assessment ||= gillick_assessments.max_by(&:updated_at)
   end
 
   def latest_triage

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -54,11 +54,13 @@ class SessionNotification < ApplicationRecord
     patient = patient_session.patient
     session = patient_session.session
 
+    programme = session.programmes.first # TODO: handle multiple programmes
+
     contacts =
       if type == :school_reminder
-        patient_session.latest_consents.select do
-          _1.response_given? && _1.parent&.contactable?
-        end
+        patient_session
+          .latest_consents(programme:)
+          .select { _1.response_given? && _1.parent&.contactable? }
       else
         patient.parents.select(&:contactable?)
       end

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -25,6 +25,7 @@
       columns: @current_tab == :consent_refused ? %i[name year_group reason] : %i[name year_group],
       params:,
       patient_sessions: @patient_sessions,
+      programme: @session.programmes.first, # TODO: handle multiple programmes
       section: :consents,
       year_groups: @session.year_groups,
     ) %>

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -30,6 +30,7 @@ describe AppActivityLogComponent do
   before do
     create(:parent_relationship, :mother, parent: mum, patient:)
     create(:parent_relationship, :father, parent: dad, patient:)
+    patient.reload
 
     patient_session.strict_loading!(false)
     patient_session.patient.strict_loading!(false)

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -7,13 +7,13 @@ describe AppConsentComponent do
     described_class.new(patient_session:, section: "triage", tab: "needed")
   end
 
-  let(:consent) { patient_session.consents.first }
-  let(:relation) { consent.parent_relationship.label }
+  let(:programme) { create(:programme) }
+  let(:consent) { patient_session.consents(programme:).first }
 
-  before { patient_session.strict_loading!(false) }
+  before { patient_session.reload.strict_loading!(false) }
 
   context "consent is not present" do
-    let(:patient_session) { create(:patient_session) }
+    let(:patient_session) { create(:patient_session, programme:) }
 
     it { should_not have_css("p.app-status", text: "Consent (given|refused)") }
     it { should_not have_css("details", text: /Consent (given|refused) by/) }
@@ -24,23 +24,30 @@ describe AppConsentComponent do
 
   context "consent is not present and session is not in progress" do
     let(:patient_session) do
-      create(:patient_session, session: create(:session, :scheduled))
+      create(
+        :patient_session,
+        session: create(:session, :scheduled, programme:)
+      )
     end
 
     it { should_not have_css("button", text: "Assess Gillick competence") }
   end
 
   context "consent is refused" do
-    let(:patient_session) { create(:patient_session, :consent_refused) }
-
-    let(:summary) do
-      "Consent refused by #{consent.parent.full_name} (#{relation})"
+    let(:patient_session) do
+      create(:patient_session, :consent_refused, programme:)
     end
 
     it { should have_css("p.app-status--red", text: "Consent refused") }
 
     it { should have_css("table tr", text: /#{consent.parent.full_name}/) }
-    it { should have_css("table tr", text: /#{relation}/) }
+
+    it do
+      expect(rendered).to have_css(
+        "table tr",
+        text: /#{consent.parent_relationship.label}/
+      )
+    end
 
     it "displays the response" do
       expect(rendered).to have_css("table tr", text: /Consent refused/)
@@ -51,15 +58,10 @@ describe AppConsentComponent do
 
   context "consent is given" do
     let(:patient_session) do
-      create(:patient_session, :consent_given_triage_needed)
-    end
-
-    let(:summary) do
-      "Consent given by #{consent.parent.full_name} (#{relation})"
+      create(:patient_session, :consent_given_triage_needed, programme:)
     end
 
     it { should have_css("p.app-status--aqua-green", text: "Consent given") }
-
     it { should_not have_css("a", text: "Contact #{consent.parent.full_name}") }
   end
 end

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -86,8 +86,9 @@ describe AppOutcomeBannerComponent do
       create(:patient_session, :triaged_do_not_vaccinate, user:)
     end
     let(:vaccination_record) { patient_session.vaccination_records.first }
+    let(:programme) { patient_session.programmes.first }
     let(:location) { patient_session.session.location }
-    let(:triage) { patient_session.triages.first }
+    let(:triage) { patient_session.triages(programme:).first }
     let(:date) { triage.created_at.to_date.to_fs(:long) }
 
     it { should have_css(".app-card--red") }
@@ -106,7 +107,10 @@ describe AppOutcomeBannerComponent do
       let(:date) { Time.zone.now - 2.days }
       let(:patient_session) do
         create(:patient_session, :triaged_do_not_vaccinate).tap do |ps|
-          ps.triages.first.update!(created_at: date)
+          ps
+            .triages(programme: ps.programmes.first)
+            .first
+            .update!(created_at: date)
         end
       end
 

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -12,11 +12,14 @@ describe AppSimpleStatusBannerComponent do
     patient_session.strict_loading!(false)
   end
 
-  let(:user) { create :user }
-  let(:patient_session) { create :patient_session, user: }
+  let(:user) { create(:user) }
+  let(:programme) { create(:programme) }
+  let(:patient_session) { create(:patient_session, programme:, user:) }
+
   let(:component) { described_class.new(patient_session:) }
+
   let(:triage_nurse_name) do
-    patient_session.latest_triage.performed_by.full_name
+    patient_session.triages(programme:).last.performed_by.full_name
   end
   let(:vaccination_nurse_name) do
     patient_session.vaccination_records.last.performed_by.full_name
@@ -28,14 +31,16 @@ describe AppSimpleStatusBannerComponent do
   end
 
   context "state is added_to_session" do
-    let(:patient_session) { create :patient_session, :added_to_session }
+    let(:patient_session) do
+      create(:patient_session, :added_to_session, programme:)
+    end
 
     it { should have_css(".app-card--blue") }
   end
 
   context "state is consent_given_triage_not_needed" do
     let(:patient_session) do
-      create :patient_session, :consent_given_triage_not_needed
+      create(:patient_session, :consent_given_triage_not_needed, programme:)
     end
 
     it { should have_css(".app-card--aqua-green") }
@@ -45,7 +50,7 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is consent_given_triage_needed" do
     let(:patient_session) do
-      create :patient_session, :consent_given_triage_needed
+      create(:patient_session, :consent_given_triage_needed, programme:)
     end
 
     it { should have_css(".app-card--blue") }
@@ -54,7 +59,9 @@ describe AppSimpleStatusBannerComponent do
   end
 
   context "state is consent_refused" do
-    let(:patient_session) { create :patient_session, :consent_refused }
+    let(:patient_session) do
+      create(:patient_session, :consent_refused, programme:)
+    end
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Consent refused") }
@@ -62,7 +69,9 @@ describe AppSimpleStatusBannerComponent do
   end
 
   context "state is triaged_kept_in_triage" do
-    let(:patient_session) { create :patient_session, :triaged_kept_in_triage }
+    let(:patient_session) do
+      create(:patient_session, :triaged_kept_in_triage, programme:)
+    end
 
     it { should have_css(".app-card--blue") }
     it { should have_css(".nhsuk-card__heading", text: "Needs triage") }
@@ -71,7 +80,7 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is triaged_ready_to_vaccinate" do
     let(:patient_session) do
-      create :patient_session, :triaged_ready_to_vaccinate
+      create(:patient_session, :triaged_ready_to_vaccinate, programme:)
     end
 
     it { should have_css(".app-card--purple") }
@@ -87,7 +96,9 @@ describe AppSimpleStatusBannerComponent do
   end
 
   context "state is triaged_do_not_vaccinate" do
-    let(:patient_session) { create :patient_session, :triaged_do_not_vaccinate }
+    let(:patient_session) do
+      create(:patient_session, :triaged_do_not_vaccinate, programme:)
+    end
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
@@ -102,7 +113,9 @@ describe AppSimpleStatusBannerComponent do
   end
 
   context "state is delay_vaccination" do
-    let(:patient_session) { create :patient_session, :delay_vaccination }
+    let(:patient_session) do
+      create(:patient_session, :delay_vaccination, programme:)
+    end
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -3,7 +3,7 @@
 describe AppTriageNotesComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(patient_session:) }
+  let(:component) { described_class.new(patient_session:, programme:) }
 
   let(:programme) { create(:programme) }
   let(:patient_session) { create(:patient_session, programme:) }

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -18,13 +18,15 @@ describe TriageMailerConcern do
   let(:sample) { SampleClass.new(current_user:) }
   let(:current_user) { create(:user) }
 
+  let(:programme) { patient_session.programmes.first }
+
   describe "#send_triage_confirmation" do
     subject(:send_triage_confirmation) do
       sample.send_triage_confirmation(patient_session, consent)
     end
 
     let(:session) { patient_session.session }
-    let(:consent) { patient_session.consents.first }
+    let(:consent) { patient_session.consents(programme:).first }
 
     context "when the parents agree, triage is required and it is safe to vaccinate" do
       let(:patient_session) do

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -14,6 +14,7 @@ describe VaccinationMailerConcern do
 
     vaccination_record.strict_loading!(false)
     vaccination_record.patient_session.strict_loading!(false)
+    vaccination_record.patient_session.patient.strict_loading!(false)
   end
 
   let(:sample) { SampleClass.new(current_user:) }

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -59,6 +59,7 @@ describe "Triage" do
       patient: @patient,
       programme: @programme
     )
+
     @patient.reload # Make sure both consents are accessible
   end
 

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -43,11 +43,12 @@ feature "Verbal consent" do
 
   def when_i_record_the_consent_given_for_that_child_from_the_same_parent
     patient_session =
-      PatientSession.includes(consents: :parent).find_by(
+      PatientSession.includes(patient: { consents: :parent }).find_by(
         session: @session,
         patient: @child
       )
-    @refusing_parent = patient_session.consents.first.parent
+    @refusing_parent =
+      patient_session.consents(programme: @programme).first.parent
 
     visit "/dashboard"
     click_on "Programmes", match: :first

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -36,7 +36,7 @@ describe PatientSession do
   end
 
   describe "#triages" do
-    subject(:triages) { patient_session.triages }
+    subject(:triages) { patient_session.triages(programme:) }
 
     let(:patient) { patient_session.patient }
     let(:later_triage) { create(:triage, programme:, patient:) }
@@ -48,7 +48,7 @@ describe PatientSession do
   end
 
   describe "#latest_triage" do
-    subject(:latest_triage) { patient_session.latest_triage }
+    subject(:latest_triage) { patient_session.latest_triage(programme:) }
 
     let(:patient) { patient_session.patient }
     let(:later_triage) do
@@ -129,7 +129,7 @@ describe PatientSession do
   describe "#consent_given?" do
     subject(:consent_given?) do
       described_class
-        .includes(consents: :parent)
+        .includes(patient: { consents: :parent })
         .find(patient_session.id)
         .consent_given?
     end
@@ -196,7 +196,7 @@ describe PatientSession do
   end
 
   describe "#latest_consents" do
-    subject(:latest_consents) { patient_session.latest_consents }
+    subject(:latest_consents) { patient_session.latest_consents(programme:) }
 
     let(:patient_session) { create(:patient_session, programme:, patient:) }
 

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -27,6 +27,8 @@ describe PatientSession do
 
   let(:programme) { create(:programme) }
 
+  it { should have_many(:gillick_assessments).order(:created_at) }
+
   it do
     expect(patient_session).to have_many(:vaccination_records).conditions(
       discarded_at: nil
@@ -248,27 +250,6 @@ describe PatientSession do
         expect(latest_consents).not_to include(invalidated_consent)
       end
     end
-  end
-
-  describe "#latest_gillick_assessment" do
-    subject(:latest_gillick_assessment) do
-      patient_session.latest_gillick_assessment
-    end
-
-    let(:later_gillick_assessment) do
-      create(:gillick_assessment, :competent, patient_session:)
-    end
-
-    before do
-      create(
-        :gillick_assessment,
-        :not_competent,
-        patient_session:,
-        created_at: 1.day.ago
-      )
-    end
-
-    it { should eq(later_gillick_assessment) }
   end
 
   describe "#safe_to_destroy?" do

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -23,21 +23,14 @@
 #
 
 describe PatientSession do
+  subject(:patient_session) { create(:patient_session, programme:) }
+
   let(:programme) { create(:programme) }
-  let(:patient_session) { create(:patient_session, programme:) }
 
-  describe "#vaccination_records" do
-    subject(:vaccination_records) { patient_session.vaccination_records }
-
-    let(:kept_vaccination_record) do
-      create(:vaccination_record, patient_session:, programme:)
-    end
-    let(:discarded_vaccination_record) do
-      create(:vaccination_record, :discarded, patient_session:, programme:)
-    end
-
-    it { should include(kept_vaccination_record) }
-    it { should_not include(discarded_vaccination_record) }
+  it do
+    expect(patient_session).to have_many(:vaccination_records).conditions(
+      discarded_at: nil
+    ).order(:created_at)
   end
 
   describe "#triages" do
@@ -276,28 +269,6 @@ describe PatientSession do
     end
 
     it { should eq(later_gillick_assessment) }
-  end
-
-  describe "#latest_vaccination_record" do
-    subject(:latest_vaccination_record) do
-      patient_session.latest_vaccination_record
-    end
-
-    let(:patient_session) { create(:patient_session, programme:) }
-    let(:later_vaccination_record) do
-      create(:vaccination_record, programme:, patient_session:)
-    end
-
-    before do
-      create(
-        :vaccination_record,
-        programme:,
-        patient_session:,
-        created_at: 1.day.ago
-      )
-    end
-
-    it { should eq(later_vaccination_record) }
   end
 
   describe "#safe_to_destroy?" do

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -51,7 +51,7 @@ describe SessionNotification do
     let(:consent) { create(:consent, :given, patient:, programme:) }
     let(:current_user) { create(:user) }
 
-    before { patient_session.strict_loading!(false) }
+    before { patient_session.patient.strict_loading!(false) }
 
     context "with a school reminder" do
       let(:type) { :school_reminder }


### PR DESCRIPTION
When handling the consents and triage we should filter by the current programme, or the programmes for the current session. This is to avoid problems where the incorrect consent, triage or vaccination record is shown resulting in an incorrect status.

For the most part this hard codes the programme as the first programme in the session and doesn't handle multiple programmes correctly, however it does fix a few potential bugs where we can select a programme appropriately.

This has highlighted more locations that will break with multiple programmes, but I anticipate they can all be fixed in a similar way once we have finalised the designs.