### PR TITLE
Add programme selection to patient session pages

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -14,7 +14,7 @@ class AppActivityLogComponent < ViewComponent::Base
     <% end %>
   ERB
 
-  def initialize(patient: nil, patient_session: nil, programme: nil)
+  def initialize(patient: nil, patient_session: nil)
     super
 
     if patient.nil? && patient_session.nil?
@@ -54,13 +54,6 @@ class AppActivityLogComponent < ViewComponent::Base
         :programme,
         :vaccine
       )
-
-    if programme
-      @consents = @consents.where(programme:)
-      @gillick_assessments = @gillick_assessments.where(programme:)
-      @triages = @triages.where(programme:)
-      @vaccination_records = @vaccination_records.where(programme:)
-    end
   end
 
   attr_reader :patient,

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -30,7 +30,8 @@
       <% consents.each do |consent| %>
         <%= body.with_row do |row| %>
           <%= row.with_cell(classes: "app-table__cell-status--#{status_colour(consent)}") do %>
-            <%= govuk_link_to consent&.parent&.full_name || consent.patient.full_name, session_patient_consent_path(session, patient, consent, section:, tab:) %>
+            <%= govuk_link_to consent&.parent&.full_name || consent.patient.full_name,
+                              session_patient_programme_consent_path(session, patient, programme, consent, section:, tab:) %>
             <br>
             <span class="nhsuk-u-font-size-16"><%= consent.who_responded %></span>
           <% end %>
@@ -49,7 +50,15 @@
 <% end %>
 
 <% if can_send_consent_request? %>
-  <%= govuk_button_to "Send consent request", send_request_session_patient_consents_path(session, patient, section: @section, tab: @tab), class: "app-button--secondary" %>
+  <%= govuk_button_to "Send consent request",
+                      send_request_session_patient_programme_consents_path(
+                        session, patient, programme, section: @section, tab: @tab,
+                      ),
+                      class: "app-button--secondary" %>
 <% end %>
 
-<%= govuk_button_to "Get consent response", session_patient_consents_path(session, patient, section: @section, tab: @tab), class: "app-button--secondary" %>
+<%= govuk_button_to "Get consent response",
+                    session_patient_programme_consents_path(
+                      session, patient, programme, section: @section, tab: @tab,
+                    ),
+                    class: "app-button--secondary" %>

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -40,9 +40,10 @@
       <% if helpers.policy(gillick_assessment).edit? %>
         <p class="nhsuk-body">
           <%= govuk_button_link_to "Edit Gillick competence",
