### PR TITLE
Show consent form link for doubles

### DIFF
--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -72,15 +72,20 @@ class AppSessionSummaryComponent < ViewComponent::Base
     if @session.open_for_consent?
       tag.ul(class: "nhsuk-list") do
         safe_join(
-          @session.programmes.map do
-            tag.li(
-              govuk_link_to(
-                "View #{it.name} parental consent form",
-                start_parent_interface_consent_forms_path(@session, it),
-                new_tab: true
+          ProgrammeGrouper
+            .call(@session.programmes)
+            .map do |programmes|
+              tag.li(
+                govuk_link_to(
+                  "View #{programmes.map(&:name).to_sentence} parental consent form",
+                  start_parent_interface_consent_forms_path(
+                    @session,
+                    programmes.map(&:to_param).join("-")
+                  ),
+                  new_tab: true
+                )
               )
-            )
-          end
+            end
         )
       end
     end

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -30,7 +30,10 @@ module ParentInterface
 
     def set_header_path
       @header_path =
-        start_parent_interface_consent_forms_path(@session, @programmes.first)
+        start_parent_interface_consent_forms_path(
+          @session,
+          @programmes.map(&:to_param).join("-")
+        )
     end
 
     def set_service_name

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -53,7 +53,8 @@ module ParentInterface
     def set_session_and_programmes
       @session = Session.find_by!(slug: params[:session_slug])
       @organisation = @session.organisation
-      @programmes = @session.programmes # TODO: .where(type: params[:programme_type] || params[:programme_types])
+      @programmes =
+        @session.programmes.where(type: params[:programme_types].split("-"))
       @team = @session.team
     end
 

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -7,7 +7,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
     consent_form: nil,
     parent: nil,
     patient: nil,
-    programme: nil,
+    programmes: [],
     sent_by: nil,
     session: nil,
     vaccination_record: nil
@@ -26,7 +26,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
         consent:,
         consent_form:,
         patient:,
-        programme:,
+        programmes:,
         vaccination_record:
       )
 

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -7,7 +7,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
     consent_form: nil,
     parent: nil,
     patient: nil,
-    programme: nil,
+    programmes: [],
     sent_by: nil,
     session: nil,
     vaccination_record: nil
@@ -26,7 +26,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
         consent:,
         consent_form:,
         patient:,
-        programme:,
+        programmes:,
         vaccination_record:
       )
 

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -7,16 +7,16 @@ class GovukNotifyPersonalisation
     consent: nil,
     consent_form: nil,
     patient: nil,
-    programme: nil,
+    programmes: nil,
     session: nil,
     vaccination_record: nil
   )
     @consent = consent
     @consent_form = consent_form
     @patient = patient || consent&.patient || vaccination_record&.patient
-    @programme =
-      programme || vaccination_record&.programme ||
-        consent_form&.programmes&.first || consent&.programme
+    @programmes =
+      programmes || [vaccination_record&.programme] ||
+        consent_form&.programmes || [consent&.programme]
     @session =
       session || consent_form&.actual_session ||
         consent_form&.original_session || vaccination_record&.session
@@ -72,7 +72,7 @@ class GovukNotifyPersonalisation
   attr_reader :consent,
               :consent_form,
               :patient,
-              :programme,
+              :programmes,
               :session,
               :team,
               :organisation,
@@ -83,13 +83,21 @@ class GovukNotifyPersonalisation
   end
 
   def catch_up
-    return nil if patient.nil? || programme.nil?
-    patient.year_group == programme.year_groups.first ? "no" : "yes"
+    return nil if patient.nil? || programmes.empty?
+    if patient.year_group == programmes.flat_map(&:year_groups).sort.uniq.first
+      "no"
+    else
+      "yes"
+    end
   end
 
   def not_catch_up
-    return nil if patient.nil? || programme.nil?
-    patient.year_group == programme.year_groups.first ? "yes" : "no"
+    return nil if patient.nil? || programmes.empty?
+    if patient.year_group == programmes.flat_map(&:year_groups).sort.uniq.first
+      "yes"
+    else
+      "no"
+    end
   end
 
   def consent_deadline
@@ -102,8 +110,12 @@ class GovukNotifyPersonalisation
   end
 
   def consent_link
-    return nil if session.nil? || programme.nil?
-    host + start_parent_interface_consent_forms_path(session, programme)
+    return nil if session.nil? || programmes.empty?
+    host +
+      start_parent_interface_consent_forms_path(
+        session,
+        programmes.map(&:to_param).join("-")
+      )
   end
 
   def day_month_year_of_vaccination
