### PR TITLE
Update imports to match latest designs

### DIFF
--- a/app/components/app_imports_navigation_component.rb
+++ b/app/components/app_imports_navigation_component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class AppImportsNavigationComponent < ViewComponent::Base
+  def initialize(active:)
+    super
+
+    @active = active
+  end
+
+  def call
+    render AppSecondaryNavigationComponent.new do |nav|
+      nav.with_item(
+        href: imports_path,
+        text: "Recent imports",
+        selected: active == :index
+      )
+
+      nav.with_item(
+        href: imports_issues_path,
+        text: issues_text,
+        selected: active == :issues
+      )
+
+      if helpers.policy(:notices).index?
+        nav.with_item(
+          href: imports_notices_path,
+          text: notices_text,
+          selected: active == :notices
+        )
+      end
+    end
+  end
+
+  private
+
+  attr_reader :active
+
+  def issues_text
+    vaccination_records_with_issues =
+      helpers.policy_scope(VaccinationRecord).with_pending_changes.distinct
+
+    patients_with_issues = helpers.policy_scope(Patient).with_pending_changes
+
+    unique_import_issues =
+      (vaccination_records_with_issues + patients_with_issues).uniq do |record|
+        record.is_a?(VaccinationRecord) ? record.patient : record
+      end
+
+    count = unique_import_issues.count
+
+    safe_join(["Import issues", " ", render(AppCountComponent.new(count:))])
+  end
+
+  def notices_text
+    count = helpers.policy_scope(Patient).with_notice.count
+
+    safe_join(["Important notices", " ", render(AppCountComponent.new(count:))])
+  end
+end

--- a/app/components/app_imports_table_component.html.erb
+++ b/app/components/app_imports_table_component.html.erb
@@ -9,8 +9,7 @@
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
         <% row.with_cell(text: "Imported on") %>
-        <% row.with_cell(text: "Imported by") %>
-        <% row.with_cell(text: "Import type") %>
+        <% row.with_cell(text: "Type") %>
         <% row.with_cell(text: "Status") %>
         <% row.with_cell(text: "Records", numeric: true) %>
       <% end %>
@@ -21,15 +20,10 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Imported on</span>
-            <%= govuk_link_to import.created_at.to_fs(:long),
-                              path(import) %>
+            <%= govuk_link_to import.created_at.to_fs(:long), path(import) %>
           <% end %>
           <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Imported by</span>
-            <%= import.uploaded_by.full_name %>
-          <% end %>
-          <% row.with_cell do %>
-            <span class="nhsuk-table-responsive__heading">Import type</span>
+            <span class="nhsuk-table-responsive__heading">Type</span>
             <%= record_type(import) %>
             <% if import.is_a?(ClassImport) %>
               <br />

--- a/app/components/app_imports_table_component.rb
+++ b/app/components/app_imports_table_component.rb
@@ -55,7 +55,7 @@ class AppImportsTableComponent < ViewComponent::Base
 
   def path(import)
     if import.is_a?(ClassImport)
-      session_class_import_path(import.session, import)
+      class_import_path(import)
     elsif import.is_a?(CohortImport)
       cohort_import_path(import)
     else

--- a/app/components/app_imports_table_component.rb
+++ b/app/components/app_imports_table_component.rb
@@ -65,7 +65,7 @@ class AppImportsTableComponent < ViewComponent::Base
 
   def record_type(import)
     if import.is_a?(ClassImport)
-      "Class list"
+      "Class list records"
     elsif import.is_a?(CohortImport)
       "Child records"
     else

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 class AppProgrammeNavigationComponent < ViewComponent::Base
-  attr_reader :programme, :organisation, :active
-
-  def initialize(programme, organisation:, active:)
+  def initialize(programme, active:)
     super
 
     @programme = programme
-    @organisation = organisation
     @active = active
   end
 
@@ -42,41 +39,10 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
         text: I18n.t("vaccination_records.index.title"),
         selected: active == :vaccination_records
       )
-
-      nav.with_item(
-        href: imports_path,
-        text: I18n.t("imports.index.title"),
-        selected: active == :imports
-      )
-
-      nav.with_item(
-        href: import_issues_path,
-        text: import_issues_text,
-        selected: active == :import_issues
-      )
     end
   end
 
   private
 
