### PR TITLE
Support special values for DOSE_SEQUENCE

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -245,12 +245,21 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
   end
 
   def dose_sequence
+    special_values =
+      ImmunisationImportRow::DOSE_SEQUENCES.keys.map { tag.i(_1) }
+
+    special_values_sentence =
+      special_values.to_sentence(
+        last_word_connector: " or ",
+        two_words_connector: " or "
+      )
+
     [
       {
         name: "DOSE_SEQUENCE",
         notes:
           "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}, " \
-            "must be #{tag.i("1")}, #{tag.i("2")} or #{tag.i("3")}"
+            "must be a number or #{special_values_sentence}"
       }
     ]
   end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -270,12 +270,22 @@ class ImmunisationImportRow
     end
   end
 
-  def dose_sequence
-    return 1 unless administered
+  DOSE_SEQUENCES = {
+    "1P" => 1,
+    "2P" => 2,
+    "3P" => 3,
+    "1B" => 4,
+    "2B" => 5
+  }.freeze
 
-    if vaccine.maximum_dose_sequence == 1 && !@data.key?("DOSE_SEQUENCE")
+  def dose_sequence
+    value = @data["DOSE_SEQUENCE"]&.gsub(/\s/, "")&.presence&.upcase
+
+    if value.blank? && (!administered || vaccine&.maximum_dose_sequence == 1)
       return 1
     end
+
+    return DOSE_SEQUENCES[value] if DOSE_SEQUENCES.include?(value)
 
     begin
       Integer(@data["DOSE_SEQUENCE"])

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1211,6 +1211,14 @@ describe ImmunisationImportRow do
 
       it { should eq(1) }
     end
+
+    %w[1P 2P 3P 1B 2B].each_with_index do |value, index|
+      context "with a special value of #{value}" do
+        let(:data) { { "DOSE_SEQUENCE" => value } }
+
+        it { should eq(index + 1) }
+      end
+    end
   end
 
   describe "#patient_date_of_birth" do


### PR DESCRIPTION
To support Td/IPV we need to support a number of special dose sequence values beyond just integer numbers. The help information for that field has also been updated to include these special values.