### PR TITLE
Import cohorts and immunisations across multiple programmes

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class AppImportFormatDetailsComponent < ViewComponent::Base
-  def initialize(import:, programme: nil)
+  def initialize(import:)
     super
 
     @import = import
-    @programme = programme
   end
 
   private
+
+  delegate :organisation, to: :@import
 
   def summary_text
     case @import
@@ -115,7 +116,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
         name: "VACCINE_GIVEN",
         notes:
           "#{tag.strong("Required")}, must be " +
-            @programme
+            organisation
               .vaccines
               .pluck(:nivs_name)
               .map { tag.i(_1) }
@@ -244,8 +245,6 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
   end
 
   def dose_sequence
-    return [] unless @programme.hpv?
-
     [
       {
         name: "DOSE_SEQUENCE",

--- a/app/components/app_imports_table_component.html.erb
+++ b/app/components/app_imports_table_component.html.erb
@@ -22,7 +22,7 @@
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Imported on</span>
             <%= govuk_link_to import.created_at.to_fs(:long),
-                              path(programme, import) %>
+                              path(import) %>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Imported by</span>

--- a/app/components/app_imports_table_component.rb
+++ b/app/components/app_imports_table_component.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class AppImportsTableComponent < ViewComponent::Base
-  def initialize(organisation:, programme:)
+  def initialize(organisation:)
     super
 
     @organisation = organisation
-    @programme = programme
   end
 
   def render?
@@ -14,7 +13,7 @@ class AppImportsTableComponent < ViewComponent::Base
 
   private
 
-  attr_reader :organisation, :programme
+  attr_reader :organisation
 
   def imports
     @imports ||=
@@ -27,7 +26,7 @@ class AppImportsTableComponent < ViewComponent::Base
   def class_import_records
     ClassImport
       .select("class_imports.*", "COUNT(patients.id) AS record_count")
-      .where(organisation:, session: programme.sessions)
+      .where(organisation:)
       .left_outer_joins(:patients)
       .includes(:uploaded_by, session: :location)
       .group("class_imports.id")
@@ -36,7 +35,7 @@ class AppImportsTableComponent < ViewComponent::Base
   def cohort_import_records
     CohortImport
       .select("cohort_imports.*", "COUNT(patients.id) AS record_count")
-      .where(organisation:, programme:)
+      .where(organisation:)
       .left_outer_joins(:patients)
       .includes(:uploaded_by)
       .group("cohort_imports.id")
@@ -48,19 +47,19 @@ class AppImportsTableComponent < ViewComponent::Base
         "immunisation_imports.*",
         "COUNT(vaccination_records.id) AS record_count"
       )
-      .where(organisation:, programme:)
+      .where(organisation:)
       .left_outer_joins(:vaccination_records)
       .includes(:uploaded_by)
       .group("immunisation_imports.id")
   end
 
-  def path(programme, import)
+  def path(import)
     if import.is_a?(ClassImport)
       session_class_import_path(import.session, import)
     elsif import.is_a?(CohortImport)
-      programme_cohort_import_path(programme, import)
+      cohort_import_path(import)
     else
-      programme_immunisation_import_path(programme, import)
+      immunisation_import_path(import)
     end
   end
 

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -44,13 +44,13 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
       )
 
       nav.with_item(
-        href: programme_imports_path(programme),
+        href: imports_path,
         text: I18n.t("imports.index.title"),
         selected: active == :imports
       )
 
       nav.with_item(
-        href: programme_import_issues_path(programme),
+        href: import_issues_path,
         text: import_issues_text,
         selected: active == :import_issues
       )

--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -6,8 +6,11 @@ class ClassImportsController < ApplicationController
   before_action :set_session
   before_action :set_class_import, only: %i[show update]
 
+  skip_after_action :verify_policy_scoped, only: %i[new create]
+
   def new
-    @class_import = ClassImport.new
+    @class_import =
+      ClassImport.new(organisation: current_user.selected_organisation)
   end
 
   def create
@@ -28,10 +31,7 @@ class ClassImportsController < ApplicationController
 
     if @class_import.slow?
       ProcessImportJob.perform_later(@class_import)
-      redirect_to programme_imports_path(@session.programmes.first),
-                  flash: {
-                    success: "Import processing started"
-                  }
+      redirect_to imports_path, flash: { success: "Import processing started" }
     else
       ProcessImportJob.perform_now(@class_import)
       redirect_to session_class_import_path(@session, @class_import)

