### PR TITLE
Add minimum doubles session page design

### DIFF
--- a/app/components/app_programme_selection_form_component.html.erb
+++ b/app/components/app_programme_selection_form_component.html.erb
@@ -1,0 +1,13 @@
+<%= form_with builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :get do |f| %>
+  <%= f.govuk_radio_buttons_fieldset :programme_type, inline: true, legend: { size: "s", text: "Programme" } do %>
+    <% programmes.each_with_index do |programme, index| %>
+      <%= f.govuk_radio_button :programme_type,
+                               programme.type,
+                               label: { text: programme.name },
+                               link_errors: index.zero?,
+                               checked: programme == active_programme %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit "Update programme", secondary: true %>
+<% end %>

--- a/app/components/app_programme_selection_form_component.rb
+++ b/app/components/app_programme_selection_form_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AppProgrammeSelectionFormComponent < ViewComponent::Base
+  def initialize(programmes, active:)
+    super
+
+    @programmes = programmes
+    @active_programme = active
+  end
+
+  private
+
+  attr_reader :programmes, :active_programme
+end

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -3,13 +3,13 @@
 class AppSessionPatientTableComponent < ViewComponent::Base
   def initialize(
     section:,
-    programme:,
     caption: nil,
     columns: %i[name year_group],
     consent_form: nil,
     params: {},
     patient_sessions: nil,
     patients: nil,
+    programme: nil,
     year_groups: nil
   )
     super
@@ -36,7 +36,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     @params = params
     @programme = programme
     @section = section
-    @year_groups = year_groups || @programme.year_groups || []
+    @year_groups = year_groups || programme&.year_groups || []
   end
 
   private
@@ -115,6 +115,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     tab = params[:tab]
 
     session = patient_session.session
+    programme = @programme || session.programmes.first
 
     # TODO: Remove this once "Record session outcomes" exists.
     # We have to guess the section and tab if it's not provided, this
@@ -153,7 +154,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
       session_patient_programme_path(
         session,
         patient,
-        @programme,
+        programme,
         section:,
         tab:
       )

--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -26,9 +26,7 @@ class RegisterAttendancesController < ApplicationController
     name = @patient.full_name
 
     flash[:info] = if session_attendance.attending?
-      programme = @patient_session.programmes.first # TODO: handle multiple programmes
-      status = @patient_session.status(programme:)
-      t("attendance_flash.#{status}", name:)
+      t("attendance_flash.present", name:)
     else
       t("attendance_flash.absent", name:)
     end

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -25,11 +25,8 @@ class SessionAttendancesController < ApplicationController
     if success
       name = @patient.full_name
 
-      programme = @patient_session.programmes.first # TODO: handle multiple programmes
-
       flash[:info] = if @session_attendance.attending?
-        status = @patient_session.status(programme:)
-        t("attendance_flash.#{status}", name:)
+        t("attendance_flash.present", name:)
       elsif @session_attendance.attending.nil?
         t("attendance_flash.not_registered", name:)
       else
@@ -38,7 +35,7 @@ class SessionAttendancesController < ApplicationController
 
       redirect_to session_patient_programme_path(
                     patient_id: @patient.id,
-                    programme_type: programme.type
+                    programme_type: @patient_session.programmes.first.type
                   )
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -39,8 +39,10 @@ class SessionsController < ApplicationController
       format.html do
         patient_sessions = @session.patient_sessions.preload_for_status
 
-        programme = @session.programmes.first # TODO: handle multiple programmes
-        @stats = PatientSessionStats.new(patient_sessions, programme:)
+        @stats_by_programme =
+          @session.programmes.index_with do |programme|
+            PatientSessionStats.new(patient_sessions, programme:)
+          end
 
         render layout: "full"
       end

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -23,7 +23,6 @@
         patients: @patients,
         programme: @consent_form.programme,
         section: :matching,
-        year_groups: @consent_form.original_session.year_groups,
       )
     end %>
 

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -10,6 +10,8 @@
 
 <%= h1 page_title, page_title: %>
 
+<%= render AppProgrammeSelectionFormComponent.new(@session.programmes, active: @programme) %>
+
 <%= render AppSecondaryNavigationComponent.new do |nav| %>
   <% TAB_PATHS[:consents].each do |tab, state| %>
     <% nav.with_item(selected: @current_tab == state,
@@ -25,7 +27,6 @@
       columns: @current_tab == :consent_refused ? %i[name year_group reason] : %i[name year_group],
       params:,
       patient_sessions: @patient_sessions,
-      programme: @session.programmes.first,
+      programme: @programme,
       section: :consents,
-      year_groups: @session.year_groups,
     ) %>

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        session_section_tab_path(@session),
+        session_section_tab_path(@session, programme_type: @programme.type),
         name: "#{@section.pluralize} page",
       ) %>
 <% end %>

