### PR TITLE
Associate consent forms with multiple programmes

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -85,13 +85,7 @@ class DevController < ApplicationController
       end
 
     consent_form =
-      FactoryBot.build(
-        :consent_form,
-        :draft,
-        programme:,
-        session:,
-        **attributes
-      )
+      FactoryBot.build(:consent_form, :draft, session:, **attributes)
 
     vaccine = programme.vaccines.first
     consent_form.health_answers = vaccine.health_questions.to_health_answers

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -12,9 +12,12 @@ module ParentInterface
     private
 
     def set_consent_form
-      @consent_form = ConsentForm.find(params[:consent_form_id] || params[:id])
+      @consent_form =
+        ConsentForm.includes(:programmes, :vaccines).find(
+          params[:consent_form_id] || params[:id]
+        )
       @organisation = @consent_form.organisation
-      @programme = @consent_form.programme
+      @programmes = @consent_form.programmes
       @session = @consent_form.original_session
       @team = @consent_form.team
     end
@@ -27,7 +30,7 @@ module ParentInterface
 
     def set_header_path
       @header_path =
-        start_parent_interface_consent_forms_path(@session, @programme)
+        start_parent_interface_consent_forms_path(@session, @programmes.first)
     end
 
     def set_service_name

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -4,7 +4,7 @@ module ParentInterface
   class ConsentFormsController < ConsentForms::BaseController
     include ConsentFormMailerConcern
 
-    prepend_before_action :set_session_and_programme,
+    prepend_before_action :set_session_and_programmes,
                           only: %i[start create deadline_passed]
     skip_before_action :set_consent_form, only: %i[start create deadline_passed]
     skip_before_action :authenticate_consent_form_user!,
@@ -19,7 +19,7 @@ module ParentInterface
     def create
       consent_form =
         ConsentForm.create!(
-          programme: @programme,
+          programmes: @programmes,
           organisation: @session.organisation,
           location: @session.location
         )
@@ -50,10 +50,10 @@ module ParentInterface
 
     private
 
-    def set_session_and_programme
+    def set_session_and_programmes
       @session = Session.find_by!(slug: params[:session_slug])
       @organisation = @session.organisation
-      @programme = @session.programmes.find_by!(type: params[:programme_type])
+      @programmes = @session.programmes # TODO: .where(type: params[:programme_type] || params[:programme_types])
       @team = @session.team
     end
 

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -15,8 +15,8 @@ class GovukNotifyPersonalisation
     @consent_form = consent_form
     @patient = patient || consent&.patient || vaccination_record&.patient
     @programme =
-      programme || vaccination_record&.programme || consent_form&.programme ||
-        consent&.programme
+      programme || vaccination_record&.programme ||
+        consent_form&.programmes&.first || consent&.programme
     @session =
       session || consent_form&.actual_session ||
         consent_form&.original_session || vaccination_record&.session

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -158,19 +158,21 @@ class Consent < ApplicationRecord
       parent =
         consent_form.find_or_create_parent_with_relationship_to!(patient:)
 
-      create!(
-        consent_form:,
-        organisation: consent_form.organisation,
-        programme: consent_form.programme,
-        patient:,
-        parent:,
-        reason_for_refusal: consent_form.reason,
-        notes: consent_form.reason_notes.presence || "",
-        response: consent_form.response,
-        route: "website",
-        health_answers: consent_form.health_answers,
-        recorded_by: current_user
-      )
+      consent_form.programmes.map do |programme|
+        create!(
+          consent_form:,
+          organisation: consent_form.organisation,
+          programme:,
+          patient:,
+          parent:,
+          reason_for_refusal: consent_form.reason,
+          notes: consent_form.reason_notes.presence || "",
+          response: consent_form.response,
+          route: "website",
+          health_answers: consent_form.health_answers,
+          recorded_by: current_user
+        )
+      end
     end
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -39,7 +39,6 @@
 #  consent_id                          :bigint
 #  location_id                         :bigint           not null
 #  organisation_id                     :bigint           not null
-#  programme_id                        :bigint           not null
 #  school_id                           :bigint
 #
 # Indexes
@@ -48,7 +47,6 @@
 #  index_consent_forms_on_location_id      (location_id)
 #  index_consent_forms_on_nhs_number       (nhs_number)
 #  index_consent_forms_on_organisation_id  (organisation_id)
-#  index_consent_forms_on_programme_id     (programme_id)
 #  index_consent_forms_on_school_id        (school_id)
 #
 # Foreign Keys
