### PR TITLE
Add Td/IPV and MenACWY vaccines

### DIFF
--- a/config/vaccines.yml
+++ b/config/vaccines.yml
@@ -47,6 +47,16 @@ gardasil:
     Gardasil vaccine suspension for injection 0.5ml pre-filled
     syringes (Merck Sharp & Dohme (UK) Ltd) (product)
 
+menquadfi:
+  brand: MenQuadfi
+  type: menacwy
+  method: injection
+  manufacturer: Sanofi
+  nivs_name: MenQuadfi
+  dose_volume_ml: 0.5
+  snomed_product_code: 39779611000001104
+  snomed_product_term: MenQuadfi vaccine solution for injection 0.5ml vials (Sanofi) (product)
+
 quadrivalent_influvac_tetra:
   brand: Quadrivalent Influvac sub-unit Tetra - QIVe
   type: flu
@@ -58,6 +68,18 @@ quadrivalent_influvac_tetra:
   snomed_product_term:
     Influvac sub-unit Tetra vaccine suspension for injection 0.5ml
     pre-filled syringes (Viatris UK Healthcare Ltd) (product)
+
+revaxis:
+  brand: Revaxis
+  type: td_ipv
+  method: injection
+  manufacturer: Sanofi
+  nivs_name: Revaxis
+  dose_volume_ml: 0.5
+  snomed_product_code: 7374511000001107
+  snomed_product_term:
+    Revaxis vaccine suspension for injection 0.5ml pre-filled syringes
+    (Sanofi) 1 pre-filled disposable injection (product)
 
 supemtek:
   brand: Supemtek - QIVr

--- a/spec/factories/programmes.rb
+++ b/spec/factories/programmes.rb
@@ -76,5 +76,15 @@ FactoryBot.define do
       flu
       vaccines { [association(:vaccine, :fluenz_tetra, programme: instance)] }
     end
+
+    trait :menacwy do
+      type { "menacwy" }
+      vaccines { [association(:vaccine, :menquadfi, programme: instance)] }
+    end
+
+    trait :td_ipv do
+      type { "td_ipv" }
+      vaccines { [association(:vaccine, :revaxis, programme: instance)] }
+    end
   end
 end

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -31,7 +31,7 @@
 #
 FactoryBot.define do
   factory :vaccine do
-    transient { type { %w[flu hpv].sample } }
+    transient { type { Programme.types.keys.sample } }
 
     programme { association :programme, type: }
 


### PR DESCRIPTION
This adds the vaccines suitable for the doubles programmes (Td/IPV and MenACWY). This will need to be followed up with adding the health questions suitable for the vaccines.