--- a/app/views/register_attendances/index.html.erb
+++ b/app/views/register_attendances/index.html.erb
@@ -13,10 +13,9 @@
 <%= render AppSessionPatientTableComponent.new(
       caption: t("patients_table.register_attendance.caption",
                  children: t("children", count: @patient_sessions.count)),
-      columns: %i[name year_group status attendance],
+      columns: %i[name year_group attendance],
       params:,
       patient_sessions: @patient_sessions,
-      programme: @session.programmes.first,
       section: :attendance,
       year_groups: @session.year_groups,
     ) %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -33,59 +33,69 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <ul class="nhsuk-grid-row nhsuk-card-group">
-      <% if @session.unscheduled? %>
+    <% if @session.unscheduled? %>
+      <ul class="nhsuk-grid-row nhsuk-card-group">
         <li class="nhsuk-grid-column-full nhsuk-card-group__item">
           <%= render AppCardComponent.new(link_to: edit_session_path) do |c| %>
             <% c.with_heading { "Schedule sessions" } %>
             <% c.with_description { "Add dates for this school." } %>
           <% end %>
         </li>
-      <% else %>
-        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: session_consents_path(@session)) do |c| %>
-            <% c.with_heading { "Check consent responses" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @stats[:without_a_response]) %> without a response<br>
-              <%= t("children", count: @stats[:with_consent_given]) %> with consent given<br>
-              <%= t("children", count: @stats[:with_consent_refused]) %> with consent refused<br>
-              <%= t("children", count: @stats[:with_conflicting_consent]) %> with conflicting consent
-            <% end %>
-          <% end %>
-        </li>
-
-        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: session_triage_path(@session)) do |c| %>
-            <% c.with_heading { "Triage health questions" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @stats[:needing_triage]) %> needing triage
-            <% end %>
-          <% end %>
-        </li>
-
-        <% if @session.today? %>
+      </ul>
+    <% else %>
+      <% if @session.today? %>
+        <ul class="nhsuk-grid-row nhsuk-card-group">
           <li class="nhsuk-grid-column-full nhsuk-card-group__item">
             <%= render AppCardComponent.new(link_to: session_attendances_path(@session)) do |c| %>
               <% c.with_heading { "Register attendance" } %>
               <% c.with_description do %>
-                <%= t("children", count: @stats[:not_registered]) %> still to register
+                <%= t("children", count: @stats_by_programme[@session.programmes.first][:not_registered]) %> still to register
               <% end %>
             <% end %>
           </li>
-        <% end %>
-
-        <li class="nhsuk-grid-column-full nhsuk-card-group__item">
-          <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session)) do |c| %>
-            <% c.with_heading { "Record vaccinations" } %>
-            <% c.with_description do %>
-              <%= t("children", count: @stats[:vaccinate]) %> to vaccinate<br>
-              <%= t("children", count: @stats[:vaccinated]) %> vaccinated<br>
-              <%= t("children", count: @stats[:could_not_vaccinate]) %> could not be vaccinated
-            <% end %>
-          <% end %>
-        </li>
+        </ul>
       <% end %>
-    </ul>
+
+      <% @session.programmes.each do |programme| %>
+        <% stats = @stats_by_programme[programme] %>
+
+        <h2 class="nhsuk-heading-m"><%= programme.name %></h2>
+
+        <ul class="nhsuk-grid-row nhsuk-card-group">
+          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+            <%= render AppCardComponent.new(link_to: session_consents_path(@session, programme_type: programme.type)) do |c| %>
+              <% c.with_heading { "Check consent responses" } %>
+              <% c.with_description do %>
+                <%= t("children", count: stats[:without_a_response]) %> without a response<br>
+                <%= t("children", count: stats[:with_consent_given]) %> with consent given<br>
+                <%= t("children", count: stats[:with_consent_refused]) %> with consent refused<br>
+                <%= t("children", count: stats[:with_conflicting_consent]) %> with conflicting consent
+              <% end %>
+            <% end %>
+          </li>
+
+          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+            <%= render AppCardComponent.new(link_to: session_triage_path(@session, programme_type: programme.type)) do |c| %>
+              <% c.with_heading { "Triage health questions" } %>
+              <% c.with_description do %>
+                <%= t("children", count: stats[:needing_triage]) %> needing triage
+              <% end %>
+            <% end %>
+          </li>
+
+          <li class="nhsuk-grid-column-full nhsuk-card-group__item">
+            <%= render AppCardComponent.new(link_to: session_vaccinations_path(@session, programme_type: programme.type)) do |c| %>
+              <% c.with_heading { "Record vaccinations" } %>
+              <% c.with_description do %>
+                <%= t("children", count: stats[:vaccinate]) %> to vaccinate<br>
+                <%= t("children", count: stats[:vaccinated]) %> vaccinated<br>
+                <%= t("children", count: stats[:could_not_vaccinate]) %> could not be vaccinated
+              <% end %>
+            <% end %>
+          </li>
+        </ul>
+      <% end %>
+    <% end %>
   </div>
 
   <div class="nhsuk-grid-column-one-third">