-                                   edit_session_patient_gillick_assessment_path(
+                                   edit_session_patient_programme_gillick_assessment_path(
                                      session,
                                      patient,
+                                     programme,
                                      section: @section,
                                      tab: @tab,
                                    ), class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
@@ -51,9 +52,10 @@
     <% elsif gillick_assessment_can_be_recorded? %>
       <p class="nhsuk-body">
         <%= govuk_button_link_to "Assess Gillick competence",
-                                 edit_session_patient_gillick_assessment_path(
+                                 edit_session_patient_programme_gillick_assessment_path(
                                    session,
                                    patient,
+                                   programme,
                                    section: @section,
                                    tab: @tab,
                                  ), class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
@@ -86,9 +88,10 @@
     <%= render AppTriageFormComponent.new(
           patient_session:,
           programme:,
-          url: session_patient_triages_path(
+          url: session_patient_programme_triages_path(
             session,
             patient,
+            programme,
             @triage,
             section: @section,
             tab: @tab,
@@ -113,7 +116,11 @@
 
       <% if helpers.policy(vaccination_record).destroy? %>
         <%= govuk_link_to "Delete vaccination record",
-                          destroy_programme_vaccination_record_path(programme, vaccination_record, return_to: session_patient_path(id: patient.id)) %>
+                          destroy_programme_vaccination_record_path(
+                            programme,
+                            vaccination_record,
+                            return_to: session_patient_programme_path(patient_id: patient.id),
+                          ) %>
       <% end %>
     </div>
   <% end %>

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -75,7 +75,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       helpers.patient_year_group(patient)
     when :reason
       patient_session
-        .consents(programme: @programme)
+        .consents(programme:)
         .map { |c| c.human_enum_name(:reason_for_refusal) }
         .uniq
         .join("<br />")
@@ -150,7 +150,13 @@ class AppSessionPatientTableComponent < ViewComponent::Base
 
     govuk_link_to(
       patient.full_name,
-      session_patient_path(session, patient, section:, tab:)
+      session_patient_programme_path(
+        session,
+        patient,
+        @programme,
+        section:,
+        tab:
+      )
     )
   end
 

--- a/app/components/app_simple_status_banner_component.html.erb
+++ b/app/components/app_simple_status_banner_component.html.erb
@@ -6,10 +6,7 @@
                       triaged_ready_to_vaccinate
                       triaged_do_not_vaccinate]) && helpers.policy(Triage).edit? %>
     <p>
-      <%= link_to "Update triage outcome", new_session_patient_triages_path(
-            session_id: @patient_session.session.id,
-            patient_id: @patient_session.patient.id,
-          ) %>
+      <%= link_to "Update triage outcome", new_session_patient_programme_triages_path(session, patient, programme) %>
     </p>
   <% end %>
 <% end %>

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -14,10 +14,12 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
   private
 
-  attr_reader :programme
+  attr_reader :patient_session, :programme
+
+  delegate :patient, :session, to: :patient_session
 
   def who_refused
-    @patient_session
+    patient_session
       .latest_consents(programme:)
       .select(&:response_refused?)
       .map(&:who_responded)
@@ -25,13 +27,13 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   end
 
   def full_name
-    @patient_session.patient.full_name
+    patient_session.patient.full_name
   end
 
   def nurse
     (
-      @patient_session.triages(programme:) +
-        @patient_session.vaccination_records(programme:)
+      patient_session.triages(programme:) +
+        patient_session.vaccination_records(programme:)
     ).max_by(&:updated_at)&.performed_by&.full_name
   end
 

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -23,9 +23,10 @@ class AppVaccinateFormComponent < ViewComponent::Base
   delegate :patient, :session, to: :patient_session
 
   def url
-    session_patient_vaccinations_path(
+    session_patient_programme_vaccinations_path(
       session,
       patient,
+      programme,
       section: @section,
       tab: @tab
     )

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -34,9 +34,10 @@ class ConsentFormsController < ApplicationController
       heading: "Consent matched for",
       heading_link_text: @patient.full_name,
       heading_link_href:
-        session_patient_path(
+        session_patient_programme_path(
           session,
-          id: @patient.id,
+          @patient,
+          session.programmes.first,
           section: "triage",
           tab: "given"
         )
@@ -102,7 +103,10 @@ class ConsentFormsController < ApplicationController
   end
 
   def set_patient
-    @patient = policy_scope(Patient).find(params[:patient_id])
+    @patient =
+      policy_scope(Patient).includes(upcoming_sessions: :programmes).find(
+        params[:patient_id]
+      )
   end
 
   def archive_params

--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -68,7 +68,13 @@ class DraftConsentsController < ApplicationController
     tab = @consent.response_given? ? "given" : "refused"
 
     heading_link_href =
-      session_patient_path(@session, id: @patient.id, section: "consents", tab:)
+      session_patient_programme_path(
+        @session,
+        @patient,
+        @programme,
+        section: "consents",
+        tab:
+      )
 
     flash[:success] = {
       heading: "Consent recorded for",
@@ -180,9 +186,10 @@ class DraftConsentsController < ApplicationController
       if @draft_consent.editing?
         wizard_path("confirm")
       elsif current_step == @draft_consent.wizard_steps.first
-        session_patient_path(
+        session_patient_programme_path(
           @session,
           @patient,
+          @programme,
           section: "consents",
           tab: "no-consent"
         )

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -112,9 +112,10 @@ class DraftVaccinationRecordsController < ApplicationController
     tab = @vaccination_record.administered? ? "vaccinated" : "could-not"
 
     heading_link_href =
-      session_patient_path(
+      session_patient_programme_path(
         @session,
-        id: @patient.id,
+        @patient,
+        @programme,
         section: "vaccinations",
         tab:
       )
@@ -207,9 +208,10 @@ class DraftVaccinationRecordsController < ApplicationController
           wizard_path("confirm")
         end
       elsif current_step == @draft_vaccination_record.wizard_steps.first
-        session_patient_path(
+        session_patient_programme_path(
           @session,
           @patient,
+          @programme,
           section: "vaccinations",
           tab: "vaccinate"
         )

--- a/app/controllers/gillick_assessments_controller.rb
+++ b/app/controllers/gillick_assessments_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class GillickAssessmentsController < ApplicationController
-  before_action :set_patient
   before_action :set_session
-  before_action :set_patient_session
   before_action :set_programme
+  before_action :set_patient
+  before_action :set_patient_session
   before_action :set_is_first_assessment
   before_action :set_gillick_assessment
 
@@ -16,7 +16,7 @@ class GillickAssessmentsController < ApplicationController
     @gillick_assessment.assign_attributes(gillick_assessment_params)
 
     if !@gillick_assessment.changed? || @gillick_assessment.save
-      redirect_to session_patient_path(id: @patient.id)
+      redirect_to session_patient_programme_path(patient_id: @patient.id)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -24,15 +24,16 @@ class GillickAssessmentsController < ApplicationController
 
   private
 
-  def set_patient
-    @patient = policy_scope(Patient).find(params[:patient_id])
+  def set_session
+    @session = policy_scope(Session).find_by!(slug: params[:session_slug])
   end
 
-  def set_session
-    @session =
-      policy_scope(Session).includes(:programmes).find_by!(
-        slug: params[:session_slug]
-      )
+  def set_programme
+    @programme = @session.programmes.find_by!(type: params[:programme_type])
+  end
+
+  def set_patient
+    @patient = policy_scope(Patient).find(params[:patient_id])
   end
 
   def set_patient_session
@@ -41,10 +42,6 @@ class GillickAssessmentsController < ApplicationController
         session: @session,
         patient: @patient
       )
-  end
-
-  def set_programme
-    @programme = @session.programmes.first # TODO: handle multiple programmes
   end
 
   def set_is_first_assessment

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -2,7 +2,7 @@
 
 class PatientSessionsController < ApplicationController
   before_action :set_patient_session
-  before_action :set_programme
+  before_action :set_programme, only: :show
   before_action :set_session
   before_action :set_patient
   before_action :set_section_and_tab
@@ -44,7 +44,8 @@ class PatientSessionsController < ApplicationController
   end
 
   def set_programme
-    @programme = @patient_session.programmes.first # TODO: handle multiple programmes
+    @programme =
+      @patient_session.programmes.find_by!(type: params[:programme_type])
   end
 
   def set_session

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -25,8 +25,9 @@ class SessionAttendancesController < ApplicationController
     if success
       name = @patient.full_name
 
+      programme = @patient_session.programmes.first # TODO: handle multiple programmes
+
       flash[:info] = if @session_attendance.attending?
-        programme = @patient_session.programmes.first # TODO: handle multiple programmes
         status = @patient_session.status(programme:)
         t("attendance_flash.#{status}", name:)
       elsif @session_attendance.attending.nil?
@@ -35,7 +36,10 @@ class SessionAttendancesController < ApplicationController
         t("attendance_flash.absent", name:)
       end
 
-      redirect_to session_patient_path(id: @patient.id)
+      redirect_to session_patient_programme_path(
+                    patient_id: @patient.id,
+                    programme_type: programme.type
+                  )
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -63,7 +63,8 @@ class TriagesController < ApplicationController
       flash[:success] = {
         heading: "Triage outcome updated for",
         heading_link_text: @patient.full_name,
-        heading_link_href: session_patient_path(@session, id: @patient.id)
+        heading_link_href:
+          session_patient_programme_path(patient_id: @patient.id)
       }
 
       redirect_to redirect_path
@@ -95,7 +96,8 @@ class TriagesController < ApplicationController
   end
 
   def set_programme
-    @programme = @patient_session.programmes.first # TODO: handle multiple programmes
+    @programme =
+      @patient_session.programmes.find_by!(type: params[:programme_type])
   end
 
   def set_triage

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -7,9 +7,9 @@ class VaccinationsController < ApplicationController
   include PatientSortingConcern
 
   before_action :set_session
+  before_action :set_programme, only: :create
   before_action :set_patient, only: :create
   before_action :set_patient_session, only: :create
-  before_action :set_programme, only: :create
   before_action :set_section_and_tab, only: :create
 
   before_action :set_batches, only: %i[index create batch update_batch]
@@ -131,9 +131,13 @@ class VaccinationsController < ApplicationController
 
   def set_session
     @session =
-      policy_scope(Session).includes(:location, :programmes).find_by!(
+      policy_scope(Session).includes(:location).find_by!(
         slug: params[:session_slug] || params[:slug]
       )
+  end
+
+  def set_programme
+    @programme = @session.programmes.find_by!(type: params[:programme_type])
   end
 
   def set_patient
@@ -156,10 +160,6 @@ class VaccinationsController < ApplicationController
         )
         .preload_for_status
         .find_by!(session: @session)
-  end
-
-  def set_programme
-    @programme = @session.programmes.first # TODO: handle multiple programmes
   end
 
   def set_section_and_tab

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -325,11 +325,10 @@ class ConsentForm < ApplicationRecord
 
   def original_session
     @original_session ||=
-      Session.has_programme(programme).find_by(
-        academic_year:,
-        location:,
-        organisation:
-      )
+      Session
+        .has_programme(programme)
+        .includes(:programmes)
+        .find_by(academic_year:, location:, organisation:)
   end
 
   def find_or_create_parent_with_relationship_to!(patient:)

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -25,7 +25,7 @@
       columns: @current_tab == :consent_refused ? %i[name year_group reason] : %i[name year_group],
       params:,
       patient_sessions: @patient_sessions,
-      programme: @programme,
+      programme: @session.programmes.first,
       section: :consents,
       year_groups: @session.year_groups,
     ) %>

--- a/app/views/consents/invalidate.html.erb
+++ b/app/views/consents/invalidate.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_consent_path, name: "consent page") %>
+  <%= render AppBacklinkComponent.new(session_patient_programme_consent_path, name: "consent page") %>
 <% end %>
 
-<%= form_with model: @consent, url: invalidate_session_patient_consent_path, method: :post do |f| %>
+<%= form_with model: @consent, url: invalidate_session_patient_programme_consent_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
   <% page_title = "Mark response as invalid" %>

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -1,5 +1,8 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_path(id: @consent.patient.id), name: @consent.patient.full_name) %>
+  <%= render AppBacklinkComponent.new(
+        session_patient_programme_path(patient_id: @consent.patient_id),
+        name: @consent.patient.full_name,
+      ) %>
 <% end %>
 
 <%= h1 "Consent response from #{@consent.name}" %>
@@ -7,13 +10,13 @@
 <ul class="app-action-list">
   <% if @consent.can_withdraw? %>
     <li class="app-action-list__item">
-      <%= link_to "Withdraw consent", withdraw_session_patient_consent_path %>
+      <%= link_to "Withdraw consent", withdraw_session_patient_programme_consent_path %>
     </li>
   <% end %>
 
   <% if @consent.can_invalidate? %>
     <li class="app-action-list__item">
-      <%= link_to "Mark as invalid", invalidate_session_patient_consent_path %>
+      <%= link_to "Mark as invalid", invalidate_session_patient_programme_consent_path %>
     </li>
   <% end %>
 </ul>

--- a/app/views/consents/withdraw.html.erb
+++ b/app/views/consents/withdraw.html.erb
@@ -1,8 +1,8 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_consent_path, name: "consent page") %>
+  <%= render AppBacklinkComponent.new(session_patient_programme_consent_path, name: "consent page") %>
 <% end %>
 
-<%= form_with model: @consent, url: withdraw_session_patient_consent_path, method: :post do |f| %>
+<%= form_with model: @consent, url: withdraw_session_patient_programme_consent_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
   <% page_title = "Withdraw consent" %>

--- a/app/views/gillick_assessments/edit.html.erb
+++ b/app/views/gillick_assessments/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: @patient.full_name) %>
+  <%= render AppBacklinkComponent.new(session_patient_programme_path(id: @patient.id), name: @patient.full_name) %>
 <% end %>
 
 <% page_title = @is_first_assessment ? "Assess Gillick competence" : "Edit Gillick competence" %>
@@ -18,7 +18,7 @@
   </p>
 <% end %>
 
-<%= form_with model: @gillick_assessment, url: session_patient_gillick_assessment_path, method: :put do |f| %>
+<%= form_with model: @gillick_assessment, url: session_patient_programme_gillick_assessment_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <% options = [OpenStruct.new(value: true, label: "Yes"), OpenStruct.new(value: false, label: "No")] %>

--- a/app/views/patient_sessions/_secondary_navigation.html.erb
+++ b/app/views/patient_sessions/_secondary_navigation.html.erb
@@ -1,0 +1,14 @@
+<%= render AppSecondaryNavigationComponent.new do |nav|
+     @session.programmes.each do |programme|
+       nav.with_item(
+         href: session_patient_programme_path(patient_id: @patient.id, programme_type: programme.type),
+         text: programme.name,
+         selected: @programme == programme,
+       )
+     end
+     nav.with_item(
+       href: session_patient_log_path(patient_id: @patient.id),
+       text: "Activity log",
+       selected: request.path.ends_with?("/log"),
+     )
+   end %>

--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -11,8 +11,8 @@
 <% end %>
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(href: session_patient_path(id: @patient.id), text: "Child record")
+      nav.with_item(href: session_patient_programme_path(programme_type: @session.programmes.first.type, id: @patient.id), text: "Child record")
       nav.with_item(href: session_patient_log_path, text: "Activity log", selected: true)
     end %>
 
-<%= render AppActivityLogComponent.new(patient_session: @patient_session, programme: @programme) %>
+<%= render AppActivityLogComponent.new(patient_session: @patient_session) %>

--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -10,9 +10,6 @@
   <%= @patient.full_name %>
 <% end %>
 
-<%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(href: session_patient_programme_path(programme_type: @session.programmes.first.type, id: @patient.id), text: "Child record")
-      nav.with_item(href: session_patient_log_path, text: "Activity log", selected: true)
-    end %>
+<%= render "patient_sessions/secondary_navigation" %>
 
 <%= render AppActivityLogComponent.new(patient_session: @patient_session) %>

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -32,17 +32,7 @@
   </ul>
 <% end %>
 
-<%= render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(
-        href: session_patient_programme_path(patient_id: @patient.id),
-        text: "Child record",
-        selected: true,
-      )
-      nav.with_item(
-        href: session_patient_log_path(patient_id: @patient.id),
-        text: "Activity log",
-      )
-    end %>
+<%= render "patient_sessions/secondary_navigation" %>
 
 <%= render AppPatientPageComponent.new(
       patient_session: @patient_session,

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -34,7 +34,7 @@
 
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
-        href: session_patient_path(id: @patient.id),
+        href: session_patient_programme_path(patient_id: @patient.id),
         text: "Child record",
         selected: true,
       )

--- a/app/views/session_attendances/edit.html.erb
+++ b/app/views/session_attendances/edit.html.erb
@@ -1,5 +1,8 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: "#{@section.pluralize} page") %>
+  <%= render AppBacklinkComponent.new(
+        session_patient_programme_path(patient_id: @patient.id, programme_type: @session.programmes.first.type),
+        name: "#{@section.pluralize} page",
+      ) %>
 <% end %>
 
 <% title = "Is #{@patient.full_name} attending today’s session?" %>

--- a/app/views/triages/new.html.erb
+++ b/app/views/triages/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(session_patient_path(id: @patient.id), name: @patient.full_name) %>
+  <%= render AppBacklinkComponent.new(session_patient_programme_path(patient_id: @patient.id), name: @patient.full_name) %>
 <% end %>
 
 <%= h1 page_title: "Update triage outcome" do %>
@@ -10,9 +10,10 @@
 <%= render AppTriageFormComponent.new(
       patient_session: @patient_session,
       programme: @programme,
-      url: session_patient_triages_path(
+      url: session_patient_programme_triages_path(
         @session,
         @patient,
+        @programme,
         @triage,
         section: @section,
         tab: @tab,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,31 +315,32 @@ Rails.application.routes.draw do
     end
 
     scope ":tab" do
-      resources :patient_sessions,
-                path: "patients",
-                as: :patient,
-                only: %i[show] do
+      resources :patient_sessions, path: "patients", as: :patient, only: [] do
         get "log"
-
-        resources :consents, only: %i[index create show] do
-          post "send-request", on: :collection, action: :send_request
-
-          member do
-            get "withdraw", action: :edit_withdraw
-            post "withdraw", action: :update_withdraw
-
-            get "invalidate", action: :edit_invalidate
-            post "invalidate", action: :update_invalidate
-          end
-        end
-
-        resource :gillick_assessment, path: "gillick", only: %i[edit update]
-        resource :triages, only: %i[new create]
-        resource :vaccinations, only: %i[create]
 
         resource :attendance,
                  controller: "session_attendances",
                  only: %i[edit update]
+
+        resources :programmes, path: "", param: :type, only: [] do
+          get "", as: "", action: :show, controller: :patient_sessions
+
+          resources :consents, only: %i[index create show] do
+            post "send-request", on: :collection, action: :send_request
+
+            member do
+              get "withdraw", action: :edit_withdraw
+              post "withdraw", action: :update_withdraw
+
+              get "invalidate", action: :edit_invalidate
+              post "invalidate", action: :update_invalidate
+            end
+          end
+
+          resource :gillick_assessment, path: "gillick", only: %i[edit update]
+          resource :triages, only: %i[new create]
+          resource :vaccinations, only: %i[create]
+        end
       end
     end
 

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -6,7 +6,7 @@ describe AppPatientPageComponent do
   before do
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(AppSimpleStatusBannerComponent).to receive(
-      :new_session_patient_triages_path
+      :new_session_patient_programme_triages_path
     ).and_return("/session/patient/triage/new")
     # rubocop:enable RSpec/AnyInstance
     stub_authorization(allowed: true)

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -4,7 +4,7 @@ describe AppSessionPatientTableComponent do
   subject(:rendered) { render_inline(component) }
 
   before do
-    allow(component).to receive(:session_patient_path).and_return(
+    allow(component).to receive(:session_patient_programme_path).and_return(
       "/session/patient/"
     )
 
@@ -158,7 +158,8 @@ describe AppSessionPatientTableComponent do
         end
 
         it "guesses the path" do
-          expect(component).to receive(:session_patient_path).with(
+          expect(component).to receive(:session_patient_programme_path).with(
+            anything,
             anything,
             anything,
             section:,

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -4,9 +4,9 @@ describe AppSimpleStatusBannerComponent do
   subject(:rendered) { render_inline(component) }
 
   before do
-    allow(component).to receive(:new_session_patient_triages_path).and_return(
-      "/session/patient/triage/new"
-    )
+    allow(component).to receive(
+      :new_session_patient_programme_triages_path
+    ).and_return("/session/patient/triage/new")
     stub_authorization(allowed: true)
 
     patient_session.strict_loading!(false)

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -116,7 +116,7 @@ describe "Self-consent" do
     expect(page).to have_content(
       "Completed Gillick assessment as not Gillick competent"
     )
-    click_on "Child record"
+    click_on "HPV"
   end
 
   def when_the_nurse_edits_the_assessment_the_child_as_gillick_competent
@@ -170,7 +170,7 @@ describe "Self-consent" do
     expect(page).to have_content(
       "Updated Gillick assessment as Gillick competent"
     )
-    click_on "Child record"
+    click_on "HPV"
   end
 
   def and_the_child_can_give_their_own_consent_that_the_nurse_records


### PR DESCRIPTION
This updates the secondary navigation on the patient session page to show the programmes and allow for switching between the various programmes that are administered in a particular session.
    
The design doesn't fully match that of the prototype, but it allows us to start testing the basic functionality with improvements to the design coming later.

## Screenshot

![Screenshot 2025-02-18 at 10 55 46](https://github.com/user-attachments/assets/f677f823-f7a8-47b4-b1e1-75b1b548670c)
