### PR TITLE
Add historical MenACWY vaccines

### DIFF
--- a/config/vaccines.yml
+++ b/config/vaccines.yml
@@ -1,13 +1,28 @@
-fluenz_tetra:
-  brand: Fluenz Tetra - LAIV
+adjuvanted_quadrivalent:
+  brand: Adjuvanted Quadrivalent - aQIV
   type: flu
-  method: nasal
-  manufacturer: AstraZeneca
-  nivs_name: AstraZeneca Fluenz Tetra LAIV
-  dose_volume_ml: 0.2
-  snomed_product_code: 27114211000001105
-  snomed_product_term: Fluenz Tetra vaccine nasal suspension 0.2ml unit dose
-    (AstraZeneca UK Ltd) (product)
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Adjuvanted Quadrivalent aQIV
+  dose_volume_ml: 0.5
+  snomed_product_code: 40085311000001103
+  snomed_product_term:
+    Adjuvanted quadrivalent influenza vaccine (surface antigen,
+    inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK
+    Ltd) (product)
+
+cell_quadrivalent:
+  brand: Cell-based Quadrivalent - QIVc
+  type: flu
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Cell based Quadrivalent QIVc
+  dose_volume_ml: 0.5
+  snomed_product_code: 40085011000001101
+  snomed_product_term:
+    Cell-based quadrivalent influenza vaccine (surface antigen,
+    inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK
+    Ltd) (product)
 
 cervarix:
   brand: Cervarix
@@ -22,17 +37,41 @@ cervarix:
     Cervarix vaccine suspension for injection 0.5ml pre-filled
     syringes (GlaxoSmithKline) (product)
 
-gardasil_9:
-  brand: Gardasil 9
-  type: hpv
+fluad_tetra:
+  brand: Fluad Tetra - aQIV
+  type: flu
+  discontinued: true
   method: injection
-  manufacturer: Merck Sharp & Dohme
-  nivs_name: Gardasil9
+  manufacturer: Seqirus
+  nivs_name: Seqirus Fluad Tetra AQIV
   dose_volume_ml: 0.5
-  snomed_product_code: 33493111000001108
+  snomed_product_code: 38973211000001108
   snomed_product_term:
-    Gardasil 9 vaccine suspension for injection 0.5ml pre-filled
-    syringes (Merck Sharp & Dohme (UK) Ltd) (product)
+    Fluad Tetra vaccine suspension for injection 0.5ml pre-filled
+    syringes (Seqirus UK Ltd) (product)
+
+flucelvax_tetra:
+  brand: Flucelvax Tetra - QIVc
+  type: flu
+  discontinued: true
+  method: injection
+  manufacturer: Seqirus
+  nivs_name: Seqirus Flucelvax Tetra QIVC
+  dose_volume_ml: 0.5
+  snomed_product_code: 36509011000001106
+  snomed_product_term: Flucelvax Tetra vaccine suspension for injection 0.5ml
+    pre-filled syringes (Seqirus UK Ltd) (product)
+
+fluenz_tetra:
+  brand: Fluenz Tetra - LAIV
+  type: flu
+  method: nasal
+  manufacturer: AstraZeneca
+  nivs_name: AstraZeneca Fluenz Tetra LAIV
+  dose_volume_ml: 0.2
+  snomed_product_code: 27114211000001105
+  snomed_product_term: Fluenz Tetra vaccine nasal suspension 0.2ml unit dose
+    (AstraZeneca UK Ltd) (product)
 
 gardasil:
   brand: Gardasil
@@ -47,6 +86,18 @@ gardasil:
     Gardasil vaccine suspension for injection 0.5ml pre-filled
     syringes (Merck Sharp & Dohme (UK) Ltd) (product)
 
+gardasil_9:
+  brand: Gardasil 9
+  type: hpv
+  method: injection
+  manufacturer: Merck Sharp & Dohme
+  nivs_name: Gardasil9
+  dose_volume_ml: 0.5
+  snomed_product_code: 33493111000001108
+  snomed_product_term:
+    Gardasil 9 vaccine suspension for injection 0.5ml pre-filled
+    syringes (Merck Sharp & Dohme (UK) Ltd) (product)
+
 menquadfi:
   brand: MenQuadfi
   type: menacwy
@@ -56,6 +107,18 @@ menquadfi:
   dose_volume_ml: 0.5
   snomed_product_code: 39779611000001104
   snomed_product_term: MenQuadfi vaccine solution for injection 0.5ml vials (Sanofi) (product)
+
+quadrivalent_influenza:
+  brand: Quadrivalent Influenza vaccine - QIVe
+  type: flu
+  method: injection
+  manufacturer: Sanofi
+  nivs_name: Sanofi Pasteur QIVe
+  dose_volume_ml: 0.5
+  snomed_product_code: 34680411000001107
+  snomed_product_term:
+    Quadrivalent influenza vaccine (split virion, inactivated)
+    suspension for injection 0.5ml pre-filled syringes (Sanofi) (product)
 
 quadrivalent_influvac_tetra:
   brand: Quadrivalent Influvac sub-unit Tetra - QIVe
