### PR TITLE
Update environment banner for Heroku review apps

### DIFF
--- a/app/components/app_hosting_environment_component.rb
+++ b/app/components/app_hosting_environment_component.rb
@@ -18,14 +18,18 @@ class AppHostingEnvironmentComponent < ViewComponent::Base
 
   ENVIRONMENT_COLOR = {
     development: "white",
+    review: "purple",
     test: "red",
     qa: "orange",
-    preview: "yellow",
-    training: "purple"
+    preview: "yellow"
   }.freeze
 
+  def pull_request
+    ENV.fetch("HEROKU_PR_NUMBER", false)
+  end
+
   def title
-    environment.titleize
+    pull_request ? "PR #{pull_request}" : environment.titleize
   end
 
   def name
@@ -39,6 +43,6 @@ class AppHostingEnvironmentComponent < ViewComponent::Base
   end
 
   def environment
-    ENV.fetch("SENTRY_ENVIRONMENT", "development")
+    pull_request ? "review" : ENV.fetch("SENTRY_ENVIRONMENT", "development")
   end
 end


### PR DESCRIPTION
- Use purple banner for Heroku review apps (training environment doesn’t show a banner as its a production environment so we can reassign this colour)
- Show PR number in tag text for Heroku review apps

<img width="600" alt="Screenshot of updated banner." src="https://github.com/user-attachments/assets/500f1139-0e2f-44ad-ac1c-30074ba75c1b" />

