### PR TITLE
Add year group selection when importing class lists

### DIFF
--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -19,7 +19,7 @@ class ClassImportsController < ApplicationController
         session: @session,
         organisation: current_user.selected_organisation,
         uploaded_by: current_user,
-        year_groups: @session.year_groups,
+        year_groups: @draft_class_import.year_groups,
         **class_import_params
       )
 

--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -19,6 +19,7 @@ class ClassImportsController < ApplicationController
         session: @session,
         organisation: current_user.selected_organisation,
         uploaded_by: current_user,
+        year_groups: @session.year_groups,
         **class_import_params
       )
 

--- a/app/controllers/draft_class_imports_controller.rb
+++ b/app/controllers/draft_class_imports_controller.rb
@@ -9,16 +9,21 @@ class DraftClassImportsController < ApplicationController
   before_action :set_session_options,
                 only: %i[show update],
                 if: -> { current_step == :session }
+  before_action :set_year_group_options,
+                only: %i[show update],
+                if: -> { current_step == :year_groups }
 
   skip_after_action :verify_policy_scoped, only: %i[show update]
 
   def new
-    session = policy_scope(Session).find_by!(slug: params[:session_slug])
-
     @draft_class_import.reset!
-    @draft_class_import.update!(session:)
 
-    redirect_to draft_class_import_path(Wicked::FINISH_STEP)
+    if (session = policy_scope(Session).find_by(slug: params[:session_slug]))
+      @draft_class_import.update!(session:)
+      redirect_to draft_class_import_path("year-groups")
+    else
+      redirect_to draft_class_import_path(Wicked::FIRST_STEP)
+    end
   end
 
   def show
@@ -50,6 +55,16 @@ class DraftClassImportsController < ApplicationController
         .where(location: { type: :school })
   end
 
+  def set_year_group_options
+    @year_group_options =
+      (@session.year_groups & @session.location.year_groups).map do |year_group|
+        OpenStruct.new(
+          value: year_group,
+          label: helpers.format_year_group(year_group)
+        )
+      end
+  end
+
   def set_steps
     self.steps = @draft_class_import.wizard_steps
   end
@@ -59,9 +74,17 @@ class DraftClassImportsController < ApplicationController
   end
 
   def update_params
-    {
-      session_id: params.dig(:draft_class_import, :session_id),
-      wizard_step: current_step
-    }
+    if current_step == :session
+      {
+        session_id: params.dig(:draft_class_import, :session_id),
+        wizard_step: current_step
+      }
+    elsif current_step == :year_groups
+      {
+        year_groups:
+          (params.dig(:draft_class_import, :year_groups) || []).compact_blank,
+        wizard_step: current_step
+      }
+    end
   end
 end

--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -48,12 +48,18 @@ class ClassImport < PatientImport
     ClassImportRow.new(data:, session:, year_groups:)
   end
 
+  def birth_academic_years
+    year_groups.map(&:to_birth_academic_year)
+  end
+
   def postprocess_rows!
     return if session.closed?
 
     # Remove patients already in the session but not in the class list.
 
-    unknown_patients = session.patients - patients
+    unknown_patients =
+      session.patients.where(birth_academic_year: birth_academic_years) -
+        patients
 
     school_moves =
       unknown_patients.map do |patient|

--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -15,6 +15,7 @@
 #  rows_count                   :integer
 #  serialized_errors            :json
 #  status                       :integer          default("pending_import"), not null
+#  year_groups                  :integer          default([]), not null, is an Array
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
@@ -44,7 +45,7 @@ class ClassImport < PatientImport
   private
 
   def parse_row(data)
-    ClassImportRow.new(data:, session:)
+    ClassImportRow.new(data:, session:, year_groups:)
   end
 
   def postprocess_rows!

--- a/app/models/class_import_row.rb
+++ b/app/models/class_import_row.rb
@@ -3,12 +3,8 @@
 class ClassImportRow < PatientImportRow
   validates :address_postcode, postcode: { allow_nil: true }
 
-  def initialize(data:, session:)
-    super(
-      data:,
-      organisation: session.organisation,
-      year_groups: session.year_groups
-    )
+  def initialize(data:, session:, year_groups:)
+    super(data:, organisation: session.organisation, year_groups:)
     @school = session.location
   end
 

--- a/app/models/draft_class_import.rb
+++ b/app/models/draft_class_import.rb
@@ -9,13 +9,18 @@ class DraftClassImport
   end
 
   attribute :session_id, :integer
