### PR TITLE
Fix main navigation overflow dropdown positioning

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -40,48 +40,50 @@
     </div>
 
     <% if @show_navigation %>
-      <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
-        <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
-          <%= render AppHeaderNavigationItemComponent.new(t("programmes.index.title"), programmes_path, request_path: request.path) %>
-          <%= render AppHeaderNavigationItemComponent.new(t("sessions.index.title"), sessions_path, request_path: request.path) %>
-          <%= render AppHeaderNavigationItemComponent.new(t("patients.index.title"), patients_path, request_path: request.path) %>
+      <div class="nhsuk-navigation-container">
+        <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
+          <ul class="nhsuk-header__navigation-list nhsuk-header__navigation-list--left-aligned">
+            <%= render AppHeaderNavigationItemComponent.new(t("programmes.index.title"), programmes_path, request_path: request.path) %>
+            <%= render AppHeaderNavigationItemComponent.new(t("sessions.index.title"), sessions_path, request_path: request.path) %>
+            <%= render AppHeaderNavigationItemComponent.new(t("patients.index.title"), patients_path, request_path: request.path) %>
 
-          <%= render AppHeaderNavigationItemComponent.new(
-            t("consent_forms.index.title_short"),
-            consent_forms_path,
-            request_path: request.path,
-            count: policy_scope(ConsentForm).unmatched.recorded.not_archived.count
-          ) %>
+            <%= render AppHeaderNavigationItemComponent.new(
+              t("consent_forms.index.title_short"),
+              consent_forms_path,
+              request_path: request.path,
+              count: policy_scope(ConsentForm).unmatched.recorded.not_archived.count
+            ) %>
 
-          <%= render AppHeaderNavigationItemComponent.new(
-            t("school_moves.index.title"),
-            school_moves_path,
-            request_path: request.path,
-            count: policy_scope(SchoolMove).count
-          ) %>
+            <%= render AppHeaderNavigationItemComponent.new(
+              t("school_moves.index.title"),
+              school_moves_path,
+              request_path: request.path,
+              count: policy_scope(SchoolMove).count
+            ) %>
 
-          <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
+            <%= render AppHeaderNavigationItemComponent.new(t("vaccines.index.title"), vaccines_path, request_path: request.path) %>
 
-          <%= render AppHeaderNavigationItemComponent.new(
-            t("imports.index.title_short"),
-            imports_path,
-            request_path: request.path,
-            count: policy_scope(ClassImport).count + policy_scope(CohortImport).count + policy_scope(ImmunisationImport).count
-          ) %>
+            <%= render AppHeaderNavigationItemComponent.new(
+              t("imports.index.title_short"),
+              imports_path,
+              request_path: request.path,
+              count: policy_scope(ClassImport).count + policy_scope(CohortImport).count + policy_scope(ImmunisationImport).count
+            ) %>
 
-          <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>
+            <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>
 
-          <li class="nhsuk-mobile-menu-container">
-            <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
-              <span class="nhsuk-u-visually-hidden">Browse</span>
-              More
-              <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
-              </svg>
-            </button>
-          </li>
-        </ul>
-      </nav>
+            <li class="nhsuk-mobile-menu-container">
+              <button class="nhsuk-header__menu-toggle nhsuk-header__navigation-link" id="toggle-menu" aria-expanded="false">
+                <span class="nhsuk-u-visually-hidden">Browse</span>
+                More
+                <svg class="nhsuk-icon nhsuk-icon__chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+                </svg>
+              </button>
+            </li>
+          </ul>
+        </nav>
+      </div>
     <% end %>
   </div>
 </header>


### PR DESCRIPTION
The overflow dropdown navigation currently appears at the bottom of the viewport.

![Screenshot 2025-02-21 at 07 05 59](https://github.com/user-attachments/assets/6214de4b-9421-4ad7-a2e1-a588731ebeef)

This adds an extra `div.nhsuk-navigation-container` wrapper with `position:relative` like on the [NHS design system](https://service-manual.nhs.uk/design-system) so that `top: 100%` on the dropdown has the desired effect.

(Make sure to hide whitespace changes when reviewing: https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3017/files?diff=unified&w=1)