-  def import_issues_text
-    vaccination_records_with_issues =
-      helpers
-        .policy_scope(VaccinationRecord)
-        .where(programme:)
-        .with_pending_changes
-        .distinct
-
-    patients_with_issues = helpers.policy_scope(Patient).with_pending_changes
-
-    unique_import_issues =
-      (vaccination_records_with_issues + patients_with_issues).uniq do |record|
-        record.is_a?(VaccinationRecord) ? record.patient : record
-      end
-
-    base_text = I18n.t("import_issues.index.title")
-    count = unique_import_issues.count
-
-    safe_join([base_text, " ", render(AppCountComponent.new(count:))])
-  end
+  attr_reader :programme, :active
 end

--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -3,7 +3,7 @@
 class ClassImportsController < ApplicationController
   include Pagy::Backend
 
-  before_action :set_session, only: %i[new create]
+  before_action :set_draft_class_import, only: %i[new create]
   before_action :set_class_import, only: %i[show update]
 
   skip_after_action :verify_policy_scoped, only: %i[new create]
@@ -60,8 +60,10 @@ class ClassImportsController < ApplicationController
 
   private
 
-  def set_session
-    @session = policy_scope(Session).upcoming.find(params[:session_id])
+  def set_draft_class_import
+    @draft_class_import =
+      DraftClassImport.new(request_session: session, current_user:)
+    @session = @draft_class_import.session
   end
 
   def set_class_import

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -6,5 +6,7 @@ class DashboardController < ApplicationController
   layout "full"
 
   def index
+    @important_notices =
+      (policy_scope(Patient).with_notice.count if policy(:notices).index?)
   end
 end

--- a/app/controllers/draft_class_imports_controller.rb
+++ b/app/controllers/draft_class_imports_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class DraftClassImportsController < ApplicationController
+  before_action :set_draft_class_import
+  before_action :set_session
+
+  include WizardControllerConcern
+
+  before_action :set_session_options,
+                only: %i[show update],
+                if: -> { current_step == :session }
+
+  skip_after_action :verify_policy_scoped, only: %i[show update]
+
+  def new
+    session = policy_scope(Session).find_by!(slug: params[:session_slug])
+
+    @draft_class_import.reset!
+    @draft_class_import.update!(session:)
+
+    redirect_to draft_class_import_path(Wicked::FINISH_STEP)
+  end
+
+  def show
+    render_wizard
+  end
+
+  def update
+    @draft_class_import.assign_attributes(update_params)
+
+    render_wizard @draft_class_import
+  end
+
+  private
+
+  def set_draft_class_import
+    @draft_class_import =
+      DraftClassImport.new(request_session: session, current_user:)
+  end
+
+  def set_session
+    @session = @draft_class_import.session
+  end
+
+  def set_session_options
+    @session_options =
+      policy_scope(Session)
+        .includes(:location)
+        .upcoming
+        .where(location: { type: :school })
+  end
+
+  def set_steps
+    self.steps = @draft_class_import.wizard_steps
+  end
+
+  def finish_wizard_path
+    new_class_import_path
+  end
+
+  def update_params
+    {
+      session_id: params.dig(:draft_class_import, :session_id),
+      wizard_step: current_step
+    }
+  end
+end

--- a/app/controllers/imports/issues_controller.rb
+++ b/app/controllers/imports/issues_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ImportIssuesController < ApplicationController
+class Imports::IssuesController < ApplicationController
   before_action :set_import_issues
   before_action :set_record, only: %i[show update]
   before_action :set_vaccination_record, only: %i[show update]
@@ -10,7 +10,6 @@ class ImportIssuesController < ApplicationController
   layout "full"
 
   def index
-    @programme = policy_scope(Programme).first # TODO: handle multiple programmes
   end
 
   def show
@@ -18,7 +17,7 @@ class ImportIssuesController < ApplicationController
 
   def update
     if @form.save
-      redirect_to import_issues_path, flash: { success: "Record updated" }
+      redirect_to imports_issues_path, flash: { success: "Record updated" }
     else
       render :show, status: :unprocessable_entity and return
     end

--- a/app/controllers/imports/notices_controller.rb
+++ b/app/controllers/imports/notices_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NoticesController < ApplicationController
+class Imports::NoticesController < ApplicationController
   layout "full"
 
   def index

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -13,15 +13,20 @@ class ImportsController < ApplicationController
   end
 
   def create
-    redirect_to(
-      if params[:type] == "vaccinations"
-        new_immunisation_import_path
-      elsif params[:type] == "children"
-        new_cohort_import_path
-      else
-        new_import_path
-      end
-    )
+    if params[:type] == "class-list"
+      DraftClassImport.new(request_session: session, current_user:).reset!
+      redirect_to draft_class_import_path(Wicked::FIRST_STEP)
+    else
+      redirect_to(
+        if params[:type] == "vaccinations"
+          new_immunisation_import_path
+        elsif params[:type] == "children"
+          new_cohort_import_path
+        else
+          new_import_path
+        end
+      )
+    end
   end
 
   private

