### PR TITLE
Allow parents to consent to just one vaccine

### DIFF
--- a/app/controllers/parent_interface/consent_forms/edit_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/edit_controller.rb
@@ -92,7 +92,7 @@ module ParentInterface
           parent_contact_method_type
           parent_contact_method_other_details
         ],
-        consent: %i[response],
+        consent: %i[response chosen_vaccine],
         reason: %i[reason],
         reason_notes: %i[reason_notes],
         injection: %i[contact_injection],

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -10,6 +10,7 @@
 #  address_postcode                    :string
 #  address_town                        :string
 #  archived_at                         :datetime
+#  chosen_vaccine                      :string
 #  contact_injection                   :boolean
 #  date_of_birth                       :date
 #  education_setting                   :integer

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -90,7 +90,7 @@ class ConsentForm < ApplicationRecord
   has_many :eligible_schools, through: :organisation, source: :schools
   has_many :vaccines, through: :programmes
 
-  enum :response, { given: 0, refused: 1 }, prefix: "consent"
+  enum :response, { given: 0, refused: 1, given_one: 2 }, prefix: "consent"
   enum :reason,
        {
          contains_gelatine: 0,
@@ -272,8 +272,8 @@ class ConsentForm < ApplicationRecord
       (:reason if consent_refused?),
       (:reason_notes if consent_refused? && reason_notes_must_be_provided?),
       (:injection if injection_offered_as_alternative?),
-      (:address if consent_given?),
-      (:health_question if consent_given?)
+      (:address if consent_given? || consent_given_one?),
+      (:health_question if consent_given? || consent_given_one?)
     ].compact
   end
 
@@ -506,7 +506,7 @@ class ConsentForm < ApplicationRecord
 
     self.parent_relationship_other_name = nil unless parent_relationship_other?
 
-    if consent_given?
+    if consent_given? || consent_given_one?
       self.contact_injection = nil
 
       self.reason = nil
@@ -530,6 +530,14 @@ class ConsentForm < ApplicationRecord
     return unless health_answers.empty?
 
     self.health_answers =
-      vaccines.active.flat_map { it.health_questions.to_health_answers }
+      chosen_vaccines.flat_map { it.health_questions.to_health_answers }
+  end
+
+  def chosen_vaccines
+    if chosen_vaccine.present?
+      programmes.find_by(type: chosen_vaccine).vaccines.active
+    else
+      vaccines.active
+    end
   end
 end

--- a/app/views/parent_interface/consent_forms/edit/consent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/consent.html.erb
@@ -14,6 +14,21 @@
     <%= f.govuk_radio_button :response, "given",
                              label: { text: t("consent_forms.consent.i_agree.#{@consent_form.programmes.first.type}") },
                              link_errors: true %>
+    <% if @session.programmes.count > 1 %>
+      <%= f.govuk_radio_button :response, "given_one",
+                               label: { text: "I agree to them having one of the vaccinations" } do %>
+        <%= f.govuk_radio_buttons_fieldset :chosen_vaccine,
+                                           legend: {
+                                             size: "s",
+                                             text: "Which vaccinations do you give consent for?",
+                                           } do %>
+          <% @session.programmes.each do |programme| %>
+            <%= f.govuk_radio_button :chosen_vaccine, programme.type,
+                                     label: { text: programme.name } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
     <%= f.govuk_radio_button :response, "refused",
                              label: { text: "No" } %>
   <% end %>

--- a/db/migrate/20250224195511_add_chosen_vaccine_to_consent_form.rb
+++ b/db/migrate/20250224195511_add_chosen_vaccine_to_consent_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddChosenVaccineToConsentForm < ActiveRecord::Migration[8.0]
+  def change
+    add_column :consent_forms, :chosen_vaccine, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,6 +197,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_24_200603) do
     t.string "nhs_number"
     t.datetime "archived_at"
     t.text "notes", default: "", null: false
+    t.string "chosen_vaccine"
     t.index ["consent_id"], name: "index_consent_forms_on_consent_id"
     t.index ["location_id"], name: "index_consent_forms_on_location_id"
     t.index ["nhs_number"], name: "index_consent_forms_on_nhs_number"

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -10,6 +10,7 @@
 #  address_postcode                    :string
 #  address_town                        :string
 #  archived_at                         :datetime
+#  chosen_vaccine                      :string
 #  contact_injection                   :boolean
 #  date_of_birth                       :date
 #  education_setting                   :integer

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
-  scenario "Doubles programme" do
+  scenario "Doubles - consent given for both programmes" do
     stub_pds_search_to_return_no_patients
 
     given_a_menacwy_programme_is_underway
     when_i_go_to_the_consent_form
     then_i_see_the_consent_form
 
