### PR TITLE
Don't move patients to clinic if consent is refused

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -66,7 +66,8 @@ class SessionsController < ApplicationController
   end
 
   def edit_close
-    @unvaccinated_patients_count = @session.unvaccinated_patients.length
+    @patients_to_move_to_clinic_count =
+      @session.patients_to_move_to_clinic.length
 
     render :close
   end

--- a/app/views/sessions/close.html.erb
+++ b/app/views/sessions/close.html.erb
@@ -9,12 +9,12 @@
 
 <p class="nhsuk-body">All sessions for this school have been completed.</p>
 
-<% if @unvaccinated_patients_count > 0 %>
+<% if @patients_to_move_to_clinic_count > 0 %>
   <p class="nhsuk-body">When you close this session, the following children will be invited to community clinics:</p>
 
   <ul class="nhsuk-list nhsuk-list--bullet">
     <li>
-      <%= t("children", count: @unvaccinated_patients_count) %> who could not be vaccinated
+      <%= t("children", count: @patients_to_move_to_clinic_count) %> who could not be vaccinated
     </li>
   </ul>
 <% end %>


### PR DESCRIPTION
When closing a school session, we move all unvaccinated patients to the clinic so they can be vaccinated outside the school. However, if the parents have refused consent for the patient to be vaccinated in school, we don't want to move them to the clinic.

[Trello Card](https://trello.com/c/OOVetSlY/1918-children-with-consent-refused-being-mistakenly-proposed-to-move-to-community-clinic-when-closing-session)