--- a/app/controllers/import_issues_controller.rb
+++ b/app/controllers/import_issues_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ImportIssuesController < ApplicationController
-  before_action :set_programme
   before_action :set_import_issues
   before_action :set_record, only: %i[show update]
   before_action :set_vaccination_record, only: %i[show update]
@@ -11,6 +10,7 @@ class ImportIssuesController < ApplicationController
   layout "full"
 
   def index
+    @programme = policy_scope(Programme).first # TODO: handle multiple programmes
   end
 
   def show
@@ -18,10 +18,7 @@ class ImportIssuesController < ApplicationController
 
   def update
     if @form.save
-      redirect_to programme_import_issues_path(@programme),
-                  flash: {
-                    success: "Record updated"
-                  }
+      redirect_to import_issues_path, flash: { success: "Record updated" }
     else
       render :show, status: :unprocessable_entity and return
     end
@@ -29,24 +26,16 @@ class ImportIssuesController < ApplicationController
 
   private
 
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
-  end
-
   def set_import_issues
     @vaccination_records =
-      policy_scope(VaccinationRecord)
-        .where(programme: @programme)
-        .with_pending_changes
-        .distinct
-        .includes(
-          :batch,
-          :location,
-          :performed_by_user,
-          session: :location,
-          patient: %i[gp_practice school],
-          vaccine: :programme
-        )
+      policy_scope(VaccinationRecord).with_pending_changes.distinct.includes(
+        :batch,
+        :location,
+        :performed_by_user,
+        session: :location,
+        patient: %i[gp_practice school],
+        vaccine: :programme
+      )
 
     @patients =
       policy_scope(Patient)

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class ImportsController < ApplicationController
-  before_action :set_organisation, :set_programme
+  before_action :set_organisation
+
+  skip_after_action :verify_policy_scoped
 
   def index
     render layout: "full"
@@ -13,11 +15,11 @@ class ImportsController < ApplicationController
   def create
     redirect_to(
       if params[:type] == "vaccinations"
-        new_programme_immunisation_import_path(@programme)
+        new_immunisation_import_path
       elsif params[:type] == "children"
-        new_programme_cohort_import_path(@programme)
+        new_cohort_import_path
       else
-        new_programme_import_path(@programme)
+        new_import_path
       end
     )
   end
@@ -26,9 +28,5 @@ class ImportsController < ApplicationController
 
   def set_organisation
     @organisation = current_user.selected_organisation
-  end
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -43,7 +43,7 @@ class CohortImport < PatientImport
   end
 
   def parse_row(data)
-    CohortImportRow.new(data:, organisation:, programme:)
+    CohortImportRow.new(data:, organisation:)
   end
 
   def postprocess_rows!

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -18,25 +18,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
-#  programme_id                 :bigint           not null
 #  uploaded_by_user_id          :bigint           not null
 #
 # Indexes
 #
 #  index_cohort_imports_on_organisation_id      (organisation_id)
-#  index_cohort_imports_on_programme_id         (programme_id)
 #  index_cohort_imports_on_uploaded_by_user_id  (uploaded_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 class CohortImport < PatientImport
   include CSVImportable
-
-  belongs_to :programme
 
   has_and_belongs_to_many :parent_relationships
   has_and_belongs_to_many :parents

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -8,8 +8,8 @@ class CohortImportRow < PatientImportRow
 
   validate :school_urn_inclusion
 
-  def initialize(data:, organisation:, programme:)
-    super(data:, organisation:, year_groups: programme.year_groups)
+  def initialize(data:, organisation:)
+    super(data:, organisation:, year_groups: organisation.year_groups)
   end
 
   def school_urn

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -18,25 +18,20 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
-#  programme_id                 :bigint           not null
 #  uploaded_by_user_id          :bigint           not null
 #
 # Indexes
 #
 #  index_immunisation_imports_on_organisation_id      (organisation_id)
-#  index_immunisation_imports_on_programme_id         (programme_id)
 #  index_immunisation_imports_on_uploaded_by_user_id  (uploaded_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 class ImmunisationImport < ApplicationRecord
   include CSVImportable
