### PR TITLE
Add Td/IPV and MenACWY programmes

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -37,13 +37,20 @@ class Programme < ApplicationRecord
 
   has_many :active_vaccines, -> { active }, class_name: "Vaccine"
 
-  enum :type, { flu: "flu", hpv: "hpv" }, validate: true
+  enum :type,
+       { flu: "flu", hpv: "hpv", menacwy: "menacwy", td_ipv: "td_ipv" },
+       validate: true
 
   def name
     human_enum_name(:type)
   end
 
-  YEAR_GROUPS_BY_TYPE = { "flu" => (0..11).to_a, "hpv" => (8..11).to_a }.freeze
+  YEAR_GROUPS_BY_TYPE = {
+    "flu" => (0..11).to_a,
+    "hpv" => (8..11).to_a,
+    "menacwy" => (9..11).to_a,
+    "td_ipv" => (9..11).to_a
+  }.freeze
 
   def year_groups
     YEAR_GROUPS_BY_TYPE.fetch(type)
@@ -54,8 +61,10 @@ class Programme < ApplicationRecord
   end
 
   SNOMED_PROCEDURE_CODES = {
+    "flu" => "822851000000102",
     "hpv" => "761841000",
-    "flu" => "822851000000102"
+    "menacwy" => "871874000",
+    "td_ipv" => "866186002"
   }.freeze
 
   def snomed_procedure_code
@@ -63,9 +72,17 @@ class Programme < ApplicationRecord
   end
 
   SNOMED_PROCEDURE_TERMS = {
+    "flu" => "Seasonal influenza vaccination (procedure)",
     "hpv" =>
-      "Administration of vaccine product containing only Human papillomavirus antigen (procedure)",
-    "flu" => "Seasonal influenza vaccination (procedure)"
+      "Administration of vaccine product containing only Human " \
+        "papillomavirus antigen (procedure)",
+    "menacwy" =>
+      "Administration of vaccine product containing only Neisseria " \
+        "meningitidis serogroup A, C, W135 and Y antigens (procedure)",
+    "td_ipv" =>
+      "Administration of vaccine product containing only Clostridium " \
+        "tetani and Corynebacterium diphtheriae and Human poliovirus " \
+        "antigens (procedure)"
   }.freeze
 
   def snomed_procedure_term

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -65,8 +65,15 @@ class Vaccine < ApplicationRecord
     end
   end
 
+  MAXIMUM_DOSE_SEQUENCE_BY_TYPE = {
+    "flu" => 1,
+    "hpv" => 3,
+    "menacwy" => 1,
+    "td_ipv" => 1
+  }.freeze
+
   def maximum_dose_sequence
-    { "flu" => 1, "hpv" => 3 }.fetch(programme.type)
+    MAXIMUM_DOSE_SEQUENCE_BY_TYPE.fetch(programme.type)
   end
 
   def seasonal?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -381,6 +381,8 @@ en:
         types:
           flu: Flu
           hpv: HPV
+          menacwy: MenACWY
+          td_ipv: Td/IPV
       school_move:
         sources:
           class_list_import: Class list

--- a/spec/factories/programmes.rb
+++ b/spec/factories/programmes.rb
@@ -15,7 +15,7 @@
 #
 FactoryBot.define do
   factory :programme do
-    type { %w[flu hpv].sample }
+    type { Programme.types.keys.sample }
     vaccines { [association(:vaccine, programme: instance)] }
 
     trait :hpv do

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -38,7 +38,7 @@ describe ClassImport do
     create(:class_import, csv:, session:, organisation:)
   end
 
-  let(:programme) { create(:programme) }
+  let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:location) { create(:school, organisation:) }
   let(:session) { create(:session, location:, programme:, organisation:) }


### PR DESCRIPTION
This adds the two new programme types needed for doubles and updates the various parts of the code that rely on the programme type to work for Td/IPV and MenACWY.

In a future commit we'll need to add the vaccines for these two programmes, and then the health questions.