### PR TITLE
Handle vaccination records outside the organisation

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -144,6 +144,7 @@ class VaccinationsController < ApplicationController
       @patient
         .patient_sessions
         .includes(
+          :organisation,
           patient: {
             parent_relationships: :parent
           },

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -55,6 +55,7 @@ class VaccinateForm
     draft_vaccination_record.patient_id = patient_session.patient_id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user
+    draft_vaccination_record.performed_ods_code = organisation.ods_code
     draft_vaccination_record.programme_id = programme_id
     draft_vaccination_record.session_id = patient_session.session_id
     draft_vaccination_record.vaccine_id = vaccine_id
@@ -63,6 +64,8 @@ class VaccinateForm
   end
 
   private
+
+  delegate :organisation, to: :patient_session
 
   def pre_screening
     @pre_screening ||=

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -23,6 +23,7 @@ class DraftVaccinationRecord
   attribute :performed_by_family_name, :string
   attribute :performed_by_given_name, :string
   attribute :performed_by_user_id, :integer
+  attribute :performed_ods_code, :string
   attribute :programme_id, :integer
   attribute :vaccine_id, :integer
 

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -36,8 +36,6 @@ class ImmunisationImportRow
             },
             if: :vaccine
 
-  validates :organisation_code, comparison: { equal_to: :ods_code }
-
   SCHOOL_URN_HOME_EDUCATED = "999999"
   SCHOOL_URN_UNKNOWN = "888888"
 
@@ -64,6 +62,13 @@ class ImmunisationImportRow
                 @data["PERSON_POSTCODE"]&.strip.present? ||
                   patient_nhs_number.blank?
               end
+            }
+
+  validates :performed_ods_code,
+            presence: true,
+            comparison: {
+              equal_to: :organisation_ods_code,
+              if: :outcome_in_this_academic_year?
             }
 
   validates :date_of_vaccination,
@@ -125,6 +130,7 @@ class ImmunisationImportRow
       performed_by_family_name:,
       performed_by_given_name:,
       performed_by_user:,
+      performed_ods_code:,
       programme: @programme,
       session:
     }
@@ -275,10 +281,6 @@ class ImmunisationImportRow
     end
   end
 
-  def organisation_code
-    @data["ORGANISATION_CODE"]&.strip&.upcase
-  end
-
   def vaccine_given
     @data["VACCINE_GIVEN"]&.strip
   end
@@ -312,6 +314,10 @@ class ImmunisationImportRow
 
   def patient_nhs_number
     @data["NHS_NUMBER"]&.gsub(/\s/, "")&.presence
+  end
+
+  def performed_ods_code
+    @data["ORGANISATION_CODE"]&.strip&.upcase
   end
 
   def school_name
@@ -369,8 +375,6 @@ class ImmunisationImportRow
 
   private
 
-  delegate :ods_code, to: :organisation
-
   def performed_at
     return nil if date_of_vaccination.nil?
 
@@ -421,6 +425,10 @@ class ImmunisationImportRow
         organisation:,
         vaccine:
       )
+  end
+
+  def organisation_ods_code
+    organisation.ods_code
   end
 
   def valid_given_vaccines

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -17,6 +17,7 @@
 #  performed_at             :datetime         not null
 #  performed_by_family_name :string
 #  performed_by_given_name  :string
+#  performed_ods_code       :string           not null
 #  uuid                     :uuid             not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -25,8 +25,17 @@ class VaccinationRecordPolicy < ApplicationPolicy
     def resolve
       scope
         .kept
-        .joins(:session)
-        .where(session: { organisation: user.selected_organisation })
+        .where(patient: PatientPolicy::Scope.new(user, Patient).resolve)
+        .or(
+          scope.kept.where(
+            session: SessionPolicy::Scope.new(user, Session).resolve
+          )
+        )
+        .or(
+          scope.kept.where(
+            performed_ods_code: user.selected_organisation.ods_code
+          )
+        )
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,6 @@ en:
         date_of_vaccination: <code>DATE_OF_VACCINATION</code>
         delivery_site: <code>ANATOMICAL_SITE</code>
         dose_sequence: <code>DOSE_SEQUENCE</code>