-
-  belongs_to :programme
 
   has_and_belongs_to_many :batches
   has_and_belongs_to_many :patient_sessions

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -43,6 +43,7 @@ class Organisation < ApplicationRecord
   has_many :patient_sessions, through: :sessions
   has_many :programmes, through: :organisation_programmes
   has_many :schools, through: :teams
+  has_many :vaccines, through: :programmes
   has_many :vaccination_records, through: :patient_sessions
 
   has_and_belongs_to_many :users

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -31,6 +31,7 @@ class Organisation < ApplicationRecord
   has_many :cohort_imports
   has_many :consent_forms
   has_many :consents
+  has_many :immunisation_records
   has_many :locations
   has_many :organisation_programmes
   has_many :patients

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -20,7 +20,6 @@ class Programme < ApplicationRecord
 
   has_and_belongs_to_many :sessions
 
-  has_many :cohort_imports
   has_many :consent_forms
   has_many :consent_notifications
   has_many :consents

--- a/app/views/cohort_imports/new.html.erb
+++ b/app/views/cohort_imports/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(programme_cohorts_path(@programme), name: @programme.name) %>
+  <%= render AppBacklinkComponent.new(new_import_path, name: "import") %>
 <% end %>
 
 <% title = "Import child records" %>
@@ -7,11 +7,10 @@
 
 <% content_for :page_title, title %>
 
-<%= form_with model: @cohort_import, url: programme_cohort_imports_path do |f| %>
+<%= form_with model: @cohort_import, url: cohort_imports_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :csv,
-                         caption: { text: @programme.name, size: "l" },
                          label: { text: title, tag: "h1", size: "l" },
                          hint: { text: hint } %>
 

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -11,7 +11,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :cohorts) %>
 
-<%= govuk_button_link_to "Import child records", new_programme_cohort_import_path(@programme), class: "app-button--secondary" %>
+<%= govuk_button_link_to "Import child records", new_cohort_import_path, class: "app-button--secondary" %>
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <% @patient_count_by_birth_academic_year.each do |birth_academic_year, patient_count| %>

--- a/app/views/immunisation_imports/new.html.erb
+++ b/app/views/immunisation_imports/new.html.erb
@@ -1,28 +1,20 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(programme_vaccination_records_path(@programme), name: "vaccinations") %>
+  <%= render AppBacklinkComponent.new(new_import_path, name: "import") %>
 <% end %>
 
 <% title = "Import vaccination records" %>
-<% hint = if @programme.hpv?
-       "These will go to NHS England. Make sure the CSV you upload has the same format as your usual reporting template."
-     elsif @programme.flu?
-       "These will go to NHS England and GPs. Make sure the CSV you upload has the same format as your usual reporting template."
-     else
-       "Make sure the CSV you upload has the same format as your usual reporting template."
-     end %>
+<% hint = "Make sure the CSV you upload has the same format as your usual reporting template." %>
 
 <% content_for :page_title, title %>
 
-<%= form_with model: @immunisation_import, url: programme_immunisation_imports_path do |f| %>
+<%= form_with model: @immunisation_import, url: immunisation_imports_path do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :csv,
-                         caption: { text: @programme.name, size: "l" },
                          label: { text: title, tag: "h1", size: "l" },
                          hint: { text: hint } %>
 
