### PR TITLE
Order programmes by name

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -33,7 +33,8 @@ class Organisation < ApplicationRecord
   has_many :consents
   has_many :immunisation_records
   has_many :locations
-  has_many :organisation_programmes
+  has_many :organisation_programmes,
+           -> { joins(:programme).order(:"programmes.type") }
   has_many :patients
   has_many :sessions
   has_many :teams

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -18,8 +18,6 @@ class Programme < ApplicationRecord
 
   audited
 
-  has_and_belongs_to_many :sessions
-
   has_many :consent_forms
   has_many :consent_notifications
   has_many :consents
@@ -27,10 +25,12 @@ class Programme < ApplicationRecord
   has_many :gillick_assessments
   has_many :immunisation_imports
   has_many :organisation_programmes
+  has_many :session_programmes
   has_many :triages
   has_many :vaccination_records, -> { kept }
   has_many :vaccines
 
+  has_many :sessions, through: :session_programmes
   has_many :patient_sessions, through: :sessions
   has_many :patients, through: :patient_sessions
   has_many :organisations, through: :organisation_programmes

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -34,12 +34,15 @@ class Session < ApplicationRecord
   has_many :patient_sessions
   has_many :session_dates, -> { order(:value) }
   has_many :session_notifications
+  has_many :session_programmes,
+           -> { joins(:programme).order(:"programmes.type") },
+           dependent: :destroy
   has_many :vaccination_records, -> { kept }
 
   has_and_belongs_to_many :immunisation_imports
-  has_and_belongs_to_many :programmes
 
   has_one :team, through: :location
+  has_many :programmes, through: :session_programmes
   has_many :gillick_assessments, through: :patient_sessions
   has_many :patients, through: :patient_sessions
   has_many :vaccines, through: :programmes

--- a/app/models/session_programme.rb
+++ b/app/models/session_programme.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: session_programmes
+#
+#  id           :bigint           not null, primary key
+#  programme_id :bigint           not null
+#  session_id   :bigint           not null
+#
+# Indexes
+#
+#  index_session_programmes_on_programme_id                 (programme_id)
+#  index_session_programmes_on_session_id                   (session_id)
+#  index_session_programmes_on_session_id_and_programme_id  (session_id,programme_id) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
+class SessionProgramme < ApplicationRecord
+  audited
+
+  belongs_to :session
+  belongs_to :programme
+end

--- a/db/migrate/20250221080758_create_session_programmes.rb
+++ b/db/migrate/20250221080758_create_session_programmes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateSessionProgrammes < ActiveRecord::Migration[8.0]
+  def change
+    rename_table :programmes_sessions, :session_programmes
+
+    change_table :session_programmes do |t|
+      t.primary_key :id
+      t.index :session_id
+      t.index :programme_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_19_100155) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_21_080758) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -601,12 +601,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_100155) do
     t.index ["type"], name: "index_programmes_on_type", unique: true
   end
 
-  create_table "programmes_sessions", id: false, force: :cascade do |t|
-    t.bigint "session_id", null: false
-    t.bigint "programme_id", null: false
-    t.index ["session_id", "programme_id"], name: "index_programmes_sessions_on_session_id_and_programme_id", unique: true
-  end
-
   create_table "school_move_log_entries", force: :cascade do |t|
     t.bigint "patient_id", null: false
     t.bigint "user_id"
@@ -663,6 +657,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_100155) do
     t.index ["patient_id"], name: "index_session_notifications_on_patient_id"
     t.index ["sent_by_user_id"], name: "index_session_notifications_on_sent_by_user_id"
     t.index ["session_id"], name: "index_session_notifications_on_session_id"
+  end
+
+  create_table "session_programmes", force: :cascade do |t|
+    t.bigint "session_id", null: false
+    t.bigint "programme_id", null: false
+    t.index ["programme_id"], name: "index_session_programmes_on_programme_id"
+    t.index ["session_id", "programme_id"], name: "index_session_programmes_on_session_id_and_programme_id", unique: true
+    t.index ["session_id"], name: "index_session_programmes_on_session_id"
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -848,8 +850,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_100155) do
   add_foreign_key "patients", "organisations"
   add_foreign_key "pre_screenings", "patient_sessions"
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
-  add_foreign_key "programmes_sessions", "programmes"
-  add_foreign_key "programmes_sessions", "sessions"
   add_foreign_key "school_move_log_entries", "locations", column: "school_id"
   add_foreign_key "school_move_log_entries", "patients"
   add_foreign_key "school_move_log_entries", "users"
@@ -862,6 +862,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_19_100155) do
   add_foreign_key "session_notifications", "patients"
   add_foreign_key "session_notifications", "sessions"
   add_foreign_key "session_notifications", "users", column: "sent_by_user_id"
+  add_foreign_key "session_programmes", "programmes"
+  add_foreign_key "session_programmes", "sessions"
   add_foreign_key "sessions", "organisations"
   add_foreign_key "teams", "organisations"
   add_foreign_key "triage", "organisations"

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -88,6 +88,23 @@ describe Session do
     end
   end
 
+  describe "#programmes" do
+    subject(:programmes) { session.reload.programmes }
+
+    let(:hpv_programme) { create(:programme, :hpv) }
+    let(:menacwy_programme) { create(:programme, :menacwy) }
+
+    let(:session) { create(:session, programme: menacwy_programme) }
+
+    before do
+      session.update!(programme_ids: [menacwy_programme.id, hpv_programme.id])
+    end
+
+    it "is ordered by name" do
+      expect(programmes).to eq([hpv_programme, menacwy_programme])
+    end
+  end
+
   describe "#today?" do
     subject(:today?) { session.today? }
 


### PR DESCRIPTION
When displaying the programmes for a patient or a session we want to ensure they appear in the same order very time. At the moment the order is not guaranteed as we have a join table with no other reference points.

To add this feature, I've reworked the join table to be an explicit `SessionProgramme` model, like the `OrganisationProgramme` model and that allow for an order to be specified on the `has_many` relationship.