### PR TITLE
Fix CSV line number in import errors

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -231,7 +231,9 @@ module CSVImportable
     rows.each.with_index do |row, index|
       next if row.errors.empty?
 
-      errors.add("row_#{index + 1}".to_sym, row.errors.full_messages)
+      # The first row is the header and the index is 0-based, so we add two
+      # to match what the user sees in the spreadsheet
+      errors.add("row_#{index + 2}".to_sym, row.errors.full_messages)
     end
   end
 

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -177,7 +177,7 @@ describe "Import child records" do
 
   def then_i_should_the_errors_page_with_invalid_fields
     expect(page).to have_content("How to format your CSV for child records")
-    expect(page).to have_content("Row 1")
+    expect(page).to have_content("Row 2")
   end
 
   def when_it_is_a_litte_bit_later

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -106,7 +106,7 @@ describe "Immunisation imports" do
     expect(page).to have_content(
       "How to format your CSV for vaccination records"
     )
-    expect(page).to have_content("Row 1")
+    expect(page).to have_content("Row 2")
     expect(page).to have_content("VACCINATED:")
     expect(page).to have_content("ORGANISATION_CODE:")
     expect(page).to have_content("CARE_SETTING:")

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -288,14 +288,14 @@ describe CohortImport do
 
       it "has a validation error" do
         expect { process! }.not_to change(Patient, :count)
-        expect(cohort_import.errors[:row_1]).to eq(
+        expect(cohort_import.errors[:row_2]).to eq(
           [
             [
               "<code>CHILD_NHS_NUMBER</code>: The same NHS number appears multiple times in this file."
             ]
           ]
         )
-        expect(cohort_import.errors[:row_2]).to eq(
+        expect(cohort_import.errors[:row_3]).to eq(
           [
             [
               "<code>CHILD_NHS_NUMBER</code>: The same NHS number appears multiple times in this file."

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -120,7 +120,8 @@ describe ImmunisationImport do
 
       it "is invalid" do
         expect(immunisation_import).to be_invalid
-        expect(immunisation_import.errors).to include(:row_1)
+        expect(immunisation_import.errors).not_to include(:row_1) # Header row
+        expect(immunisation_import.errors).to include(:row_2, :row_3)
       end
     end
   end


### PR DESCRIPTION
Changes the import issues feedback to report row numbers that correspond to what a user sees in the spreadsheet, i.e. including the header row.

Resolves MAVIS-1785.