### PR TITLE
Associate consent notifications with multiple programmes

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -24,7 +24,7 @@ class AppConsentComponent < ViewComponent::Base
       patient
         .consent_notifications
         .request
-        .where(programme: session.programmes)
+        .has_programme(session.programmes)
         .order(sent_at: :desc)
         .first
   end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -61,7 +61,7 @@ class ConsentsController < ApplicationController
 
     ConsentNotification.create_and_send!(
       patient: @patient,
-      programme: @programme,
+      programmes: [@programme],
       session: @session,
       type: :request,
       current_user:

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -21,10 +21,7 @@ class ProgrammesController < ApplicationController
     @vaccinations_count =
       policy_scope(VaccinationRecord).where(programme: @programme).count
     @consent_notifications_count =
-      @programme
-        .consent_notifications
-        .where(patient: patients, programme: @programme)
-        .count
+      @programme.consent_notifications.has_programme(@programme).count
     @consents =
       policy_scope(Consent).where(patient: patients, programme: @programme)
   end

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -27,7 +27,7 @@ class SchoolConsentRemindersJob < ApplicationJob
 
           ConsentNotification.create_and_send!(
             patient:,
-            programme:,
+            programmes: [programme],
             session:,
             type:
               sent_initial_reminder ? :subsequent_reminder : :initial_reminder

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -8,22 +8,18 @@
 #  sent_at         :datetime         not null
 #  type            :integer          not null
 #  patient_id      :bigint           not null
-#  programme_id    :bigint           not null
 #  sent_by_user_id :bigint
 #  session_id      :bigint           not null
 #
 # Indexes
 #
-#  index_consent_notifications_on_patient_id                   (patient_id)
-#  index_consent_notifications_on_patient_id_and_programme_id  (patient_id,programme_id)
-#  index_consent_notifications_on_programme_id                 (programme_id)
-#  index_consent_notifications_on_sent_by_user_id              (sent_by_user_id)
-#  index_consent_notifications_on_session_id                   (session_id)
+#  index_consent_notifications_on_patient_id       (patient_id)
+#  index_consent_notifications_on_sent_by_user_id  (sent_by_user_id)
+#  index_consent_notifications_on_session_id       (session_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #  fk_rails_...  (session_id => sessions.id)
 #
@@ -33,12 +29,20 @@ class ConsentNotification < ApplicationRecord
   self.inheritance_column = :nil
 
   belongs_to :patient
-  belongs_to :programme
   belongs_to :session
+
+  has_many :consent_notification_programmes,
+           -> { joins(:programme).order(:"programmes.type") },
+           dependent: :destroy
+
+  has_many :programmes, through: :consent_notification_programmes
 
   enum :type,
        { request: 0, initial_reminder: 1, subsequent_reminder: 2 },
        validate: true
+
+  scope :has_programme,
+        ->(programme) { joins(:programmes).where(programmes: programme) }
 
   def reminder?
     initial_reminder? || subsequent_reminder?
@@ -46,7 +50,7 @@ class ConsentNotification < ApplicationRecord
 
   def self.create_and_send!(
     patient:,
-    programme:,
+    programmes:,
     session:,
     type:,
     current_user: nil
@@ -60,7 +64,7 @@ class ConsentNotification < ApplicationRecord
     # queue and restarted at a later date.
 
     ConsentNotification.create!(
-      programme:,
+      programmes:,
       patient:,
       session:,
       type:,
@@ -84,7 +88,7 @@ class ConsentNotification < ApplicationRecord
         mail_template,
         parent:,
         patient:,
-        programmes: [programme],
+        programmes:,
         session:,
         sent_by: current_user
       )
@@ -93,7 +97,7 @@ class ConsentNotification < ApplicationRecord
         text_template,
         parent:,
         patient:,
-        programmes: [programme],
+        programmes:,
         session:,
         sent_by: current_user
       )

--- a/app/models/consent_notification_programme.rb
+++ b/app/models/consent_notification_programme.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: consent_notification_programmes
+#
+#  id                      :bigint           not null, primary key
+#  consent_notification_id :bigint           not null
+#  programme_id            :bigint           not null
+#
+# Indexes
+#
+#  idx_on_consent_notification_id_bde310472f               (consent_notification_id)
+#  idx_on_programme_id_consent_notification_id_e185bde5f5  (programme_id,consent_notification_id) UNIQUE
+#  index_consent_notification_programmes_on_programme_id   (programme_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (consent_notification_id => consent_notifications.id)
+#  fk_rails_...  (programme_id => programmes.id)
+#
+class ConsentNotificationProgramme < ApplicationRecord
+  audited
+
+  belongs_to :consent_notification
+  belongs_to :programme
+end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -19,7 +19,7 @@ class Programme < ApplicationRecord
   audited
 
   has_many :consent_forms
-  has_many :consent_notifications
+  has_many :consent_notification_programmes
   has_many :consents
   has_many :dps_exports
   has_many :gillick_assessments
@@ -30,6 +30,7 @@ class Programme < ApplicationRecord
   has_many :vaccination_records, -> { kept }
   has_many :vaccines
 
+  has_many :consent_notifications, through: :consent_notification_programmes
   has_many :sessions, through: :session_programmes
   has_many :patient_sessions, through: :sessions
   has_many :patients, through: :patient_sessions

--- a/db/migrate/20250221155425_create_consent_notification_programmes.rb
+++ b/db/migrate/20250221155425_create_consent_notification_programmes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class CreateConsentNotificationProgrammes < ActiveRecord::Migration[8.0]
+  def up
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :consent_notification_programmes do |t|
+      t.references :programme, foreign_key: true, null: false
+      t.references :consent_notification, foreign_key: true, null: false
+      t.index %i[programme_id consent_notification_id], unique: true
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+
+    ConsentNotification
+      .pluck(:id, :programme_id)
+      .each do |consent_notification_id, programme_id|
+        ConsentNotificationProgramme.create!(
+          consent_notification_id:,
+          programme_id:
+        )
+      end
+
+    remove_reference :consent_notifications, :programme
+  end
+
+  def down
+    add_reference :consent_notifications, :programme, foreign_key: true
+
+    ConsentNotification
+      .includes(:consent_notification_programmes)
+      .find_each do |consent_notification|
+        consent_notification.update_column(
+          :programme_id,
+          consent_notification
+            .consent_notification_programmes
+            .first
+            .programme_id
+        )
+      end
+
+    change_column_null :consent_notifications, :programme_id, false
+
+    drop_table :consent_notification_programmes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_21_155425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -204,16 +204,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
     t.index ["school_id"], name: "index_consent_forms_on_school_id"
   end
 
+  create_table "consent_notification_programmes", force: :cascade do |t|
+    t.bigint "programme_id", null: false
+    t.bigint "consent_notification_id", null: false
+    t.index ["consent_notification_id"], name: "idx_on_consent_notification_id_bde310472f"
+    t.index ["programme_id", "consent_notification_id"], name: "idx_on_programme_id_consent_notification_id_e185bde5f5", unique: true
+    t.index ["programme_id"], name: "index_consent_notification_programmes_on_programme_id"
+  end
+
   create_table "consent_notifications", force: :cascade do |t|
     t.bigint "patient_id", null: false
-    t.bigint "programme_id", null: false
     t.datetime "sent_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "type", null: false
     t.bigint "sent_by_user_id"
     t.bigint "session_id", null: false
-    t.index ["patient_id", "programme_id"], name: "index_consent_notifications_on_patient_id_and_programme_id"
     t.index ["patient_id"], name: "index_consent_notifications_on_patient_id"
-    t.index ["programme_id"], name: "index_consent_notifications_on_programme_id"
     t.index ["sent_by_user_id"], name: "index_consent_notifications_on_sent_by_user_id"
     t.index ["session_id"], name: "index_consent_notifications_on_session_id"
   end
@@ -815,8 +820,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
   add_foreign_key "consent_forms", "locations"
   add_foreign_key "consent_forms", "locations", column: "school_id"
   add_foreign_key "consent_forms", "organisations"
+  add_foreign_key "consent_notification_programmes", "consent_notifications"
+  add_foreign_key "consent_notification_programmes", "programmes"
   add_foreign_key "consent_notifications", "patients"
-  add_foreign_key "consent_notifications", "programmes"
   add_foreign_key "consent_notifications", "sessions"
   add_foreign_key "consent_notifications", "users", column: "sent_by_user_id"
   add_foreign_key "consents", "organisations"

--- a/spec/factories/consent_notifications.rb
+++ b/spec/factories/consent_notifications.rb
@@ -8,30 +8,26 @@
 #  sent_at         :datetime         not null
 #  type            :integer          not null
 #  patient_id      :bigint           not null
-#  programme_id    :bigint           not null
 #  sent_by_user_id :bigint
 #  session_id      :bigint           not null
 #
 # Indexes
 #
-#  index_consent_notifications_on_patient_id                   (patient_id)
-#  index_consent_notifications_on_patient_id_and_programme_id  (patient_id,programme_id)
-#  index_consent_notifications_on_programme_id                 (programme_id)
-#  index_consent_notifications_on_sent_by_user_id              (sent_by_user_id)
-#  index_consent_notifications_on_session_id                   (session_id)
+#  index_consent_notifications_on_patient_id       (patient_id)
+#  index_consent_notifications_on_sent_by_user_id  (sent_by_user_id)
+#  index_consent_notifications_on_session_id       (session_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #  fk_rails_...  (session_id => sessions.id)
 #
 FactoryBot.define do
   factory :consent_notification do
     patient
-    programme
-    session { association :session, programme: }
+    session
+    programmes { session.programmes }
 
     traits_for_enum :type
   end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -153,7 +153,9 @@ FactoryBot.define do
           :consent_notification,
           :request,
           patient:,
-          programme: context.programme,
+          session:
+            context.session || create(:session, programme: context.programme),
+          programmes: [context.programme],
           sent_at: 1.week.ago
         )
       end
@@ -165,7 +167,9 @@ FactoryBot.define do
           :consent_notification,
           :initial_reminder,
           patient:,
-          programme: context.programme
+          session:
+            context.session || create(:session, programme: context.programme),
+          programmes: [context.programme]
         )
       end
     end

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -3,7 +3,7 @@
 describe SchoolConsentRemindersJob do
   subject(:perform_now) { described_class.perform_now }
 