@@ -56,7 +54,6 @@
 #  fk_rails_...  (consent_id => consents.id)
 #  fk_rails_...  (location_id => locations.id)
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 
@@ -78,14 +75,19 @@ class ConsentForm < ApplicationRecord
 
   belongs_to :consent, optional: true
   belongs_to :location
-  belongs_to :programme
   belongs_to :school, class_name: "Location", optional: true
   belongs_to :organisation
 
   has_many :notify_log_entries
+  has_many :consent_form_programmes,
+           -> { joins(:programme).order(:"programme.type") },
+           dependent: :destroy
 
   has_one :team, through: :location
+
+  has_many :programmes, through: :consent_form_programmes
   has_many :eligible_schools, through: :organisation, source: :schools
+  has_many :vaccines, through: :programmes
 
   enum :response, { given: 0, refused: 1 }, prefix: "consent"
   enum :reason,
@@ -137,8 +139,6 @@ class ConsentForm < ApplicationRecord
 
   normalizes :parent_email, with: EmailAddressNormaliser.new
   normalizes :parent_phone, with: PhoneNumberNormaliser.new
-
-  validates :programme, inclusion: { in: -> { _1.organisation.programmes } }
 
   validates :address_line_1,
             :address_line_2,
@@ -258,8 +258,6 @@ class ConsentForm < ApplicationRecord
     validate :health_answers_valid?
   end
 
-  delegate :vaccines, to: :programme
-
   def wizard_steps
     [
       :name,
@@ -327,7 +325,8 @@ class ConsentForm < ApplicationRecord
     # The session that the consent form was filled out for.
     @original_session ||=
       Session
-        .has_programme(programme)
+        .joins(:programmes)
+        .where(programmes:)
         .preload(:programmes)
         .find_by(academic_year:, location:, organisation:)
   end
@@ -435,7 +434,7 @@ class ConsentForm < ApplicationRecord
   end
 
   def injection_offered_as_alternative?
-    refused_and_not_had_it_already? && programme.flu?
+    refused_and_not_had_it_already? && programmes.any?(&:flu?)
     # checking for flu here is a simplification
     # the actual logic is: if the parent has refused a nasal vaccine AND the session is for a nasal vaccine
     # AND the SAIS organisation offers an alternative injection vaccine, then show the injection step
@@ -524,7 +523,7 @@ class ConsentForm < ApplicationRecord
     return unless health_answers.empty?
 
     # TODO: handle multiple active vaccines
-    vaccine = programme.vaccines.active.first
+    vaccine = vaccines.select(&:active?).first
 
     self.health_answers = vaccine.health_questions.to_health_answers
   end

--- a/app/models/consent_form_programme.rb
+++ b/app/models/consent_form_programme.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: consent_form_programmes
+#
+#  id              :bigint           not null, primary key
+#  consent_form_id :bigint           not null
+#  programme_id    :bigint           not null
+#
+# Indexes
+#
+#  idx_on_programme_id_consent_form_id_2113cb7f37    (programme_id,consent_form_id) UNIQUE
+#  index_consent_form_programmes_on_consent_form_id  (consent_form_id)
+#  index_consent_form_programmes_on_programme_id     (programme_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (consent_form_id => consent_forms.id)
+#  fk_rails_...  (programme_id => programmes.id)
+#
+class ConsentFormProgramme < ApplicationRecord
+  audited
+
+  belongs_to :consent_form
+  belongs_to :programme
+end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -52,6 +52,10 @@ class Vaccine < ApplicationRecord
 
   delegate :first_health_question, to: :health_questions
 
+  def active?
+    !discontinued
+  end
+
   def contains_gelatine?
     programme.flu? && nasal?
   end

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -21,7 +21,6 @@
         consent_form: @consent_form,
         params:,
         patients: @patients,
-        programme: @consent_form.programme,
         section: :matching,
       )
     end %>

