### PR TITLE
Invalidate self-consents on a schedule 

### DIFF
--- a/app/jobs/invalidate_self_consents_job.rb
+++ b/app/jobs/invalidate_self_consents_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class InvalidateSelfConsentsJob < ApplicationJob
+  queue_as :consents
+
+  def perform
+    organisation_ids = Organisation.pluck(:id)
+    programme_ids = Programme.pluck(:id)
+
+    organisation_ids
+      .product(programme_ids)
+      .each do |organisation_id, programme_id|
+        consents =
+          Consent
+            .via_self_consent
+            .where(organisation_id:, programme_id:)
+            .where("created_at < ?", Date.current.beginning_of_day)
+            .not_withdrawn
+
+        triages =
+          Triage
+            .where(organisation_id:, programme_id:)
+            .where("created_at < ?", Date.current.beginning_of_day)
+            .where(patient_id: consents.pluck(:patient_id))
+
+        ActiveRecord::Base.transaction do
+          consents.invalidate_all
+          triages.invalidate_all
+        end
+      end
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -210,20 +210,13 @@ class Session < ApplicationRecord
     return unless completed?
 
     ActiveRecord::Base.transaction do
-      self_consents =
-        Consent.via_self_consent.where(
-          patient: patients_to_move_to_clinic,
-          organisation:,
-          programme: programmes
-        )
+      generic_clinic_session_id = organisation.generic_clinic_session.id
 
-      self_consents.invalidate_all
-
-      Triage.where(
-        patient: self_consents.map(&:patient),
-        organisation:,
-        programme: programmes
-      ).invalidate_all
+      PatientSession.import!(
+        %i[patient_id session_id],
+        patients_to_move_to_clinic.map { [_1.id, generic_clinic_session_id] },
+        on_duplicate_key_ignore: true
+      )
 
       update!(closed_at: Time.current)
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,6 +119,12 @@ Rails.application.configure do
       description:
         "Send school consent reminder emails to parents for each session"
     },
+    invalidate_self_consents: {
+      cron: "every day at 2am",
+      class: "InvalidateSelfConsentsJob",
+      description:
+        "Invalidate all self-consents and associated triage for the previous day"
+    },
     session_reminder: {
       cron: "every day at 9am",
       class: "SchoolSessionRemindersJob",

--- a/spec/jobs/invalidate_self_consents_job_spec.rb
+++ b/spec/jobs/invalidate_self_consents_job_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+describe InvalidateSelfConsentsJob do
+  subject(:perform_now) { described_class.perform_now }
+
+  context "with parental consent from yesterday" do
+    let(:consent) { create(:consent, created_at: 1.day.ago) }
+
+    it "does not invalidate the consent" do
+      expect { perform_now }.not_to(change { consent.reload.invalidated? })
+    end
+
+    context "with triage" do
+      let(:triage) do
+        create(
+          :triage,
+          created_at: 1.day.ago,
+          organisation: consent.organisation,
+          programme: consent.programme,
+          patient: consent.patient
+        )
+      end
+
+      it "does not invalidate the triage" do
+        expect { perform_now }.not_to(change { triage.reload.invalidated? })
+      end
+    end
+  end
+
+  context "with parental consent from today" do
+    let(:consent) { create(:consent) }
+
+    it "does not invalidate the consent" do
+      expect { perform_now }.not_to(change { consent.reload.invalidated? })
+    end
+
+    context "with triage" do
+      let(:triage) do
+        create(
+          :triage,
+          organisation: consent.organisation,
+          programme: consent.programme,
+          patient: consent.patient
+        )
+      end
+
+      it "does not invalidate the triage" do
+        expect { perform_now }.not_to(change { triage.reload.invalidated? })
+      end
+    end
+  end
+
+  context "with self-consent from yesterday" do
+    let(:consent) { create(:consent, :self_consent, created_at: 1.day.ago) }
+
+    it "invalidates the consent" do
+      expect { perform_now }.to change { consent.reload.invalidated? }.from(
+        false
+      ).to(true)
+    end
+
+    context "with triage" do
+      let(:triage) do
+        create(
+          :triage,
+          created_at: 1.day.ago,
+          organisation: consent.organisation,
+          programme: consent.programme,
+          patient: consent.patient
+        )
+      end
+
+      it "invalidates the triage" do
+        expect { perform_now }.to change { triage.reload.invalidated? }.from(
+          false
+        ).to(true)
+      end
+    end
+  end
+
+  context "with self-consent from today" do
+    let(:consent) { create(:consent, :self_consent) }
+
+    it "does not invalidate the consent" do
+      expect { perform_now }.not_to(change { consent.reload.invalidated? })
+    end
+
+    context "with triage" do
+      let(:triage) do
+        create(
+          :triage,
+          organisation: consent.organisation,
+          programme: consent.programme,
+          patient: consent.patient
+        )
+      end
+
+      it "does not invalidate the triage" do
+        expect { perform_now }.not_to(change { triage.reload.invalidated? })
+      end
+    end
+  end
+
+  context "with two programmes, parental consent for one and self-consent for the other" do
+    let(:parent_programme) { create(:programme, :flu) }
+    let(:self_programme) { create(:programme, :hpv) }
+
+    let(:organisation) do
+      create(:organisation, programmes: [parent_programme, self_programme])
+    end
+
+    let(:patient) { create(:patient) }
+
+    let!(:self_consent) do
+      create(
+        :consent,
+        :self_consent,
+        patient:,
+        created_at: 1.day.ago,
+        programme: self_programme,
+        organisation:
+      )
+    end
+    let!(:parent_consent) do
+      create(
+        :consent,
+        patient:,
+        created_at: 1.day.ago,
+        programme: parent_programme,
+        organisation:
+      )
+    end
+
+    it "does not invalidate the parent consent" do
+      expect { perform_now }.not_to(
+        change { parent_consent.reload.invalidated? }
+      )
+    end
+
+    it "invalidates the self-consent" do
+      expect { perform_now }.to change {
+        self_consent.reload.invalidated?
+      }.from(false).to(true)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new job which handles the logic related to invalidating self-consents after the day of the session. Currently this behaviour is triggered when a session is closed, but that isn't quite right. Self-consent is only valid in the particular session date that it was captured in, and it becomes invalid the day after.

Right now, self-consent transfers between dates in a single session and this is not correct. As we're removing the functionality to close a session, we need a different way of invalidating these self-consents, and putting it in a scheduled job seemed like the quickest way to achieve that, and it resolves the issue described above.

There are a number of problems with this approach that I would want to fix in the future, but these problems exist with the current solution so we're not introducing new problems:

- Gillick assessments remain valid. This is incorrect, they should also be invalidated, but we don't have a mechanism to do that currently.
- We invalidate triage at the same time which works fine, unless both the parent consented and the child consented, in which case the triage might still be valid as it came from the parental consent.