### PR TITLE
Update consent links to show per programme

### DIFF
--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -27,16 +27,10 @@ class AppSessionSummaryComponent < ViewComponent::Base
         row.with_key { "Consent period" }
         row.with_value { consent_period }
       end
-      if consent_link
+      if consent_form_links
         summary_list.with_row do |row|
-          row.with_key { "Consent link" }
-          row.with_value do
-            govuk_link_to(
-              "View parental consent form",
-              consent_link,
-              new_tab: true
-            )
-          end
+          row.with_key { "Consent links" }
+          row.with_value { consent_form_links }
         end
       end
       if consent_form_downloads
@@ -78,13 +72,21 @@ class AppSessionSummaryComponent < ViewComponent::Base
     helpers.session_consent_period(@session)
   end
 
-  def consent_link
+  def consent_form_links
     if @session.open_for_consent?
-      # TODO: handle multiple programmes
-      start_parent_interface_consent_forms_path(
-        @session,
-        @session.programmes.first
-      )
+      tag.ul(class: "nhsuk-list") do
+        safe_join(
+          @session.programmes.map do
+            tag.li(
+              govuk_link_to(
+                "View #{it.name} parental consent form",
+                start_parent_interface_consent_forms_path(@session, it),
+                new_tab: true
+              )
+            )
+          end
+        )
+      end
     end
   end
 

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -53,6 +53,6 @@ describe AppSessionSummaryComponent do
     end
 
     it { should have_content("Consent link") }
-    it { should have_link("View parental consent form (opens in new tab)") }
+    it { should have_link("View HPV parental consent form (opens in new tab)") }
   end
 end


### PR DESCRIPTION
The MenACWY and Td/IPV links don't work at the moment, but it brings us closer to the eventual design and resolves a usage of `session.programmes.first` which we need to remove to support multiple programmes.

## Screenshot

![Screenshot 2025-02-18 at 11 20 41](https://github.com/user-attachments/assets/06db82b3-0e21-46c9-86ab-6496bdd603dc)