--- a/app/views/triages/index.html.erb
+++ b/app/views/triages/index.html.erb
@@ -10,6 +10,8 @@
 
 <%= h1 page_title, page_title: %>
 
+<%= render AppProgrammeSelectionFormComponent.new(@session.programmes, active: @programme) %>
+
 <%= render AppSecondaryNavigationComponent.new do |nav| %>
   <% TAB_PATHS[:triage].each do |tab, state| %>
     <% nav.with_item(selected: @current_tab == state,
@@ -25,7 +27,6 @@
       columns: %i[name year_group],
       params:,
       patient_sessions: @patient_sessions,
-      programme: @session.programmes.first,
+      programme: @programme,
       section: :triage,
-      year_groups: @session.year_groups,
     ) %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -10,6 +10,8 @@
 
 <%= h1 "Record vaccinations" %>
 
+<%= render AppProgrammeSelectionFormComponent.new(@session.programmes, active: @programme) %>
+
 <% if @todays_batch.present? %>
   <%= govuk_inset_text html_attributes: { class: "nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-4" } do %>
     <span class="nhsuk-visually-hidden">Information: </span>
@@ -41,7 +43,6 @@
         %i[name year_group status],
       params:,
       patient_sessions: @patient_sessions,
-      programme: @session.programmes.first,
+      programme: @programme,
       section: :vaccinations,
-      year_groups: @session.year_groups,
     ) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -877,18 +877,8 @@ en:
       title: Vaccines
   attendance_flash:
     absent: "%{name} is absent from today’s session."
-    added_to_session: "%{name} is attending today’s session. They still need consent to vaccinate."
-    consent_conflicts: "%{name} is attending today’s session. They still need consent to vaccinate."
-    consent_given_triage_needed: "%{name} is attending today’s session. A nurse needs to triage their record."
-    consent_given_triage_not_needed: "%{name} is attending today’s session. They are ready for the nurse."
-    consent_refused: "%{name} needs to leave the session because their parent or guardian refused to give consent."
-    delay_vaccination: "%{name} needs to leave the session because their vaccination is delayed to a later date."
     not_registered: "%{name} is not registered yet."
-    triaged_do_not_vaccinate: "%{name} needs to leave the session because their parent or guardian refused to give consent."
-    triaged_kept_in_triage: "%{name} is attending today’s session. A nurse needs to triage their record."
-    triaged_ready_to_vaccinate: "%{name} is attending today’s session. They are safe to vaccinate."
-    unable_to_vaccinate: "%{name} needs to leave the session because they cannot be vaccinated."
-    vaccinated: "%{name} needs to leave the session because they have already been vaccinated."
+    present: "%{name} is attending today’s session."
   wicked:
     address: address
     agree: agree

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,7 +249,8 @@ Rails.application.routes.draw do
             as: "consents",
             to:
               redirect(
-                "/sessions/%{session_slug}/consents/#{TAB_PATHS[:consents].keys.first}"
+                path:
+                  "/sessions/%{session_slug}/consents/#{TAB_PATHS[:consents].keys.first}"
               )
 
         get ":tab",
@@ -266,7 +267,8 @@ Rails.application.routes.draw do
             as: "triage",
             to:
               redirect(
-                "/sessions/%{session_slug}/triage/#{TAB_PATHS[:triage].keys.first}"
+                path:
+                  "/sessions/%{session_slug}/triage/#{TAB_PATHS[:triage].keys.first}"
               )
 
         get ":tab",