--- a/app/models/draft_class_import.rb
+++ b/app/models/draft_class_import.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class DraftClassImport
+  include RequestSessionPersistable
+  include WizardStepConcern
+
+  def self.request_session_key
+    "class_import"
+  end
+
+  attribute :session_id, :integer
+
+  on_wizard_step :session, exact: true do
+    validates :session_id, presence: true
+  end
+
+  def wizard_steps
+    %i[session]
+  end
+
+  def session
+    SessionPolicy::Scope
+      .new(@current_user, Session)
+      .resolve
+      .find_by(id: session_id)
+  end
+
+  def session=(value)
+    self.session_id = value.id
+  end
+
+  private
+
+  def reset_unused_fields
+  end
+end

--- a/app/views/class_imports/new.html.erb
+++ b/app/views/class_imports/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
+  <%= render AppBacklinkComponent.new(draft_class_import_path("session")) %>
 <% end %>
 
 <% title = "Import class list" %>
@@ -9,8 +9,6 @@
 
 <%= form_with model: @class_import, url: class_imports_path do |f| %>
   <%= f.govuk_error_summary %>
-
-  <%= hidden_field_tag :session_id, @session.id %>
 
   <%= f.govuk_file_field :csv,
                          caption: { text: @session.location.name, size: "l" },

--- a/app/views/class_imports/new.html.erb
+++ b/app/views/class_imports/new.html.erb
@@ -7,8 +7,10 @@
 
 <% content_for :page_title, title %>
 
-<%= form_with model: @class_import, url: session_class_imports_path do |f| %>
+<%= form_with model: @class_import, url: class_imports_path do |f| %>
   <%= f.govuk_error_summary %>
+
+  <%= hidden_field_tag :session_id, @session.id %>
 
   <%= f.govuk_file_field :csv,
                          caption: { text: @session.location.name, size: "l" },

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :cohorts) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, active: :cohorts) %>
 
 <%= govuk_button_link_to "Import child records", new_cohort_import_path, class: "app-button--secondary" %>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,11 @@
 <%= h1 "#{@service_name} (Mavis)", size: "xl" %>
 
+<% if (count = @important_notices) %>
+  <%= render AppWarningCalloutComponent.new(heading: "Important notices") do %>
+    <p><%= link_to t(".notices.description", count:), imports_notices_path %></p>
+  <% end %>
+<% end %>
+
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: programmes_path) do |card| %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -40,13 +40,6 @@
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: vaccines_path, secondary: true) do |card| %>
-      <% card.with_heading { t("vaccines.index.title") } %>
-      <% card.with_description { "Add and edit vaccine batches" } %>
-    <% end %>
-  </li>
-
-  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: consent_forms_path, secondary: true) do |card| %>
       <% card.with_heading { t("consent_forms.index.title") } %>
       <% card.with_description { "Review incoming consent responses that can’t be automatically matched" } %>
@@ -60,14 +53,19 @@
     <% end %>
   </li>
 
-  <% if policy(:notices).index? %>
-    <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-      <%= render AppCardComponent.new(link_to: notices_path, secondary: true) do |card| %>
-        <% card.with_heading { t("notices.index.title") } %>
-        <% card.with_description { "View notices about important updates to patient records" } %>
-      <% end %>
-    </li>
-  <% end %>
+  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    <%= render AppCardComponent.new(link_to: imports_path, secondary: true) do |card| %>
+      <% card.with_heading { t("imports.index.title") } %>
+      <% card.with_description { "Import child, cohort and vaccination records and see important notices" } %>
+    <% end %>
+  </li>
+
+  <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
+    <%= render AppCardComponent.new(link_to: vaccines_path, secondary: true) do |card| %>
+      <% card.with_heading { t("vaccines.index.title") } %>
+      <% card.with_description { "Add and edit vaccine batches" } %>
+    <% end %>
+  </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
     <%= render AppCardComponent.new(link_to: organisation_path, secondary: true) do |card| %>