+  attribute :year_groups, array: true, default: []
+
+  def wizard_steps
+    %i[session year_groups]
+  end
 
   on_wizard_step :session, exact: true do
     validates :session_id, presence: true
   end
 
-  def wizard_steps
-    %i[session]
+  on_wizard_step :year_groups, exact: true do
+    validates :year_groups, presence: true
   end
 
   def session

--- a/app/views/draft_class_imports/year_groups.html.erb
+++ b/app/views/draft_class_imports/year_groups.html.erb
@@ -1,0 +1,16 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(session_path(@session)) %>
+<% end %>
+
+<% title = "Which year groups do you want to import class list records for?" %>
+<% content_for :page_title, title %>
+
+<%= form_with model: @draft_class_import, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_check_boxes :year_groups, @year_group_options, :value, :label,
+                                     legend: { text: title, size: "l", tag: "h1" },
+                                     caption: { text: @session.location.name, size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -42,6 +42,13 @@
       <% end %>
     <% end %>
 
+    <% if import.is_a?(ClassImport) %>
+      <%= summary_list.with_row do |row| %>
+        <%= row.with_key { "Year groups" } %>
+        <%= row.with_value { import.year_groups.map { format_year_group(_1) }.to_sentence } %>
+      <% end %>
+    <% end %>
+
     <% if import.exact_duplicate_record_count.present? %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key { "Omitted records" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,6 +165,8 @@ en:
           attributes:
             session_id:
               blank: Choose which school this class list for
+            year_groups:
+              blank: Choose which year groups you want to import class list records for
         draft_consent:
           attributes:
             new_or_existing_contact:
@@ -921,3 +923,4 @@ en:
     vaccine: vaccine
     when: when
     who: who
+    year_groups: year-groups

--- a/db/migrate/20250211092238_add_year_groups_to_class_imports.rb
+++ b/db/migrate/20250211092238_add_year_groups_to_class_imports.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddYearGroupsToClassImports < ActiveRecord::Migration[8.0]
+  def change
+    add_column :class_imports,
+               :year_groups,
+               :integer,
+               array: true,
+               default: [],
+               null: false
+
+    reversible do |dir|
+      dir.up do
+        ClassImport
+          .includes(session: :programmes)
+          .find_each do |class_import|
+            year_groups = class_import.session.year_groups
+            class_import.update!(year_groups:)
+          end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_10_092331) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_11_092238) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -92,6 +92,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_10_092331) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "rows_count"
+    t.integer "year_groups", default: [], null: false, array: true
     t.index ["organisation_id"], name: "index_class_imports_on_organisation_id"
     t.index ["session_id"], name: "index_class_imports_on_session_id"
     t.index ["uploaded_by_user_id"], name: "index_class_imports_on_uploaded_by_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -244,7 +244,7 @@ def create_imports(user, organisation)
       :class_import,
       status,
       organisation:,
-      session: organisation.sessions.first,
+      session: organisation.sessions.includes(:programmes).first,
       uploaded_by: user
     )
   end

--- a/spec/factories/class_imports.rb
+++ b/spec/factories/class_imports.rb
@@ -15,6 +15,7 @@
 #  rows_count                   :integer
 #  serialized_errors            :json
 #  status                       :integer          default("pending_import"), not null
+#  year_groups                  :integer          default([]), not null, is an Array
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
@@ -38,6 +39,8 @@ FactoryBot.define do
     session
     organisation { session.organisation }
     uploaded_by
+
+    year_groups { session.year_groups }
 
     csv_data { "my,csv\n" }
     csv_filename { Faker::File.file_name(ext: "csv") }

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -8,6 +8,7 @@ describe "Import class lists - Moving patients" do
 
     when_i_visit_a_session_page_for_the_hpv_programme
     and_i_start_adding_children_to_the_session
+    and_i_select_the_year_groups
     then_i_should_see_the_import_page
 
     when_i_upload_a_valid_file
@@ -15,6 +16,7 @@ describe "Import class lists - Moving patients" do
 
     when_i_visit_a_different_session_page_for_the_hpv_programme
     and_i_start_adding_children_to_the_session
+    and_i_select_the_year_groups
     and_i_upload_a_valid_file
     then_i_should_see_the_import_complete_page
 
@@ -79,6 +81,14 @@ describe "Import class lists - Moving patients" do
 
   def and_i_start_adding_children_to_the_session
     click_on "Import class list records"