-  <%= render AppImportFormatDetailsComponent.new(import: @immunisation_import,
-                                                 programme: @programme) %>
+  <%= render AppImportFormatDetailsComponent.new(import: @immunisation_import) %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/import_issues/index.html.erb
+++ b/app/views/import_issues/index.html.erb
@@ -50,8 +50,7 @@
 
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Actions</span>
-              <%= link_to programme_import_issue_path(
-                    @programme,
+              <%= link_to import_issue_path(
                     import_issue,
                     type: import_issue.is_a?(VaccinationRecord) ?
                       "vaccination-record" :

--- a/app/views/import_issues/show.html.erb
+++ b/app/views/import_issues/show.html.erb
@@ -2,8 +2,7 @@
   <%= render AppBreadcrumbComponent.new(
         items: [
           { text: t("programmes.index.title"), href: programmes_path },
-          { text: @programme.name, href: programme_path(@programme) },
-          { text: "Import issues", href: programme_import_issues_path(@programme) },
+          { text: "Import issues", href: import_issues_path },
         ],
       ) %>
 <% end %>
@@ -54,7 +53,7 @@
 
 <%= form_with(
       model: @form,
-      url: programme_import_issue_path(@programme, @record, type: params[:type]),
+      url: import_issue_path(@record, type: params[:type]),
       method: :patch,
       class: "nhsuk-u-width-one-half",
     ) do |f| %>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -1,25 +1,27 @@
+<% programme = current_user.selected_organisation.programmes.first # TODO: handle multiple programmes %>
+
 <%= content_for :page_title,
-               "#{@programme.name} – #{t("imports.index.title")}" %>
+                "#{programme.name} – #{t("imports.index.title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(
         items: [
           { text: t("programmes.index.title"), href: programmes_path },
-          { text: @programme.name, href: programme_path(@programme) },
+          { text: programme.name, href: programme_path(programme) },
         ],
       ) %>
 <% end %>
 
-<h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
+<h1 class="nhsuk-heading-l"><%= programme.name %></h1>
 
 <%= render AppProgrammeNavigationComponent.new(
-      @programme,
+      programme,
       organisation: current_user.selected_organisation,
       active: :imports,
     ) %>
 
 <%= govuk_button_link_to "Import records",
-                         new_programme_import_path,
+                         new_import_path,
                          class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
 
-<%= render AppImportsTableComponent.new(organisation: @organisation, programme: @programme) %>
+<%= render AppImportsTableComponent.new(organisation: @organisation) %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -2,10 +2,10 @@
 <% content_for :page_title, title %>
 
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(programme_imports_path, name: "imports") %>
+  <%= render AppBacklinkComponent.new(imports_path, name: "imports") %>
 <% end %>
 
-<%= form_with(url: programme_imports_path) do |f| %>
+<%= form_with(url: imports_path) do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:type, legend: { text: title, tag: "h1", size: "l" }) do %>
     <%= f.govuk_radio_button(
           :type, :children,

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -1,17 +1,16 @@
 <% content_for :before_main do %>
-  <% if @programme %>
+  <% if @session %>
     <%= render AppBreadcrumbComponent.new(
           items: [
-            { text: t("programmes.index.title"), href: programmes_path },
-            { text: @programme.name, href: programme_path(@programme) },
-            { text: t("imports.index.title"), href: programme_imports_path(@programme) },
+            { text: t("sessions.index.title"), href: sessions_path },
+            { text: @session.location.name, href: session_path(@session) },
           ],
         ) %>
   <% else %>
     <%= render AppBreadcrumbComponent.new(
           items: [
-            { text: t("sessions.index.title"), href: sessions_path },
-            { text: @session.location.name, href: session_path(@session) },
+            { text: t("programmes.index.title"), href: programmes_path },
+            { text: t("imports.index.title"), href: imports_path },
           ],
         ) %>
   <% end %>
@@ -35,13 +34,6 @@
     <%= summary_list.with_row do |row| %>
       <%= row.with_key { "Imported by" } %>
       <%= row.with_value { import.uploaded_by.full_name } %>
-    <% end %>
-
-    <% if @programme %>
-      <%= summary_list.with_row do |row| %>
-        <%= row.with_key { "Programme" } %>
-        <%= row.with_value { @programme.name } %>
-      <% end %>
     <% end %>
 
     <%= summary_list.with_row do |row| %>
@@ -91,8 +83,7 @@
       When fixing these errors, note that the header does not count as a row.
     </p>
 
-    <%= render AppImportFormatDetailsComponent.new(import:,
-                                                   programme: @programme) %>
+    <%= render AppImportFormatDetailsComponent.new(import:) %>
   <% end %>
 <% end %>
 
@@ -136,10 +127,7 @@
 
               <% row.with_cell do %>
                 <span class="nhsuk-table-responsive__heading">Actions</span>
-                <%= link_to programme_import_issue_path(
-                      # TODO: ClassImports don't have a programme, and
-                      # the import issues controller needs a programme.
-                      @programme || @session.programmes.first,
+                <%= link_to import_issue_path(
                       record,
                       type: record.is_a?(VaccinationRecord) ?
                         "vaccination-record" :

--- a/app/views/programmes/patients.html.erb
+++ b/app/views/programmes/patients.html.erb
@@ -16,7 +16,7 @@
                                                active: :patients) %>
 
 <%= govuk_button_link_to "Import child records",
-                         new_programme_cohort_import_path(@programme),
+                         new_cohort_import_path,
                          class: "app-button--secondary" %>
 
 <%= render AppSessionPatientTableComponent.new(

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -11,7 +11,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :vaccination_records) %>
 
-<%= govuk_button_link_to "Import vaccination records", new_programme_immunisation_import_path, class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
+<%= govuk_button_link_to "Import vaccination records", new_immunisation_import_path, class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
 
 <%= render AppVaccinationRecordTableComponent.new(@vaccination_records, count: @pagy.count) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]
+
   resources :consent_forms, path: "consent-forms", only: %i[index show] do
     member do
       get "match/:patient_id", action: :edit_match, as: :match
@@ -110,6 +112,17 @@ Rails.application.routes.draw do
            path: "draft-vaccination-report/:id" do
     get "download", on: :member
   end
+
+  resources :immunisation_imports,
+            path: "immunisation-imports",
+            except: %i[index destroy]
+
+  resources :import_issues, path: "import-issues", only: %i[index] do
+    get ":type", action: :show, on: :member, as: ""
+    patch ":type", action: :update, on: :member
+  end
+
+  resources :imports, only: %i[index new create]
 
   resources :notices, only: :index
 
@@ -139,20 +152,7 @@ Rails.application.routes.draw do
       get "patients"
     end
 
-    resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]
-
     resources :cohorts, only: %i[index show]
-
-    resources :immunisation_imports,
-              path: "immunisation-imports",
-              except: %i[index destroy]
-
-    resources :import_issues, path: "import-issues", only: %i[index] do
-      get ":type", action: :show, on: :member, as: ""
-      patch ":type", action: :update, on: :member
-    end
-
-    resources :imports, only: %i[index new create]
 
     resources :vaccination_records,
               path: "vaccination-records",

--- a/db/migrate/20250210091908_remove_programme_from_immunisation_imports.rb
+++ b/db/migrate/20250210091908_remove_programme_from_immunisation_imports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveProgrammeFromImmunisationImports < ActiveRecord::Migration[8.0]
+  def change
+    remove_reference :immunisation_imports,
+                     :programme,
+                     foreign_key: true,
+                     null: false
+  end
+end

--- a/db/migrate/20250210092331_remove_programme_from_cohort_imports.rb
+++ b/db/migrate/20250210092331_remove_programme_from_cohort_imports.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveProgrammeFromCohortImports < ActiveRecord::Migration[8.0]
+  def change
+    remove_reference :cohort_imports, :programme, foreign_key: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_10_091908) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_10_092331) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -129,10 +129,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_10_091908) do
     t.bigint "organisation_id", null: false
     t.integer "status", default: 0, null: false
     t.jsonb "serialized_errors"