--- a/app/views/draft_class_imports/session.html.erb
+++ b/app/views/draft_class_imports/session.html.erb
@@ -1,0 +1,23 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(new_import_path) %>
+<% end %>
+
+<% title = "Which school is this class list for?" %>
+<% content_for :page_title, title %>
+
+<%= form_with model: @draft_class_import, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_select :session_id, label: { text: title, size: "l", tag: "h1" },
+                                  data: { module: "autocomplete" } do %>
+    <%= tag.option "", value: "" %>
+
+    <% @session_options.each do |session| %>
+      <%= tag.option session.location.name,
+                     value: session.id,
+                     selected: session.id == @draft_class_import.session_id %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -1,27 +1,7 @@
-<% programme = current_user.selected_organisation.programmes.first # TODO: handle multiple programmes %>
+<%= h1 t(".title"), size: "xl" %>
 
-<%= content_for :page_title,
-                "#{programme.name} – #{t("imports.index.title")}" %>
+<%= govuk_button_link_to "Import records", new_import_path, class: "app-button--secondary" %>
 
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: t("programmes.index.title"), href: programmes_path },
-          { text: programme.name, href: programme_path(programme) },
-        ],
-      ) %>
-<% end %>
-
-<h1 class="nhsuk-heading-l"><%= programme.name %></h1>
-
-<%= render AppProgrammeNavigationComponent.new(
-      programme,
-      organisation: current_user.selected_organisation,
-      active: :imports,
-    ) %>
-
-<%= govuk_button_link_to "Import records",
-                         new_import_path,
-                         class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
+<%= render AppImportsNavigationComponent.new(active: :index) %>
 
 <%= render AppImportsTableComponent.new(organisation: @organisation) %>

--- a/app/views/imports/issues/index.html.erb
+++ b/app/views/imports/issues/index.html.erb
@@ -1,17 +1,8 @@
-<% content_for :page_title, "#{@programme.name} – Import issues" %>
+<%= h1 t("imports.index.title"), size: "xl" %>
 
-<% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: t("programmes.index.title"), href: programmes_path },
-          { text: @programme.name, href: programme_path(@programme) },
-        ],
-      ) %>
-<% end %>
+<%= govuk_button_link_to "Import records", new_import_path, class: "app-button--secondary" %>
 
-<h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
-
-<%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :import_issues) %>
+<%= render AppImportsNavigationComponent.new(active: :issues) %>
 
 <% if @import_issues.any? %>
   <div class="nhsuk-table__panel-with-heading-tab">
