### PR TITLE
Add GraphRecords module.

### DIFF
--- a/lib/graph_records.rb
+++ b/lib/graph_records.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+class GraphRecords
+  # @param parents [Array] Array of objects to focus on
+  # @param focus_config [Hash] Hash of class names to ids to focus on (make bold)
+  # @param node_order [Array] Array of class names in order to render nodes
+  # @param traversals_config [Hash] Hash of class names and arrays of associations to traverse
+  def initialize(
+    focus_config: {},
+    node_order: %i[class_import cohort_import patient consent parent],
+    traversals_config: {}
+  )
+    @focus_config = focus_config
+    @node_order = node_order
+    @traversals_config = traversals_config
+  end
+
+  def graph(**objects)
+    @nodes = Set.new
+    @edges = Set.new
+    @inspected = Set.new
+    @focus = @focus_config.map { _1.to_s.classify.constantize.where(id: _2) }
+
+    objects.map do |klass, ids|
+      class_name = klass.to_s.singularize
+      associated_objects =
+        load_association(
+          class_name,
+          class_name.classify.constantize.where(id: ids)
+        )
+
+      @focus += associated_objects
+
+      associated_objects.each do |obj|
+        @nodes << obj
+        inspect(obj)
+      end
+    end
+    ["flowchart TB"] + render_styles + render_nodes + render_edges
+  end
+
+  def traversals
+    @traversals ||= {
+      patient: %i[parents consents class_imports cohort_imports],
+      parent: %i[consents class_imports cohort_imports]
+    }.merge(@traversals_config)
+  end
+
+  def render_styles
+    {
+      patient: "fill:#c2e598",
+      parent: "fill:#faa0a0",
+      consent: "fill:#fffaa0",
+      class_import: "fill:#7fd7df",
+      cohort_import: "fill:#a2d2ff",
+      patient_focused: "fill:#c2e598,stroke:#000,stroke-width:3px",
+      parent_focused: "fill:#faa0a0,stroke:#000,stroke-width:3px"
+    }.with_indifferent_access
+      .slice(*(@nodes.map { class_text_for_obj(it) }))
+      .map { |klass, style| "  classDef #{klass} #{style}" }
+  end
+
+  def render_nodes
+    @nodes.to_a.map { "  #{node_with_class(it)}" }
+  end
+
+  def render_edges
+    @edges.map { |from, to| "  #{node_name(from)} --> #{node_name(to)}" }
+  end
+
+  def inspect(obj)
+    associations_list = traversals[obj.class.name.underscore.to_sym]
+    return if associations_list.blank?
+
+    return if @inspected.include?(obj)
+    @inspected << obj
+
+    associations_list.each do
+      get_associated_objects(obj, it).each do
+        @nodes << it
+        @edges << order_nodes(obj, it)
+
+        inspect(it)
+      end
+    end
+  end
+
+  def get_associated_objects(obj, association_name)
+    obj
+      .send(association_name)
+      .then do |associated_objects|
+        load_association(association_name, associated_objects)
+      end
+  end
+
+  def load_association(association_name, associated_objects)
+    if respond_to?("#{association_name}_loader")
+      send("#{association_name}_loader", associated_objects)
+    else
+      associated_objects
+    end
+  end
+
+  def parents_loader(parents)
+    parents.includes(:consents, :class_imports, :cohort_imports)
+  end
+
+  def patients_loader(patients)
+    patients.includes(:parents, :class_imports, :cohort_imports)
+  end
+
+  def order_nodes(*nodes)
+    nodes.sort_by { @node_order.index(it.class.name.underscore.to_sym) }
+  end
+
+  def node_name(obj)
+    klass = obj.class.name.underscore
+    "#{klass}-#{obj.id}"
+  end
+
+  def node_with_class(obj)
+    "#{node_name(obj)}:::#{class_text_for_obj(obj)}"
+  end
+
+  def class_text_for_obj(obj)
+    obj.class.name.underscore + (obj.in?(@focus) ? "_focused" : "")
+  end
+end

--- a/lib/graph_records.rb
+++ b/lib/graph_records.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+# Spit out a Mermaid-style graph of records.
+#
+# Usage:
+#  graph = GraphRecords.new.graph(patients: [patient])
+#  puts graph
+#
 class GraphRecords
