### PR TITLE
Use programme to generate patient session status

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -1,6 +1,6 @@
 <%= render AppConsentStatusComponent.new(patient_session:, programme:) %>
 
-<% if patient_session.no_consent? %>
+<% if patient_session.no_consent?(programme:) %>
   <% if latest_consent_request %>
     <p class="nhsuk-body">
       No-one responded to our requests for consent.

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -30,7 +30,7 @@ class AppConsentComponent < ViewComponent::Base
   end
 
   def can_send_consent_request?
-    patient_session.no_consent? && patient.send_notifications? &&
+    patient_session.no_consent?(programme:) && patient.send_notifications? &&
       session.open_for_consent? && patient.parents.any?
   end
 

--- a/app/components/app_consent_status_component.rb
+++ b/app/components/app_consent_status_component.rb
@@ -1,16 +1,6 @@
 # frozen_string_literal: true
 
 class AppConsentStatusComponent < ViewComponent::Base
-  def call
-    if @patient_session.consent_given?
-      icon_tick "Consent given", "aqua-green"
-    elsif @patient_session.consent_refused?
-      icon_cross "Consent refused", "red"
-    elsif @patient_session.consent_conflicts?
-      icon_cross "Conflicting consent", "dark-orange"
-    end
-  end
-
   def initialize(patient_session:, programme:)
     super
 
@@ -18,7 +8,19 @@ class AppConsentStatusComponent < ViewComponent::Base
     @programme = programme
   end
 
+  def call
+    if @patient_session.consent_given?(programme:)
+      icon_tick "Consent given", "aqua-green"
+    elsif @patient_session.consent_refused?(programme:)
+      icon_cross "Consent refused", "red"
+    elsif @patient_session.consent_conflicts?(programme:)
+      icon_cross "Conflicting consent", "dark-orange"
+    end
+  end
+
   private