-        organisation_code: <code>ORGANISATION_CODE</code>
         patient_date_of_birth: <code>PERSON_DOB</code>
         patient_first_name: <code>PERSON_FORENAME</code>
         patient_gender_code: <code>PERSON_GENDER_CODE</code>/<code>PERSON_GENDER</code>
@@ -65,6 +64,7 @@ en:
         performed_by_family_name: <code>PERFORMING_PROFESSIONAL_SURNAME</code>
         performed_by_given_name: <code>PERFORMING_PROFESSIONAL_FORENAME</code>
         performed_by_user: <code>PERFORMING_PROFESSIONAL_EMAIL</code>
+        performed_ods_code: <code>ORGANISATION_CODE</code>
         reason: <code>REASON_NOT_VACCINATED</code>
         school_name: <code>SCHOOL_NAME</code>
         school_urn: <code>SCHOOL_URN</code>
@@ -260,9 +260,6 @@ en:
               blank: The dose sequence number cannot be greater than 3. Enter a dose sequence number, for example, 1, 2 or 3.
             existing_patients:
               too_long: Two or more possible patients match the patient first name, last name, date of birth or postcode.
-            organisation_code:
-              blank: Enter an organisation code that matches the current organisation.
-              equal_to: Enter an organisation code that matches the current organisation.
             patient_date_of_birth:
               blank: Enter a date of birth in the correct format.
               less_than: Enter a date of birth in the past.
@@ -284,6 +281,9 @@ en:
               blank: Enter a first name
             performed_by_family_name:
               blank: Enter a last name
+            performed_ods_code:
+              blank: Enter an organisation code.
+              equal_to: Enter an organisation code that matches the current organisation.
             reason:
               blank: Enter a valid reason
             school_name:

--- a/db/migrate/20250207091449_add_organisation_to_vaccination_records.rb
+++ b/db/migrate/20250207091449_add_organisation_to_vaccination_records.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddOrganisationToVaccinationRecords < ActiveRecord::Migration[8.0]
+  def up
+    add_column :vaccination_records, :performed_ods_code, :string
+
+    VaccinationRecord
+      .includes(:organisation)
+      .find_each do |vaccination_record|
+        vaccination_record.update_column(
+          :performed_ods_code,
+          vaccination_record.organisation.ods_code
+        )
+      end
+
+    change_column_null :vaccination_records, :performed_ods_code, false
+  end
+
+  def down
+    remove_column :vaccination_records, :performed_ods_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -764,6 +764,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_08_145823) do
     t.datetime "confirmation_sent_at"
     t.bigint "patient_id"
     t.bigint "session_id"
+    t.string "performed_ods_code", null: false
     t.index ["batch_id"], name: "index_vaccination_records_on_batch_id"
     t.index ["discarded_at"], name: "index_vaccination_records_on_discarded_at"
     t.index ["patient_id"], name: "index_vaccination_records_on_patient_id"

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -17,6 +17,7 @@
 #  performed_at             :datetime         not null
 #  performed_by_family_name :string
 #  performed_by_given_name  :string
+#  performed_ods_code       :string           not null
 #  uuid                     :uuid             not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
@@ -57,6 +58,8 @@ FactoryBot.define do
     end
 
     programme
+
+    performed_ods_code { organisation.ods_code }
 
     patient do
       association :patient,

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -108,7 +108,6 @@ describe "Immunisation imports" do
     )
     expect(page).to have_content("Row 2")
     expect(page).to have_content("VACCINATED:")