@@ -50,7 +41,7 @@
 
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Actions</span>
-              <%= link_to import_issue_path(
+              <%= link_to imports_issue_path(
                     import_issue,
                     type: import_issue.is_a?(VaccinationRecord) ?
                       "vaccination-record" :

--- a/app/views/imports/issues/show.html.erb
+++ b/app/views/imports/issues/show.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBreadcrumbComponent.new(
         items: [
           { text: t("programmes.index.title"), href: programmes_path },
-          { text: "Import issues", href: import_issues_path },
+          { text: "Import issues", href: imports_issues_path },
         ],
       ) %>
 <% end %>
@@ -53,7 +53,7 @@
 
 <%= form_with(
       model: @form,
-      url: import_issue_path(@record, type: params[:type]),
+      url: imports_issue_path(@record, type: params[:type]),
       method: :patch,
       class: "nhsuk-u-width-one-half",
     ) do |f| %>

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -10,9 +10,17 @@
     <%= f.govuk_radio_button(
           :type, :children,
           label: { text: "Child records" },
-          hint: { text: "Records of children from a CHIS, local authority or school, used to create cohorts " },
+          hint: { text: "Records of children from a CHIS, local authority or school, used to create cohorts" },
           link_errors: true,
         ) %>
+
+    <%= f.govuk_radio_button(
+          :type, "class-list",
+          label: { text: "Class list records" },
+          hint: { text: "Records of children from a school, used to update cohorts" },
+          link_errors: true,
+        ) %>
+
     <%= f.govuk_radio_button(
           :type, :vaccinations,
           label: { text: "Vaccination records" },

--- a/app/views/imports/notices/index.html.erb
+++ b/app/views/imports/notices/index.html.erb
@@ -1,7 +1,11 @@
-<%= h1 t("notices.index.title"), size: "xl" %>
+<%= h1 t("imports.index.title"), size: "xl" %>
+
+<%= govuk_button_link_to "Import records", new_import_path, class: "app-button--secondary" %>
+
+<%= render AppImportsNavigationComponent.new(active: :notices) %>
 
 <% if @deceased_patients.any? || @invalidated_patients.any? || @restricted_patients.any? %>
   <%= render AppNoticesTableComponent.new(deceased_patients: @deceased_patients, invalidated_patients: @invalidated_patients, restricted_patients: @restricted_patients) %>
 <% else %>
-  <p class="nhsuk-body"><%= t("notices.index.no_results") %></p>
+  <p class="nhsuk-body"><%= t(".no_results") %></p>
 <% end %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -1,19 +1,9 @@
 <% content_for :before_main do %>
-  <% if @session %>
-    <%= render AppBreadcrumbComponent.new(
-          items: [
-            { text: t("sessions.index.title"), href: sessions_path },
-            { text: @session.location.name, href: session_path(@session) },
-          ],
-        ) %>
-  <% else %>
-    <%= render AppBreadcrumbComponent.new(
-          items: [
-            { text: t("programmes.index.title"), href: programmes_path },
-            { text: t("imports.index.title"), href: imports_path },
-          ],
-        ) %>
-  <% end %>
+  <%= render AppBreadcrumbComponent.new(
+        items: [
+          { text: t("imports.index.title"), href: imports_path },
+        ],
+      ) %>
 <% end %>
 
 <%= h1 "Import (#{import.created_at.to_fs(:long)})" %>
@@ -127,7 +117,7 @@
 
               <% row.with_cell do %>
                 <span class="nhsuk-table-responsive__heading">Actions</span>
-                <%= link_to import_issue_path(
+                <%= link_to imports_issue_path(
                       record,
                       type: record.is_a?(VaccinationRecord) ?
                         "vaccination-record" :

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -60,16 +60,14 @@
             count: policy_scope(SchoolMove).count
           ) %>
 
-          <% if policy(:notices).index? %>
-            <%= render AppHeaderNavigationItemComponent.new(
-              t("notices.index.title_short"),
-              notices_path,
-              request_path: request.path,
-              count: policy_scope(Patient).with_notice.count
-            ) %>
-          <% end %>
-
           <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
+
+          <%= render AppHeaderNavigationItemComponent.new(
+            t("imports.index.title_short"),
+            imports_path,
+            request_path: request.path,
+            count: policy_scope(ClassImport).count + policy_scope(CohortImport).count + policy_scope(ImmunisationImport).count
+          ) %>
 
           <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>
 

--- a/app/views/programmes/patients.html.erb
+++ b/app/views/programmes/patients.html.erb
@@ -11,9 +11,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme,
-                                               organisation: current_user.selected_organisation,
-                                               active: :patients) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, active: :patients) %>
 
 <%= govuk_button_link_to "Import child records",
                          new_cohort_import_path,

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -9,6 +9,6 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :sessions) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, active: :sessions) %>
 
 <%= render AppProgrammeSessionTableComponent.new(@sessions) %>

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -8,7 +8,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :overview) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, active: :overview) %>
 
 <%= govuk_button_to "Download vaccination report", programme_vaccination_reports_path(@programme), class: "app-button--secondary nhsuk-u-margin-bottom-5" %>
 

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -30,7 +30,7 @@
 
   <% if @session.open? && @session.location.school? %>
     <li class="app-action-list__item">
-      <%= govuk_link_to "Import class list", new_session_class_import_path(@session) %>
+      <%= govuk_link_to "Import class list", new_class_import_path(session_id: @session.id) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -30,7 +30,7 @@
 
   <% if @session.open? && @session.location.school? %>
     <li class="app-action-list__item">
-      <%= govuk_link_to "Import class list", new_class_import_path(session_id: @session.id) %>
+      <%= govuk_link_to "Import class list records", new_draft_class_import_path(@session) %>
     </li>
   <% end %>
 </ul>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -9,7 +9,7 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, organisation: current_user.selected_organisation, active: :vaccination_records) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, active: :vaccination_records) %>
 
 <%= govuk_button_link_to "Import vaccination records", new_immunisation_import_path, class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -163,6 +163,10 @@ en:
               inclusion: The school URN is not recognised. If you’ve checked the URN, and you believe it’s valid, contact our support organisation.
             year_group:
               inclusion: is not part of this programme
+        draft_class_import:
+          attributes:
+            session_id:
+              blank: Choose which school this class list for
         draft_consent:
           attributes:
             new_or_existing_contact:
@@ -906,6 +910,7 @@ en:
     reason_notes: reason-notes
     route: route
     school: school
+    session: session
     timeline: timeline
     triage: triage
     vaccine: vaccine

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -716,6 +716,13 @@ en:
       title:
         flu: Give or refuse consent for a flu vaccination
         hpv: Give or refuse consent for an HPV vaccination
+  dashboard:
+    index:
+      notices:
+        header: Important notices
+        description:
+          one: "%{count} important notice needs attention"
+          other: "%{count} important notices need attention"
   draft_consents:
     agree:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -728,15 +728,11 @@ en:
   hosting_environment: This is a %{name} environment. Do not use it to make clinical decisions.
   imports:
     index:
-      title: Imports
-  import_issues:
-    index:
-      title: Import issues
-  notices:
-    index:
-      title: Important notices
-      title_short: Notices
-      no_results: There are currently no important notices.
+      title: Import records
+      title_short: Import
+    notices:
+      index:
+        no_results: There are currently no important notices.
   mailers:
     consent_form_mailer:
       reasons_for_refusal:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,14 +119,16 @@ Rails.application.routes.draw do
             path: "immunisation-imports",
             except: %i[index destroy]
 
-  resources :import_issues, path: "import-issues", only: %i[index] do
-    get ":type", action: :show, on: :member, as: ""
-    patch ":type", action: :update, on: :member
-  end
-
   resources :imports, only: %i[index new create]
 
-  resources :notices, only: :index
+  namespace :imports do
+    resources :issues, path: "issues", only: %i[index] do
+      get ":type", action: :show, on: :member, as: ""
+      patch ":type", action: :update, on: :member
+    end
+
+    resources :notices, only: :index
+  end
 
   resources :notifications, only: :create
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,10 +105,19 @@ Rails.application.routes.draw do
     end
   end
 
+  resource :draft_class_import,
+           only: :new,
+           path: "draft-class-import/:session_slug"
+  resource :draft_class_import,
+           only: %i[show update],
+           path: "draft-class-import/:id"
+
   resource :draft_consent, only: %i[show update], path: "draft-consent/:id"
+
   resource :draft_vaccination_record,
            only: %i[show update],
            path: "draft-vaccination-record/:id"
+
   resource :vaccination_report,
            only: %i[show update],
            path: "draft-vaccination-report/:id" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :class_imports, path: "class-imports", except: %i[index destroy]
+
   resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]
 
   resources :consent_forms, path: "consent-forms", only: %i[index show] do
@@ -218,8 +220,6 @@ Rails.application.routes.draw do
         post "setup-offline", to: "offline_passwords#create"
       end
     end
-
-    resources :class_imports, path: "class-imports", except: %i[index destroy]
 
     resource :dates, controller: "session_dates", only: %i[show update]
   end

--- a/spec/components/app_imports_table_component_spec.rb
+++ b/spec/components/app_imports_table_component_spec.rb
@@ -66,8 +66,8 @@ describe AppImportsTableComponent do
 
   it "renders the headers" do
     expect(rendered).to have_css(".nhsuk-table__header", text: "Imported on")
-    expect(rendered).to have_css(".nhsuk-table__header", text: "Imported by")
-    expect(rendered).to have_css(".nhsuk-table__header", text: "Import type")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Type")
+    expect(rendered).to have_css(".nhsuk-table__header", text: "Status")
     expect(rendered).to have_css(".nhsuk-table__header", text: "Records")
   end
 
@@ -86,9 +86,7 @@ describe AppImportsTableComponent do
       text: "Vaccination record"
     )
     expect(rendered).to have_css(".nhsuk-table__cell", text: "Class list")
-    expect(rendered).to have_css(".nhsuk-table__cell", text: "John Smith")
-    expect(rendered).to have_css(".nhsuk-table__cell", text: "Jennifer Smith")
-    expect(rendered).to have_css(".nhsuk-table__cell", text: "Jack Smith")
+    expect(rendered).to have_css(".nhsuk-table__cell", text: "Completed")
     expect(rendered).to have_css(".nhsuk-table__cell", text: "1")
     expect(rendered).to have_content("Test School")
   end

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -42,14 +42,14 @@ describe "Import child records" do
     when_i_click_on_the_cohort
     then_i_should_see_the_children
 
-    when_i_click_on_the_imports_tab
+    when_i_click_on_the_imports_page
     and_i_choose_to_import_child_records
     then_i_should_see_the_import_page
 
     travel_to 1.minute.from_now # to ensure the created_at is different for the import jobs
 
     when_i_upload_a_valid_file_with_changes
-    and_i_go_to_the_imports_page
+    and_i_go_to_the_import_page
     then_i_should_see_import_issues_with_the_count
   end
 
@@ -109,9 +109,8 @@ describe "Import child records" do
     expect(page).to have_content("Imported byTest User")
   end
 
-  def when_i_click_on_the_imports_tab
-    click_on "HPV"
-    click_on "Imports"
+  def when_i_click_on_the_imports_page
+    click_on "Import", match: :first
   end
 
   def then_i_should_see_the_import
@@ -218,8 +217,8 @@ describe "Import child records" do
     click_on "Continue"
   end
 