@@ -91,66 +154,3 @@ supemtek:
   snomed_product_code: 39566211000001103
   snomed_product_term: Supemtek Quadrivalent vaccine (recombinant) solution for
     injection 0.5ml pre-filled syringes (Sanofi) (product)
-
-quadrivalent_influenza:
-  brand: Quadrivalent Influenza vaccine - QIVe
-  type: flu
-  method: injection
-  manufacturer: Sanofi
-  nivs_name: Sanofi Pasteur QIVe
-  dose_volume_ml: 0.5
-  snomed_product_code: 34680411000001107
-  snomed_product_term:
-    Quadrivalent influenza vaccine (split virion, inactivated)
-    suspension for injection 0.5ml pre-filled syringes (Sanofi) (product)
-
-fluad_tetra:
-  brand: Fluad Tetra - aQIV
-  type: flu
-  discontinued: true
-  method: injection
-  manufacturer: Seqirus
-  nivs_name: Seqirus Fluad Tetra AQIV
-  dose_volume_ml: 0.5
-  snomed_product_code: 38973211000001108
-  snomed_product_term:
-    Fluad Tetra vaccine suspension for injection 0.5ml pre-filled
-    syringes (Seqirus UK Ltd) (product)
-
-flucelvax_tetra:
-  brand: Flucelvax Tetra - QIVc
-  type: flu
-  discontinued: true
-  method: injection
-  manufacturer: Seqirus
-  nivs_name: Seqirus Flucelvax Tetra QIVC
-  dose_volume_ml: 0.5
-  snomed_product_code: 36509011000001106
-  snomed_product_term: Flucelvax Tetra vaccine suspension for injection 0.5ml
-    pre-filled syringes (Seqirus UK Ltd) (product)
-
-cell_quadrivalent:
-  brand: Cell-based Quadrivalent - QIVc
-  type: flu
-  method: injection
-  manufacturer: Seqirus
-  nivs_name: Seqirus Cell based Quadrivalent QIVc
-  dose_volume_ml: 0.5
-  snomed_product_code: 40085011000001101
-  snomed_product_term:
-    Cell-based quadrivalent influenza vaccine (surface antigen,
-    inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK
-    Ltd) (product)
-
-adjuvanted_quadrivalent:
-  brand: Adjuvanted Quadrivalent - aQIV
-  type: flu
-  method: injection
-  manufacturer: Seqirus
-  nivs_name: Seqirus Adjuvanted Quadrivalent aQIV
-  dose_volume_ml: 0.5
-  snomed_product_code: 40085311000001103
-  snomed_product_term:
-    Adjuvanted quadrivalent influenza vaccine (surface antigen,
-    inactivated) suspension for injection 0.5ml pre-filled syringes (Seqirus UK
-    Ltd) (product)

--- a/config/vaccines.yml
+++ b/config/vaccines.yml
@@ -101,12 +101,38 @@ gardasil_9:
 menquadfi:
   brand: MenQuadfi
   type: menacwy
+  discontinued: true
   method: injection
   manufacturer: Sanofi
   nivs_name: MenQuadfi
   dose_volume_ml: 0.5
   snomed_product_code: 39779611000001104
   snomed_product_term: MenQuadfi vaccine solution for injection 0.5ml vials (Sanofi) (product)
+
+menveo:
+  brand: Menveo
+  type: menacwy
+  discontinued: true
+  method: injection
+  manufacturer: GlaxoSmithKline
+  nivs_name: Menveo
+  dose_volume_ml: 0.5
+  snomed_product_code: 17188711000001105
+  snomed_product_term:
+    Menveo vaccine powder and solvent for solution for injection
+    0.5ml vials (Novartis Vaccines and Diagnostics Ltd) (product)
+
+nimenrix:
+  brand: Nimenrix
+  type: menacwy
+  method: injection
+  manufacturer: Pfizer
+  nivs_name: Nimenrix
+  dose_volume_ml: 0.5
+  snomed_product_code: 20517811000001104
+  snomed_product_term:
+    Nimenrix vaccine powder and solvent for solution for injection
+    0.5ml pre-filled syringes (GlaxoSmithKline UK Ltd) (product)
 
 quadrivalent_influenza:
   brand: Quadrivalent Influenza vaccine - QIVe

--- a/spec/factories/programmes.rb
+++ b/spec/factories/programmes.rb
@@ -82,6 +82,17 @@ FactoryBot.define do
       vaccines { [association(:vaccine, :menquadfi, programme: instance)] }
     end
 
+    trait :menacwy_all_vaccines do
+      type { "menacwy" }
+      vaccines do
+        [
+          association(:vaccine, :menquadfi, programme: instance),
+          association(:vaccine, :menveo, programme: instance),
+          association(:nimenrix, :menquadfi, programme: instance)
+        ]
+      end
+    end
+
     trait :td_ipv do
       type { "td_ipv" }
       vaccines { [association(:vaccine, :revaxis, programme: instance)] }


### PR DESCRIPTION
This adds two more vaccines for MenACWY that we expect to be able to import historical vaccination records for, but won't be administering when recording new vaccination records.

In the first commit I've sorted the vaccines alphabetically, the new vaccines are added in the second commit.