### PR TITLE
Require VACCINE_GIVEN when importing immunisations

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -114,7 +114,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
       {
         name: "VACCINE_GIVEN",
         notes:
-          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}, must be " +
+          "#{tag.strong("Required")}, must be " +
             @programme
               .vaccines
               .pluck(:nivs_name)

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -10,7 +10,6 @@ class ImmunisationImportRow
     validates :batch_number, presence: true
     validates :delivery_site, presence: true
     validates :reason, absence: true
-    validates :vaccine_given, inclusion: { in: :valid_given_vaccines }
   end
 
   with_options unless: :administered do
@@ -18,8 +17,9 @@ class ImmunisationImportRow
     validates :batch_number, absence: true
     validates :delivery_site, absence: true
     validates :reason, presence: true
-    validates :vaccine_given, absence: true
   end
+
+  validates :vaccine_given, inclusion: { in: :valid_given_vaccines }
 
   validates :batch_expiry_date,
             comparison: {

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -203,6 +203,7 @@ describe "HPV vaccination" do
     )
     row_for_unvaccinated_patient["TIME_OF_VACCINATION"] = "10:01"
     row_for_unvaccinated_patient["VACCINATED"] = "N"
+    row_for_unvaccinated_patient["VACCINE_GIVEN"] = "Gardasil9"
     row_for_unvaccinated_patient["REASON_NOT_VACCINATED"] = "did not attend"
     row_for_unvaccinated_patient["NOTES"] = "Some notes."
     row_for_unvaccinated_patient[

--- a/spec/fixtures/immunisation_import/valid_flu.csv
+++ b/spec/fixtures/immunisation_import/valid_flu.csv
@@ -6,8 +6,8 @@ R1L,120026,shaftesbury junior school ,2675725722,Berry,Hamilton,20120915,Female,
 R1L,120026,shaftesbury junior school ,1108533868,Jordin,Mould,20120916,Male,LE2 2PX,Yes,20240514,Seqirus Flucelvax Tetra QIVC,123013325,20220730,Left Upper Arm,Vaccinator1,Name1,,Parental Consent,LocalPatient5,www.LocalPatient5
 R1L,120026,shaftesbury junior school ,8160442742,Oliver,Bowers,20120917,Male,LE5 2RP,Yes,20240514,Sanofi Pasteur QIVe,123013326,20220730,Right Upper Arm,Vaccinator1,Name1,,Parental Consent,LocalPatient6,www.LocalPatient6
 R1L,120026,shaftesbury junior school ,3314278071,Rosalind,Penn,20120918,Female,LE10 2DA,Yes,20240514,Sanofi Pasteur QIVe,123013326,20220730,Right Thigh,Vaccinator1,Name1,,Parental Consent,LocalPatient7,www.LocalPatient7
-R1L,120026,shaftesbury junior school ,3017356345,Trudie,Chadwick,20120919,Female,LE3 3DE,no,20240514,,,,,Vaccinator1,Name1,Did Not Attend,,LocalPatient8,www.LocalPatient8
-R1L,144012,Home Schooled,5404296666,Alecia,Ainsworth,20120920,Female,LE7 2DA,no,20240514,,,,,Vaccinator1,Name1,Vaccination Contraindicated,,LocalPatient9,www.LocalPatient9
-R1L,999999,Home Schooled,6401122986,Lily,Fletcher,20120921,Female,LE7 2PX,no,20240514,,,,,Vaccinator1,Name1,Unwell,,LocalPatient10,www.LocalPatient10
-R1L,888888,Unknown School,1234567890,Pete,Jones,20120922,Male,LE7 2FF,no,20240514,,,,,Vaccinator1,Name1,Unwell,,LocalPatient11,www.LocalPatient11
+R1L,120026,shaftesbury junior school ,3017356345,Trudie,Chadwick,20120919,Female,LE3 3DE,no,20240514,Sanofi Pasteur QIVe,,,,Vaccinator1,Name1,Did Not Attend,,LocalPatient8,www.LocalPatient8
+R1L,144012,Home Schooled,5404296666,Alecia,Ainsworth,20120920,Female,LE7 2DA,no,20240514,AstraZeneca Fluenz Tetra LAIV,,,,Vaccinator1,Name1,Vaccination Contraindicated,,LocalPatient9,www.LocalPatient9
+R1L,999999,Home Schooled,6401122986,Lily,Fletcher,20120921,Female,LE7 2PX,no,20240514,AstraZeneca Fluenz Tetra LAIV,,,,Vaccinator1,Name1,Unwell,,LocalPatient10,www.LocalPatient10
+R1L,888888,Unknown School,1234567890,Pete,Jones,20120922,Male,LE7 2FF,no,20240514,AstraZeneca Fluenz Tetra LAIV,,,,Vaccinator1,Name1,Unwell,,LocalPatient11,www.LocalPatient11
 ,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
Currently we only require this to be provided when importing administered records, but in the future we will allow importing a file containing records across multiple programmes. To support this we need a way of inferring the programme, and this comes from the vaccine.