### PR TITLE
Add ability to assign programmes to sessions 

### DIFF
--- a/app/components/app_programme_tags_component.rb
+++ b/app/components/app_programme_tags_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AppProgrammeTagsComponent < ViewComponent::Base
+  def initialize(programmes)
+    super
+
+    @programmes = programmes
+  end
+
+  def call
+    safe_join(
+      programmes.map do
+        tag.strong(it.name, class: "nhsuk-tag nhsuk-tag--white")
+      end,
+      " "
+    )
+  end
+
+  private
+
+  attr_reader :programmes
+end

--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -17,7 +17,9 @@ class AppSessionSummaryComponent < ViewComponent::Base
       end
       summary_list.with_row do |row|
         row.with_key { "Programmes" }
-        row.with_value { programmes }
+        row.with_value do
+          render AppProgrammeTagsComponent.new(@session.programmes)
+        end
       end
       summary_list.with_row do |row|
         row.with_key { "Session dates" }
@@ -50,12 +52,6 @@ class AppSessionSummaryComponent < ViewComponent::Base
 
   def type
     @session.location.clinic? ? "Community clinic" : "School session"
-  end
-
-  def programmes
-    tag.ul(class: "nhsuk-list") do
-      safe_join(@session.programmes.map { tag.li(_1.name) })
-    end
   end
 
   def dates

--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -50,11 +50,7 @@
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Programmes</span>
 
-              <ul class="nhsuk-list">
-                <% session.programmes.each do |programme| %>
-                  <li><%= programme.name %></li>
-                <% end %>
-              </ul>
+              <%= render AppProgrammeTagsComponent.new(session.programmes) %>
             <% end %>
           <% end %>
 

--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -3,6 +3,18 @@
 class Sessions::EditController < ApplicationController
   before_action :set_session
 
+  def edit_programmes
+    render :programmes
+  end
+
+  def update_programmes
+    if @session.can_change_programmes? && @session.update(programmes_params)
+      redirect_to edit_session_path(@session)
+    else
+      render :programmes, status: :unprocessable_entity
+    end
+  end
+
   def edit_send_consent_requests_at
     render :send_consent_requests_at
   end
@@ -51,6 +63,10 @@ class Sessions::EditController < ApplicationController
 
   def set_session
     @session = policy_scope(Session).find_by!(slug: params[:slug])
+  end
+
+  def programmes_params
+    params.expect(session: { programme_ids: [] })
   end
 
   def send_consent_requests_at_validator

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -210,14 +210,6 @@ class Session < ApplicationRecord
     return unless completed?
 
     ActiveRecord::Base.transaction do
-      generic_clinic_session_id = organisation.generic_clinic_session.id
-
-      PatientSession.import!(
-        %i[patient_id session_id],
-        patients_to_move_to_clinic.map { [_1.id, generic_clinic_session_id] },
-        on_duplicate_key_ignore: true
-      )
-
       self_consents =
         Consent.via_self_consent.where(
           patient: patients_to_move_to_clinic,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -122,8 +122,7 @@ class Session < ApplicationRecord
                 location.generic_clinic?
             end
 
-  validates :programmes, presence: true
-  validate :programmes_part_of_organisation
+  validates :programme_ids, presence: true
 
   before_create :set_slug
 
@@ -171,6 +170,10 @@ class Session < ApplicationRecord
 
   def future_dates
     dates.select(&:future?)
+  end
+
+  def can_change_programmes?
+    open? && dates.all?(&:future?)
   end
 
   def can_change_notification_dates?
@@ -284,14 +287,6 @@ class Session < ApplicationRecord
 
   def set_slug
     self.slug = SecureRandom.alphanumeric(10) if slug.nil?
-  end
-
-  def programmes_part_of_organisation
-    return if programmes.empty?
-
-    unless programmes.all? { organisation.programmes.include?(_1) }
-      errors.add(:programmes, :inclusion)
-    end
   end
 
   def earliest_date

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -13,7 +13,7 @@
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Programmes" }
-          row.with_value { safe_join(@session.programmes.map(&:name), tag.br) }
+          row.with_value { render AppProgrammeTagsComponent.new(@session.programmes) }
         end
       
         summary_list.with_row do |row|

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -14,6 +14,9 @@
         summary_list.with_row do |row|
           row.with_key { "Programmes" }
           row.with_value { render AppProgrammeTagsComponent.new(@session.programmes) }
+          if @session.can_change_programmes?
+            row.with_action(text: "Change", href: edit_programmes_session_path(@session), visually_hidden_text: "programmes")
+          end
         end
       
         summary_list.with_row do |row|

--- a/app/views/sessions/edit/programmes.html.erb
+++ b/app/views/sessions/edit/programmes.html.erb
@@ -1,0 +1,16 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(edit_session_path(@session), name: "edit session") %>
+<% end %>
+
+<% legend = "Which programmes is this session part of?" %>
+<% content_for :page_title, legend %>
+
+<%= form_with model: @session, url: edit_programmes_session_path(@session), method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_collection_check_boxes :programme_ids, policy_scope(Programme), :id, :name,
+                                     legend: { text: legend, size: "l", tag: "h1" },
+                                     caption: { text: @session.location.name, size: "l" } %>
+
+  <%= f.govuk_submit "Continue" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -585,6 +585,8 @@ en:
               match_type: Vaccines must be suitable for the programme type
         session:
           attributes:
+            programme_ids:
+              blank: Choose which programmes this session is part of
             send_consent_requests_at:
               blank: Enter a date
               missing_day: Enter a day

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,13 @@ Rails.application.routes.draw do
       get "close", action: "edit_close"
       post "close", action: "update_close"
 
+      get "edit/programmes",
+          controller: "sessions/edit",
+          action: "edit_programmes"
+      put "edit/programmes",
+          controller: "sessions/edit",
+          action: "update_programmes"
+
       get "edit/send-consent-requests-at",
           controller: "sessions/edit",
           action: "edit_send_consent_requests_at"

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -47,7 +47,7 @@ describe "Manage school sessions" do
     then_i_see_no_sessions
 
     when_i_go_to_unscheduled_sessions
-    then_i_see_no_sessions
+    then_i_see_the_organisation_clinic
 
     when_i_go_to_scheduled_sessions
     then_i_see_the_school
@@ -91,7 +91,7 @@ describe "Manage school sessions" do
         programmes: [@programme]
       )
     @location = create(:school, :secondary, organisation: @organisation)
