### PR TITLE
Preload programmes for original_session

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -328,7 +328,7 @@ class ConsentForm < ApplicationRecord
     @original_session ||=
       Session
         .has_programme(programme)
-        .includes(:programmes)
+        .preload(:programmes)
         .find_by(academic_year:, location:, organisation:)
   end
 


### PR DESCRIPTION
Without this, `original_session` only has the specified `programme` as the proxy association doesn't fetch all the records for efficiency.

We need all the associated `programme` records for the consent form page that lets parents choose which vaccine to give consent for.