### PR TITLE
Search globally for patients when merging

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -95,6 +95,13 @@ class PatientMerger
       patient_to_destroy.cohort_imports.clear
       patient_to_destroy.immunisation_imports.clear
 
+      # Add patient back to the cohort if the patient to destroy was in the cohort.
+      if patient_to_keep.organisation_id.nil?
+        patient_to_keep.update!(
+          organisation_id: patient_to_destroy.organisation_id
+        )
+      end
+
       patient_to_destroy.reload.destroy!
     end
   end

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -184,5 +184,22 @@ describe PatientMerger do
         )
       end
     end
+
+    it "doesn't change the cohort" do
+      expect { call }.not_to(change { patient_to_keep.reload.organisation })
+    end
+
+    context "if the patient to keep is not in the cohort" do
+      let(:organisation) { create(:organisation) }
+
+      let(:patient_to_keep) { create(:patient, organisation: nil) }
+      let(:patient_to_destroy) { create(:patient, organisation:) }
+
+      it "adds the patient back in to the cohort" do
+        expect { call }.to change { patient_to_keep.reload.organisation }.to(
+          organisation
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This prevents a bug where a user cannot be merged with a patient that has been moved out of the cohort as they can't be found by the policy scope.

To support this, we've slightly updated the logic around the patient merging to move the patient back in to the cohort if they are not currently part of any cohort as this is likely to be the expected behaviour.

There is an outstanding question about what happens if we're merging two patients from two different organisation's cohorts, it's unclear which organisation's cohort the merged patient should belong to.

[Trello Card](https://trello.com/c/LIFt9GVO/1821-for-some-patients-when-you-try-to-add-an-nhs-number-to-a-duplicate-record-so-that-you-can-merge-them-you-get-an-error-saying-nhs)