@@ -283,7 +285,8 @@ Rails.application.routes.draw do
             as: "vaccinations",
             to:
               redirect(
-                "/sessions/%{session_slug}/vaccinations/#{TAB_PATHS[:vaccinations].keys.first}"
+                path:
+                  "/sessions/%{session_slug}/vaccinations/#{TAB_PATHS[:vaccinations].keys.first}"
               )
 
         get "batch", to: "vaccinations#batch"

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -68,7 +68,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "name", direction: "asc" } }
 
       it "sorts patient sessions by name in ascending order" do
-        controller.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions, programme:)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Alex Blair Casey]
         )
@@ -79,7 +79,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "dob", direction: "desc" } }
 
       it "sorts patient sessions by date of birth in descending order" do
-        controller.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions, programme:)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Alex Blair Casey]
         )
@@ -90,7 +90,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "outcome", direction: "desc" } }
 
       it "sorts patient sessions by state in descending order" do
-        controller.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions, programme:)
         expect(patient_sessions.map { it.status(programme:) }).to eq(
           %w[vaccinated delay_vaccination added_to_session]
         )
@@ -101,7 +101,7 @@ describe PatientSortingConcern do
       let(:params) { { sort: "postcode", direction: "desc" } }
 
       it "sorts patient sessions by name in ascending order" do
-        controller.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions, programme:)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Blair Alex Casey]
         )
@@ -111,7 +111,7 @@ describe PatientSortingConcern do
         before { blair.update!(restricted_at: Time.current) }
 
         it "they are treated as though they have no postcode" do
-          controller.sort_patients!(patient_sessions)
+          controller.sort_patients!(patient_sessions, programme:)
           expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
             %w[Alex Casey Blair]
           )
@@ -123,7 +123,7 @@ describe PatientSortingConcern do
       let(:params) { {} }
 
       it "does not change the order of patient sessions" do
-        controller.sort_patients!(patient_sessions)
+        controller.sort_patients!(patient_sessions, programme:)
         expect(patient_sessions.map(&:patient).map(&:given_name)).to eq(
           %w[Alex Blair Casey]
         )
@@ -136,7 +136,7 @@ describe PatientSortingConcern do
       let(:params) { { name: "Alex" } }
 
       it "filters patient sessions by patient name" do
-        controller.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions, programme:)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Alex")
       end
@@ -146,7 +146,7 @@ describe PatientSortingConcern do
       let(:params) { { postcode: "SW2A" } }
 
       it "filters patient sessions by date of birth" do
-        controller.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions, programme:)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Blair")
       end
@@ -155,7 +155,7 @@ describe PatientSortingConcern do
         before { blair.update!(restricted_at: Time.current) }
 
         it "excludes the patient from the result" do
-          controller.filter_patients!(patient_sessions)
+          controller.filter_patients!(patient_sessions, programme:)
           expect(patient_sessions.size).to eq(0)
         end
       end
@@ -165,7 +165,7 @@ describe PatientSortingConcern do
       let(:params) { { year_groups: %w[9] } }
 
       it "filters patient sessions by date of birth" do
-        controller.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions, programme:)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Blair")
       end
@@ -175,7 +175,7 @@ describe PatientSortingConcern do
       let(:params) { { name: "Alex", year_groups: %w[8] } }
 
       it "filters patient sessions by both name and date of birth" do
-        controller.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions, programme:)
         expect(patient_sessions.size).to eq(1)
         expect(patient_sessions.first.patient.given_name).to eq("Alex")
       end
@@ -185,7 +185,7 @@ describe PatientSortingConcern do
       let(:params) { {} }
 
       it "does not filter patient sessions" do
-        controller.filter_patients!(patient_sessions)
+        controller.filter_patients!(patient_sessions, programme:)
         expect(patient_sessions.size).to eq(3)
       end
     end


### PR DESCRIPTION
This updates the session page to support doubles while making the minimal number of changes. See https://github.com/nhsuk/manage-vaccinations-in-schools-prototype/pull/60#issuecomment-2654614711 for the original design ideas.

I haven't added any feature tests for this feature, but the tests we've got for HPV continue to pass so we can be confident that nothing has broken for HPV. I wanted to get this feature out to the testers and then I will add feature tests in the mean time while they can start on the manual testing.

## Screenshots

<img width="578" alt="Screenshot 2025-02-19 at 11 56 55" src="https://github.com/user-attachments/assets/0832577f-7190-4faa-b2cd-722caa230eed" />

<img width="393" alt="Screenshot 2025-02-19 at 12 26 29" src="https://github.com/user-attachments/assets/44d38b4d-adb8-4752-a190-6b3db1ffe16d" />