-    t.bigint "programme_id", null: false
     t.integer "rows_count"
     t.index ["organisation_id"], name: "index_cohort_imports_on_organisation_id"
-    t.index ["programme_id"], name: "index_cohort_imports_on_programme_id"
     t.index ["uploaded_by_user_id"], name: "index_cohort_imports_on_uploaded_by_user_id"
   end
 
@@ -807,7 +805,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_10_091908) do
   add_foreign_key "class_imports_patients", "class_imports"
   add_foreign_key "class_imports_patients", "patients"
   add_foreign_key "cohort_imports", "organisations"
-  add_foreign_key "cohort_imports", "programmes"
   add_foreign_key "cohort_imports", "users", column: "uploaded_by_user_id"
   add_foreign_key "cohort_imports_parent_relationships", "cohort_imports"
   add_foreign_key "cohort_imports_parent_relationships", "parent_relationships"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_08_145823) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_10_091908) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -403,7 +403,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_08_145823) do
     t.bigint "uploaded_by_user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "programme_id", null: false
     t.datetime "processed_at"
     t.integer "new_record_count"
     t.integer "exact_duplicate_record_count"
@@ -415,7 +414,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_08_145823) do
     t.jsonb "serialized_errors"
     t.integer "rows_count"
     t.index ["organisation_id"], name: "index_immunisation_imports_on_organisation_id"
-    t.index ["programme_id"], name: "index_immunisation_imports_on_programme_id"
     t.index ["uploaded_by_user_id"], name: "index_immunisation_imports_on_uploaded_by_user_id"
   end
 