-  def and_i_go_to_the_imports_page
-    click_on "Imports"
+  def and_i_go_to_the_import_page
+    click_on "Import", match: :first
   end
 
   def then_i_should_see_import_issues_with_the_count

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -46,7 +46,7 @@ describe "Child record imports duplicates" do
     and_the_third_record_should_be_persisted
     and_a_new_patient_record_should_be_created
 
-    when_i_go_to_the_programme
+    when_i_go_to_the_import_page
     then_i_should_see_no_import_issues_with_the_count
   end
 
@@ -244,8 +244,8 @@ describe "Child record imports duplicates" do
     expect(page).to have_content("Year groupYear 7 (")
   end
 
-  def when_i_go_to_the_programme
-    click_link "HPV"
+  def when_i_go_to_the_import_page
+    click_link "Import", match: :first
   end
 
   def then_i_should_see_import_issues_with_the_count
@@ -256,13 +256,5 @@ describe "Child record imports duplicates" do
   def then_i_should_see_no_import_issues_with_the_count
     expect(page).to have_link("Import issues")
     expect(page).to have_selector(".app-count", text: "( 0 )")
-  end
-
-  def when_i_go_to_import_issues
-    click_link "Import issues"
-  end
-
-  def then_i_should_see_that_a_record_needs_review
-    expect(page).to have_content("1 imported record needs review")
   end
 end

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -78,7 +78,7 @@ describe "Import class lists - Moving patients" do
   end
 
   def and_i_start_adding_children_to_the_session
-    click_on "Import class list"
+    click_on "Import class list records"
   end
 
   def then_i_should_see_the_import_page
@@ -92,7 +92,7 @@ describe "Import class lists - Moving patients" do
   alias_method :and_i_upload_a_valid_file, :when_i_upload_a_valid_file
 
   def when_i_go_to_the_upload_page
-    click_on "Import class list"
+    click_on "Import class list records"
   end
 
   def then_i_should_see_the_import_complete_page

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -160,6 +160,12 @@ describe "Import class lists" do
 
   def when_i_go_back_to_the_upload_page
     click_on "Back"
+
+    # TODO: test flow via "Import records" radio selection
+    click_on "Sessions", match: :first
+    click_on "Unscheduled"
+    click_on "Waterloo Road"
+
     click_on "Import class list"
   end
 

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -67,7 +67,7 @@ describe "Import class lists" do
   end
 
   def and_i_start_adding_children_to_the_session
-    click_on "Import class list"
+    click_on "Import class list records"
   end
 
   def then_i_should_see_the_import_page
@@ -161,12 +161,12 @@ describe "Import class lists" do
   def when_i_go_back_to_the_upload_page
     click_on "Back"
 
-    # TODO: test flow via "Import records" radio selection
-    click_on "Sessions", match: :first
-    click_on "Unscheduled"
-    click_on "Waterloo Road"
+    click_on "Import records"
+    choose "Class list records"
+    click_on "Continue"
 
-    click_on "Import class list"
+    select "Waterloo Road"
+    click_on "Continue"
   end
 
   def then_i_should_see_the_imports_page_with_the_processing_flash

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -120,7 +120,7 @@ describe "Class list imports duplicates" do
   end
 
   def and_i_start_adding_children_to_the_session
-    click_on "Import class list"
+    click_on "Import class list records"
   end
 
   def and_i_upload_a_file_with_duplicate_records

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -31,7 +31,7 @@ describe "Immunisation imports duplicates" do
     then_i_should_see_a_success_message
     and_the_second_record_should_not_be_updated
 
-    when_i_go_to_the_programme
+    when_i_go_to_the_import_page
     then_i_should_see_no_import_issues_with_the_count
   end
 
@@ -251,8 +251,8 @@ describe "Immunisation imports duplicates" do
     expect(page).to have_content("Vaccination report")
   end
 
-  def when_i_go_to_the_programme
-    click_link "HPV"
+  def when_i_go_to_the_import_page
+    click_link "Import", match: :first
   end
 
   def then_i_should_see_import_issues_with_the_count
@@ -263,13 +263,5 @@ describe "Immunisation imports duplicates" do
   def then_i_should_see_no_import_issues_with_the_count
     expect(page).to have_link("Import issues")
     expect(page).to have_selector(".app-count", text: "( 0 )")
-  end
-
-  def when_i_go_to_import_issues
-    click_link "Import issues"
-  end
-
-  def then_i_should_see_that_a_record_needs_review
-    expect(page).to have_content("1 imported record needs review")
   end
 end

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -95,7 +95,7 @@ describe "Manage children" do
   end
 
   scenario "Viewing important notices" do
