### PR TITLE
Avoid double ORGANISATION_CODE errors

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -65,7 +65,9 @@ class ImmunisationImportRow
             }
 
   validates :performed_ods_code,
-            presence: true,
+            presence: {
+              unless: :outcome_in_this_academic_year?
+            },
             comparison: {
               equal_to: :organisation_ods_code,
               if: :outcome_in_this_academic_year?

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -289,6 +289,19 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "vaccination in this academic year and no organisation provided" do
+      let(:data) do
+        { "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901" }
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:performed_ods_code]).to eq(
+          ["Enter an organisation code."]
+        )
+      end
+    end
+
     context "vaccination in this academic year, no vaccinator details provided" do
       let(:data) do
         valid_data.except(


### PR DESCRIPTION
When validating an immunisation import row we only need to check for presence if we're not already checking the value is equal to the current organisation, as that check already checks for the presence of the value.