### PR TITLE
Validate date of vaccination is after date of birth

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -75,8 +75,9 @@ class ImmunisationImportRow
 
   validates :date_of_vaccination,
             comparison: {
-              greater_than_or_equal_to: Date.new(2021, 9, 1),
-              less_than_or_equal_to: -> { Date.current }
+              greater_than: :patient_date_of_birth,
+              less_than_or_equal_to: -> { Date.current },
+              if: :patient_date_of_birth
             }
   validates :time_of_vaccination,
             presence: {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,8 +254,8 @@ en:
               inclusion: Enter a clinic name
             date_of_vaccination:
               blank: Enter a date in the correct format
-              greater_than_or_equal_to: The vaccination date is outside the programme. Enter a date after the programme started.
-              less_than_or_equal_to: The vaccination date is outside the programme. Enter a date before today.
+              greater_than: The vaccination date is before the date of birth
+              less_than_or_equal_to: The vaccination date is in the future
               inclusion: Enter a date for a current session
             delivery_site:
               blank: Enter an anatomical site.

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -165,6 +165,21 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "with a date of vaccination before the child was born" do
+      around { |example| freeze_time { example.run } }
+
+      let(:data) do
+        { "PERSON_DOB" => "20100101", "DATE_OF_VACCINATION" => "20090101" }
+      end
+
+      it "has an error" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:date_of_vaccination]).to include(
+          "The vaccination date is before the date of birth"
+        )
+      end
+    end
+
     context "when vaccinated and a reason not given" do
       let(:data) do
         { "VACCINATED" => "Y", "REASON_NOT_VACCINATED" => "unwell" }


### PR DESCRIPTION
This changes how we validate the date of vaccination when importing vaccination records to ensure it comes after the date of birth. This is necessary for doubles where some patients will have received vaccinations before starting school.