### PR TITLE
Add links to consent form start page

### DIFF
--- a/app/views/parent_interface/consent_forms/start.html.erb
+++ b/app/views/parent_interface/consent_forms/start.html.erb
@@ -6,7 +6,7 @@
   </h2>
 
   <% t("consent_forms.start.vaccines.#{programme.type}.description").each do %>
-    <p><%= _1 %></p>
+    <p><%= _1.html_safe %></p>
   <% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -733,6 +733,9 @@ en:
             - >-
               The number of doses you need depends on your age and how well your
               immune system works. Young people usually only need 1 dose.
+            - >-
+              <a href="https://www.nhs.uk/conditions/vaccinations/hpv-human-papillomavirus-vaccine/">Find
+              out more about the HPV vaccine</a>
         menacwy:
           title: MenACWY
           description:
@@ -740,12 +743,24 @@ en:
               The MenACWY vaccine helps protect against meningitis and sepsis.
               It is recommended for all teenagers. Most people only need one
               dose of the vaccine.
+            - >-
+              <a href="https://www.nhs.uk/vaccinations/menacwy-vaccine/">Find
+              out more about the MenACWY vaccine</a>
         td_ipv:
           title: Td/IPV (3-in-1 teenage booster)
           description:
             - >-
               The Td/IPV vaccine (also called the 3-in-1 teenage booster) helps
               protect against tetanus, diphtheria and polio.
+            - >-
+              It boosts the protection provided by the
+              <a href="https://www.nhs.uk/vaccinations/6-in-1-vaccine/">6-in-1
+              vaccine</a> and
+              <a href="https://www.nhs.uk/vaccinations/4-in-1-preschool-booster-vaccine/">4-in-1
+              pre-school booster vaccine</a>.
+            - >-
+              <a href="https://www.nhs.uk/vaccinations/td-ipv-vaccine-3-in-1-teenage-booster/">Find
+              out more about the Td/IPV vaccine</a>
       title: Give or refuse consent for vaccinations
   dashboard:
     index:


### PR DESCRIPTION
This updates the content from the consent form journey to match the prototype by adding the missing paragraphs with links.

`html_safe` is a little bit controversial here, but given that this is designed to be static content and shouldn't get variables passed into it from the `t` helper, it should be okay.

### Screenshots

<img width="811" alt="Screenshot 2025-02-20 at 16 50 43" src="https://github.com/user-attachments/assets/132d49e2-a8c3-40a5-8eaa-ee7a5ee6e77b" />
<img width="797" alt="Screenshot 2025-02-20 at 16 50 46" src="https://github.com/user-attachments/assets/a0fa1e86-43f1-404e-8e67-772aed256704" />
