### PR TITLE
Filter vaccination records by programme

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -49,7 +49,7 @@ class AppActivityLogComponent < ViewComponent::Base
     @triages = @patient.triages.includes(:performed_by)
 
     @vaccination_records =
-      (patient || patient_session).vaccination_records.with_discarded.includes(
+      @patient.vaccination_records.with_discarded.includes(
         :performed_by_user,
         :programme,
         :vaccine

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -49,9 +49,8 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   def vaccination_record
     @vaccination_record ||=
       @patient_session
-        .vaccination_records
-        .select { it.programme_id == programme.id }
-        .tap { it.select(&:administered?) if @patient_session.vaccinated? }
+        .vaccination_records(programme:)
+        .then { @patient_session.vaccinated? ? it.select(&:administered?) : it }
         .last
   end
 

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -97,7 +97,7 @@
   <% end %>
 <% end %>
 
-<% patient_session.vaccination_records.each do |vaccination_record| %>
+<% patient_session.vaccination_records(programme:).each do |vaccination_record| %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Vaccination details" } %>
     <%= render AppVaccinationRecordSummaryComponent.new(vaccination_record, current_user:) %>

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -26,9 +26,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   def nurse
     (
       @patient_session.triages(programme:) +
-        @patient_session.vaccination_records.select do
-          it.programme_id == programme.id
-        end
+        @patient_session.vaccination_records(programme:)
     ).max_by(&:updated_at)&.performed_by&.full_name
   end
 

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -28,10 +28,10 @@ class PatientSessionsController < ApplicationController
           patient: {
             consents: %i[parent],
             parent_relationships: :parent,
-            triages: :performed_by
-          },
-          vaccination_records: {
-            vaccine: :programme
+            triages: :performed_by,
+            vaccination_records: {
+              vaccine: :programme
+            }
           }
         )
         .find_by!(

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -59,7 +59,7 @@ class PatientsController < ApplicationController
       if organisation_id.nil?
         @patient
           .patient_sessions
-          .includes(:session_attendances)
+          .includes(:programmes, :session_attendances)
           .where(session: old_organisation.sessions)
           .find_each(&:destroy_if_safe!)
       end

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -45,7 +45,7 @@ class SessionAttendancesController < ApplicationController
     @patient_session =
       policy_scope(PatientSession)
         .eager_load(:patient, :session)
-        .preload(:vaccination_records, patient: %i[consents triages])
+        .preload(patient: %i[consents triages vaccination_records])
         .find_by!(
           session: {
             slug: params.fetch(:session_slug)
@@ -75,7 +75,7 @@ class SessionAttendancesController < ApplicationController
     @session_attendance =
       authorize @patient_session
                   .session_attendances
-                  .includes(:session_date)
+                  .includes(:patient, :session_date)
                   .find_or_initialize_by(session_date: @session_date)
   end
 

--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -11,8 +11,7 @@ class ClinicSessionInvitationsJob < ApplicationJob
           :programmes,
           patient_sessions: [
             :session_notifications,
-            :vaccination_records,
-            { patient: %i[consents parents] }
+            { patient: %i[consents parents vaccination_records] }
           ]
         )
         .preload(:session_dates)

--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -74,6 +74,7 @@ class Reports::CareplusExporter
         .patient_sessions
         .includes(
           :location,
+          :programmes,
           patient: [
             :school,
             :vaccination_records,
@@ -114,11 +115,17 @@ class Reports::CareplusExporter
 
   def rows(patient_session:)
     patient = patient_session.patient
-    vaccination_records =
-      patient_session.vaccination_records.administered.order(:performed_at)
 
-    if vaccination_records.any?
-      [existing_row(patient:, patient_session:, vaccination_records:)]
+    patient_session.programmes.filter_map do |programme|
+      vaccination_records =
+        patient_session.vaccination_records(
+          programme:,
+          for_session: true
+        ).select(&:administered?)
+
+      if vaccination_records.any?
+        existing_row(patient:, patient_session:, vaccination_records:)
+      end
     end
   end
 

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -129,19 +129,18 @@ module PatientSessionStatusConcern
     end
 
     def vaccination_administered?
-      vaccination_records.any?(&:administered?)
+      programme = programmes.first # TODO: handle multiple programmes
+      vaccination_records(programme:).any?(&:administered?)
     end
 
     def vaccination_not_administered?
-      vaccination_records.any?(&:not_administered?)
+      programme = programmes.first # TODO: handle multiple programmes
+      vaccination_records(programme:).any?(&:not_administered?)
     end
 
     def vaccination_can_be_delayed?
-      programme_id = programmes.first.id # TODO: handle multiple programmes
-      if (
-           vaccination_record =
-             vaccination_records.select { it.programme_id == programme_id }.last
-         )
+      programme = programmes.first # TODO: handle multiple programmes
+      if (vaccination_record = vaccination_records(programme:).last)
         vaccination_record.not_administered? &&
           vaccination_record.retryable_reason?
       end

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -124,9 +124,10 @@ class ImmunisationImport < ApplicationRecord
       patient = row.patient
 
       next unless patient.vaccinated?(row.programme)
+
       patient
         .patient_sessions
-        .includes(:session_attendances)
+        .includes(:programmes, :session_attendances)
         .where(session: organisation.sessions.upcoming)
         .find_each(&:destroy_if_safe!)
     end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -44,7 +44,6 @@ class Organisation < ApplicationRecord
   has_many :programmes, through: :organisation_programmes
   has_many :schools, through: :teams
   has_many :vaccines, through: :programmes
-  has_many :vaccination_records, through: :patient_sessions
 
   has_and_belongs_to_many :users
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -67,15 +67,15 @@ class Patient < ApplicationRecord
 
   has_many :access_log_entries
   has_many :consent_notifications
-  has_many :consents
+  has_many :consents, -> { order(:created_at) }
   has_many :notify_log_entries
   has_many :parent_relationships
   has_many :patient_sessions
   has_many :school_move_log_entries
   has_many :school_moves
   has_many :session_notifications
-  has_many :triages
-  has_many :vaccination_records, -> { kept }
+  has_many :triages, -> { order(:created_at) }
+  has_many :vaccination_records, -> { kept.order(:performed_at) }
 
   has_many :parents, through: :parent_relationships
   has_many :gillick_assessments,
@@ -398,9 +398,10 @@ class Patient < ApplicationRecord
   def clear_upcoming_sessions
     patient_sessions
       .includes(
+        :programmes,
         :gillick_assessments,
         :session_attendances,
-        :vaccination_records
+        patient: :vaccination_records
       )
       .where(session: upcoming_sessions)
       .find_each(&:destroy_if_safe!)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -35,7 +35,7 @@ class Session < ApplicationRecord
   has_many :patient_sessions
   has_many :session_dates, -> { order(:value) }
   has_many :session_notifications
-  has_many :vaccination_records
+  has_many :vaccination_records, -> { kept }
 
   has_and_belongs_to_many :immunisation_imports
   has_and_belongs_to_many :programmes

--- a/app/policies/session_attendance_policy.rb
+++ b/app/policies/session_attendance_policy.rb
@@ -11,10 +11,10 @@ class SessionAttendancePolicy < ApplicationPolicy
 
   private
 
-  delegate :patient_session, :session_date, to: :record
+  delegate :patient, :session_date, to: :record
 
   def was_seen_by_nurse?
-    patient_session
+    patient
       .vaccination_records
       .where(performed_at: session_date.value.all_day)
       .exists?

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -10,6 +10,7 @@ describe AppSimpleStatusBannerComponent do
     stub_authorization(allowed: true)
 
     patient_session.strict_loading!(false)
+    patient_session.patient.strict_loading!(false)
   end
 
   let(:user) { create(:user) }
@@ -22,7 +23,7 @@ describe AppSimpleStatusBannerComponent do
     patient_session.triages(programme:).last.performed_by.full_name
   end
   let(:vaccination_nurse_name) do
-    patient_session.vaccination_records.last.performed_by.full_name
+    patient_session.vaccination_records(programme:).last.performed_by.full_name
   end
   let(:patient_name) { patient_session.patient.full_name }
 

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -29,13 +29,6 @@ describe PatientSession do
 
   it { should have_many(:gillick_assessments).order(:created_at) }
 
-  it do
-    expect(patient_session).to have_many(:vaccination_records)
-      .through(:patient)
-      .conditions(discarded_at: nil, session_id: patient_session.session_id)
-      .order(:created_at)
-  end
-
   describe "#triages" do
     subject(:triages) { patient_session.triages(programme:) }
 
@@ -82,6 +75,20 @@ describe PatientSession do
     end
 
     it { should eq(later_triage) }
+  end
+
+  describe "#vaccination_records" do
+    subject(:vaccination_records) do
+      patient_session.vaccination_records(programme:)
+    end
+
+    let(:patient) { patient_session.patient }
+    let(:later_record) { create(:vaccination_record, programme:, patient:) }
+    let(:earlier_record) do
+      create(:vaccination_record, programme:, patient:, performed_at: 1.day.ago)
+    end
+
+    it { should eq([earlier_record, later_record]) }
   end
 
   describe "#no_consent?" do


### PR DESCRIPTION
This follows up on #2939 to ensure that vaccination records are filtered by the current programme. At the moment this is the first programme administered in a session but in the future this will come from a selection by the user.

At the same time, this also fixes a bug where vaccination records administered outside of the current session weren't shown on a patient's record. Now we show all vaccination records for a particular patient.

[Trello Card](https://trello.com/c/cfPtR6Am/2000-if-a-child-is-added-to-a-clinic-and-vaccinated-in-school-you-cant-see-in-the-clinic-area-that-they-are-already-vaccinated)