### PR TITLE
MAV-384: Fix bug in getting DB_NAME

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,7 @@ module ManageVaccinations
       username = CGI.escape(db_config["username"])
       password = CGI.escape(db_config["password"])
       host = CGI.escape(ENV["DB_HOST"])
-      dbname = CGI.escape(db_config["DB_NAME"])
+      dbname = CGI.escape(ENV["DB_NAME"])
       port = ENV.fetch("DB_PORT", 5432)
       ENV[
         "DATABASE_URL"


### PR DESCRIPTION
* The DB_NAME should be an environment variable
  *  In the autogenerated configuration it is not included in the db secret