-  # @param parents [Array] Array of objects to focus on
-  # @param focus_config [Hash] Hash of class names to ids to focus on (make bold)
-  # @param node_order [Array] Array of class names in order to render nodes
-  # @param traversals_config [Hash] Hash of class names and arrays of associations to traverse
+  # @param focus_config [Hash] Hash of model names to ids to focus on (make bold)
+  # @param node_order [Array] Array of model names in order to render nodes
+  # @param traversals_config [Hash] Hash of model names to arrays of associations to traverse
   def initialize(
     focus_config: {},
     node_order: %i[class_import cohort_import patient consent parent],
@@ -15,6 +20,7 @@ class GraphRecords
     @traversals_config = traversals_config
   end
 
+  # @param objects [Hash] Hash of model name to ids to be graphed
   def graph(**objects)
     @nodes = Set.new
     @edges = Set.new

--- a/spec/lib/graph_records_spec.rb
+++ b/spec/lib/graph_records_spec.rb
@@ -1,0 +1,55 @@
+describe GraphRecords do
+  subject(:graph) { described_class.new.graph(patients: [patient]) }
+
+  let!(:programme) { create(:programme, :hpv) }
+  let!(:organisation) { create(:organisation, programmes: [programme]) }
+  let!(:session) { create(:session, organisation:, programmes: [programme]) }
+  let!(:class_import) { create(:class_import, session:) }
+  let!(:cohort_import) { create(:cohort_import, organisation:) }
+  let!(:parent) do
+    create(
+      :parent,
+      class_imports: [class_import],
+      cohort_imports: [cohort_import]
+    )
+  end
+  let!(:patient) do
+    create(
+      :patient,
+      parents: [parent],
+      session:,
+      organisation:,
+      programme:,
+      class_imports: [class_import],
+      cohort_imports: [cohort_import]
+    )
+  end
+  let!(:consent) do
+    create(:consent, :given, patient:, parent:, organisation:, programme:)
+  end
+
+  it { should start_with "flowchart TB" }
+
+  it "generates the graph" do
+    expect(graph).to contain_exactly(
+      "flowchart TB",
+      "  classDef patient_focused fill:#c2e598,stroke:#000,stroke-width:3px",
+      "  classDef parent fill:#faa0a0",
+      "  classDef consent fill:#fffaa0",
+      "  classDef class_import fill:#7fd7df",
+      "  classDef cohort_import fill:#a2d2ff",
+      "  patient-#{patient.id}:::patient_focused",
+      "  parent-#{parent.id}:::parent",
+      "  consent-#{consent.id}:::consent",
+      "  class_import-#{class_import.id}:::class_import",
+      "  cohort_import-#{cohort_import.id}:::cohort_import",
+      "  patient-#{patient.id} --> parent-#{parent.id}",
+      "  consent-#{consent.id} --> parent-#{parent.id}",
+      "  class_import-#{class_import.id} --> parent-#{parent.id}",
+      "  cohort_import-#{cohort_import.id} --> parent-#{parent.id}",
+      "  patient-#{patient.id} --> consent-#{consent.id}",
+      "  class_import-#{class_import.id} --> patient-#{patient.id}",
+      "  cohort_import-#{cohort_import.id} --> patient-#{patient.id}"
+    )
+  end
+end

--- a/spec/lib/graph_records_spec.rb
+++ b/spec/lib/graph_records_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe GraphRecords do
   subject(:graph) { described_class.new.graph(patients: [patient]) }
 


### PR DESCRIPTION
This can be used to output a mermaid-style flow diagram to visualise connections between records: patients, parents, consents, etc. The output data does not contain any pii, complete or partial, from these records.

For now this can be used through the console to generate these graphs to understand the structure and relationships connected to a patient, or other records. The next step will be to make this available in the non-prod envs through the browser on a page that will load in mermaid and render the graphs out.

Example from `test`:

```rb
manage-vaccinations(staging)> puts GraphRecords.new.graph(patients: [Patient.all.sample])
flowchart TB
  classDef patient_focused fill:#c2e598,stroke:#000,stroke-width:3px
  classDef parent fill:#faa0a0
  classDef consent fill:#fffaa0
  classDef cohort_import fill:#a2d2ff
  patient-7269:::patient_focused
  parent-7530:::parent
  consent-1240:::consent
  cohort_import-959:::cohort_import
  cohort_import-961:::cohort_import
  parent-7531:::parent
  patient-7269 --> parent-7530
  consent-1240 --> parent-7530
  cohort_import-959 --> parent-7530
  cohort_import-961 --> parent-7530
  patient-7269 --> parent-7531
  cohort_import-959 --> parent-7531
  cohort_import-961 --> parent-7531
  cohort_import-961 --> patient-7269
```

Which results in the following mermaid diagram:

```mermaid
flowchart TB
  classDef patient_focused fill:#c2e598,stroke:#000,stroke-width:3px
  classDef parent fill:#faa0a0
  classDef consent fill:#fffaa0
  classDef cohort_import fill:#a2d2ff
  patient-7269:::patient_focused
  parent-7530:::parent
  consent-1240:::consent
  cohort_import-959:::cohort_import
  cohort_import-961:::cohort_import
  parent-7531:::parent
  patient-7269 --> parent-7530
  consent-1240 --> parent-7530
  cohort_import-959 --> parent-7530
  cohort_import-961 --> parent-7530
  patient-7269 --> parent-7531
  cohort_import-959 --> parent-7531
  cohort_import-961 --> parent-7531
  cohort_import-961 --> patient-7269
  ```