### PR TITLE
Invite patients to clinics

### DIFF
--- a/app/components/app_programme_session_table_component.html.erb
+++ b/app/components/app_programme_session_table_component.html.erb
@@ -37,9 +37,9 @@
                   Last session completed <%= session.dates.max&.to_fs(:long) %>
                 <% else %>
                   <% if session.started? %>
-                    Next session starts <%= session.today_or_future_dates.first.to_fs(:long) %>
+                    Next session starts <%= session.next_date.to_fs(:long) %>
                   <% else %>
-                    First session starts <%= session.today_or_future_dates.first.to_fs(:long) %>
+                    First session starts <%= session.next_date.to_fs(:long) %>
                   <% end %>
 
                   <br />

--- a/app/controllers/sessions/invite_to_clinic_controller.rb
+++ b/app/controllers/sessions/invite_to_clinic_controller.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class Sessions::InviteToClinicController < ApplicationController
+  before_action :set_session
+  before_action :set_generic_clinic_session
+  before_action :set_invitations_to_send
+
+  skip_after_action :verify_policy_scoped
+
+  def edit
+    @initial_invitations = @session.school?
+  end
+
+  def update
+    if @session.school?
+      SendClinicInitialInvitationsJob.perform_later(
+        @generic_clinic_session,
+        school: @session.location,
+        programme_ids: @session.programmes.map(&:id)
+      )
+      flash[
+        :success
+      ] = "Clinic invitations sent for #{I18n.t("children", count: @invitations_to_send)}"
+    else
+      SendClinicSubsequentInvitationsJob.perform_later(@session)
+      flash[
+        :success
+      ] = "Booking reminders sent for #{I18n.t("children", count: @invitations_to_send)}"
+    end
+
+    redirect_to session_path(@session)
+  end
+
+  private
+
+  def set_session
+    @session = authorize Session.find_by!(slug: params[:session_slug])
+
+    render status: :not_found unless @session.can_send_clinic_invitations?
+  end
+
+  def set_generic_clinic_session
+    @generic_clinic_session =
+      @session.clinic? ? @session : @session.organisation.generic_clinic_session
+  end
+
+  def set_invitations_to_send
+    session_date = @generic_clinic_session.next_date
+
+    @invitations_to_send =
+      if @session.school?
+        SendClinicInitialInvitationsJob
+          .new
+          .patient_sessions(
+            @generic_clinic_session,
+            school: @session.location,
+            programmes: @session.programmes,
+            session_date:
+          )
+          .length
+      else
+        SendClinicSubsequentInvitationsJob
+          .new
+          .patient_sessions(@session, session_date:)
+          .length
+      end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -69,8 +69,6 @@ class SessionsController < ApplicationController
 
   private
 
-  delegate :organisation, to: :current_user
-
   def set_session
     @session = authorize sessions_scope.find_by!(slug: params[:slug])
   end

--- a/app/jobs/clinic_session_invitations_job.rb
+++ b/app/jobs/clinic_session_invitations_job.rb
@@ -12,7 +12,11 @@ class ClinicSessionInvitationsJob < ApplicationJob
         # We're only inviting patients who don't have a school.
         # Patients who have a school are sent invitations manually by the
         # nurse when they're finished at a school.
-        SendClinicInitialInvitationsJob.perform_now(session, school: nil)
+        SendClinicInitialInvitationsJob.perform_now(
+          session,
+          school: nil,
+          programme_ids: session.programmes.pluck(:id)
+        )
       end
   end
 end

--- a/app/jobs/concerns/send_clinic_invitations_concern.rb
+++ b/app/jobs/concerns/send_clinic_invitations_concern.rb
@@ -3,15 +3,7 @@
 module SendClinicInvitationsConcern
   extend ActiveSupport::Concern
 
-  def send_notification(patient_session:, programmes:, session_date:)
-    unless should_send_notification?(
-             patient_session:,
-             programmes:,
-             session_date:
-           )
-      return
-    end
-
+  def send_notification(patient_session:, session_date:)
     type =
       if patient_session.session_notifications.any?
         :clinic_subsequent_invitation

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -8,7 +8,7 @@ class SendClinicInitialInvitationsJob < ApplicationJob
   def perform(session, school:)
     raise InvalidLocation unless session.clinic?
 