-    when_i_go_to_the_dashboard
+    when_i_go_to_the_imports_page
     then_i_cannot_see_notices
 
     when_i_go_to_the_notices_page
@@ -103,7 +103,7 @@ describe "Manage children" do
   end
 
   scenario "Viewing deceased patient notices as a superuser" do
-    when_i_go_to_the_dashboard_as_a_superuser
+    when_i_go_to_the_imports_page_as_a_superuser
     and_i_click_on_notices
     then_i_see_no_notices
 
@@ -113,7 +113,7 @@ describe "Manage children" do
   end
 
   scenario "Viewing invalidated patient notices as a superuser" do
-    when_i_go_to_the_dashboard_as_a_superuser
+    when_i_go_to_the_imports_page_as_a_superuser
     and_i_click_on_notices
     then_i_see_no_notices
 
@@ -123,7 +123,7 @@ describe "Manage children" do
   end
 
   scenario "Viewing restricted patient notices as a superuser" do
-    when_i_go_to_the_dashboard_as_a_superuser
+    when_i_go_to_the_imports_page_as_a_superuser
     and_i_click_on_notices
     then_i_see_no_notices
 
@@ -307,10 +307,16 @@ describe "Manage children" do
     visit "/dashboard"
   end
 
-  def when_i_go_to_the_dashboard_as_a_superuser
+  def when_i_go_to_the_imports_page
+    sign_in @organisation.users.first
+
+    visit "/imports"
+  end
+
+  def when_i_go_to_the_imports_page_as_a_superuser
     sign_in @organisation.users.first, superuser: true
 
-    visit "/dashboard"
+    visit "/imports"
   end
 
   def then_i_cannot_see_notices
@@ -318,7 +324,7 @@ describe "Manage children" do
   end
 
   def when_i_go_to_the_notices_page
-    visit "/notices"
+    visit "/imports/notices"
   end
 
   def then_i_see_permission_denied
@@ -326,7 +332,7 @@ describe "Manage children" do
   end
 
   def when_i_click_on_notices
-    click_on "Notices"
+    click_on "Important notices"
   end
 
   alias_method :and_i_click_on_notices, :when_i_click_on_notices
@@ -336,19 +342,19 @@ describe "Manage children" do
   end
 
   def then_i_see_the_notice_of_date_of_death
-    expect(page).to have_content("Notices (1)")
+    expect(page).to have_content("Important notices ( 1 )")
     expect(page).to have_content(@deceased_patient.full_name)
     expect(page).to have_content("Record updated with child’s date of death")
   end
 
   def then_i_see_the_notice_of_invalid
-    expect(page).to have_content("Notices (1)")
+    expect(page).to have_content("Important notices ( 1 )")
     expect(page).to have_content(@invalidated_patient.full_name)
     expect(page).to have_content("Record flagged as invalid")
   end
 
   def then_i_see_the_notice_of_sensitive
-    expect(page).to have_content("Notices (1)")
+    expect(page).to have_content("Important notices ( 1 )")
     expect(page).to have_content(@restricted_patient.full_name)
     expect(page).to have_content("Record flagged as sensitive")
   end


### PR DESCRIPTION
This updates the design of the imports page to move it to the global level as we have in the latest prototype. This is possible now that we have allowed imports to apply across multiple programmes at once.

This also adds a new page when importing a class list from the global import page to allow choosing the session that the user wishes to upload the file for.

## Screenshots

![Screenshot 2025-02-12 at 09 43 22](https://github.com/user-attachments/assets/c21c0168-c440-4f50-aba6-17bb202f8208)
![Screenshot 2025-02-12 at 09 43 27](https://github.com/user-attachments/assets/26a87e49-6221-409b-8bdd-dccff55b2100)
![Screenshot 2025-02-12 at 09 24 59](https://github.com/user-attachments/assets/523196d5-7c52-4c47-abbf-2bb2fdc71d77)
![Screenshot 2025-02-12 at 09 26 04](https://github.com/user-attachments/assets/b29796da-d702-4b3d-bcef-e55ceea5936f)
![Screenshot 2025-02-12 at 09 26 50](https://github.com/user-attachments/assets/94f458b4-f52c-4ea8-96f0-ebfb53ad2e0c)
<img width="1176" alt="Screenshot 2025-02-13 at 14 20 08" src="https://github.com/user-attachments/assets/16f550a5-91f0-433b-b8b6-b9cf636bdac8" />