--- a/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_agreed.html.erb
@@ -1,4 +1,4 @@
-<% title = t("consent_forms.confirmation_agreed.title.#{@consent_form.programme.type}",
+<% title = t("consent_forms.confirmation_agreed.title.#{@consent_form.programmes.first.type}",
             full_name: @consent_form.full_name) %>
 
 <% content_for :page_title, title %>

--- a/app/views/parent_interface/consent_forms/_confirmation_injection.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_injection.html.erb
@@ -1,3 +1,3 @@
-<%= h1 t("consent_forms.confirmation_injection.title.#{@consent_form.programme.type}") %>
+<%= h1 t("consent_forms.confirmation_injection.title.#{@consent_form.programmes.first.type}") %>
 
 <p>Someone will be in touch to discuss them having an injection instead.</p>

--- a/app/views/parent_interface/consent_forms/_confirmation_needs_triage.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_needs_triage.html.erb
@@ -1,4 +1,4 @@
-<%= h1 t("consent_forms.confirmation_needs_triage.title.#{@consent_form.programme.type}") %>
+<%= h1 t("consent_forms.confirmation_needs_triage.title.#{@consent_form.programmes.first.type}") %>
 
 <p>
   As you answered ‘yes’ to some of the health questions, we need to check the

--- a/app/views/parent_interface/consent_forms/_confirmation_refused.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_refused.html.erb
@@ -1,1 +1,1 @@
-<%= h1 t("consent_forms.confirmation_refused.title.#{@consent_form.programme.type}") %>
+<%= h1 t("consent_forms.confirmation_refused.title.#{@consent_form.programmes.first.type}") %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -17,13 +17,13 @@
 <%= h1 "Check and confirm" %>
 
 <%= render AppCardComponent.new do |c| %>
-  <% c.with_heading { t("consent_forms.confirm.consent_card_title.#{@consent_form.programme.type}") } %>
+  <% c.with_heading { t("consent_forms.confirm.consent_card_title.#{@consent_form.programmes.first.type}") } %>
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Do you agree?" }
           row.with_value {
             @consent_form.consent_given? ?
-              t("consent_forms.confirm.i_agree.#{@consent_form.programme.type}") :
+              t("consent_forms.confirm.i_agree.#{@consent_form.programmes.first.type}") :
               "No"
           }
           row.with_action(text: "Change",

--- a/app/views/parent_interface/consent_forms/edit/consent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/consent.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
-<% title = t("consent_forms.consent.title.#{@consent_form.programme.type}") %>
+<% title = t("consent_forms.consent.title.#{@consent_form.programmes.first.type}") %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @consent_form, url: wizard_path, method: :put do |f| %>
@@ -10,9 +10,9 @@
 
   <%= f.govuk_radio_buttons_fieldset(:response,
                                      legend: { size: "l", text: title, tag: "h1" },
-                                     hint: { text: t("consent_forms.consent.hint.#{@consent_form.programme.type}") }) do %>
+                                     hint: { text: t("consent_forms.consent.hint.#{@consent_form.programmes.first.type}") }) do %>
     <%= f.govuk_radio_button :response, "given",
-                             label: { text: t("consent_forms.consent.i_agree.#{@consent_form.programme.type}") },
+                             label: { text: t("consent_forms.consent.i_agree.#{@consent_form.programmes.first.type}") },
                              link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",
                              label: { text: "No" } %>

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        start_parent_interface_consent_forms_path(@session, @programme),
+        start_parent_interface_consent_forms_path(@session, @programmes.first),
         name: "start consent page",
       ) %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/start.html.erb
+++ b/app/views/parent_interface/consent_forms/start.html.erb
@@ -1,6 +1,6 @@
 <%= h1 t("consent_forms.start.title"), size: "xl" %>
 
-<% @session.programmes.each do |programme| %>
+<% @programmes.each do |programme| %>
   <h2 class="nhsuk-heading-m">
     <%= t("consent_forms.start.vaccines.#{programme.type}.title") %>
   </h2>
@@ -14,7 +14,9 @@
 
 <%= form_with url: url_for(action: :create) do |f| %>
   <%= hidden_field_tag :session_slug, @session.slug %>
-  <%= hidden_field_tag :programme_type, @programme.type %>
+  <% @programmes.each do |programme| %>
+    <%= hidden_field_tag :"programme_types[]", programme.type %>
+  <% end %>
   <%= f.govuk_submit "Start now" %>
 <% end %>
 

--- a/db/migrate/20250221105126_create_consent_form_programmes.rb
+++ b/db/migrate/20250221105126_create_consent_form_programmes.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class CreateConsentFormProgrammes < ActiveRecord::Migration[8.0]
+  def up
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :consent_form_programmes do |t|
+      t.references :programme, foreign_key: true, null: false
+      t.references :consent_form, foreign_key: true, null: false
+      t.index %i[programme_id consent_form_id], unique: true
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+
+    ConsentForm
+      .pluck(:id, :programme_id)
+      .each do |consent_form_id, programme_id|
+        ConsentFormProgramme.create!(consent_form_id:, programme_id:)
+      end
+
+    remove_reference :consent_forms, :programme
+  end
+
+  def down
+    add_reference :consent_forms, :programme, foreign_key: true
+
+    ConsentForm
+      .includes(:consent_form_programmes)
+      .find_each do |consent_form|
+        consent_form.update_column(
+          :programme_id,
+          consent_form.consent_form_programmes.first.programme_id
+        )
+      end
+
+    change_column_null :consent_forms, :programme_id, false
+
+    drop_table :consent_form_programmes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_21_080758) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -153,6 +153,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_080758) do
     t.index ["cohort_import_id", "patient_id"], name: "idx_on_cohort_import_id_patient_id_7864d1a8b0", unique: true
   end
 