@@ -840,7 +838,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_08_145823) do
   add_foreign_key "health_questions", "health_questions", column: "next_question_id"
   add_foreign_key "health_questions", "vaccines"
   add_foreign_key "immunisation_imports", "organisations"
-  add_foreign_key "immunisation_imports", "programmes"
   add_foreign_key "immunisation_imports", "users", column: "uploaded_by_user_id"
   add_foreign_key "immunisation_imports_patient_sessions", "immunisation_imports"
   add_foreign_key "immunisation_imports_patient_sessions", "patient_sessions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -232,28 +232,19 @@ def create_patients(organisation)
 end
 
 def create_imports(user, organisation)
-  programme = organisation.programmes.includes(:sessions).find_by(type: "hpv")
-
   %i[pending invalid processed].each do |status|
-    FactoryBot.create(
-      :cohort_import,
-      status,
-      organisation:,
-      programme:,
-      uploaded_by: user
-    )
+    FactoryBot.create(:cohort_import, status, organisation:, uploaded_by: user)
     FactoryBot.create(
       :immunisation_import,
       status,
       organisation:,
-      programme:,
       uploaded_by: user
     )
     FactoryBot.create(
       :class_import,
       status,
       organisation:,
-      session: programme.sessions.first,
+      session: organisation.sessions.first,
       uploaded_by: user
     )
   end

--- a/spec/components/app_import_format_details_component_spec.rb
+++ b/spec/components/app_import_format_details_component_spec.rb
@@ -2,22 +2,23 @@
 
 describe AppImportFormatDetailsComponent do
   let(:programme) { create(:programme, :hpv) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
 
   it "renders the correct summary text for ClassImport" do
-    import = ClassImport.new
+    import = ClassImport.new(organisation:)
     render_inline(described_class.new(import:))
     expect(page).to have_content("How to format your CSV for class lists")
   end
 
   it "renders the correct summary text for CohortImport" do
-    import = CohortImport.new
+    import = CohortImport.new(organisation:)
     render_inline(described_class.new(import:))
     expect(page).to have_content("How to format your CSV for child records")
   end
 
   it "renders the correct summary text for ImmunisationImport" do
-    import = ImmunisationImport.new(programme:)
-    render_inline(described_class.new(import:, programme:))
+    import = ImmunisationImport.new(organisation:)
+    render_inline(described_class.new(import:))
     expect(page).to have_content(
       "How to format your CSV for vaccination records"
     )
@@ -32,7 +33,7 @@ describe AppImportFormatDetailsComponent do
   end
 
   it "renders the correct columns for ClassImport" do
-    import = ClassImport.new
+    import = ClassImport.new(organisation:)
     render_inline(described_class.new(import:))
     expect(page).to have_content("CHILD_FIRST_NAME")
     expect(page).to have_content("CHILD_LAST_NAME")
@@ -45,7 +46,7 @@ describe AppImportFormatDetailsComponent do
   end
 
   it "renders the correct columns for CohortImport" do
-    import = CohortImport.new
+    import = CohortImport.new(organisation:)
     render_inline(described_class.new(import:))
     expect(page).to have_content("CHILD_FIRST_NAME")
     expect(page).to have_content("CHILD_LAST_NAME")
@@ -59,8 +60,8 @@ describe AppImportFormatDetailsComponent do
   end
 
   it "renders the correct columns for ImmunisationImport" do
-    import = ImmunisationImport.new(programme:)
-    render_inline(described_class.new(import:, programme:))
+    import = ImmunisationImport.new(organisation:)
+    render_inline(described_class.new(import:))
     expect(page).to have_content("ORGANISATION_CODE")
     expect(page).to have_content("SCHOOL_URN")
     expect(page).to have_content("PERSON_FORENAME")
@@ -69,18 +70,5 @@ describe AppImportFormatDetailsComponent do
     expect(page).to have_content("VACCINE_GIVEN")
     expect(page).to have_content("CARE_SETTING")
     expect(page).to have_content("CLINIC_NAME")
-  end
-
-  it "includes HPV-specific columns for HPV programmes" do
-    import = ImmunisationImport.new(programme:)
-    render_inline(described_class.new(import:, programme:))
-    expect(page).to have_content("DOSE_SEQUENCE")
-  end
-
-  it "does not include HPV-specific columns for non-HPV programmes" do
-    programme = create(:programme, :flu)
-    import = ImmunisationImport.new(programme:)
-    render_inline(described_class.new(import:, programme:))
-    expect(page).not_to have_content("DOSE_SEQUENCE")
   end
 end

--- a/spec/components/app_imports_table_component_spec.rb
+++ b/spec/components/app_imports_table_component_spec.rb
@@ -3,10 +3,10 @@
 describe AppImportsTableComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(organisation:, programme:) }