@@ -174,7 +186,7 @@ class GovukNotifyPersonalisation
   end
 
   def programme_name
-    programme&.name
+    programmes.map(&:name).to_sentence
   end
 
   def reason_did_not_vaccinate

--- a/app/lib/programme_grouper.rb
+++ b/app/lib/programme_grouper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ProgrammeGrouper
+  def initialize(programmes)
+    @programmes = programmes
+  end
+
+  def call
+    programmes.group_by { programme_group(it) }.map(&:second)
+  end
+
+  def self.call(*args, **kwargs)
+    new(*args, **kwargs).call
+  end
+
+  private_class_method :new
+
+  private
+
+  attr_reader :programmes
+
+  def programme_group(programme)
+    if programme.hpv?
+      0
+    elsif programme.td_ipv? || programme.menacwy?
+      1 # Td/IPV and MenACWY is administered together ("doubles")
+    else
+      raise "Unknown programme type #{programme.type}"
+    end
+  end
+end

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -84,7 +84,7 @@ class ConsentNotification < ApplicationRecord
         mail_template,
         parent:,
         patient:,
-        programme:,
+        programmes: [programme],
         session:,
         sent_by: current_user
       )
@@ -93,7 +93,7 @@ class ConsentNotification < ApplicationRecord
         text_template,
         parent:,
         patient:,
-        programme:,
+        programmes: [programme],
         session:,
         sent_by: current_user
       )

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        start_parent_interface_consent_forms_path(@session, @programmes.first),
-        name: "start consent page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@header_path, name: "start consent page") %>
 <% end %>
 
 <%= h1 "What is your child’s name?" %>

--- a/app/views/parent_interface/consent_forms/start.html.erb
+++ b/app/views/parent_interface/consent_forms/start.html.erb
@@ -14,9 +14,7 @@
 
 <%= form_with url: url_for(action: :create) do |f| %>
   <%= hidden_field_tag :session_slug, @session.slug %>
-  <% @programmes.each do |programme| %>
-    <%= hidden_field_tag :"programme_types[]", programme.type %>
-  <% end %>
+  <%= hidden_field_tag :programme_types, @programmes.map(&:type).join("-") %>
   <%= f.govuk_submit "Start now" %>
 <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,8 +72,8 @@ Rails.application.routes.draw do
   namespace :parent_interface, path: "/" do
     resources :consent_forms, path: "/consents", only: %i[create] do
       collection do
-        get ":session_slug/:programme_type/start", action: "start", as: :start
-        get ":session_slug/:programme_type/deadline-passed",
+        get ":session_slug/:programme_types/start", action: "start", as: :start
+        get ":session_slug/:programme_types/deadline-passed",
             action: "deadline_passed",
             as: :deadline_passed
       end

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -35,7 +35,10 @@ describe "Parental consent" do
   end
 
   def when_i_go_to_the_consent_form
-    visit start_parent_interface_consent_forms_path(@session, @programme1)
+    visit start_parent_interface_consent_forms_path(
+            @session,
+            "#{@programme1.to_param}-#{@programme2.to_param}"
+          )
   end
 
   def then_i_see_the_consent_form

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -34,22 +34,24 @@ describe EmailDeliveryJob do
         consent_form:,
         parent:,
         patient:,
-        programme:,
+        programmes:,
         sent_by:,
         vaccination_record:
       )
     end
 
     let(:template_name) { GOVUK_NOTIFY_EMAIL_TEMPLATES.keys.first }
-    let(:programme) { create(:programme) }
+    let(:programmes) { [create(:programme)] }
     let(:organisation) do
       create(
         :organisation,
         reply_to_id: "54bf1d28-8851-43f2-893d-1853f43a50cd",
-        programmes: [programme]
+        programmes:
       )
     end
-    let(:session) { create(:session, programme:, organisation:) }
+    let(:session) do
+      create(:session, programme: programmes.first, organisation:)
+    end
     let(:parent) { create(:parent, email: "test@example.com") }
     let(:consent) { nil }
     let(:consent_form) { nil }
@@ -63,7 +65,7 @@ describe EmailDeliveryJob do
         consent:,
         consent_form:,
         patient:,
-        programme:,
+        programmes:,
         vaccination_record:
       )
       perform_now