+  create_table "consent_form_programmes", force: :cascade do |t|
+    t.bigint "programme_id", null: false
+    t.bigint "consent_form_id", null: false
+    t.index ["consent_form_id"], name: "index_consent_form_programmes_on_consent_form_id"
+    t.index ["programme_id", "consent_form_id"], name: "idx_on_programme_id_consent_form_id_2113cb7f37", unique: true
+    t.index ["programme_id"], name: "index_consent_form_programmes_on_programme_id"
+  end
+
   create_table "consent_forms", force: :cascade do |t|
     t.datetime "recorded_at"
     t.datetime "created_at", null: false
@@ -179,7 +187,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_080758) do
     t.string "parent_relationship_other_name"
     t.string "parent_relationship_type"
     t.boolean "parent_phone_receive_updates", default: false, null: false
-    t.bigint "programme_id", null: false
     t.boolean "school_confirmed"
     t.bigint "location_id", null: false
     t.bigint "organisation_id", null: false
@@ -194,7 +201,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_080758) do
     t.index ["location_id"], name: "index_consent_forms_on_location_id"
     t.index ["nhs_number"], name: "index_consent_forms_on_nhs_number"
     t.index ["organisation_id"], name: "index_consent_forms_on_organisation_id"
-    t.index ["programme_id"], name: "index_consent_forms_on_programme_id"
     t.index ["school_id"], name: "index_consent_forms_on_school_id"
   end
 
@@ -803,11 +809,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_080758) do
   add_foreign_key "cohort_imports_parents", "parents"
   add_foreign_key "cohort_imports_patients", "cohort_imports"
   add_foreign_key "cohort_imports_patients", "patients"
+  add_foreign_key "consent_form_programmes", "consent_forms"
+  add_foreign_key "consent_form_programmes", "programmes"
   add_foreign_key "consent_forms", "consents"
   add_foreign_key "consent_forms", "locations"
   add_foreign_key "consent_forms", "locations", column: "school_id"
   add_foreign_key "consent_forms", "organisations"