+  let(:component) { described_class.new(organisation:) }
 
-  let(:organisation) { create(:organisation) }
   let(:programme) { create(:programme) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:school) { create(:school, organisation:, name: "Test School") }
   let(:session) { create(:session, programme:, location: school) }
 
@@ -17,12 +17,11 @@ describe AppImportsTableComponent do
           :cohort_import,
           :processed,
           organisation:,
-          programme:,
           created_at: Date.new(2020, 1, 1),
           uploaded_by:
             create(:user, given_name: "Jennifer", family_name: "Smith")
         )
-      ] + create_list(:cohort_import, 4, :processed, organisation:, programme:)
+      ] + create_list(:cohort_import, 4, :processed, organisation:)
 
     cohort_imports.each do |cohort_import|
       create(:patient, cohort_imports: [cohort_import])
@@ -34,22 +33,15 @@ describe AppImportsTableComponent do
           :immunisation_import,
           :processed,
           organisation:,
-          programme:,
           created_at: Date.new(2020, 1, 1),
           uploaded_by: create(:user, given_name: "John", family_name: "Smith")
         )
-      ] +
-        create_list(
-          :immunisation_import,
-          4,
-          :processed,
-          organisation:,
-          programme:
-        )
+      ] + create_list(:immunisation_import, 4, :processed, organisation:)
 
     immunisation_imports.each do |immunisation_import|
       create(
         :vaccination_record,
+        organisation:,
         programme:,
         immunisation_imports: [immunisation_import]
       )

--- a/spec/factories/cohort_imports.rb
+++ b/spec/factories/cohort_imports.rb
@@ -18,28 +18,21 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
-#  programme_id                 :bigint           not null
 #  uploaded_by_user_id          :bigint           not null
 #
 # Indexes
 #
 #  index_cohort_imports_on_organisation_id      (organisation_id)
-#  index_cohort_imports_on_programme_id         (programme_id)
 #  index_cohort_imports_on_uploaded_by_user_id  (uploaded_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 FactoryBot.define do
   factory :cohort_import do
-    programme
-    organisation do
-      programme.organisations.first ||
-        association(:organisation, programmes: [programme])
-    end
+    organisation
     uploaded_by
 
     csv_data { "my,csv\n" }

--- a/spec/factories/immunisation_imports.rb
+++ b/spec/factories/immunisation_imports.rb
@@ -18,25 +18,21 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
-#  programme_id                 :bigint           not null
 #  uploaded_by_user_id          :bigint           not null
 #
 # Indexes
 #
 #  index_immunisation_imports_on_organisation_id      (organisation_id)
-#  index_immunisation_imports_on_programme_id         (programme_id)
 #  index_immunisation_imports_on_uploaded_by_user_id  (uploaded_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 FactoryBot.define do
   factory :immunisation_import do
     organisation
-    programme
     uploaded_by
 
     csv_data { "my,csv\n" }

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -115,7 +115,7 @@ describe "End-to-end journey" do
     click_on "Import child records"
     attach_file "cohort_import[csv]", csv_file.path
     click_on "Continue"
-    visit programme_cohort_import_path(@programme, CohortImport.last)
+    visit cohort_import_path(CohortImport.last)
   end
 
   def then_i_see_that_the_cohort_has_been_uploaded

--- a/spec/features/import_child_records_slow_spec.rb
+++ b/spec/features/import_child_records_slow_spec.rb
@@ -75,7 +75,6 @@ describe "Import child records" do
   def then_i_should_see_the_upload
     expect(page).to have_content("Imported on")
     expect(page).to have_content("Imported byTest User")
-    expect(page).to have_content("ProgrammeHPV")
   end
 
   def then_i_should_see_the_imports_page_with_the_processing_flash

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -107,7 +107,6 @@ describe "Import child records" do
   def then_i_should_see_the_upload
     expect(page).to have_content("Imported on")
     expect(page).to have_content("Imported byTest User")