@@ -80,7 +82,7 @@ describe EmailDeliveryJob do
     end
 
     context "without a reply-to id" do
-      let(:organisation) { create(:organisation, programmes: [programme]) }
+      let(:organisation) { create(:organisation, programmes:) }
 
       it "sends a text using GOV.UK Notify" do
         expect(notifications_client).to receive(:send_email).with(
@@ -135,7 +137,7 @@ describe EmailDeliveryJob do
       end
 
       context "without a reply-to id" do
-        let(:organisation) { create(:organisation, programmes: [programme]) }
+        let(:organisation) { create(:organisation, programmes:) }
 
         it "sends a text using GOV.UK Notify" do
           expect(notifications_client).to receive(:send_email).with(

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -34,15 +34,15 @@ describe SMSDeliveryJob do
         consent_form:,
         parent:,
         patient:,
-        programme:,
+        programmes:,
         sent_by:,
         vaccination_record:
       )
     end
 
     let(:template_name) { GOVUK_NOTIFY_SMS_TEMPLATES.keys.first }
-    let(:programme) { create(:programme) }
-    let(:session) { create(:session, programme:) }
+    let(:programmes) { [create(:programme)] }
+    let(:session) { create(:session, programme: programmes.first) }
     let(:parent) { create(:parent, phone: "01234 567890") }
     let(:consent) { nil }
     let(:consent_form) { nil }
@@ -56,7 +56,7 @@ describe SMSDeliveryJob do
         consent:,
         consent_form:,
         patient:,
-        programme:,
+        programmes:,
         vaccination_record:
       )
       perform_now

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -7,19 +7,19 @@ describe GovukNotifyPersonalisation do
       session:,
       consent:,
       consent_form:,
-      programme:,
+      programmes:,
       vaccination_record:
     )
   end
 
-  let(:programme) { create(:programme, :hpv) }
+  let(:programmes) { [create(:programme, :hpv)] }
   let(:organisation) do
     create(
       :organisation,
       name: "Organisation",
       email: "organisation@example.com",
       phone: "01234 567890",
-      programmes: [programme]
+      programmes:
     )
   end
 
@@ -38,7 +38,7 @@ describe GovukNotifyPersonalisation do
       :session,
       location:,
       organisation:,
-      programme:,
+      programme: programmes.first,
       date: Date.new(2026, 1, 1)
     )
   end
@@ -116,7 +116,12 @@ describe GovukNotifyPersonalisation do
 
   context "with a consent" do
     let(:consent) do
-      create(:consent, :refused, programme:, created_at: Date.new(2024, 1, 1))
+      create(
+        :consent,
+        :refused,
+        programme: programmes.first,
+        created_at: Date.new(2024, 1, 1)
+      )
     end
 
     it do
@@ -156,13 +161,26 @@ describe GovukNotifyPersonalisation do
           :consent_form,
           :given,
           :recorded,
-          session: create(:session, location:, programme:, organisation:),
+          session:
+            create(
+              :session,
+              location:,
+              programme: programmes.first,
+              organisation:
+            ),
           school_confirmed: false,
           school:
         )
       end
 
-      before { create(:session, location: school, programme:, organisation:) }
+      before do
+        create(
+          :session,
+          location: school,
+          programme: programmes.first,
+          organisation:
+        )
+      end
 
       it { should include(location_name: "Waterloo Road") }
     end
@@ -173,7 +191,7 @@ describe GovukNotifyPersonalisation do
       create(
         :vaccination_record,
         :not_administered,
-        programme:,
+        programme: programmes.first,
         performed_at: Date.new(2024, 1, 1)
       )
     end