-    when_i_fill_in_my_childs_name_and_birthday
-    when_i_give_consent
+    when_i_fill_in_my_details
+    then_i_see_the_consent_page
+
+    when_i_give_consent_to_both_programmes
+    and_i_fill_in_my_address
     and_i_answer_no_to_all_the_medical_questions
     then_i_can_check_my_answers
   end
@@ -47,7 +50,7 @@ describe "Parental consent" do
     expect(page).to have_heading("Td/IPV")
   end
 
-  def when_i_fill_in_my_childs_name_and_birthday
+  def when_i_fill_in_my_details
     click_on "Start now"
 
     expect(page).to have_content("What is your child’s name?")
@@ -61,9 +64,7 @@ describe "Parental consent" do
     fill_in "Month", with: @child.date_of_birth.month
     fill_in "Year", with: @child.date_of_birth.year
     click_on "Continue"
-  end
 
-  def when_i_give_consent
     choose "Yes, they go to this school"
     click_on "Continue"
 
@@ -78,11 +79,14 @@ describe "Parental consent" do
     expect(page).to have_content("Phone contact method")
     choose "I do not have specific needs"
     click_on "Continue"
+  end
 
-    expect(page).to have_content("Do you agree")
+  def when_i_give_consent_to_both_programmes
     choose "Yes, I agree"
     click_on "Continue"
+  end
 
+  def and_i_fill_in_my_address
     expect(page).to have_content("Home address")
     fill_in "Address line 1", with: "1 Test Street"
     fill_in "Address line 2 (optional)", with: "2nd Floor"
@@ -101,5 +105,9 @@ describe "Parental consent" do
   def then_i_can_check_my_answers
     expect(page).to have_content("Check and confirm")
     expect(page).to have_content("Child’s name#{@child.full_name}")
+  end
+
+  def then_i_see_the_consent_page
+    expect(page).to have_heading("Do you agree")
   end
 end

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -17,6 +17,22 @@ describe "Parental consent" do
     then_i_can_check_my_answers
   end
 
+  scenario "Doubles - consent given for one programme" do
+    stub_pds_search_to_return_no_patients
+
+    given_a_menacwy_programme_is_underway
+    when_i_go_to_the_consent_form
+    then_i_see_the_consent_form
+
+    when_i_fill_in_my_details
+    then_i_see_the_consent_page
+
+    when_i_give_consent_to_one_programme
+    and_i_fill_in_my_address
+    and_i_answer_no_to_all_the_medical_questions
+    then_i_can_check_my_answers
+  end
+
   def given_a_menacwy_programme_is_underway
     @programme1 = create(:programme, :menacwy)
     @programme2 = create(:programme, :td_ipv)
@@ -109,5 +125,13 @@ describe "Parental consent" do
 
   def then_i_see_the_consent_page
     expect(page).to have_heading("Do you agree")
+  end
+
+  def when_i_give_consent_to_one_programme
+    expect(page).to have_field("MenACWY", type: "radio")
+    expect(page).to have_field("Td/IPV", type: "radio")
+    choose "I agree to them having one of the vaccinations"
+    choose "MenACWY"
+    click_on "Continue"
   end
 end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -10,6 +10,7 @@
 #  address_postcode                    :string
 #  address_town                        :string
 #  archived_at                         :datetime
+#  chosen_vaccine                      :string
 #  contact_injection                   :boolean
 #  date_of_birth                       :date
 #  education_setting                   :integer

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -660,6 +660,31 @@ describe ConsentForm do
     )
   end
 
+  it "only shows the health questions for the chosen vaccine" do
+    programme1 = create(:programme, :menacwy)
+    programme2 = create(:programme, :td_ipv)
+    consent_form =
+      create(
+        :consent_form,
+        session: create(:session, programmes: [programme1, programme2]),
+        programmes: [programme1, programme2],
+        response: "refused"
+      )
+
+    consent_form.update!(
+      response: "given",
+      chosen_vaccine: programme2.type,
+      address_line_1: "123 Fake St",
+      address_town: "London",
+      address_postcode: "SW1A 1AA"
+    )
+    consent_form.reload
+
+    expect(consent_form.health_answers.count).to eq(
+      programme2.vaccines.first.health_questions.count
+    )
+  end
+
   it "removes the health questions when the parent refuses consent for HPV" do
     consent_form =
       create(


### PR DESCRIPTION
This updates the `response` enum to include a new `given_one` option that is used when the user only gave consent for one vaccine.

In this case, a new `chosen_vaccine` field is populated which is also used to filter the health questions.

The "Check your answers" page looks off currently, but will be updated in a follow-up PR.

### Screenshots

<img width="959" alt="Screenshot 2025-02-21 at 16 58 02" src="https://github.com/user-attachments/assets/f1c332df-76ae-46f2-8d90-d3103605d932" />