-    expect(page).to have_content("ORGANISATION_CODE:")
     expect(page).to have_content("CARE_SETTING:")
 
     expect(page).to have_content("Row 2")

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -62,8 +62,8 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row.errors[:administered]).to include(
           /You need to record whether the child was vaccinated or not/
         )
-        expect(immunisation_import_row.errors[:organisation_code]).to include(
-          "Enter an organisation code that matches the current organisation."
+        expect(immunisation_import_row.errors[:performed_ods_code]).to include(
+          "Enter an organisation code."
         )
       end
     end
@@ -82,9 +82,6 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row.errors[:delivery_site]).to eq(
           ["Enter an anatomical site."]
         )
-        expect(immunisation_import_row.errors[:organisation_code]).to eq(
-          ["Enter an organisation code that matches the current organisation."]
-        )
         expect(immunisation_import_row.errors[:patient_date_of_birth]).to eq(
           ["Enter a date of birth in the correct format."]
         )
@@ -93,6 +90,9 @@ describe ImmunisationImportRow do
         )
         expect(immunisation_import_row.errors[:patient_postcode]).to eq(
           ["Enter a valid postcode, such as SW1A 1AA"]
+        )
+        expect(immunisation_import_row.errors[:performed_ods_code]).to eq(
+          ["Enter an organisation code."]
         )
       end
 
@@ -103,17 +103,6 @@ describe ImmunisationImportRow do
           expect(immunisation_import_row).to be_invalid
           expect(immunisation_import_row.errors[:patient_postcode]).to be_empty
         end
-      end
-    end
-
-    context "with an invalid organisation code" do
-      let(:data) { { "ORGANISATION_CODE" => "this is too long" } }
-
-      it "has errors" do
-        expect(immunisation_import_row).to be_invalid
-        expect(immunisation_import_row.errors[:organisation_code]).to eq(
-          ["Enter an organisation code that matches the current organisation."]
-        )
       end
     end
 
@@ -1175,22 +1164,6 @@ describe ImmunisationImportRow do
     end
   end
 
-  describe "#organisation_code" do
-    subject(:organisation_code) { immunisation_import_row.organisation_code }
-
-    context "without a value" do
-      let(:data) { {} }
-
-      it { should be_nil }
-    end
-
-    context "with a value" do
-      let(:data) { { "ORGANISATION_CODE" => "abc" } }
-
-      it { should eq("ABC") }
-    end
-  end
-
   describe "#patient_date_of_birth" do
     subject(:patient_date_of_birth) do
       immunisation_import_row.patient_date_of_birth
@@ -1293,6 +1266,22 @@ describe ImmunisationImportRow do
       let(:data) { { "PERSON_POSTCODE" => "sw11aa" } }
 
       it { should eq("SW1 1AA") }
+    end
+  end
+
+  describe "#performed_ods_code" do
+    subject(:performed_ods_code) { immunisation_import_row.performed_ods_code }
+
+    context "without a value" do
+      let(:data) { {} }
+
+      it { should be_nil }
+    end
+
+    context "with a value" do
+      let(:data) { { "ORGANISATION_CODE" => "abc" } }
+
+      it { should eq("ABC") }
     end
   end
 

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -17,6 +17,7 @@
 #  performed_at             :datetime         not null
 #  performed_by_family_name :string
 #  performed_by_given_name  :string
+#  performed_ods_code       :string           not null
 #  uuid                     :uuid             not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null


### PR DESCRIPTION
This adds a new column to vaccination records which tracks the ODS code of the organisation that performed the vaccination (whether that's a school immunisations team, a hospital or a GP). This is necessary to support importing historical vaccinations that weren't performed by the SAIS organisation directly.

I've chosen to go with a ODS code column rather than something more structured (perhaps a foreign key to the organisations or the locations) because we won't always have a reference, for example if a vaccination took place in a hospital we don't have those in our locations table currently.

In the future we might want to make the data more structured, particularly if we introduce a foreign key on locations to replace the `location_name` column.