### PR TITLE
Add programme to activity log entries

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -31,12 +31,16 @@ class AppActivityLogComponent < ViewComponent::Base
       @patient.consents.includes(
         :consent_form,
         :parent,
+        :programme,
         :recorded_by,
         patient: :parent_relationships
       )
 
     @gillick_assessments =
-      (patient || patient_session).gillick_assessments.includes(:performed_by)
+      (patient || patient_session).gillick_assessments.includes(
+        :performed_by,
+        :programme
+      )
 
     @notify_log_entries = @patient.notify_log_entries.includes(:sent_by)
 
@@ -46,7 +50,7 @@ class AppActivityLogComponent < ViewComponent::Base
     @session_attendances =
       (patient || patient_session).session_attendances.includes(:location)
 
-    @triages = @patient.triages.includes(:performed_by)
+    @triages = @patient.triages.includes(:performed_by, :programme)
 
     @vaccination_records =
       @patient.vaccination_records.with_discarded.includes(
@@ -94,14 +98,16 @@ class AppActivityLogComponent < ViewComponent::Base
           title: "Consent #{original_response}",
           at: consent_form.recorded_at,
           by:
-            "#{consent_form.parent_full_name} (#{consent_form.parent_relationship_label})"
+            "#{consent_form.parent_full_name} (#{consent_form.parent_relationship_label})",
+          programme: consent.programme
         }
       else
         {
           title:
             "Consent #{original_response} by #{consent.name} (#{consent.who_responded})",
           at: consent.created_at,
-          by: consent.recorded_by
+          by: consent.recorded_by,
+          programme: consent.programme
         }
       end
 
@@ -109,21 +115,24 @@ class AppActivityLogComponent < ViewComponent::Base
         events << {
           title: "Consent response manually matched with child record",
           at: consent.created_at,
-          by: consent.recorded_by
+          by: consent.recorded_by,
+          programme: consent.programme
         }
       end
 
       if consent.invalidated?
         events << {
           title: "Consent from #{consent.name} invalidated",
-          at: consent.invalidated_at
+          at: consent.invalidated_at,
+          programme: consent.programme
         }
       end
 
       if consent.withdrawn?
         events << {
           title: "Consent from #{consent.name} withdrawn",
-          at: consent.withdrawn_at
+          at: consent.withdrawn_at,
+          programme: consent.programme
         }
       end
 
@@ -147,18 +156,20 @@ class AppActivityLogComponent < ViewComponent::Base
         title: "#{action} Gillick assessment as #{outcome}",
         body: gillick_assessment.notes,
         at: gillick_assessment.created_at,
-        by: gillick_assessment.performed_by
+        by: gillick_assessment.performed_by,
+        programme: gillick_assessment.programme
       }
     end
   end
 
   def notify_events
-    notify_log_entries.map do
+    notify_log_entries.map do |notify_log_entry|
       {
-        title: "#{_1.title} sent",
-        body: patient.restricted? ? "" : _1.recipient_deterministic,
-        at: _1.created_at,
-        by: _1.sent_by
+        title: "#{notify_log_entry.title} sent",
+        body:
+          patient.restricted? ? "" : notify_log_entry.recipient_deterministic,
+        at: notify_log_entry.created_at,
+        by: notify_log_entry.sent_by
       }
     end
   end
@@ -186,12 +197,13 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def triage_events
-    triages.map do
+    triages.map do |triage|
       {
-        title: "Triaged decision: #{_1.human_enum_name(:status)}",
-        body: _1.notes,
-        at: _1.created_at,
-        by: _1.performed_by
+        title: "Triaged decision: #{triage.human_enum_name(:status)}",
+        body: triage.notes,
+        at: triage.created_at,
+        by: triage.performed_by,
+        programme: triage.programme
       }
     end
   end
@@ -209,7 +221,8 @@ class AppActivityLogComponent < ViewComponent::Base
         title:,
         body: vaccination_record.notes,
         at: vaccination_record.performed_at,
-        by: vaccination_record.performed_by
+        by: vaccination_record.performed_by,
+        programme: vaccination_record.programme
       }
 
       discarded =
@@ -217,7 +230,8 @@ class AppActivityLogComponent < ViewComponent::Base
           {
             title:
               "#{vaccination_record.programme.name} vaccination record deleted",
-            at: vaccination_record.discarded_at
+            at: vaccination_record.discarded_at,
+            programme: vaccination_record.programme
           }
         end
 

--- a/app/components/app_log_event_component.rb
+++ b/app/components/app_log_event_component.rb
@@ -17,6 +17,10 @@ class AppLogEventComponent < ViewComponent::Base
     <% end %>
     
     <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
+      <% if programme %>
+        <%= render AppProgrammeTagsComponent.new([programme]) %>
+        &nbsp;
+      <% end %>
       <%= invalidated ? tag.s(subtitle) : subtitle %>
     </p>
     
@@ -30,6 +34,7 @@ class AppLogEventComponent < ViewComponent::Base
     at:,
     body: nil,
     by: nil,
+    programme: nil,
     invalidated: false,
     card: false
   )
@@ -39,13 +44,14 @@ class AppLogEventComponent < ViewComponent::Base
     @body = body
     @at = at.to_fs(:long)
     @by = by.respond_to?(:full_name) ? by.full_name : by
+    @programme = programme
     @invalidated = invalidated
     @card = card
   end
 
   private
 
