### PR TITLE
Remove max threads override for test environment

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -90,7 +90,6 @@ environments:
       SENTRY_ENVIRONMENT: test
       MAVIS__HOST: "test.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "test.mavistesting.com"
-      GOOD_JOB_MAX_THREADS: 1
   training:
     http:
       alias:


### PR DESCRIPTION
This aligns it to the other environments for consistency.

We might choose to add this back in to all environments, but we're instead trying to bump the rate limit from 5 to higher, which should improve performance.