### PR TITLE
Simplify seeds generation

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -52,11 +52,6 @@ class Location < ApplicationRecord
 
   scope :clinic, -> { generic_clinic.or(community_clinic) }
 
-  scope :for_year_groups,
-        ->(year_groups) do
-          where("year_groups && ARRAY[?]::integer[]", year_groups)
-        end
-
   validates :name, presence: true
   validates :url, url: true, allow_nil: true
   validates :urn, uniqueness: true, allow_nil: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,6 @@
 
 allow_dev_phone_numbers: false
 disallow_database_seeding: true
-fast_reset: false
 web_concurrency: 2
 
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,5 @@
 allow_dev_phone_numbers: true
 disallow_database_seeding: false
-fast_reset: true
 web_concurrency: 0
 
 cis2:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,5 @@
 allow_dev_phone_numbers: true
 disallow_database_seeding: false
-fast_reset: true
 web_concurrency: 0
 
 cis2:

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -33,20 +33,6 @@
 #
 
 describe Location do
-  describe "scopes" do
-    describe "#for_year_groups" do
-      subject(:scope) { described_class.for_year_groups(year_groups) }
-
-      let(:year_groups) { [8, 9, 10, 11] }
-
-      let(:matching) { create(:school, :secondary) } # 7-11
-      let(:mismatch) { create(:school, :primary) } # 0-6
-
-      it { should include(matching) }
-      it { should_not include(mismatch) }
-    end
-  end
-
   describe "validations" do
     it { should validate_presence_of(:name) }
 


### PR DESCRIPTION
This simplifies how the seeds are generated to avoid a potential never ending loop, by only creating locations when we're setting up the sessions. This does mean that we can no longer generate the seeds from real school data, but we generally weren't doing that anyway since importing all the schools takes a relatively long time and it's useful that the seeds run quickly.

For the QA environment, we should be moving towards using the onboarding process anyway to ensure consistency, whereas the seeds are useful for quickly setting up a development environment.