-  attr_reader :title, :body, :invalidated, :card
+  attr_reader :title, :body, :programme, :invalidated, :card
 
   def subtitle
     safe_join([@at, @by].compact, " &middot; ".html_safe)

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -36,7 +36,7 @@ describe AppActivityLogComponent do
     patient_session.patient.strict_loading!(false)
   end
 
-  shared_examples "card" do |title:, date:, notes: nil, by: nil|
+  shared_examples "card" do |title:, date:, notes: nil, by: nil, programme: nil|
     it "renders card '#{title}'" do
       expect(rendered).to have_css(".nhsuk-card h3", text: title)
 
@@ -45,6 +45,7 @@ describe AppActivityLogComponent do
       expect(card).to have_css("p", text: date)
       expect(card).to have_css("blockquote", text: notes) if notes
       expect(card).to have_css("p", text: by) if by
+      expect(card).to have_css("strong", text: programme) if programme
     end
   end
 
@@ -141,32 +142,38 @@ describe AppActivityLogComponent do
                      title: "Vaccinated with Gardasil 9 (HPV)",
                      date: "31 May 2024 at 12:00pm",
                      notes: "Some notes",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Vaccinated with Gardasil (HPV)",
                      date: "31 May 2024 at 1:00pm",
-                     notes: "Some notes"
+                     notes: "Some notes",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Triaged decision: Safe to vaccinate",
                      date: "30 May 2024 at 2:30pm",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Triaged decision: Keep in triage",
                      date: "30 May 2024 at 2:00pm",
                      notes: "Some notes",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Consent refused by John Doe (Dad)",
-                     date: "30 May 2024 at 1:00pm"
+                     date: "30 May 2024 at 1:00pm",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Consent given by Jane Doe (Mum)",
                      date: "30 May 2024 at 12:00pm",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Added to session at Hogwarts",
@@ -198,7 +205,8 @@ describe AppActivityLogComponent do
                      title: "HPV vaccination not given: Unwell",
                      date: "31 May 2024 at 1:00pm",
                      notes: "Some notes.",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
   end
 
   describe "discarded vaccination" do
@@ -218,11 +226,13 @@ describe AppActivityLogComponent do
     include_examples "card",
                      title: "Vaccinated with Gardasil 9 (HPV)",
                      date: "31 May 2024 at 1:00pm",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "HPV vaccination record deleted",
-                     date: "31 May 2024 at 2:00pm"
+                     date: "31 May 2024 at 2:00pm",
+                     programme: "HPV"
   end
 
   describe "self-consent" do
@@ -240,7 +250,8 @@ describe AppActivityLogComponent do
     include_examples "card",
                      title:
                        "Consent given by Sarah Doe (Child (Gillick competent))",
-                     date: "30 May 2024 at 12:00pm"
+                     date: "30 May 2024 at 12:00pm",
+                     programme: "HPV"
   end
 
   describe "manually matched consent" do
@@ -271,7 +282,8 @@ describe AppActivityLogComponent do
     include_examples "card",
                      title: "Consent given",
                      date: "30 May 2024 at 12:00pm",
-                     by: "Jane Doe (Mum)"
+                     by: "Jane Doe (Mum)",
+                     programme: "HPV"
 
     include_examples "card",
                      title:
@@ -296,11 +308,13 @@ describe AppActivityLogComponent do
 
     include_examples "card",
                      title: "Consent from Jane Doe withdrawn",
-                     date: "30 June 2024 at 12:00pm"
+                     date: "30 June 2024 at 12:00pm",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Consent given by Jane Doe (Mum)",
-                     date: "30 May 2024 at 12:00pm"
+                     date: "30 May 2024 at 12:00pm",
+                     programme: "HPV"
   end
 
   describe "invalidated consent" do
@@ -319,15 +333,17 @@ describe AppActivityLogComponent do
 
     include_examples "card",
                      title: "Consent from Jane Doe invalidated",
-                     date: "30 June 2024 at 12:00pm"
+                     date: "30 June 2024 at 12:00pm",
+                     programme: "HPV"
 
     include_examples "card",
                      title: "Consent given by Jane Doe (Mum)",
-                     date: "30 May 2024 at 12:00pm"
+                     date: "30 May 2024 at 12:00pm",
+                     programme: "HPV"
   end
 
   describe "gillick assessments" do
-    let(:programme) { create(:programme) }
+    let(:programme) { create(:programme, :td_ipv) }
     let(:patient_session) { create(:patient_session, patient:, programme:) }
 
     before do
@@ -353,14 +369,16 @@ describe AppActivityLogComponent do
                      title: "Completed Gillick assessment as Gillick competent",
                      notes: "First notes",
                      date: "1 June 2024 at 12:00pm",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "Td/IPV"
 
     include_examples "card",
                      title:
                        "Updated Gillick assessment as not Gillick competent",
                      notes: "Second notes",
                      date: "1 June 2024 at 1:00pm",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "Td/IPV"
   end
 
   describe "pre-screenings" do


### PR DESCRIPTION
This makes it clear which programme the activity log entry is referring to now that a patient can be vaccinated across multiple programmes. Not all activity log events have a programme, but for those that do it is shown next to the date.

## Screenshot

<img width="877" alt="Screenshot 2025-02-20 at 16 13 00" src="https://github.com/user-attachments/assets/956fdd2c-ad5b-47f6-8cb5-ed06694e31f6" />
