### PR TITLE
Send session notifications for all programmes

### DIFF
--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -48,7 +48,6 @@ describe SessionNotification do
     let(:session) { create(:session, location:, programme:, organisation:) }
     let(:session_date) { session.dates.min }
     let(:patient_session) { create(:patient_session, patient:, session:) }
-    let(:consent) { create(:consent, :given, patient:, programme:) }
     let(:current_user) { create(:user) }
 
     before { patient_session.patient.strict_loading!(false) }
@@ -56,9 +55,11 @@ describe SessionNotification do
     context "with a school reminder" do
       let(:type) { :school_reminder }
 
-      it "creates a record" do
-        consent # ensure it exists
+      let(:parent) { parents.first }
 
+      before { create(:consent, :given, patient:, parent:, programme:) }
+
+      it "creates a record" do
         expect { create_and_send! }.to change(described_class, :count).by(1)
 
         session_notification = described_class.last
@@ -71,13 +72,13 @@ describe SessionNotification do
       it "enqueues an email per parent who gave consent" do
         expect { create_and_send! }.to have_delivered_email(
           :session_school_reminder
-        ).with(consent:, session:, sent_by: current_user)
+        ).with(parent:, patient:, session:, sent_by: current_user)
       end
 
       it "enqueues a text per parent" do
         expect { create_and_send! }.to have_delivered_sms(
           :session_school_reminder
-        ).with(consent:, session:, sent_by: current_user)
+        ).with(parent:, patient:, session:, sent_by: current_user)
       end
 
       context "when parent doesn't want to receive updates by text" do


### PR DESCRIPTION
If a patient is part of a programme and they're being administered a vaccine, we should send the session reminder email to all the parents who consents for any of the programmes in the session. In most cases, this will be only the two parents of the child, but it's possible for a situation where one parent consented to one programme and another parent consented to the other.