+  end
+
+  def and_i_select_the_year_groups
+    check "Year 8"
+    check "Year 9"
+    check "Year 10"
+    check "Year 11"
+    click_on "Continue"
   end
 
   def then_i_should_see_the_import_page

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -8,6 +8,7 @@ describe "Import class lists" do
 
     when_i_visit_a_session_page_for_the_hpv_programme
     and_i_start_adding_children_to_the_session
+    and_i_select_the_year_groups
     then_i_should_see_the_import_page
 
     when_i_continue_without_uploading_a_file
@@ -30,6 +31,7 @@ describe "Import class lists" do
     then_i_should_the_errors_page_with_invalid_fields
 
     when_i_go_back_to_the_upload_page
+    and_i_select_the_year_groups
     and_i_upload_a_valid_file
     then_i_should_see_the_upload
     and_i_should_see_the_patients
@@ -70,6 +72,14 @@ describe "Import class lists" do
     click_on "Import class list records"
   end
 
+  def and_i_select_the_year_groups
+    check "Year 8"
+    check "Year 9"
+    check "Year 10"
+    check "Year 11"
+    click_on "Continue"
+  end
+
   def then_i_should_see_the_import_page
     expect(page).to have_content("Import class list")
   end
@@ -95,6 +105,9 @@ describe "Import class lists" do
   def then_i_should_see_the_upload
     expect(page).to have_content("Imported on")
     expect(page).to have_content("Imported byTest User")
+    expect(page).to have_content(
+      "Year groupsYear 8, Year 9, Year 10, and Year 11"
+    )
   end
 
   def when_i_click_on_the_imports_tab

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -10,6 +10,7 @@ describe "Class list imports duplicates" do
 
     when_i_visit_a_session_page_for_the_hpv_programme
     and_i_start_adding_children_to_the_session
+    and_i_select_the_year_groups
     and_i_upload_a_file_with_duplicate_records
     then_i_should_see_the_import_page_with_duplicate_records
 
@@ -121,6 +122,14 @@ describe "Class list imports duplicates" do
 
   def and_i_start_adding_children_to_the_session
     click_on "Import class list records"
+  end
+
+  def and_i_select_the_year_groups
+    check "Year 8"
+    check "Year 9"
+    check "Year 10"
+    check "Year 11"
+    click_on "Continue"
   end
 
   def and_i_upload_a_file_with_duplicate_records

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 describe ClassImportRow do
-  subject(:class_import_row) { described_class.new(data:, session:) }
+  subject(:class_import_row) do
+    described_class.new(data:, session:, year_groups: session.year_groups)
+  end
 
   let(:today) { Date.new(2024, 12, 1) }
 

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -15,6 +15,7 @@
 #  rows_count                   :integer
 #  serialized_errors            :json
 #  status                       :integer          default("pending_import"), not null
+#  year_groups                  :integer          default([]), not null, is an Array
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -385,7 +385,7 @@ describe ClassImport do
     end
 
     context "with an existing patient not in the class list" do
-      let!(:existing_patient) { create(:patient, session:) }
+      let!(:existing_patient) { create(:patient, session:, year_group: 8) }
 
       it "proposes a school move for the child" do
         expect(existing_patient.school_moves).to be_empty
@@ -406,6 +406,14 @@ describe ClassImport do
           patient: existing_patient,
           organisation:
         )
+
+        expect { process! }.not_to(
+          change { existing_patient.reload.school_moves.count }
+        )
+      end
+
+      it "doesn't propose a move if the patient is in a different year group" do
+        existing_patient.update!(birth_academic_year: 7.to_birth_academic_year)
 
         expect { process! }.not_to(
           change { existing_patient.reload.school_moves.count }


### PR DESCRIPTION
This is a new feature that allows the nurses to choose the year groups they are going to import in the class list. Depending on the year groups selected, patients not in the year group won't be removed from the session.

For now this is behind a feature flag (`class_import_year_groups`) so we can deploy the code sooner and only enable the feature once it's ready to be tested.

## Screenshots

![Screenshot 2025-02-11 at 11 40 58](https://github.com/user-attachments/assets/40a9fb80-9cd0-4143-96a7-04802efd25a3)
![Screenshot 2025-02-11 at 11 44 59](https://github.com/user-attachments/assets/1b238802-c0d9-4618-a41f-f80d475626ae)