-    session_date = session.today_or_future_dates.first
+    session_date = session.next_date
     raise NoSessionDates if session_date.nil?
 
     programmes = session.programmes

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -5,30 +5,43 @@ class SendClinicInitialInvitationsJob < ApplicationJob
 
   queue_as :notifications
 
-  def perform(session, school:)
+  def perform(session, school:, programme_ids:)
     raise InvalidLocation unless session.clinic?
 
     session_date = session.next_date
     raise NoSessionDates if session_date.nil?
 
-    programmes = session.programmes
+    programmes = session.programmes.where(id: programme_ids)
 
-    patient_sessions =
-      session
-        .patient_sessions
-        .eager_load(:patient)
-        .preload(
-          :session_notifications,
-          patient: %i[consents parents vaccination_records]
-        )
-        .where(patient: { school: })
+    patient_sessions(
+      session,
+      school:,
+      programmes:,
+      session_date:
+    ).each do |patient_session|
+      send_notification(patient_session:, session_date:)
+    end
+  end
 
+  def patient_sessions(session, school:, programmes:, session_date:)
     # We only send initial invitations to patients who haven't already
     # received an invitation.
-    patient_sessions
+
+    session
+      .patient_sessions
+      .eager_load(:patient)
+      .preload(
+        :session_notifications,
+        patient: %i[consents parents vaccination_records]
+      )
+      .where(patient: { school: })
       .reject { it.session_notifications.any? }
-      .each do |patient_session|
-        send_notification(patient_session:, programmes:, session_date:)
+      .select do
+        should_send_notification?(
+          patient_session: it,
+          programmes:,
+          session_date:
+        )
       end
   end
 end

--- a/app/jobs/send_clinic_subsequent_invitations_job.rb
+++ b/app/jobs/send_clinic_subsequent_invitations_job.rb
@@ -8,7 +8,7 @@ class SendClinicSubsequentInvitationsJob < ApplicationJob
   def perform(session)
     raise InvalidLocation unless session.clinic?
 
-    session_date = session.today_or_future_dates.first
+    session_date = session.next_date
     raise NoSessionDates if session_date.nil?
 
     programmes = session.programmes

--- a/app/jobs/send_clinic_subsequent_invitations_job.rb
+++ b/app/jobs/send_clinic_subsequent_invitations_job.rb
@@ -11,23 +11,27 @@ class SendClinicSubsequentInvitationsJob < ApplicationJob
     session_date = session.next_date
     raise NoSessionDates if session_date.nil?
 
-    programmes = session.programmes
+    patient_sessions(session, session_date:).each do |patient_session|
+      send_notification(patient_session:, session_date:)
+    end
+  end
 
-    patient_sessions =
-      session
-        .patient_sessions
-        .eager_load(:patient)
-        .preload(
-          :session_notifications,
-          patient: %i[consents parents vaccination_records]
-        )
+  def patient_sessions(session, session_date:)
+    programmes = session.programmes
 
     # We only send subsequent invitations (reminders) to patients who
     # have already received an invitation.
-    patient_sessions
+
+    session
+      .patient_sessions
+      .eager_load(:patient)
+      .preload(
+        :session_notifications,
+        patient: %i[consents parents vaccination_records]
+      )
       .select { it.session_notifications.any? }
-      .each do |patient_session|
-        send_notification(patient_session:, programmes:, session_date:)
+      .select do |patient_session|
+        should_send_notification?(patient_session:, programmes:, session_date:)
       end
   end
 end

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -134,7 +134,7 @@ class GovukNotifyPersonalisation
   end
 
   def next_session_date
-    session.today_or_future_dates.first&.to_fs(:short_day_of_week)
+    session.next_date&.to_fs(:short_day_of_week)
   end
 
   def next_session_dates

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -167,6 +167,10 @@ class Session < ApplicationRecord
     dates.select(&:future?)
   end
 
+  def next_date
+    today_or_future_dates.first
+  end
+
   def can_change_notification_dates?
     consent_notifications.empty? && session_notifications.empty?
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -127,7 +127,7 @@ class Session < ApplicationRecord
 
   before_create :set_slug
 
-  delegate :clinic?, to: :location
+  delegate :clinic?, :school?, to: :location
 
   def to_param
     slug
@@ -173,6 +173,14 @@ class Session < ApplicationRecord
 
   def can_change_notification_dates?
     consent_notifications.empty? && session_notifications.empty?