-  let(:programme) { create(:programme) }
+  let(:programmes) { [create(:programme)] }
 
   let(:parents) { create_list(:parent, 2) }
 
@@ -13,15 +13,26 @@ describe SchoolConsentRemindersJob do
       :consent_request_sent,
       :initial_consent_reminder_sent,
       parents:,
-      programme:
+      programme: programmes.first
     )
   end
   let(:patient_not_sent_reminder) do
-    create(:patient, :consent_request_sent, parents:, programme:)
+    create(
+      :patient,
+      :consent_request_sent,
+      parents:,
+      programme: programmes.first
+    )
   end
-  let(:patient_not_sent_request) { create(:patient, parents:, programme:) }
+  let(:patient_not_sent_request) do
+    create(:patient, parents:, programme: programmes.first)
+  end
   let(:patient_with_consent) do
-    create(:patient, :consent_given_triage_not_needed, programme:)
+    create(
+      :patient,
+      :consent_given_triage_not_needed,
+      programme: programmes.first
+    )
   end
   let(:deceased_patient) { create(:patient, :deceased) }
   let(:invalid_patient) { create(:patient, :invalidated) }
@@ -41,7 +52,7 @@ describe SchoolConsentRemindersJob do
 
   let(:dates) { [Date.new(2024, 1, 12), Date.new(2024, 1, 15)] }
 
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:location) { create(:school, organisation:) }
 
   let!(:session) do