-  add_foreign_key "consent_forms", "programmes"
   add_foreign_key "consent_notifications", "patients"
   add_foreign_key "consent_notifications", "programmes"
   add_foreign_key "consent_notifications", "sessions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -129,7 +129,6 @@ def create_session(
         FactoryBot.create(
           :consent_form,
           :recorded,
-          programme:,
           given_name: patient.given_name,
           family_name: patient.family_name,
           session:
@@ -141,7 +140,6 @@ def create_session(
       FactoryBot.create(
         :consent_form,
         :recorded,
-        programme:,
         given_name: temporary_patient.given_name,
         family_name: temporary_patient.family_name,
         nhs_number: temporary_patient.nhs_number,

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -259,7 +259,6 @@ describe AppActivityLogComponent do
       consent_form =
         create(
           :consent_form,
-          programme:,
           session:,
           recorded_at: Time.zone.local(2024, 5, 30, 12),
           parent_full_name: "Jane Doe",

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -87,11 +87,7 @@ describe AppSessionPatientTableComponent do
         programme:,
         section: :matching,
         consent_form:
-          create(
-            :consent_form,
-            programme:,
-            session: patient_sessions.first.session
-          ),
+          create(:consent_form, session: patient_sessions.first.session),
         columns: %i[name postcode year_group select_for_matching]
       )
     end

--- a/spec/components/previews/app_session_patient_table_component_preview.rb
+++ b/spec/components/previews/app_session_patient_table_component_preview.rb
@@ -34,7 +34,7 @@ class AppSessionPatientTableComponentPreview < ViewComponent::Preview
 
     session = patient_sessions.first.session
 
-    consent_form = create(:consent_form, programme:, session:)
+    consent_form = create(:consent_form, session:)
 
     render AppSessionPatientTableComponent.new(
              session:,

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -73,7 +73,6 @@ describe ConsentFormMailerConcern do
         create(
           :consent_form,
           organisation:,
-          programme:,
           school_confirmed: false,
           school: create(:school, organisation:),
           session: create(:session, organisation:, programme:)

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -39,7 +39,6 @@
 #  consent_id                          :bigint
 #  location_id                         :bigint           not null
 #  organisation_id                     :bigint           not null
-#  programme_id                        :bigint           not null
 #  school_id                           :bigint
 #
 # Indexes
@@ -48,7 +47,6 @@
 #  index_consent_forms_on_location_id      (location_id)
 #  index_consent_forms_on_nhs_number       (nhs_number)
 #  index_consent_forms_on_organisation_id  (organisation_id)
-#  index_consent_forms_on_programme_id     (programme_id)
 #  index_consent_forms_on_school_id        (school_id)
 #
 # Foreign Keys
@@ -56,7 +54,6 @@
 #  fk_rails_...  (consent_id => consents.id)
 #  fk_rails_...  (location_id => locations.id)
 #  fk_rails_...  (organisation_id => organisations.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 
@@ -94,7 +91,7 @@ FactoryBot.define do
 
     parental_responsibility { "yes" }
 
-    programme { session.programmes.first }
+    programmes { session.programmes }
     organisation { session.organisation }
 
     location { session.location }

--- a/spec/features/dev_reset_organisation_spec.rb
+++ b/spec/features/dev_reset_organisation_spec.rb
@@ -69,8 +69,7 @@ describe "Dev endpoint to reset a organisation" do
 
   def and_consent_exists
     @patients.each do |patient|
-      consent_form =
-        create(:consent_form, programme: @programme, session: Session.first)
+      consent_form = create(:consent_form, session: Session.first)
       parent =
         patient.parents.first || create(:parent_relationship, patient:).parent
       create(

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -55,7 +55,6 @@ describe "Parental consent manual matching" do
       create(
         :consent_form,
         :recorded,
-        programme: @programme,
         session: @session,
         parent_full_name: "John Smith"
       )

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -119,12 +119,7 @@ describe EmailDeliveryJob do
 
     context "with a consent form" do
       let(:consent_form) do
-        create(
-          :consent_form,
-          programme:,
-          session:,
-          parent_email: "test@example.com"
-        )
+        create(:consent_form, session:, parent_email: "test@example.com")
       end
       let(:parent) { nil }
       let(:patient) { nil }
@@ -170,7 +165,7 @@ describe EmailDeliveryJob do
 
       context "when the parent doesn't have a phone number" do
         let(:consent_form) do
-          create(:consent_form, programme:, session:, parent_email: nil)
+          create(:consent_form, session:, parent_email: nil)
         end
 
         it "doesn't send a text" do

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -98,7 +98,7 @@ describe SMSDeliveryJob do
 
     context "with a consent form" do
       let(:consent_form) do
-        create(:consent_form, programme:, session:, parent_phone: "01234567890")
+        create(:consent_form, session:, parent_phone: "01234567890")
       end
       let(:parent) { nil }
       let(:patient) { nil }
@@ -128,7 +128,7 @@ describe SMSDeliveryJob do
 
       context "when the parent doesn't have a phone number" do
         let(:consent_form) do
-          create(:consent_form, programme:, session:, parent_phone: nil)
+          create(:consent_form, session:, parent_phone: nil)
         end
 
         it "doesn't send a text" do

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -106,7 +106,7 @@ describe Consent do
           consent_form,
           patient:,
           current_user:
-        )
+        ).first
       end
 
       let(:consent_form) { create(:consent_form, :recorded, reason_notes: nil) }
@@ -120,7 +120,7 @@ describe Consent do
       it "copies over attributes from consent_form" do
         expect(consent).to(
           have_attributes(
-            programme: consent_form.programme,
+            programme: consent_form.programmes.first,
             patient:,
             consent_form:,
             reason_for_refusal: consent_form.reason,

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -58,8 +58,8 @@ describe PatientSessionStats do
           session:
         ) # ready to vaccinate, consent given
 
-        create(:consent_form, :recorded, programme:, session:, consent_id: nil) # => unmatched response
-        create(:consent_form, :draft, programme:, session:, consent_id: nil) # => still draft, should not be counted
+        create(:consent_form, :recorded, session:, consent_id: nil) # => unmatched response
+        create(:consent_form, :draft, session:, consent_id: nil) # => still draft, should not be counted
 
         create(:patient_session, :consent_conflicting, programme:, session:) # conflicting consent
 


### PR DESCRIPTION
This is necessary to support doubles where we will have two kinds of consent forms, those for only HPV and those for Td/IPV and MenACWY. The changes in this PR include adding a migration to create a join table between consent forms and programmes, and assigning the programmes for a consent form from the session.

The next bit of working coming up after this will be to update the start links to support linking to an HPV or a Td/IPV + MenACWY consent form.