### PR TITLE
Restrict editing vaccination records

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -22,13 +22,15 @@ class DraftVaccinationRecordsController < ApplicationController
   after_action :verify_authorized
 
   def show
-    authorize VaccinationRecord, :edit?
+    authorize @vaccination_record,
+              @vaccination_record.new_record? ? :new? : :edit?
 
     render_wizard
   end
 
   def update
-    authorize VaccinationRecord
+    authorize @vaccination_record,
+              @vaccination_record.new_record? ? :create? : :update?
 
     @draft_vaccination_record.assign_attributes(update_params)
 

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -10,7 +10,8 @@ class VaccinationRecordPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.is_nurse?
+    user.is_nurse? && record.session_id.present? &&
+      record.performed_ods_code == user.selected_organisation.ods_code
   end
 
   def update?

--- a/spec/policies/vaccination_record_policy_spec.rb
+++ b/spec/policies/vaccination_record_policy_spec.rb
@@ -3,6 +3,45 @@
 describe VaccinationRecordPolicy do
   subject(:policy) { described_class.new(user, vaccination_record) }
 
+  describe "update?" do
+    subject(:update?) { policy.update? }
+
+    let(:programme) { create(:programme) }
+    let(:organisation) { create(:organisation, programmes: [programme]) }
+
+    let(:vaccination_record) { create(:vaccination_record, programme:) }
+
+    context "with an admin" do
+      let(:user) { build(:admin, organisations: [organisation]) }
+
+      it { should be(false) }
+
+      context "when vaccination record is managed by the organisation" do
+        let(:session) { create(:session, organisation:, programme:) }
+        let(:vaccination_record) do
+          create(:vaccination_record, organisation:, programme:, session:)
+        end
+
+        it { should be(false) }
+      end
+    end
+
+    context "with a nurse" do
+      let(:user) { build(:nurse, organisations: [organisation]) }
+
+      it { should be(false) }
+
+      context "when vaccination record is managed by the organisation" do
+        let(:session) { create(:session, organisation:, programme:) }
+        let(:vaccination_record) do
+          create(:vaccination_record, organisation:, programme:, session:)
+        end
+
+        it { should be(true) }
+      end
+    end
+  end
+
   describe "destroy?" do
     subject(:destroy?) { policy.destroy? }
 


### PR DESCRIPTION
To vaccination records that are associated with a session (i.e. managed within Mavis and not historical) and were performed by the current organisation.