-    expect(page).to have_content("ProgrammeHPV")
   end
 
   def when_i_click_on_the_imports_tab

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -108,7 +108,6 @@ describe "Immunisation imports" do
     )
     expect(page).to have_content("Row 2")
     expect(page).to have_content("VACCINATED:")
-    expect(page).to have_content("CARE_SETTING:")
 
     expect(page).to have_content("Row 2")
     expect(page).to have_content("BATCH_EXPIRY_DATE:")
@@ -159,7 +158,6 @@ describe "Immunisation imports" do
   def then_i_should_see_the_upload
     expect(page).to have_content("Imported on")
     expect(page).to have_content("Imported byTest User")
-    expect(page).to have_content("ProgrammeHPV")
   end
 
   def when_i_click_on_a_vaccination_record

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 describe CohortImportRow do
-  subject(:cohort_import_row) do
-    described_class.new(data:, organisation:, programme:)
-  end
+  subject(:cohort_import_row) { described_class.new(data:, organisation:) }
 
   let(:today) { Date.new(2024, 12, 1) }
 

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -31,9 +31,7 @@
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 describe CohortImport do
-  subject(:cohort_import) do
-    create(:cohort_import, csv:, programme:, organisation:)
-  end
+  subject(:cohort_import) { create(:cohort_import, csv:, organisation:) }
 
   let(:programme) { create(:programme) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
@@ -261,7 +259,7 @@ describe CohortImport do
     end
 
     it "ignores and counts duplicate records" do
-      create(:cohort_import, csv:, organisation:, programme:).process!
+      create(:cohort_import, csv:, organisation:).process!
       csv.rewind
 
       process!

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -18,19 +18,16 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
-#  programme_id                 :bigint           not null
 #  uploaded_by_user_id          :bigint           not null
 #
 # Indexes
 #
 #  index_cohort_imports_on_organisation_id      (organisation_id)
-#  index_cohort_imports_on_programme_id         (programme_id)
 #  index_cohort_imports_on_uploaded_by_user_id  (uploaded_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 describe CohortImport do

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -2,7 +2,7 @@
 
 describe ImmunisationImportRow do
   subject(:immunisation_import_row) do
-    described_class.new(data:, organisation:, programme:)
+    described_class.new(data:, organisation:)
   end
 
   let(:programme) { create(:programme, :flu) }

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -33,7 +33,7 @@
 
 describe ImmunisationImport do
   subject(:immunisation_import) do
-    create(:immunisation_import, organisation:, programme:, csv:, uploaded_by:)
+    create(:immunisation_import, organisation:, csv:, uploaded_by:)
   end
 
   before do
@@ -158,13 +158,7 @@ describe ImmunisationImport do
       end
 
       it "ignores and counts duplicate records" do
-        create(
-          :immunisation_import,
-          programme:,
-          csv:,
-          organisation:,
-          uploaded_by:
-        ).process!
+        create(:immunisation_import, csv:, organisation:, uploaded_by:).process!
         csv.rewind
 
         process!
@@ -217,13 +211,7 @@ describe ImmunisationImport do
       end
 
       it "ignores and counts duplicate records" do
-        create(
-          :immunisation_import,
-          programme:,
-          csv:,
-          organisation:,
-          uploaded_by:
-        ).process!
+        create(:immunisation_import, csv:, organisation:, uploaded_by:).process!
         csv.rewind
 
         process!

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -18,19 +18,16 @@
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
 #  organisation_id              :bigint           not null
-#  programme_id                 :bigint           not null
 #  uploaded_by_user_id          :bigint           not null
 #
 # Indexes
 #
 #  index_immunisation_imports_on_organisation_id      (organisation_id)
-#  index_immunisation_imports_on_programme_id         (programme_id)
 #  index_immunisation_imports_on_uploaded_by_user_id  (uploaded_by_user_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (uploaded_by_user_id => users.id)
 #
 


### PR DESCRIPTION
Previously the cohort and immunisation import models would be attached to a programme. This has been changed to allow imports across multiple programmes to happen at the same time. To support this, we need to update various places in the code that relies on the programme.

In the future we will introduce a new design for the imports which moves them out of the programme view and in to the global view. This PR helps us build that in the future but for now leaves the UI the same as it is currently to allow this to be deployed first.