### PR TITLE
Add patient to sessions when importing vaccinations

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -166,6 +166,12 @@ class ImmunisationImportRow
     vaccination_record
   end
 
+  def to_patient_session
+    return if patient.nil? || session.nil?
+
+    PatientSession.new(patient:, session:)
+  end
+
   def patient
     return unless valid?
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -137,6 +137,7 @@ describe ImmunisationImport do
           .and change(immunisation_import.vaccination_records, :count).by(11)
           .and change(immunisation_import.patients, :count).by(11)
           .and change(immunisation_import.batches, :count).by(4)
+          .and not_change(immunisation_import.patient_sessions, :count)
 
         # Second import should not duplicate the vaccination records if they're
         # identical.
@@ -177,6 +178,23 @@ describe ImmunisationImport do
           .times
           .on_queue(:imports)
       end
+
+      it "adds patients to the session if it exists" do
+        # must match a session in valid_flu.csv
+        location = Location.school.find_by!(urn: "120026")
+        create(
+          :session,
+          location:,
+          organisation:,
+          programme:,
+          date: Date.new(2024, 5, 14)
+        )
+
+        expect { process! }.to change(
+          immunisation_import.patient_sessions,
+          :count
+        ).by(8)
+      end
     end
 
     context "with valid HPV rows" do
@@ -190,6 +208,7 @@ describe ImmunisationImport do
           .and change(immunisation_import.vaccination_records, :count).by(11)
           .and change(immunisation_import.patients, :count).by(10)
           .and change(immunisation_import.batches, :count).by(9)
+          .and not_change(immunisation_import.patient_sessions, :count)
 
         # Second import should not duplicate the vaccination records if they're
         # identical.
@@ -229,6 +248,23 @@ describe ImmunisationImport do
           .exactly(9)
           .times
           .on_queue(:imports)
+      end
+
+      it "adds patients to the session if it exists" do
+        # must match a session in valid_hpv.csv
+        location = Location.school.find_by!(urn: "110158")
+        create(
+          :session,
+          location:,
+          organisation:,
+          programme:,
+          date: Date.new(2024, 5, 14)
+        )
+
+        expect { process! }.to change(
+          immunisation_import.patient_sessions,
+          :count
+        ).by(6)
       end
     end
 


### PR DESCRIPTION
This fixes a regression that was added in a01aa7f5632344c45f0d517d3184bd9466faa7d2 which meant that when importing vaccination records for the current academic year (where a session must exist) we weren't adding the patients to that session if they weren't already in the session.

Although the data model allows patients to be vaccinated and doesn't require them to be in the session at that point in time, in this case it's important that the patients are visible in the session so their status is represented accurately.