@@ -52,7 +63,7 @@ describe SchoolConsentRemindersJob do
       days_before_consent_reminders: 7,
       location:,
       patients:,
-      programme:,
+      programme: programmes.first,
       organisation:
     )
   end
@@ -74,7 +85,7 @@ describe SchoolConsentRemindersJob do
     it "sends notifications to one patient" do
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_not_sent_reminder,
-        programme:,
+        programmes:,
         session:,
         type: :initial_reminder
       )
@@ -103,7 +114,7 @@ describe SchoolConsentRemindersJob do
         :consent_notification,
         :initial_reminder,
         patient: patient_not_sent_reminder,
-        programme:
+        session:
       )
     end
 
@@ -119,14 +130,14 @@ describe SchoolConsentRemindersJob do
     it "sends notifications to two patients" do
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_not_sent_reminder,
-        programme:,
+        programmes:,
         session:,
         type: :initial_reminder
       )
 
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_with_initial_reminder_sent,
-        programme:,
+        programmes:,
         session:,
         type: :subsequent_reminder
       )

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -3,16 +3,27 @@
 describe SchoolConsentRequestsJob do
   subject(:perform_now) { described_class.perform_now }
 
-  let(:programme) { create(:programme) }
+  let(:programmes) { [create(:programme)] }
 
   let(:parents) { create_list(:parent, 2) }
 
   let(:patient_with_request_sent) do