+
+  attr_reader :programme
 
   def icon_tick(content, color)
     template = <<-ERB

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -1,7 +1,7 @@
-<%= if patient_session.status.in? %w[
-                                   vaccinated
-                                   unable_to_vaccinate
-                                 ]
+<%= if patient_session.status(programme:).in? %w[
+                                               vaccinated
+                                               unable_to_vaccinate
+                                             ]
      render AppOutcomeBannerComponent.new(
        patient_session:,
        programme:,
@@ -81,7 +81,7 @@
   <% end %>
 <% end %>
 
-<% if helpers.policy(Triage).create? && patient_session.next_step == :triage && patient_session.session.open? %>
+<% if helpers.policy(Triage).create? && patient_session.next_step(programme:) == :triage && patient_session.session.open? %>
   <%= render AppCardComponent.new do %>
     <%= render AppTriageFormComponent.new(
           patient_session:,

--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AppProgrammeSessionTableComponent < ViewComponent::Base
-  def initialize(sessions)
+  def initialize(sessions, programme:)
     super
 
     @sessions = sessions
@@ -10,6 +10,7 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
       sessions.index_with do |session|
         PatientSessionStats.new(
           session.patient_sessions,
+          programme:,
           keys: %i[without_a_response needing_triage vaccinated]
         ).to_h
       end

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -8,7 +8,9 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
     @programme = programme
   end
 
-  delegate :status, to: :@patient_session
+  def status
+    @status ||= @patient_session.status(programme:)
+  end
 
   private
 

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -12,7 +12,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def render?
-    patient_session.next_step == :vaccinate && session.open? &&
+    patient_session.next_step(programme:) == :vaccinate && session.open? &&
       (patient_session.attending_today? || false)
   end
 

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -38,14 +38,19 @@ module TriageMailerConcern
   private
 
   def vaccination_will_happen?(patient_session, consent)
-    consent.triage_needed? && patient_session.triaged_ready_to_vaccinate?
+    programme = consent.programme
+    consent.triage_needed? &&
+      patient_session.triaged_ready_to_vaccinate?(programme:)
   end
 
   def vaccination_wont_happen?(patient_session, consent)
-    consent.triage_needed? && patient_session.triaged_do_not_vaccinate?
+    programme = consent.programme
+    consent.triage_needed? &&
+      patient_session.triaged_do_not_vaccinate?(programme:)
   end
 
   def vaccination_at_clinic?(patient_session, consent)
-    consent.triage_needed? && patient_session.delay_vaccination?
+    programme = consent.programme
+    consent.triage_needed? && patient_session.delay_vaccination?(programme:)
   end
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -22,9 +22,12 @@ class ConsentsController < ApplicationController
         .eager_load(:patient)
         .order_by_name
 
+    @programme = @session.programmes.first # TODO: handle multiple programmes
+
     tab_patient_sessions =
       group_patient_sessions_by_conditions(
         all_patient_sessions,
+        programme: @programme,
         section: :consents
       )
 
@@ -55,17 +58,17 @@ class ConsentsController < ApplicationController
   end
 
   def send_request
-    return unless @patient_session.no_consent?
+    programme = @session.programmes.first # TODO: handle multiple programmes
 
-    @session.programmes.each do |programme|
-      ConsentNotification.create_and_send!(
-        patient: @patient,
-        programme:,
-        session: @session,
-        type: :request,
-        current_user:
-      )
-    end
+    return unless @patient_session.no_consent?(programme:)
+
+    ConsentNotification.create_and_send!(
+      patient: @patient,
+      programme:,
+      session: @session,
+      type: :request,
+      current_user:
+    )
 
     redirect_to session_patient_path(
                   @session,

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -26,7 +26,9 @@ class RegisterAttendancesController < ApplicationController
     name = @patient.full_name
 
     flash[:info] = if session_attendance.attending?
-      t("attendance_flash.#{@patient_session.status}", name:)
+      programme = @patient_session.programmes.first # TODO: handle multiple programmes
+      status = @patient_session.status(programme:)
+      t("attendance_flash.#{status}", name:)
     else
       t("attendance_flash.absent", name:)
     end

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -26,7 +26,9 @@ class SessionAttendancesController < ApplicationController
       name = @patient.full_name
 
       flash[:info] = if @session_attendance.attending?
-        t("attendance_flash.#{@patient_session.status}", name:)
+        programme = @patient_session.programmes.first # TODO: handle multiple programmes
+        status = @patient_session.status(programme:)
+        t("attendance_flash.#{status}", name:)
       elsif @session_attendance.attending.nil?
         t("attendance_flash.not_registered", name:)
       else
@@ -45,7 +47,7 @@ class SessionAttendancesController < ApplicationController
     @patient_session =
       policy_scope(PatientSession)
         .eager_load(:patient, :session)
-        .preload(patient: %i[consents triages vaccination_records])
+        .preload(:programmes, patient: %i[consents triages vaccination_records])
         .find_by!(
           session: {
             slug: params.fetch(:session_slug)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,7 +39,8 @@ class SessionsController < ApplicationController
       format.html do
         patient_sessions = @session.patient_sessions.preload_for_status
 
-        @stats = PatientSessionStats.new(patient_sessions)
+        programme = @session.programmes.first # TODO: handle multiple programmes
+        @stats = PatientSessionStats.new(patient_sessions, programme:)
 
         render layout: "full"
       end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -22,9 +22,15 @@ class TriagesController < ApplicationController
         .eager_load(:patient)
         .order_by_name
 
+    programme = @session.programmes.first # TODO: handle multiple programmes
+
     @current_tab = TAB_PATHS[:triage][params[:tab]]
     tab_patient_sessions =
-      group_patient_sessions_by_state(all_patient_sessions, section: :triage)
+      group_patient_sessions_by_state(
+        all_patient_sessions,
+        programme,
+        section: :triage
+      )
     @tab_counts = count_patient_sessions(tab_patient_sessions)
     @patient_sessions = tab_patient_sessions[@current_tab] || []
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -27,9 +27,12 @@ class VaccinationsController < ApplicationController
         .eager_load(:patient)
         .order_by_name
 
+    programme = @session.programmes.first # TODO: handle multiple programmes
+
     grouped_patient_sessions =
       group_patient_sessions_by_state(
         all_patient_sessions,
+        programme,
         section: :vaccinations
       )
 

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -10,6 +10,7 @@ class SchoolSessionRemindersJob < ApplicationJob
       PatientSession
         .includes(
           :gillick_assessments,
+          :programmes,
           patient: [
             :parents,
             :triages,
@@ -37,9 +38,18 @@ class SchoolSessionRemindersJob < ApplicationJob
   def should_send_notification?(patient_session:)
     return false unless patient_session.send_notifications?
 
-    return false if patient_session.vaccination_administered?
+    programmes = patient_session.programmes
 
-    patient_session.consent_given_triage_not_needed? ||
-      patient_session.triaged_ready_to_vaccinate?
+    all_vaccinated =
+      programmes.all? do |programme|
+        patient_session.vaccination_administered?(programme:)
+      end
+
+    return false if all_vaccinated
+
+    programmes.any? do |programme|
+      patient_session.consent_given_triage_not_needed?(programme:) ||
+        patient_session.triaged_ready_to_vaccinate?(programme:)
+    end
   end
 end

--- a/app/lib/reports/export_formatters.rb
+++ b/app/lib/reports/export_formatters.rb
@@ -25,12 +25,12 @@ module Reports::ExportFormatters
     location.school? ? "" : vaccination_record.location_name
   end
 
-  def consent_status(patient_session:)
-    if patient_session.consent_given?
+  def consent_status(patient_session:, programme:)
+    if patient_session.consent_given?(programme:)
       "Consent given"
-    elsif patient_session.consent_refused?
+    elsif patient_session.consent_refused?(programme:)
       "Consent refused"
-    elsif patient_session.consent_conflicts?
+    elsif patient_session.consent_conflicts?(programme:)
       "Conflicting consent"
     else
       ""

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -141,23 +141,23 @@ class Reports::OfflineSessionExporter
   end
 
   def rows(patient_session:)
-    bg_color =
-      if patient_session.consent_refused?
-        "F7D4D1"
-      elsif patient_session.consent_conflicts?
-        "FFDC8E"
-      end
-
-    row_style = {
-      strike: patient_session.patient.invalidated?,
-      bg_color:,
-      border: {
-        style: :thin,
-        color: "000000"
-      }
-    }
-
     session.programmes.flat_map do |programme|
+      bg_color =
+        if patient_session.consent_refused?(programme:)
+          "F7D4D1"
+        elsif patient_session.consent_conflicts?(programme:)
+          "FFDC8E"
+        end
+
+      row_style = {
+        strike: patient_session.patient.invalidated?,
+        bg_color:,
+        border: {
+          style: :thin,
+          color: "000000"
+        }
+      }
+
       vaccination_records =
         patient_session.vaccination_records(programme:, for_session: true)
 
@@ -209,7 +209,7 @@ class Reports::OfflineSessionExporter
       patient.address_postcode unless patient.restricted?
     )
     row[:nhs_number] = patient.nhs_number
-    row[:consent_status] = consent_status(patient_session:)
+    row[:consent_status] = consent_status(patient_session:, programme:)
     row[:consent_details] = consent_details(consents:)
     row[:health_question_answers] = Cell.new(
       health_question_answers(consents:),

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -181,7 +181,7 @@ class Reports::ProgrammeVaccinationsExporter
       nhs_number_status_code(patient:),
       patient.gp_practice&.ods_code || "",
       patient.gp_practice&.name || "",
-      patient_session ? consent_status(patient_session:) : "",
+      patient_session ? consent_status(patient_session:, programme:) : "",
       consent_details(consents:),
       health_question_answers(consents:),
       triage&.status&.humanize || "",

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -20,41 +20,45 @@ module PatientSessionStatusConcern
   end
 
   included do
-    def status
-      @status ||=
-        if vaccination_administered?
-          "vaccinated"
-        elsif triage_delay_vaccination? || vaccination_can_be_delayed?
-          "delay_vaccination"
-        elsif vaccination_not_administered?
-          "unable_to_vaccinate"
-        elsif triage_keep_in_triage?
-          "triaged_kept_in_triage"
-        elsif consent_given? && triage_ready_to_vaccinate?
-          "triaged_ready_to_vaccinate"
-        elsif triage_do_not_vaccinate?
-          "triaged_do_not_vaccinate"
-        elsif consent_given? && triage_needed?
-          "consent_given_triage_needed"
-        elsif consent_given? && triage_not_needed?
-          "consent_given_triage_not_needed"
-        elsif consent_refused?
-          "consent_refused"
-        elsif consent_conflicts?
-          "consent_conflicts"
-        else
-          "added_to_session"
-        end
+    def status(programme:)
+      @status_by_programme ||= {}
+
+      @status_by_programme[programme] ||= if vaccination_administered?(
+           programme:
+         )
+        "vaccinated"
+      elsif triage_delay_vaccination?(programme:) ||
+            vaccination_can_be_delayed?(programme:)
+        "delay_vaccination"
+      elsif vaccination_not_administered?(programme:)
+        "unable_to_vaccinate"
+      elsif triage_keep_in_triage?(programme:)
+        "triaged_kept_in_triage"
+      elsif consent_given?(programme:) && triage_ready_to_vaccinate?(programme:)
+        "triaged_ready_to_vaccinate"
+      elsif triage_do_not_vaccinate?(programme:)
+        "triaged_do_not_vaccinate"
+      elsif consent_given?(programme:) && triage_needed?(programme:)
+        "consent_given_triage_needed"
+      elsif consent_given?(programme:) && triage_not_needed?(programme:)
+        "consent_given_triage_not_needed"
+      elsif consent_refused?(programme:)
+        "consent_refused"
+      elsif consent_conflicts?(programme:)
+        "consent_conflicts"
+      else
+        "added_to_session"
+      end
     end
 
     PatientSessionStatusConcern.available_statuses.each do |status|
-      define_method("#{status}?") { self.status == status }
+      define_method("#{status}?") do |programme:|
+        self.status(programme:) == status
+      end
     end
 
-    def consent_given?
-      return false if no_consent?
-
-      programme = programmes.first # TODO: handle multiple programmes
+    def consent_given?(programme:)
+      return false if no_consent?(programme:)
 
       if (
            self_consents =
@@ -66,18 +70,14 @@ module PatientSessionStatusConcern
       end
     end
 
-    def consent_refused?
-      return false if no_consent?
-
-      programme = programmes.first # TODO: handle multiple programmes
+    def consent_refused?(programme:)
+      return false if no_consent?(programme:)
 
       latest_consents(programme:).all?(&:response_refused?)
     end
 
-    def consent_conflicts?
-      return false if no_consent?
-
-      programme = programmes.first # TODO: handle multiple programmes
+    def consent_conflicts?(programme:)
+      return false if no_consent?(programme:)
 
       if (
            self_consents =
@@ -91,66 +91,59 @@ module PatientSessionStatusConcern
       end
     end
 
-    def no_consent?
-      programme = programmes.first # TODO: handle multiple programmes
+    def no_consent?(programme:)
       consents(programme:).empty? ||
         consents(programme:).all? do
           _1.response_not_provided? || _1.invalidated?
         end
     end
 
-    def triage_needed?
-      programme = programmes.first # TODO: handle multiple programmes
+    def triage_needed?(programme:)
       latest_consents(programme:).any?(&:triage_needed?)
     end
 
-    def triage_not_needed?
-      !triage_needed?
+    def triage_not_needed?(programme:)
+      !triage_needed?(programme:)
     end
 
-    def triage_ready_to_vaccinate?
-      programme = programmes.first # TODO: handle multiple programmes
+    def triage_ready_to_vaccinate?(programme:)
       latest_triage(programme:)&.ready_to_vaccinate?
     end
 
-    def triage_keep_in_triage?
-      programme = programmes.first # TODO: handle multiple programmes
+    def triage_keep_in_triage?(programme:)
       latest_triage(programme:)&.needs_follow_up?
     end
 
-    def triage_do_not_vaccinate?
-      programme = programmes.first # TODO: handle multiple programmes
+    def triage_do_not_vaccinate?(programme:)
       latest_triage(programme:)&.do_not_vaccinate?
     end
 
-    def triage_delay_vaccination?
-      programme = programmes.first # TODO: handle multiple programmes
+    def triage_delay_vaccination?(programme:)
       latest_triage(programme:)&.delay_vaccination?
     end
 
-    def vaccination_administered?
-      programme = programmes.first # TODO: handle multiple programmes
+    def vaccination_administered?(programme:)
       vaccination_records(programme:).any?(&:administered?)
     end
 
-    def vaccination_not_administered?
-      programme = programmes.first # TODO: handle multiple programmes
+    def vaccination_not_administered?(programme:)
       vaccination_records(programme:).any?(&:not_administered?)
     end
 
-    def vaccination_can_be_delayed?
-      programme = programmes.first # TODO: handle multiple programmes
+    def vaccination_can_be_delayed?(programme:)
       if (vaccination_record = vaccination_records(programme:).last)
         vaccination_record.not_administered? &&
           vaccination_record.retryable_reason?
       end
     end
 
-    def next_step
-      if consent_given_triage_needed? || triaged_kept_in_triage?
+    def next_step(programme:)
+      if consent_given_triage_needed?(programme:) ||
+           triaged_kept_in_triage?(programme:)
         :triage
-      elsif consent_given_triage_not_needed? || triaged_ready_to_vaccinate? ||
-            delay_vaccination?
+      elsif consent_given_triage_not_needed?(programme:) ||
+            triaged_ready_to_vaccinate?(programme:) ||
+            delay_vaccination?(programme:)
         :vaccinate
       end
     end

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -131,7 +131,7 @@ class ImmunisationImport < ApplicationRecord
     rows.each do |row|
       patient = row.patient
 
-      next unless patient.vaccinated?(row.programme)
+      next unless patient.vaccinated?(programme: row.programme)
 
       patient
         .patient_sessions

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -106,13 +106,6 @@ class Patient < ApplicationRecord
 
   scope :with_notice, -> { deceased.or(restricted).or(invalidated) }
 
-  scope :unvaccinated_for,
-        ->(programmes:) do
-          includes(:vaccination_records).reject do |patient|
-            programmes.all? { |programme| patient.vaccinated?(programme) }
-          end
-        end
-
   scope :in_programme,
         ->(programme) do
           where(birth_academic_year: programme.birth_academic_years)
@@ -253,7 +246,7 @@ class Patient < ApplicationRecord
     super.merge("full_name" => full_name, "age" => age)
   end
 
-  def vaccinated?(programme)
+  def vaccinated?(programme:)
     # TODO: This logic doesn't work for vaccinations that require multiple doses.
 
     vaccination_records.any? do

--- a/app/models/patient_session_stats.rb
+++ b/app/models/patient_session_stats.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class PatientSessionStats
-  def initialize(patient_sessions, keys: nil)
+  def initialize(patient_sessions, programme:, keys: nil)
     @patient_sessions =
       patient_sessions.sort_by(&:created_at).reverse.uniq(&:patient_id)
+    @programme = programme
     @keys =
       keys ||
         %i[
@@ -27,6 +28,8 @@ class PatientSessionStats
 
   private
 
+  attr_reader :programme
+
   def statistics
     @statistics ||=
       @keys.index_with do |key|
@@ -37,26 +40,27 @@ class PatientSessionStats
   def include_in_statistics?(patient_session, key)
     case key
     when :with_consent_given
-      patient_session.consent_given?
+      patient_session.consent_given?(programme:)
     when :with_consent_refused
-      patient_session.consent_refused?
+      patient_session.consent_refused?(programme:)
     when :with_conflicting_consent
-      patient_session.consent_conflicts?
+      patient_session.consent_conflicts?(programme:)
     when :without_a_response
-      patient_session.no_consent?
+      patient_session.no_consent?(programme:)
     when :needing_triage
-      patient_session.consent_given_triage_needed? ||
-        patient_session.triaged_kept_in_triage?
+      patient_session.consent_given_triage_needed?(programme:) ||
+        patient_session.triaged_kept_in_triage?(programme:)
     when :vaccinate
-      patient_session.triaged_ready_to_vaccinate? ||
-        patient_session.consent_given_triage_not_needed?
+      patient_session.triaged_ready_to_vaccinate?(programme:) ||
+        patient_session.consent_given_triage_not_needed?(programme:)
     when :vaccinated
-      patient_session.vaccinated?
+      patient_session.vaccinated?(programme:)
     when :could_not_vaccinate
-      patient_session.delay_vaccination? || patient_session.consent_refused? ||
-        patient_session.consent_conflicts? ||
-        patient_session.triaged_do_not_vaccinate? ||
-        patient_session.unable_to_vaccinate?
+      patient_session.delay_vaccination?(programme:) ||
+        patient_session.consent_refused?(programme:) ||
+        patient_session.consent_conflicts?(programme:) ||
+        patient_session.triaged_do_not_vaccinate?(programme:) ||
+        patient_session.unable_to_vaccinate?(programme:)
     when :not_registered
       patient_session.todays_attendance&.attending.nil?
     end

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -89,7 +89,16 @@ class SchoolMove < ApplicationRecord
     # session if they haven't been vaccinated for any programmes that session
     # administers. What happens if the patient needs a Flu vaccine but the new
     # session doesn't administer flu? Move to community clinic and the school?
-    patient_sessions.any?(&:vaccinated?)
+
+    org = school&.organisation || organisation
+
+    # TODO: What happens if the school they're moving to doesn't have an organisation?
+    # We don't know which programmes that organisation administers.
+    return false if org.nil?
+
+    org.programmes.all? do |programme|
+      patient_sessions.any? { it.vaccinated?(programme:) }
+    end
   end
 
   def update_patient!

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -21,6 +21,7 @@
         consent_form: @consent_form,
         params:,
         patients: @patients,
+        programme: @consent_form.programme,
         section: :matching,
         year_groups: @consent_form.original_session.year_groups,
       )

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -25,7 +25,7 @@
       columns: @current_tab == :consent_refused ? %i[name year_group reason] : %i[name year_group],
       params:,
       patient_sessions: @patient_sessions,
-      programme: @session.programmes.first, # TODO: handle multiple programmes
+      programme: @programme,
       section: :consents,
       year_groups: @session.year_groups,
     ) %>

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -11,4 +11,4 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :sessions) %>
 
-<%= render AppProgrammeSessionTableComponent.new(@sessions) %>
+<%= render AppProgrammeSessionTableComponent.new(@sessions, programme: @programme) %>

--- a/app/views/register_attendances/index.html.erb
+++ b/app/views/register_attendances/index.html.erb
@@ -16,6 +16,7 @@
       columns: %i[name year_group status attendance],
       params:,
       patient_sessions: @patient_sessions,
+      programme: @session.programmes.first,
       section: :attendance,
       year_groups: @session.year_groups,
     ) %>

--- a/app/views/triages/index.html.erb
+++ b/app/views/triages/index.html.erb
@@ -25,6 +25,7 @@
       columns: %i[name year_group],
       params:,
       patient_sessions: @patient_sessions,
+      programme: @session.programmes.first,
       section: :triage,
       year_groups: @session.year_groups,
     ) %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -41,6 +41,7 @@
         %i[name year_group status],
       params:,
       patient_sessions: @patient_sessions,
+      programme: @session.programmes.first,
       section: :vaccinations,
       year_groups: @session.year_groups,
     ) %>

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -3,7 +3,7 @@
 describe AppProgrammeSessionTableComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(sessions) }
+  let(:component) { described_class.new(sessions, programme:) }
 
   let(:programme) { create(:programme) }
   let(:location) { create(:school, name: "Waterloo Road") }

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -84,6 +84,7 @@ describe AppSessionPatientTableComponent do
     let(:component) do
       described_class.new(
         patient_sessions:,
+        programme:,
         section: :matching,
         consent_form:
           create(
@@ -103,7 +104,9 @@ describe AppSessionPatientTableComponent do
   context "when passing in patients" do
     let(:patients) { patient_sessions.map(&:patient) }
 
-    let(:component) { described_class.new(params:, patients:, section:) }
+    let(:component) do
+      described_class.new(params:, patients:, programme:, section:)
+    end
 
     it { should have_css(".nhsuk-table") }
     it { should have_css(".nhsuk-table__head") }
@@ -120,7 +123,13 @@ describe AppSessionPatientTableComponent do
     let(:patients) { patient_sessions.map(&:patient) + [create(:patient)] }
 
     let(:component) do
-      described_class.new(params:, patients:, patient_sessions:, section:)
+      described_class.new(
+        params:,
+        patients:,
+        patient_sessions:,
+        programme:,
+        section:
+      )
     end
 
     it { should have_css(".nhsuk-table__body .nhsuk-table__row", count: 3) }
@@ -206,7 +215,7 @@ describe AppSessionPatientTableComponent do
   describe "columns parameter" do
     context "is not set" do
       let(:component) do
-        described_class.new(patient_sessions:, section:, params:)
+        described_class.new(patient_sessions:, programme:, section:, params:)
       end
 
       it { should have_column("Full name") }

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -91,7 +91,7 @@ describe PatientSortingConcern do
 
       it "sorts patient sessions by state in descending order" do
         controller.sort_patients!(patient_sessions)
-        expect(patient_sessions.map(&:status)).to eq(
+        expect(patient_sessions.map { it.status(programme:) }).to eq(
           %w[vaccinated delay_vaccination added_to_session]
         )
       end

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -68,6 +68,7 @@ describe PatientTabsConcern do
       result =
         controller.group_patient_sessions_by_conditions(
           patient_sessions,
+          programme:,
           section: :consents
         )
 
@@ -95,6 +96,7 @@ describe PatientTabsConcern do
         result =
           controller.group_patient_sessions_by_conditions(
             [consent_given_triage_not_needed],
+            programme:,
             section: :consents
           )
 
@@ -116,6 +118,7 @@ describe PatientTabsConcern do
         result =
           controller.group_patient_sessions_by_state(
             patient_sessions,
+            programme,
             section: :triage
           )
 
@@ -143,6 +146,7 @@ describe PatientTabsConcern do
         result =
           controller.group_patient_sessions_by_state(
             patient_sessions,
+            programme,
             section: :vaccinations
           )
 
@@ -167,13 +171,14 @@ describe PatientTabsConcern do
 
     context "some of the groups are empty" do
       let(:patient_sessions) do
-        create_list(:patient_session, 1, :consent_refused)
+        create_list(:patient_session, 1, :consent_refused, programme:)
       end
 
       it "returns an empty array for all the empty groups" do
         result =
           controller.group_patient_sessions_by_state(
             patient_sessions,
+            programme,
             section: :triage
           )
 

--- a/spec/models/concerns/patient_session_status_concern_spec.rb
+++ b/spec/models/concerns/patient_session_status_concern_spec.rb
@@ -12,7 +12,9 @@ describe PatientSessionStatusConcern do
   end
 
   describe "#status" do
-    subject { fake_instance.status }
+    subject { fake_instance.status(programme:) }
+
+    let(:programme) { create(:programme) }
 
     shared_examples "it supports the status" do |status, conditions:|
       conditions_list = conditions.to_sentence

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -339,13 +339,13 @@ describe ImmunisationImport do
       let(:patient) { create(:patient, nhs_number: "7420180008", session:) }
 
       it "removes the patient from the upcoming session" do
-        expect(patient.vaccinated?(programme)).to be(false)
+        expect(patient.vaccinated?(programme:)).to be(false)
         expect(patient.upcoming_sessions).to contain_exactly(session)
 
         process!
 
         expect(patient.reload.upcoming_sessions).to be_empty
-        expect(patient.vaccinated?(programme)).to be(true)
+        expect(patient.vaccinated?(programme:)).to be(true)
       end
     end
   end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -92,7 +92,7 @@ describe PatientSession do
   end
 
   describe "#no_consent?" do
-    subject(:no_consent?) { patient_session.no_consent? }
+    subject(:no_consent?) { patient_session.no_consent?(programme:) }
 
     let(:patient) { patient_session.patient }
 
@@ -139,7 +139,7 @@ describe PatientSession do
       described_class
         .includes(patient: { consents: :parent })
         .find(patient_session.id)
-        .consent_given?
+        .consent_given?(programme:)
     end
 
     let(:patient) { patient_session.patient }

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -3,7 +3,10 @@
 describe PatientSessionStats do
   describe "#to_h" do
     subject(:to_h) do
-      described_class.new(session.patient_sessions.preload_for_status).to_h
+      described_class.new(
+        session.patient_sessions.preload_for_status,
+        programme:
+      ).to_h
     end
 
     let(:programme) { create(:programme) }


### PR DESCRIPTION
When generating the status of a patient session, we need the programme to be available so we can generate the status approriate for the specific programme. This updates the various parts of the code where the status is used to ensure a programme is available.

This reduces the number of times we rely on `session.programmes.first` and helps us to build the redesigned session pages where the programme is selected at the top of the page.