-    session =
+    @session =
       create(
         :session,
         :unscheduled,
@@ -99,7 +99,13 @@ describe "Manage school sessions" do
         organisation: @organisation,
         programme: @programme
       )
-    @patient = create(:patient, year_group: 8, session:)
+    @patient = create(:patient, year_group: 8, session: @session)
+
+    create(
+      :patient_session,
+      patient: @patient,
+      session: @organisation.generic_clinic_session
+    )
   end
 
   def when_i_go_to_todays_sessions_as_a_nurse
@@ -245,7 +251,7 @@ describe "Manage school sessions" do
   end
 
   def when_the_parent_visits_the_consent_form
-    visit start_parent_interface_consent_forms_path(Session.last, @programme)
+    visit start_parent_interface_consent_forms_path(@session, @programme)
   end
 
   def then_they_can_give_consent
@@ -259,7 +265,7 @@ describe "Manage school sessions" do
   end
 
   def then_they_can_no_longer_give_consent
-    visit start_parent_interface_consent_forms_path(Session.last, @programme)
+    visit start_parent_interface_consent_forms_path(@session, @programme)
     expect(page).to have_content("The deadline for responding has passed")
   end
 

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -25,6 +25,11 @@ describe "Manage school sessions" do
     when_i_choose_the_dates
     then_i_see_the_confirmation_page
 
+    when_i_click_on_change_programmes
+    then_i_see_the_change_programmes_page
+    and_i_change_the_programmes
+    and_i_confirm
+
     when_i_click_on_change_consent_requests
     then_i_see_the_change_consent_requests_page
     and_i_change_consent_requests_date
@@ -183,6 +188,18 @@ describe "Manage school sessions" do
 
   def then_i_see_the_confirmation_page
     expect(page).to have_content("Edit session")
+  end
+
+  def when_i_click_on_change_programmes
+    click_on "Change programmes"
+  end
+
+  def then_i_see_the_change_programmes_page
+    expect(page).to have_content("Which programmes is this session part of?")
+  end
+
+  def and_i_change_the_programmes
+    check "HPV"
   end
 
   def when_i_click_on_change_consent_requests

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -232,43 +232,6 @@ describe Session do
     end
   end
 
-  describe "#close!" do
-    subject(:close!) { session.close! }
-
-    let(:programme) { create(:programme) }
-    let(:organisation) { create(:organisation, programmes: [programme]) }
-    let(:session) { create(:session, :completed, organisation:, programme:) }
-
-    context "with a vaccinated patient" do
-      let(:patient) { create(:patient, :vaccinated, programme:, session:) }
-
-      it "doesn't add the patient to the clinic" do
-        expect { close! }.not_to(change { patient.reload.sessions.count })
-        expect(patient.sessions).to contain_exactly(session)
-      end
-    end
-
-    context "with an unvaccinated patient" do
-      let(:patient) { create(:patient, session:) }
-
-      it "adds the patient to the clinic" do
-        expect { close! }.to(change { patient.reload.sessions.count })
-        expect(patient.sessions).to include(organisation.generic_clinic_session)
-      end
-    end
-
-    context "with an unvaccinated patient and consent refused" do
-      let(:patient) { create(:patient, session:) }
-
-      before { create(:consent, :refused, patient:, programme:) }
-
-      it "doesn't add the patient to the clinic" do
-        expect { close! }.not_to(change { patient.reload.sessions.count })
-        expect(patient.sessions).to contain_exactly(session)
-      end
-    end
-  end
-
   describe "#open_for_consent?" do
     subject(:open_for_consent?) { session.open_for_consent? }
 


### PR DESCRIPTION
This makes it possible to edit the programmes that a session administers after the session dates have been scheduled, as long as all the dates are in the past and the session is still open.

## Screenshots

<img width="792" alt="Screenshot 2025-02-18 at 13 44 47" src="https://github.com/user-attachments/assets/bb7ac5a3-43d1-41df-a821-ec0265371a2e" />
<img width="803" alt="Screenshot 2025-02-18 at 13 44 41" src="https://github.com/user-attachments/assets/23f9f32c-f7b7-4f5e-8696-d547afd8c715" />
<img width="809" alt="Screenshot 2025-02-18 at 13 44 26" src="https://github.com/user-attachments/assets/cfbe0d37-6bd4-4294-bc08-0f27e268ac42" />
<img width="318" alt="Screenshot 2025-02-18 at 13 31 26" src="https://github.com/user-attachments/assets/cbc21e40-818b-49b3-97a6-515839d54fb1" />
<img width="276" alt="Screenshot 2025-02-18 at 13 31 20" src="https://github.com/user-attachments/assets/22afa74c-4ca3-4757-a4cf-2a136e5b288d" />