--- a/spec/lib/programme_grouper_spec.rb
+++ b/spec/lib/programme_grouper_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe ProgrammeGrouper do
+  describe "#call" do
+    subject(:call) { described_class.call(programmes) }
+
+    let(:hpv) { create(:programme, :hpv) }
+    let(:menacwy) { create(:programme, :menacwy) }
+    let(:td_ipv) { create(:programme, :td_ipv) }
+
+    context "with only HPV" do
+      let(:programmes) { [hpv] }
+
+      it { should eq([[hpv]]) }
+    end
+
+    context "with Td/IPV and MenACWY" do
+      let(:programmes) { [menacwy, td_ipv] }
+
+      it { should eq([[menacwy, td_ipv]]) }
+    end
+
+    context "with HPV, Td/IPV and MenACWY" do
+      let(:programmes) { [hpv, menacwy, td_ipv] }
+
+      it { should eq([[hpv], [menacwy, td_ipv]]) }
+    end
+  end
+end

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -33,7 +33,7 @@ describe ConsentNotification do
       travel_to(today) do
         described_class.create_and_send!(
           patient:,
-          programme:,
+          programme: programmes.first,
           session:,
           type:,
           current_user:
@@ -45,14 +45,14 @@ describe ConsentNotification do
 
     let(:parents) { create_list(:parent, 2) }
     let(:patient) { create(:patient, parents:) }
-    let(:programme) { create(:programme) }
-    let(:organisation) { create(:organisation, programmes: [programme]) }
+    let(:programmes) { [create(:programme)] }
+    let(:organisation) { create(:organisation, programmes:) }
     let(:location) { create(:school, organisation:) }
     let(:session) do
       create(
         :session,
         location:,
-        programme:,
+        programme: programmes.first,
         patients: [patient],
         organisation:
       )
@@ -67,7 +67,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).not_to be_reminder
-        expect(consent_notification.programme).to eq(programme)
+        expect(consent_notification.programme).to eq(programmes.first)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -78,13 +78,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_email(:consent_school_request).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -96,13 +96,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_sms(:consent_school_request).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -116,7 +116,13 @@ describe ConsentNotification do
         it "still enqueues a text" do
           expect { create_and_send! }.to have_delivered_sms(
             :consent_school_request
-          ).with(parent:, patient:, programme:, session:, sent_by: current_user)
+          ).with(
+            parent:,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
         end
       end
     end
@@ -130,7 +136,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).not_to be_reminder
-        expect(consent_notification.programme).to eq(programme)
+        expect(consent_notification.programme).to eq(programmes.first)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -141,13 +147,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_email(:consent_clinic_request).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -159,13 +165,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_sms(:consent_clinic_request).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -179,7 +185,13 @@ describe ConsentNotification do
         it "still enqueues a text" do
           expect { create_and_send! }.to have_delivered_sms(
             :consent_clinic_request
-          ).with(parent:, patient:, programme:, session:, sent_by: current_user)
+          ).with(
+            parent:,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
         end
       end
     end
@@ -192,7 +204,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).to be_reminder
-        expect(consent_notification.programme).to eq(programme)
+        expect(consent_notification.programme).to eq(programmes.first)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -203,13 +215,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_email(:consent_school_initial_reminder).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -221,13 +233,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_sms(:consent_school_reminder).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -241,7 +253,13 @@ describe ConsentNotification do
         it "still enqueues a text" do
           expect { create_and_send! }.to have_delivered_sms(
             :consent_school_reminder
-          ).with(parent:, patient:, programme:, session:, sent_by: current_user)
+          ).with(
+            parent:,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
         end
       end
     end
@@ -254,7 +272,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).to be_reminder
-        expect(consent_notification.programme).to eq(programme)
+        expect(consent_notification.programme).to eq(programmes.first)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -265,13 +283,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_email(:consent_school_subsequent_reminder).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -283,13 +301,13 @@ describe ConsentNotification do
         ).with(
           parent: parents.first,
           patient:,
-          programme:,
+          programmes:,
           session:,
           sent_by: current_user
         ).and have_delivered_sms(:consent_school_reminder).with(
                 parent: parents.second,
                 patient:,
-                programme:,
+                programmes:,
                 session:,
                 sent_by: current_user
               )
@@ -303,7 +321,13 @@ describe ConsentNotification do
         it "still enqueues a text" do
           expect { create_and_send! }.to have_delivered_sms(
             :consent_school_reminder
-          ).with(parent:, patient:, programme:, session:, sent_by: current_user)
+          ).with(
+            parent:,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
         end
       end
     end


### PR DESCRIPTION
When rendering the consent links on a session page, this now ensures that Td/IPV and MenACWY are grouped together a single link is shown for that particular consent form as consent for these programmes is collected together.

To support this I've made the consent form start link accept a `-` separated list of programme types, which are then used together to generate the consent form. For HPV the links continue to work as they do currently, and for doubles the programmes slug will look like `menacwy-td_ipv` or `td_ipv-menacwy`.

## Screenshot

![Screenshot 2025-02-21 at 15 07 20](https://github.com/user-attachments/assets/5cae0053-06c4-439e-85b8-baa6eee2de46)
