### PR TITLE
Filter programme stats by programme

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -18,9 +18,13 @@ class ProgrammesController < ApplicationController
     patients = policy_scope(Patient).in_programme(@programme)
 
     @patients_count = patients.count
-    @vaccinations_count = policy_scope(VaccinationRecord).count
+    @vaccinations_count =
+      policy_scope(VaccinationRecord).where(programme: @programme).count
     @consent_notifications_count =
-      @programme.consent_notifications.where(patient: patients).count
+      @programme
+        .consent_notifications
+        .where(patient: patients, programme: @programme)
+        .count
     @consents =
       policy_scope(Consent).where(patient: patients, programme: @programme)
   end

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -33,7 +33,7 @@
 
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccinations</span>
-            <%= policy_scope(VaccinationRecord).count %>
+            <%= policy_scope(VaccinationRecord).where(programme:).count %>
           <% end %>
         <% end %>
       <% end %>


### PR DESCRIPTION
When displaying the stats for a programme, we should ensure that the query is filtered by the programme to make sure the right numbers are shown.