-    create(:patient, :consent_request_sent, :consent_request_sent, programme:)
+    create(
+      :patient,
+      :consent_request_sent,
+      :consent_request_sent,
+      programme: programmes.first
+    )
   end
-  let(:patient_not_sent_request) { create(:patient, parents:, programme:) }
+  let(:patient_not_sent_request) do
+    create(:patient, parents:, programme: programmes.first)
+  end
   let(:patient_with_consent) do
-    create(:patient, :consent_given_triage_not_needed, programme:)
+    create(
+      :patient,
+      :consent_given_triage_not_needed,
+      programme: programmes.first
+    )
   end
   let(:deceased_patient) { create(:patient, :deceased) }
   let(:invalid_patient) { create(:patient, :invalidated) }
@@ -30,7 +41,9 @@ describe SchoolConsentRequestsJob do
   end
 
   context "when session is unscheduled" do
-    let(:session) { create(:session, :unscheduled, patients:, programme:) }
+    let(:session) do
+      create(:session, :unscheduled, patients:, programme: programmes.first)
+    end
 
     it "doesn't send any notifications" do
       expect(ConsentNotification).not_to receive(:create_and_send!)
@@ -43,7 +56,7 @@ describe SchoolConsentRequestsJob do
       create(
         :session,
         patients:,
-        programme:,
+        programme: programmes.first,
         send_consent_requests_at: 2.days.from_now
       )
     end
@@ -59,7 +72,7 @@ describe SchoolConsentRequestsJob do
       create(
         :session,
         patients:,
-        programme:,
+        programme: programmes.first,
         date: 3.weeks.from_now.to_date,
         send_consent_requests_at: Date.current
       )
@@ -68,7 +81,7 @@ describe SchoolConsentRequestsJob do
     it "sends notifications to one patient" do
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_not_sent_request,
-        programme:,
+        programmes:,
         session:,
         type: :request
       )
@@ -76,13 +89,13 @@ describe SchoolConsentRequestsJob do
     end
 
     context "when location is a generic clinic" do
-      let(:organisation) { create(:organisation, programmes: [programme]) }
+      let(:organisation) { create(:organisation, programmes:) }
       let(:location) { create(:generic_clinic, organisation:) }
       let(:session) do
         create(
           :session,
           patients:,
-          programme:,
+          programme: programmes.first,
           send_consent_requests_at: Date.current,
           organisation:
         )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -38,7 +38,7 @@ describe PatientMerger do
         :consent_notification,
         :request,
         patient: patient_to_destroy,
-        programme:
+        session:
       )
     end
     let(:gillick_assessment) do

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -8,22 +8,18 @@
 #  sent_at         :datetime         not null
 #  type            :integer          not null
 #  patient_id      :bigint           not null
-#  programme_id    :bigint           not null
 #  sent_by_user_id :bigint
 #  session_id      :bigint           not null
 #
 # Indexes
 #
-#  index_consent_notifications_on_patient_id                   (patient_id)
-#  index_consent_notifications_on_patient_id_and_programme_id  (patient_id,programme_id)
-#  index_consent_notifications_on_programme_id                 (programme_id)
-#  index_consent_notifications_on_sent_by_user_id              (sent_by_user_id)
-#  index_consent_notifications_on_session_id                   (session_id)
+#  index_consent_notifications_on_patient_id       (patient_id)
+#  index_consent_notifications_on_sent_by_user_id  (sent_by_user_id)
+#  index_consent_notifications_on_session_id       (session_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #  fk_rails_...  (session_id => sessions.id)
 #
@@ -33,7 +29,7 @@ describe ConsentNotification do
       travel_to(today) do
         described_class.create_and_send!(
           patient:,
-          programme: programmes.first,
+          programmes:,
           session:,
           type:,
           current_user:
@@ -67,7 +63,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).not_to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -136,7 +132,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).not_to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -204,7 +200,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -272,7 +268,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end


### PR DESCRIPTION
This is to support sending consent requests and reminders for multiple programmes in one go, we can record the programmes that were associated with the consent notification.

This is necessary to support doubles where the consent forms are sent for Td/IPV and MenACWY together.