+  end
+
+  def can_send_clinic_invitations?
+    if clinic?
+      next_date && !completed?
+    else
+      completed? && organisation.generic_clinic_session.next_date
+    end
   end
 
   def <=>(other)

--- a/app/views/sessions/invite_to_clinic/edit.html.erb
+++ b/app/views/sessions/invite_to_clinic/edit.html.erb
@@ -1,0 +1,32 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
+<% end %>
+
+<% title = @initial_invitations ? "Invite parents to book a clinic appointment" : "Remind parents to book a clinic appointment" %>
+
+<%= h1 title do %>
+  <span class="nhsuk-caption-l"><%= @session.location.name %></span>
+  <%= title %>
+<% end %>
+
+<% if @initial_invitations %>
+  <p>This school session has been completed.</p>
+
+  <% if @invitations_to_send == 1 %>
+    <p>There is <%= @invitations_to_send %> child currently without clinic appointments. You can send invitations to their parents to book an appointment.</p>
+  <% else %>
+    <p>There are <%= @invitations_to_send %> children currently without clinic appointments. You can send invitations to their parents to book an appointment.</p>
+  <% end %>
+<% else %>
+  <% if @invitations_to_send == 1 %>
+    <p>This will send booking reminders to the parents of <%= @invitations_to_send %> child who has not yet been sent a reminder.</p>
+  <% else %>
+    <p>This will send booking reminders to the parents of <%= @invitations_to_send %> children who have not yet been sent a reminder.</p>
+  <% end %>
+<% end %>
+
+<p>The next clinic is on <%= @generic_clinic_session.next_date.to_fs(:long) %>.</p>
+
+<%= form_with url: session_invite_to_clinic_path(@session), method: :put do |f| %>
+  <%= f.govuk_submit @initial_invitations ? "Send clinic invitations" : "Send booking reminders" %>
+<% end %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -27,6 +27,16 @@
       <%= govuk_link_to "Import class list records", new_draft_class_import_path(@session) %>
     </li>
   <% end %>
+
+  <% if @session.clinic? && @session.can_send_clinic_invitations? %>
+    <li class="app-action-list__item">
+      <%= govuk_link_to "Send booking reminders", edit_session_invite_to_clinic_path(@session) %>
+    </li>
+  <% elsif @session.school? && @session.can_send_clinic_invitations? %>
+    <li class="app-action-list__item">
+      <%= govuk_link_to "Send clinic invitations", edit_session_invite_to_clinic_path(@session) %>
+    </li>
+  <% end %>
 </ul>
 
 <div class="nhsuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,11 @@ Rails.application.routes.draw do
   resources :school_moves, path: "school-moves", only: %i[index show update]
 
   resources :sessions, only: %i[edit index show], param: :slug do
+    resource :invite_to_clinic,
+             path: "invite-to-clinic",
+             only: %i[edit update],
+             controller: "sessions/invite_to_clinic"
+
     collection do
       get "completed"
       get "scheduled"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -237,6 +237,16 @@ def setup_clinic(user, organisation)
       year_group: 8
     )
   end
+
+  # All patients belong to the community clinic. This is normally
+  # handled by school moves, but here we need to do it manually.
+
+  PatientSession.import(
+    organisation.patients.map do
+      PatientSession.new(patient: it, session: clinic_session)
+    end,
+    on_duplicate_key_ignore: :all
+  )
 end
 
 def create_patients(organisation)

--- a/spec/features/manage_clinic_sessions_spec.rb
+++ b/spec/features/manage_clinic_sessions_spec.rb
@@ -3,7 +3,7 @@
 describe "Manage clinic sessions" do
   around { |example| travel_to(Time.zone.local(2024, 2, 18)) { example.run } }
 
-  scenario "Adding dates to the session and closing consent" do
+  scenario "Adding dates to the session, sending reminders and closing consent" do
     given_my_organisation_is_running_an_hpv_vaccination_programme
 
     when_i_go_to_todays_sessions_as_a_nurse
@@ -41,7 +41,17 @@ describe "Manage clinic sessions" do
     when_i_go_to_scheduled_sessions
     then_i_see_the_community_clinic
 
-    when_i_go_to_completed_sessions
+    when_the_patient_has_been_invited
+    and_i_click_on_the_community_clinic
+    and_i_click_on_send_reminders
+    then_i_see_the_send_reminders_page
+
+    when_i_click_on_send_reminders
+    then_i_see_the_reminder_confirmation
+    and_the_parent_receives_a_reminder
+
+    when_i_go_to_todays_sessions_as_a_nurse
+    and_i_go_to_completed_sessions
     then_i_see_no_sessions
 
     when_the_parent_visits_the_consent_form
@@ -65,7 +75,12 @@ describe "Manage clinic sessions" do
         programmes: [@programme]
       )
 
-    @organisation.generic_clinic_session # ensure it exists
+    @session = @organisation.generic_clinic_session
+
+    @parent = create(:parent)
+
+    @patient =
+      create(:patient, year_group: 8, session: @session, parents: [@parent])
   end
 
   def when_i_go_to_todays_sessions_as_a_nurse
@@ -181,6 +196,46 @@ describe "Manage clinic sessions" do
     expect(page).to have_content("11 March 2024")
   end
 
+  def then_i_see_the_community_clinic
+    expect(page).to have_content("Community clinics")
+  end
+
+  def when_the_patient_has_been_invited
+    create(
+      :session_notification,
+      :clinic_initial_invitation,
+      patient: @patient,
+      session: @session,
+      session_date: Date.current
+    )
+  end
+
+  def and_i_click_on_the_community_clinic
+    click_on "Community clinics"
+  end
+
+  def when_i_click_on_send_reminders
+    click_on "Send booking reminders"
+  end
+
+  alias_method :and_i_click_on_send_reminders, :when_i_click_on_send_reminders
+
+  def then_i_see_the_send_reminders_page
+    expect(page).to have_content("Remind parents to book a clinic appointment")
+    expect(page).to have_content(
+      "This will send booking reminders to the parents of 1 child who has not yet been sent a reminder."
+    )
+  end
+
+  def then_i_see_the_reminder_confirmation
+    expect(page).to have_content("Booking reminders sent for 1 child")
+  end
+
+  def and_the_parent_receives_a_reminder
+    perform_enqueued_jobs
+    expect_email_to @parent.email, :session_clinic_subsequent_invitation
+  end
+
   def when_the_parent_visits_the_consent_form
     visit start_parent_interface_consent_forms_path(Session.last, @programme)
   end
@@ -196,9 +251,5 @@ describe "Manage clinic sessions" do
   def then_they_can_no_longer_give_consent
     visit start_parent_interface_consent_forms_path(Session.last, @programme)
     expect(page).to have_content("The deadline for responding has passed")
-  end
-
-  def then_i_see_the_community_clinic
-    expect(page).to have_content("Community clinics")
   end
 end

--- a/spec/jobs/send_clinic_initial_invitations_job_spec.rb
+++ b/spec/jobs/send_clinic_initial_invitations_job_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 describe SendClinicInitialInvitationsJob do
-  subject(:perform_now) { described_class.perform_now(session, school: nil) }
+  subject(:perform_now) do
+    described_class.perform_now(
+      session,
+      school: nil,
+      programme_ids: [programme.id]
+    )
+  end
 
   let(:programme) { create(:programme) }
   let(:organisation) { create(:organisation, programmes: [programme]) }


### PR DESCRIPTION
This changes how invitations to get patients in to a clinic works to make it a manual process where the nurses have to trigger the invitation emails manually when the school session is completed, and similarly the nurses have to manually send the reminder emails from the community clinic session page.

## Screenshots

<img width="379" alt="Screenshot 2025-02-20 at 14 08 16" src="https://github.com/user-attachments/assets/84d675ba-483e-4961-a578-bfc3a72cf084" />
<img width="833" alt="Screenshot 2025-02-20 at 14 08 05" src="https://github.com/user-attachments/assets/f08e22c1-251a-46b3-bee2-6388244fa827" />
<img width="1178" alt="Screenshot 2025-02-20 at 14 07 37" src="https://github.com/user-attachments/assets/a2aacc76-f5f6-416b-9605-68caecb5d330" />
<img width="742" alt="Screenshot 2025-02-20 at 14 07 31" src="https://github.com/user-attachments/assets/5da3fd29-01b7-42db-9815-a2c2a36c05b6" />
<img width="1167" alt="Screenshot 2025-02-20 at 13 40 29" src="https://github.com/user-attachments/assets/ec64b527-832a-4253-b680-2a9d2ca2e414" />
<img width="460" alt="Screenshot 2025-02-20 at 12 30 47" src="https://github.com/user-attachments/assets/b82c2c17-5ba1-4490-b1ad-c03afd1f1876" />
