### PR TITLE
Customise consent email templates by group

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -24,7 +24,7 @@ class AppConsentComponent < ViewComponent::Base
       patient
         .consent_notifications
         .request
-        .where(programme: session.programmes)
+        .has_programme(session.programmes)
         .order(sent_at: :desc)
         .first
   end

--- a/app/components/app_session_summary_component.rb
+++ b/app/components/app_session_summary_component.rb
@@ -74,7 +74,7 @@ class AppSessionSummaryComponent < ViewComponent::Base
         safe_join(
           ProgrammeGrouper
             .call(@session.programmes)
-            .map do |programmes|
+            .map do |_group, programmes|
               tag.li(
                 govuk_link_to(
                   "View #{programmes.map(&:name).to_sentence} parental consent form",

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -59,9 +59,15 @@ class ConsentsController < ApplicationController
   def send_request
     return unless @patient_session.no_consent?(programme: @programme)
 
+    # For programmes that are administered together we should send the consent request together.
+    programmes =
+      ProgrammeGrouper
+        .call(@session.programmes)
+        .find { it.include?(@programme) }
+
     ConsentNotification.create_and_send!(
       patient: @patient,
-      programmes: [@programme],
+      programmes:,
       session: @session,
       type: :request,
       current_user:

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -63,6 +63,7 @@ class ConsentsController < ApplicationController
     programmes =
       ProgrammeGrouper
         .call(@session.programmes)
+        .values
         .find { it.include?(@programme) }
 
     ConsentNotification.create_and_send!(

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -61,7 +61,7 @@ class ConsentsController < ApplicationController
 
     ConsentNotification.create_and_send!(
       patient: @patient,
-      programme: @programme,
+      programmes: [@programme],
       session: @session,
       type: :request,
       current_user:

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -21,10 +21,7 @@ class ProgrammesController < ApplicationController
     @vaccinations_count =
       policy_scope(VaccinationRecord).where(programme: @programme).count
     @consent_notifications_count =
-      @programme
-        .consent_notifications
-        .where(patient: patients, programme: @programme)
-        .count
+      @programme.consent_notifications.has_programme(@programme).count
     @consents =
       policy_scope(Consent).where(patient: patients, programme: @programme)
   end

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -20,7 +20,7 @@ class SchoolConsentRemindersJob < ApplicationJob
 
       ProgrammeGrouper
         .call(session.programmes)
-        .each do |programmes|
+        .each_value do |programmes|
           session.patients.each do |patient|
             unless should_send_notification?(patient:, programmes:, session:)
               next

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -27,7 +27,7 @@ class SchoolConsentRemindersJob < ApplicationJob
 
           ConsentNotification.create_and_send!(
             patient:,
-            programme:,
+            programmes: [programme],
             session:,
             type:
               sent_initial_reminder ? :subsequent_reminder : :initial_reminder

--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -18,41 +18,60 @@ class SchoolConsentRemindersJob < ApplicationJob
     sessions.each do |session|
       next unless session.open_for_consent?
 
-      session.programmes.each do |programme|
-        session.patients.each do |patient|
-          next unless should_send_notification?(patient:, programme:, session:)
+      ProgrammeGrouper
+        .call(session.programmes)
+        .each do |programmes|
+          session.patients.each do |patient|
+            unless should_send_notification?(patient:, programmes:, session:)
+              next
+            end
 
-          sent_initial_reminder =
-            patient.consent_notifications.any?(&:initial_reminder?)
+            sent_initial_reminder =
+              programmes.all? do |programme|
+                patient
+                  .consent_notifications
+                  .select { it.programmes.include?(programme) }
+                  .any?(&:initial_reminder?)
+              end
 
-          ConsentNotification.create_and_send!(
-            patient:,
-            programmes: [programme],
-            session:,
-            type:
-              sent_initial_reminder ? :subsequent_reminder : :initial_reminder
-          )
+            ConsentNotification.create_and_send!(
+              patient:,
+              programmes:,
+              session:,
+              type:
+                sent_initial_reminder ? :subsequent_reminder : :initial_reminder
+            )
+          end
         end
-      end
     end
   end
 
-  def should_send_notification?(patient:, programme:, session:)
+  def should_send_notification?(patient:, programmes:, session:)
     return false unless patient.send_notifications?
 
-    return false if patient.has_consent?(programme)
+    return false if programmes.all? { patient.has_consent?(it) }
 
-    return false if patient.consent_notifications.none?(&:request?)
+    programmes.any? do |programme|
+      no_requests =
+        patient.consent_notifications.none? do
+          it.request? && it.programmes.include?(programme)
+        end
 
-    date_index_to_send_reminder_for =
-      patient.consent_notifications.select(&:reminder?).length
+      next false if no_requests
 
-    return if date_index_to_send_reminder_for >= session.dates.length
+      date_index_to_send_reminder_for =
+        patient
+          .consent_notifications
+          .select { it.reminder? && it.programmes.include?(programme) }
+          .length
 
-    date_to_send_reminder_for = session.dates[date_index_to_send_reminder_for]
-    earliest_date_to_send_reminder =
-      date_to_send_reminder_for - session.days_before_consent_reminders.days
+      next false if date_index_to_send_reminder_for >= session.dates.length
 
-    Date.current >= earliest_date_to_send_reminder
+      date_to_send_reminder_for = session.dates[date_index_to_send_reminder_for]
+      earliest_date_to_send_reminder =
+        date_to_send_reminder_for - session.days_before_consent_reminders.days
+
+      Date.current >= earliest_date_to_send_reminder
+    end
   end
 end

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -24,7 +24,7 @@ class SchoolConsentRequestsJob < ApplicationJob
 
       ProgrammeGrouper
         .call(session.programmes)
-        .each do |programmes|
+        .each_value do |programmes|
           session.patients.each do |patient|
             next unless should_send_notification?(patient:, programmes:)
 

--- a/app/lib/programme_grouper.rb
+++ b/app/lib/programme_grouper.rb
@@ -6,7 +6,9 @@ class ProgrammeGrouper
   end
 
   def call
-    programmes.group_by { programme_group(it) }.map(&:second)
+    programmes
+      .group_by { programme_group(it) }
+      .map { it.second.sort_by(&:type) }
   end
 
   def self.call(*args, **kwargs)
@@ -20,10 +22,12 @@ class ProgrammeGrouper
   attr_reader :programmes
 
   def programme_group(programme)
-    if programme.hpv?
-      0
+    if programme.flu?
+      :flu
+    elsif programme.hpv?
+      :hpv
     elsif programme.td_ipv? || programme.menacwy?
-      1 # Td/IPV and MenACWY is administered together ("doubles")
+      :doubles # Td/IPV and MenACWY is administered together
     else
       raise "Unknown programme type #{programme.type}"
     end

--- a/app/lib/programme_grouper.rb
+++ b/app/lib/programme_grouper.rb
@@ -8,7 +8,8 @@ class ProgrammeGrouper
   def call
     programmes
       .group_by { programme_group(it) }
-      .map { it.second.sort_by(&:type) }
+      .transform_values { it.sort_by(&:type) }
+      .to_h
   end
 
   def self.call(*args, **kwargs)

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -73,12 +73,19 @@ class ConsentNotification < ApplicationRecord
 
     is_school = session.location.school?
 
+    template = :"consent_#{(is_school ? :"school_#{type}" : :"clinic_#{type}")}"
+
     mail_template =
-      :"consent_#{(is_school ? :"school_#{type}" : :"clinic_#{type}")}"
+      if is_school
+        group = ProgrammeGrouper.call(programmes).first.first
+        :"#{template}_#{group}"
+      else
+        template
+      end
 
     text_template =
       if type == :request
-        mail_template
+        template
       elsif is_school
         :consent_school_reminder
       end

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -8,22 +8,18 @@
 #  sent_at         :datetime         not null
 #  type            :integer          not null
 #  patient_id      :bigint           not null
-#  programme_id    :bigint           not null
 #  sent_by_user_id :bigint
 #  session_id      :bigint           not null
 #
 # Indexes
 #
-#  index_consent_notifications_on_patient_id                   (patient_id)
-#  index_consent_notifications_on_patient_id_and_programme_id  (patient_id,programme_id)
-#  index_consent_notifications_on_programme_id                 (programme_id)
-#  index_consent_notifications_on_sent_by_user_id              (sent_by_user_id)
-#  index_consent_notifications_on_session_id                   (session_id)
+#  index_consent_notifications_on_patient_id       (patient_id)
+#  index_consent_notifications_on_sent_by_user_id  (sent_by_user_id)
+#  index_consent_notifications_on_session_id       (session_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #  fk_rails_...  (session_id => sessions.id)
 #
@@ -33,12 +29,20 @@ class ConsentNotification < ApplicationRecord
   self.inheritance_column = :nil
 
   belongs_to :patient
-  belongs_to :programme
   belongs_to :session
+
+  has_many :consent_notification_programmes,
+           -> { joins(:programme).order(:"programmes.type") },
+           dependent: :destroy
+
+  has_many :programmes, through: :consent_notification_programmes
 
   enum :type,
        { request: 0, initial_reminder: 1, subsequent_reminder: 2 },
        validate: true
+
+  scope :has_programme,
+        ->(programme) { joins(:programmes).where(programmes: programme) }
 
   def reminder?
     initial_reminder? || subsequent_reminder?
@@ -46,7 +50,7 @@ class ConsentNotification < ApplicationRecord
 
   def self.create_and_send!(
     patient:,
-    programme:,
+    programmes:,
     session:,
     type:,
     current_user: nil
@@ -60,7 +64,7 @@ class ConsentNotification < ApplicationRecord
     # queue and restarted at a later date.
 
     ConsentNotification.create!(
-      programme:,
+      programmes:,
       patient:,
       session:,
       type:,
@@ -84,7 +88,7 @@ class ConsentNotification < ApplicationRecord
         mail_template,
         parent:,
         patient:,
-        programmes: [programme],
+        programmes:,
         session:,
         sent_by: current_user
       )
@@ -93,7 +97,7 @@ class ConsentNotification < ApplicationRecord
         text_template,
         parent:,
         patient:,
-        programmes: [programme],
+        programmes:,
         session:,
         sent_by: current_user
       )

--- a/app/models/consent_notification_programme.rb
+++ b/app/models/consent_notification_programme.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: consent_notification_programmes
+#
+#  id                      :bigint           not null, primary key
+#  consent_notification_id :bigint           not null
+#  programme_id            :bigint           not null
+#
+# Indexes
+#
+#  idx_on_consent_notification_id_bde310472f               (consent_notification_id)
+#  idx_on_programme_id_consent_notification_id_e185bde5f5  (programme_id,consent_notification_id) UNIQUE
+#  index_consent_notification_programmes_on_programme_id   (programme_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (consent_notification_id => consent_notifications.id)
+#  fk_rails_...  (programme_id => programmes.id)
+#
+class ConsentNotificationProgramme < ApplicationRecord
+  audited
+
+  belongs_to :consent_notification
+  belongs_to :programme
+end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -19,7 +19,7 @@ class Programme < ApplicationRecord
   audited
 
   has_many :consent_forms
-  has_many :consent_notifications
+  has_many :consent_notification_programmes
   has_many :consents
   has_many :dps_exports
   has_many :gillick_assessments
@@ -30,6 +30,7 @@ class Programme < ApplicationRecord
   has_many :vaccination_records, -> { kept }
   has_many :vaccines
 
+  has_many :consent_notifications, through: :consent_notification_programmes
   has_many :sessions, through: :session_programmes
   has_many :patient_sessions, through: :sessions
   has_many :patients, through: :patient_sessions

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -7,9 +7,10 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   consent_confirmation_injection: "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
   consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",
   consent_confirmation_triage: "604ee667-c996-471e-b986-79ab98d0767c",
-  consent_school_initial_reminder: "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
-  consent_school_request: "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
-  consent_school_subsequent_reminder: "6410145f-dac1-46ba-82f3-a49cad0f66a6",
+  consent_school_initial_reminder_hpv: "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
+  consent_school_request_hpv: "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
+  consent_school_subsequent_reminder_hpv:
+    "6410145f-dac1-46ba-82f3-a49cad0f66a6",
   session_clinic_initial_invitation: "fc99ac81-9eeb-4df8-9aa0-04f0eb48e37f",
   session_clinic_subsequent_invitation: "eee59c1b-3af4-4ccd-8653-940887066390",
   session_school_reminder: "79e131b2-7816-46d0-9c74-ae14956dd77d",

--- a/db/migrate/20250221155425_create_consent_notification_programmes.rb
+++ b/db/migrate/20250221155425_create_consent_notification_programmes.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class CreateConsentNotificationProgrammes < ActiveRecord::Migration[8.0]
+  def up
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :consent_notification_programmes do |t|
+      t.references :programme, foreign_key: true, null: false
+      t.references :consent_notification, foreign_key: true, null: false
+      t.index %i[programme_id consent_notification_id], unique: true
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+
+    ConsentNotification
+      .pluck(:id, :programme_id)
+      .each do |consent_notification_id, programme_id|
+        ConsentNotificationProgramme.create!(
+          consent_notification_id:,
+          programme_id:
+        )
+      end
+
+    remove_reference :consent_notifications, :programme
+  end
+
+  def down
+    add_reference :consent_notifications, :programme, foreign_key: true
+
+    ConsentNotification
+      .includes(:consent_notification_programmes)
+      .find_each do |consent_notification|
+        consent_notification.update_column(
+          :programme_id,
+          consent_notification
+            .consent_notification_programmes
+            .first
+            .programme_id
+        )
+      end
+
+    change_column_null :consent_notifications, :programme_id, false
+
+    drop_table :consent_notification_programmes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_21_155425) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -204,16 +204,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
     t.index ["school_id"], name: "index_consent_forms_on_school_id"
   end
 
+  create_table "consent_notification_programmes", force: :cascade do |t|
+    t.bigint "programme_id", null: false
+    t.bigint "consent_notification_id", null: false
+    t.index ["consent_notification_id"], name: "idx_on_consent_notification_id_bde310472f"
+    t.index ["programme_id", "consent_notification_id"], name: "idx_on_programme_id_consent_notification_id_e185bde5f5", unique: true
+    t.index ["programme_id"], name: "index_consent_notification_programmes_on_programme_id"
+  end
+
   create_table "consent_notifications", force: :cascade do |t|
     t.bigint "patient_id", null: false
-    t.bigint "programme_id", null: false
     t.datetime "sent_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.integer "type", null: false
     t.bigint "sent_by_user_id"
     t.bigint "session_id", null: false
-    t.index ["patient_id", "programme_id"], name: "index_consent_notifications_on_patient_id_and_programme_id"
     t.index ["patient_id"], name: "index_consent_notifications_on_patient_id"
-    t.index ["programme_id"], name: "index_consent_notifications_on_programme_id"
     t.index ["sent_by_user_id"], name: "index_consent_notifications_on_sent_by_user_id"
     t.index ["session_id"], name: "index_consent_notifications_on_session_id"
   end
@@ -815,8 +820,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_105126) do
   add_foreign_key "consent_forms", "locations"
   add_foreign_key "consent_forms", "locations", column: "school_id"
   add_foreign_key "consent_forms", "organisations"
+  add_foreign_key "consent_notification_programmes", "consent_notifications"
+  add_foreign_key "consent_notification_programmes", "programmes"
   add_foreign_key "consent_notifications", "patients"
-  add_foreign_key "consent_notifications", "programmes"
   add_foreign_key "consent_notifications", "sessions"
   add_foreign_key "consent_notifications", "users", column: "sent_by_user_id"
   add_foreign_key "consents", "organisations"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -111,7 +111,7 @@ def create_session(
         FactoryBot.create_list(
           :patient_session,
           2,
-          programme:,
+          programmes: [programme],
           session:,
           user:,
           year_group:
@@ -152,7 +152,7 @@ def create_session(
           :patient_session,
           1,
           trait,
-          programme:,
+          programmes: [programme],
           session:,
           user:,
           year_group:

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -111,7 +111,7 @@ describe AppActivityLogComponent do
       create(
         :notify_log_entry,
         :email,
-        template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[:consent_school_request],
+        template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[:consent_school_request_hpv],
         patient:,
         consent_form: nil,
         recipient: "test@example.com",
@@ -180,7 +180,7 @@ describe AppActivityLogComponent do
                      date: "29 May 2024 at 12:00pm"
 
     include_examples "card",
-                     title: "Consent school request sent",
+                     title: "Consent school request hpv sent",
                      date: "10 May 2024 at 12:00am",
                      notes: "test@example.com",
                      by: "Nurse Joy"

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -343,7 +343,9 @@ describe AppActivityLogComponent do
 
   describe "gillick assessments" do
     let(:programme) { create(:programme, :td_ipv) }
-    let(:patient_session) { create(:patient_session, patient:, programme:) }
+    let(:patient_session) do
+      create(:patient_session, patient:, programmes: [programme])
+    end
 
     before do
       create(
@@ -381,8 +383,9 @@ describe AppActivityLogComponent do
   end
 
   describe "pre-screenings" do
-    let(:programme) { create(:programme) }
-    let(:patient_session) { create(:patient_session, patient:, programme:) }
+    let(:patient_session) do
+      create(:patient_session, patient:, programmes: [programme])
+    end
 
     before do
       create(

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -6,19 +6,19 @@ describe AppConsentComponent do
   let(:component) do
     described_class.new(
       patient_session:,
-      programme:,
+      programme: programmes.first,
       section: "triage",
       tab: "needed"
     )
   end
 
-  let(:programme) { create(:programme) }
-  let(:consent) { patient_session.consents(programme:).first }
+  let(:programmes) { [create(:programme)] }
+  let(:consent) { patient_session.consents(programme: programmes.first).first }
 
   before { patient_session.reload.strict_loading!(false) }
 
   context "consent is not present" do
-    let(:patient_session) { create(:patient_session, programme:) }
+    let(:patient_session) { create(:patient_session, programmes:) }
 
     it { should_not have_css("p.app-status", text: "Consent (given|refused)") }
     it { should_not have_css("details", text: /Consent (given|refused) by/) }
@@ -28,19 +28,15 @@ describe AppConsentComponent do
   end
 
   context "consent is not present and session is not in progress" do
-    let(:patient_session) do
-      create(
-        :patient_session,
-        session: create(:session, :scheduled, programme:)
-      )
-    end
+    let(:session) { create(:session, :scheduled, programmes:) }
+    let(:patient_session) { create(:patient_session, session:, programmes:) }
 
     it { should_not have_css("button", text: "Assess Gillick competence") }
   end
 
   context "consent is refused" do
     let(:patient_session) do
-      create(:patient_session, :consent_refused, programme:)
+      create(:patient_session, :consent_refused, programmes:)
     end
 
     it { should have_css("p.app-status--red", text: "Consent refused") }
@@ -63,7 +59,7 @@ describe AppConsentComponent do
 
   context "consent is given" do
     let(:patient_session) do
-      create(:patient_session, :consent_given_triage_needed, programme:)
+      create(:patient_session, :consent_given_triage_needed, programmes:)
     end
 
     it { should have_css("p.app-status--aqua-green", text: "Consent given") }

--- a/spec/components/app_consent_status_component_spec.rb
+++ b/spec/components/app_consent_status_component_spec.rb
@@ -4,7 +4,9 @@ describe AppConsentStatusComponent do
   subject(:rendered) { render_inline(component) }
 
   let(:programme) { create(:programme) }
-  let(:patient_session) { create(:patient_session, programme:) }
+  let(:session) { create(:session, programmes: [programme]) }
+
+  let(:patient_session) { create(:patient_session, session:) }
 
   let(:component) { described_class.new(patient_session:, programme:) }
 
@@ -12,7 +14,7 @@ describe AppConsentStatusComponent do
 
   context "when consent is given" do
     let(:patient_session) do
-      create(:patient_session, :consent_given_triage_needed, programme:)
+      create(:patient_session, :consent_given_triage_needed, session:)
     end
 
     it { should have_css("p.app-status--aqua-green", text: "Consent given") }
@@ -20,7 +22,7 @@ describe AppConsentStatusComponent do
 
   context "when consent is refused" do
     let(:patient_session) do
-      create(:patient_session, :consent_refused, programme:)
+      create(:patient_session, :consent_refused, session:)
     end
 
     it { should have_css("p.app-status--red", text: "Consent refused") }
@@ -28,7 +30,7 @@ describe AppConsentStatusComponent do
 
   context "when consent conflicts" do
     let(:patient_session) do
-      create(:patient_session, :consent_conflicting, programme:)
+      create(:patient_session, :consent_conflicting, session:)
     end
 
     it do

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -3,9 +3,6 @@
 describe AppOutcomeBannerComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:user) { create(:user) }
-  let(:programme) { create(:programme, :hpv) }
-  let(:patient_session) { create(:patient_session, programme:) }
   let(:component) do
     described_class.new(
       patient_session:
@@ -14,6 +11,14 @@ describe AppOutcomeBannerComponent do
       current_user: user
     )
   end
+
+  let(:user) { create(:user) }
+  let(:programme) { create(:programme, :hpv) }
+
+  let(:session) { create(:session, programmes: [programme]) }
+
+  let(:patient_session) { create(:patient_session, session:) }
+
   let(:location_name) { patient_session.session.location.name }
   let(:patient_name) { patient_session.patient.full_name }
 
@@ -23,7 +28,7 @@ describe AppOutcomeBannerComponent do
 
   context "state is unable_to_vaccinate" do
     let(:patient_session) do
-      create(:patient_session, :unable_to_vaccinate, programme:)
+      create(:patient_session, :unable_to_vaccinate, session:)
     end
 
     it { should have_css(".app-card--red") }
@@ -34,7 +39,7 @@ describe AppOutcomeBannerComponent do
 
   context "triaged, not possible to vaccinate" do
     let(:patient_session) do
-      create(:patient_session, :unable_to_vaccinate, programme:)
+      create(:patient_session, :unable_to_vaccinate, session:)
     end
 
     it { should have_css(".app-card--red") }
@@ -44,11 +49,7 @@ describe AppOutcomeBannerComponent do
 
   context "not triaged, not possible to vaccinate" do
     let(:patient_session) do
-      create(
-        :patient_session,
-        :unable_to_vaccinate_and_had_no_triage,
-        programme:
-      )
+      create(:patient_session, :unable_to_vaccinate_and_had_no_triage, session:)
     end
 
     it { should have_css(".app-card--red") }
@@ -57,7 +58,7 @@ describe AppOutcomeBannerComponent do
   end
 
   context "state is vaccinated" do
-    let(:patient_session) { create(:patient_session, :vaccinated, programme:) }
+    let(:patient_session) { create(:patient_session, :vaccinated, session:) }
     let(:vaccination_record) do
       patient_session.vaccination_records(programme:).first
     end
@@ -78,7 +79,7 @@ describe AppOutcomeBannerComponent do
     context "vaccination was not administered today" do
       let(:date) { Time.zone.now - 2.days }
       let(:patient_session) do
-        create(:patient_session, :vaccinated, programme:).tap do |ps|
+        create(:patient_session, :vaccinated, session:).tap do |ps|
           ps.strict_loading!(false)
           ps.vaccination_records(programme:).first.update!(performed_at: date)
         end
@@ -96,7 +97,7 @@ describe AppOutcomeBannerComponent do
 
   context "state is triaged_do_not_vaccinate" do
     let(:patient_session) do
-      create(:patient_session, :triaged_do_not_vaccinate, programme:, user:)
+      create(:patient_session, :triaged_do_not_vaccinate, session:, user:)
     end
     let(:vaccination_record) { patient_session.vaccination_records.first }
     let(:location) { patient_session.session.location }
@@ -121,7 +122,7 @@ describe AppOutcomeBannerComponent do
         create(
           :patient_session,
           :triaged_do_not_vaccinate,
-          programme:
+          session:
         ).tap do |ps|
           ps
             .triages(programme: ps.programmes.first)

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -14,13 +14,13 @@ describe AppPatientPageComponent do
     patient_session.strict_loading!(false)
   end
 
-  let(:programme) { create(:programme, :hpv) }
+  let(:programmes) { [create(:programme, :hpv)] }
   let(:vaccine) { programme.vaccines.first }
 
   let(:component) do
     described_class.new(
       patient_session:,
-      programme:,
+      programme: programmes.first,
       section: "triage",
       tab: "needed",
       triage: nil
@@ -33,7 +33,7 @@ describe AppPatientPageComponent do
         :patient_session,
         :consent_given_triage_needed,
         :session_in_progress,
-        programme:
+        programmes:
       )
     end
 
@@ -61,7 +61,7 @@ describe AppPatientPageComponent do
         :triaged_ready_to_vaccinate,
         :session_in_progress,
         :in_attendance,
-        programme:
+        programmes:
       )
     end
 
@@ -82,7 +82,7 @@ describe AppPatientPageComponent do
 
   context "session in progress, patient without consent, no Gillick assessment" do
     let(:patient_session) do
-      create(:patient_session, :session_in_progress, programme:)
+      create(:patient_session, :session_in_progress, programmes:)
     end
 
     context "nurse user" do
@@ -104,7 +104,7 @@ describe AppPatientPageComponent do
         :patient_session,
         :session_in_progress,
         :gillick_competent,
-        programme:
+        programmes:
       )
     end
 

--- a/spec/components/app_session_patient_table_component_spec.rb
+++ b/spec/components/app_session_patient_table_component_spec.rb
@@ -12,8 +12,8 @@ describe AppSessionPatientTableComponent do
   end
 
   let(:section) { :consent }
-  let(:programme) { create(:programme) }
-  let(:session) { create(:session, programme:) }
+  let(:programmes) { [create(:programme)] }
+  let(:session) { create(:session, programmes:) }
   let(:patient_sessions) { create_list(:patient_session, 2, session:) }
   let(:columns) { %i[name year_group] }
   let(:params) { { session_slug: session.slug, section:, tab: :needed } }
@@ -25,7 +25,7 @@ describe AppSessionPatientTableComponent do
       params:,
       patient_sessions:,
       section:,
-      programme:,
+      programme: programmes.first,
       year_groups: session.year_groups
     )
   end
@@ -49,7 +49,7 @@ describe AppSessionPatientTableComponent do
       [
         create(
           :patient_session,
-          programme:,
+          programmes:,
           patient: create(:patient, preferred_given_name: "Bobby")
         )
       ]
@@ -65,7 +65,7 @@ describe AppSessionPatientTableComponent do
       [
         create(
           :patient_session,
-          programme:,
+          programmes:,
           patient: create(:patient, :restricted, address_postcode: "SW11 1AA")
         )
       ]
@@ -84,7 +84,7 @@ describe AppSessionPatientTableComponent do
     let(:component) do
       described_class.new(
         patient_sessions:,
-        programme:,
+        programme: programmes.first,
         section: :matching,
         consent_form:
           create(:consent_form, session: patient_sessions.first.session),
@@ -101,7 +101,12 @@ describe AppSessionPatientTableComponent do
     let(:patients) { patient_sessions.map(&:patient) }
 
     let(:component) do
-      described_class.new(params:, patients:, programme:, section:)
+      described_class.new(
+        params:,
+        patients:,
+        programme: programmes.first,
+        section:
+      )
     end
 
     it { should have_css(".nhsuk-table") }
@@ -123,7 +128,7 @@ describe AppSessionPatientTableComponent do
         params:,
         patients:,
         patient_sessions:,
-        programme:,
+        programme: programmes.first,
         section:
       )
     end
@@ -150,7 +155,7 @@ describe AppSessionPatientTableComponent do
     shared_examples "guesses the path" do |status, section, tab|
       context "for #{status}" do
         let(:patient_sessions) do
-          create_list(:patient_session, 1, status, session:, programme:)
+          create_list(:patient_session, 1, status, session:, programmes:)
         end
 
         it "guesses the path" do
@@ -212,7 +217,12 @@ describe AppSessionPatientTableComponent do
   describe "columns parameter" do
     context "is not set" do
       let(:component) do
-        described_class.new(patient_sessions:, programme:, section:, params:)
+        described_class.new(
+          patient_sessions:,
+          programme: programmes.first,
+          section:,
+          params:
+        )
       end
 
       it { should have_column("Full name") }

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -15,7 +15,9 @@ describe AppSimpleStatusBannerComponent do
 
   let(:user) { create(:user) }
   let(:programme) { create(:programme) }
-  let(:patient_session) { create(:patient_session, programme:, user:) }
+  let(:patient_session) do
+    create(:patient_session, programmes: [programme], user:)
+  end
 
   let(:component) { described_class.new(patient_session:, programme:) }
 
@@ -33,7 +35,7 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is added_to_session" do
     let(:patient_session) do
-      create(:patient_session, :added_to_session, programme:)
+      create(:patient_session, :added_to_session, programmes: [programme])
     end
 
     it { should have_css(".app-card--blue") }
@@ -41,7 +43,11 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is consent_given_triage_not_needed" do
     let(:patient_session) do
-      create(:patient_session, :consent_given_triage_not_needed, programme:)
+      create(
+        :patient_session,
+        :consent_given_triage_not_needed,
+        programmes: [programme]
+      )
     end
 
     it { should have_css(".app-card--aqua-green") }
@@ -51,7 +57,11 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is consent_given_triage_needed" do
     let(:patient_session) do
-      create(:patient_session, :consent_given_triage_needed, programme:)
+      create(
+        :patient_session,
+        :consent_given_triage_needed,
+        programmes: [programme]
+      )
     end
 
     it { should have_css(".app-card--blue") }
@@ -61,7 +71,7 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is consent_refused" do
     let(:patient_session) do
-      create(:patient_session, :consent_refused, programme:)
+      create(:patient_session, :consent_refused, programmes: [programme])
     end
 
     it { should have_css(".app-card--red") }
@@ -71,7 +81,7 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is triaged_kept_in_triage" do
     let(:patient_session) do
-      create(:patient_session, :triaged_kept_in_triage, programme:)
+      create(:patient_session, :triaged_kept_in_triage, programmes: [programme])
     end
 
     it { should have_css(".app-card--blue") }
@@ -81,7 +91,11 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is triaged_ready_to_vaccinate" do
     let(:patient_session) do
-      create(:patient_session, :triaged_ready_to_vaccinate, programme:)
+      create(
+        :patient_session,
+        :triaged_ready_to_vaccinate,
+        programmes: [programme]
+      )
     end
 
     it { should have_css(".app-card--purple") }
@@ -98,7 +112,11 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is triaged_do_not_vaccinate" do
     let(:patient_session) do
-      create(:patient_session, :triaged_do_not_vaccinate, programme:)
+      create(
+        :patient_session,
+        :triaged_do_not_vaccinate,
+        programmes: [programme]
+      )
     end
 
     it { should have_css(".app-card--red") }
@@ -115,7 +133,7 @@ describe AppSimpleStatusBannerComponent do
 
   context "state is delay_vaccination" do
     let(:patient_session) do
-      create(:patient_session, :delay_vaccination, programme:)
+      create(:patient_session, :delay_vaccination, programmes: [programme])
     end
 
     it { should have_css(".app-card--red") }

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -3,12 +3,13 @@
 describe AppTriageFormComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:programme) { create(:programme) }
-  let(:patient_session) { create(:patient_session, programme:) }
-  let(:patient) { patient_session.patient }
   let(:component) do
     described_class.new(patient_session:, programme:, url: "#")
   end
+
+  let(:programme) { create(:programme) }
+  let(:patient_session) { create(:patient_session, programmes: [programme]) }
+  let(:patient) { patient_session.patient }
 
   it { should have_text("Is it safe to vaccinate") }
   it { should have_css(".app-fieldset__legend--reset") }

--- a/spec/components/app_triage_notes_component_spec.rb
+++ b/spec/components/app_triage_notes_component_spec.rb
@@ -6,7 +6,8 @@ describe AppTriageNotesComponent do
   let(:component) { described_class.new(patient_session:, programme:) }
 
   let(:programme) { create(:programme) }
-  let(:patient_session) { create(:patient_session, programme:) }
+  let(:session) { create(:session, programmes: [programme]) }
+  let(:patient_session) { create(:patient_session, session:) }
   let(:patient) { patient_session.patient }
 
   before { patient_session.strict_loading!(false) }

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -5,25 +5,25 @@ describe AppVaccinateFormComponent do
 
   let(:heading) { "A Heading" }
   let(:body) { "A Body" }
-  let(:programme) { create(:programme, :hpv) }
-  let(:session) { create(:session, :today, programme:) }
+  let(:programmes) { [create(:programme, :hpv)] }
+  let(:session) { create(:session, :today, programmes:) }
   let(:vaccine) { programme.vaccines.first }
   let(:patient) do
     create(
       :patient,
       :consent_given_triage_not_needed,
-      programme:,
+      programmes:,
       given_name: "Hari"
     )
   end
   let(:patient_session) do
-    create(:patient_session, :in_attendance, programme:, patient:, session:)
+    create(:patient_session, :in_attendance, programmes:, patient:, session:)
   end
 
   let(:component) do
     described_class.new(
       patient_session:,
-      programme:,
+      programme: programmes.first,
       vaccinate_form: VaccinateForm.new,
       section: "vaccinate",
       tab: "needed"
@@ -53,13 +53,13 @@ describe AppVaccinateFormComponent do
       end
 
       context "session is in progress" do
-        let(:session) { create(:session, :today, programme:) }
+        let(:session) { create(:session, :today, programmes:) }
 
         it { should be(false) }
       end
 
       context "session is in the future" do
-        let(:session) { create(:session, :scheduled, programme:) }
+        let(:session) { create(:session, :scheduled, programmes:) }
 
         it { should be(false) }
       end
@@ -71,13 +71,13 @@ describe AppVaccinateFormComponent do
       end
 
       context "session is progress" do
-        let(:session) { create(:session, :today, programme:) }
+        let(:session) { create(:session, :today, programmes:) }
 
         it { should be(true) }
       end
 
       context "session is in the future" do
-        let(:session) { create(:session, :scheduled, programme:) }
+        let(:session) { create(:session, :scheduled, programmes:) }
 
         it { should be(false) }
       end

--- a/spec/controllers/concerns/patient_sorting_concern_spec.rb
+++ b/spec/controllers/concerns/patient_sorting_concern_spec.rb
@@ -35,31 +35,13 @@ describe PatientSortingConcern do
   end
 
   let(:programme) { create(:programme) }
-  let(:session) { create(:session, programme:) }
+  let(:session) { create(:session, programmes: [programme]) }
 
   let(:patient_sessions) do
     [
-      create(
-        :patient_session,
-        :added_to_session,
-        patient: alex,
-        programme:,
-        session:
-      ),
-      create(
-        :patient_session,
-        :delay_vaccination,
-        patient: blair,
-        programme:,
-        session:
-      ),
-      create(
-        :patient_session,
-        :vaccinated,
-        patient: casey,
-        programme:,
-        session:
-      )
+      create(:patient_session, :added_to_session, patient: alex, session:),
+      create(:patient_session, :delay_vaccination, patient: blair, session:),
+      create(:patient_session, :vaccinated, patient: casey, session:)
     ]
   end
 

--- a/spec/controllers/concerns/patient_tabs_concern_spec.rb
+++ b/spec/controllers/concerns/patient_tabs_concern_spec.rb
@@ -3,46 +3,51 @@
 describe PatientTabsConcern do
   subject(:controller) { Class.new { include PatientTabsConcern }.new }
 
-  let(:programme) { create(:programme) }
-  let(:session) { create(:session, programme:) }
+  let(:programmes) { [create(:programme)] }
+  let(:session) { create(:session, programmes:) }
 
   let(:added_to_session) do
-    create(:patient_session, :added_to_session, programme:, session:)
+    create(:patient_session, :added_to_session, programmes:, session:)
   end
   let(:consent_conflicts) do
-    create(:patient_session, :consent_conflicting, programme:, session:)
+    create(:patient_session, :consent_conflicting, programmes:, session:)
   end
   let(:consent_given_triage_not_needed) do
     create(
       :patient_session,
       :consent_given_triage_not_needed,
-      programme:,
+      programmes:,
       session:
     )
   end
   let(:consent_given_triage_needed) do
-    create(:patient_session, :consent_given_triage_needed, programme:, session:)
+    create(
+      :patient_session,
+      :consent_given_triage_needed,
+      programmes:,
+      session:
+    )
   end
   let(:consent_refused) do
-    create(:patient_session, :consent_refused, programme:, session:)
+    create(:patient_session, :consent_refused, programmes:, session:)
   end
   let(:delay_vaccination) do
-    create(:patient_session, :delay_vaccination, programme:, session:)
+    create(:patient_session, :delay_vaccination, programmes:, session:)
   end
   let(:triaged_do_not_vaccinate) do
-    create(:patient_session, :triaged_do_not_vaccinate, programme:, session:)
+    create(:patient_session, :triaged_do_not_vaccinate, programmes:, session:)
   end
   let(:triaged_kept_in_triage) do
-    create(:patient_session, :triaged_kept_in_triage, programme:, session:)
+    create(:patient_session, :triaged_kept_in_triage, programmes:, session:)
   end
   let(:triaged_ready_to_vaccinate) do
-    create(:patient_session, :triaged_ready_to_vaccinate, programme:, session:)
+    create(:patient_session, :triaged_ready_to_vaccinate, programmes:, session:)
   end
   let(:unable_to_vaccinate) do
-    create(:patient_session, :unable_to_vaccinate, programme:, session:)
+    create(:patient_session, :unable_to_vaccinate, programmes:, session:)
   end
   let(:vaccinated) do
-    create(:patient_session, :vaccinated, programme:, session:)
+    create(:patient_session, :vaccinated, programmes:, session:)
   end
 
   let(:patient_sessions) do
@@ -68,7 +73,7 @@ describe PatientTabsConcern do
       result =
         controller.group_patient_sessions_by_conditions(
           patient_sessions,
-          programme:,
+          programme: programmes.first,
           section: :consents
         )
 
@@ -96,7 +101,7 @@ describe PatientTabsConcern do
         result =
           controller.group_patient_sessions_by_conditions(
             [consent_given_triage_not_needed],
-            programme:,
+            programme: programmes.first,
             section: :consents
           )
 
@@ -118,7 +123,7 @@ describe PatientTabsConcern do
         result =
           controller.group_patient_sessions_by_state(
             patient_sessions,
-            programme,
+            programmes.first,
             section: :triage
           )
 
@@ -146,7 +151,7 @@ describe PatientTabsConcern do
         result =
           controller.group_patient_sessions_by_state(
             patient_sessions,
-            programme,
+            programmes.first,
             section: :vaccinations
           )
 
@@ -171,14 +176,14 @@ describe PatientTabsConcern do
 
     context "some of the groups are empty" do
       let(:patient_sessions) do
-        create_list(:patient_session, 1, :consent_refused, programme:)
+        create_list(:patient_session, 1, :consent_refused, programmes:)
       end
 
       it "returns an empty array for all the empty groups" do
         result =
           controller.group_patient_sessions_by_state(
             patient_sessions,
-            programme,
+            programmes.first,
             section: :triage
           )
 
@@ -194,12 +199,12 @@ describe PatientTabsConcern do
   end
 
   describe "#count_patient_sessions" do
-    let(:session) { create(:session, programme:) }
+    let(:session) { create(:session, programmes:) }
     let(:no_consent_patient_sessions) do
-      create_list(:patient_session, 2, programme:, session:)
+      create_list(:patient_session, 2, programmes:, session:)
     end
     let(:refuser_patient_session) do
-      create(:patient_session, :consent_refused, programme:, session:)
+      create(:patient_session, :consent_refused, programmes:, session:)
     end
 
     it "counts patient session groups" do

--- a/spec/factories/consent_notifications.rb
+++ b/spec/factories/consent_notifications.rb
@@ -8,30 +8,26 @@
 #  sent_at         :datetime         not null
 #  type            :integer          not null
 #  patient_id      :bigint           not null
-#  programme_id    :bigint           not null
 #  sent_by_user_id :bigint
 #  session_id      :bigint           not null
 #
 # Indexes
 #
-#  index_consent_notifications_on_patient_id                   (patient_id)
-#  index_consent_notifications_on_patient_id_and_programme_id  (patient_id,programme_id)
-#  index_consent_notifications_on_programme_id                 (programme_id)
-#  index_consent_notifications_on_sent_by_user_id              (sent_by_user_id)
-#  index_consent_notifications_on_session_id                   (session_id)
+#  index_consent_notifications_on_patient_id       (patient_id)
+#  index_consent_notifications_on_sent_by_user_id  (sent_by_user_id)
+#  index_consent_notifications_on_session_id       (session_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #  fk_rails_...  (session_id => sessions.id)
 #
 FactoryBot.define do
   factory :consent_notification do
     patient
-    programme
-    session { association :session, programme: }
+    session
+    programmes { session.programmes }
 
     traits_for_enum :type
   end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
     end
 
     trait :with_generic_clinic do
-      after(:create) do |organisation, _evaluator|
+      after(:create) do |organisation|
         create(:generic_clinic, team: organisation.generic_team)
       end
     end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -58,16 +58,16 @@ FactoryBot.define do
     transient do
       parents { [] }
       performed_by { association(:user) }
-      programme { session&.programmes&.first }
+      programmes { session&.programmes || [] }
       session { nil }
-      year_group { programme&.year_groups&.first }
+      year_group { programmes.flat_map(&:year_groups).sort.uniq.first }
       location_name { nil }
       in_attendance { false }
     end
 
     organisation do
       session&.organisation || school&.organisation ||
-        association(:organisation, programmes: [programme].compact)
+        association(:organisation, programmes:)
     end
 
     nhs_number do
@@ -148,35 +148,37 @@ FactoryBot.define do
     end
 
     trait :consent_request_sent do
-      after(:create) do |patient, context|
+      after(:create) do |patient, evaluator|
         create(
           :consent_notification,
           :request,
           patient:,
           session:
-            context.session || create(:session, programme: context.programme),
-          programmes: [context.programme],
+            evaluator.session ||
+              create(:session, programmes: evaluator.programmes),
+          programmes: evaluator.programmes,
           sent_at: 1.week.ago
         )
       end
     end
 
     trait :initial_consent_reminder_sent do
-      after(:create) do |patient, context|
+      after(:create) do |patient, evaluator|
         create(
           :consent_notification,
           :initial_reminder,
           patient:,
           session:
-            context.session || create(:session, programme: context.programme),
-          programmes: [context.programme]
+            evaluator.session ||
+              create(:session, programmes: evaluator.programmes),
+          programmes: evaluator.programmes
         )
       end
     end
 
     trait :consent_given_triage_not_needed do
       consents do
-        [
+        programmes.map do |programme|
           association(
             :consent,
             :given,
@@ -185,13 +187,13 @@ FactoryBot.define do
             organisation:,
             programme:
           )
-        ]
+        end
       end
     end
 
     trait :consent_given_triage_needed do
       consents do
-        [
+        programmes.map do |programme|
           association(
             :consent,
             :given,
@@ -201,13 +203,13 @@ FactoryBot.define do
             programme:,
             organisation:
           )
-        ]
+        end
       end
     end
 
     trait :consent_refused do
       consents do
-        [
+        programmes.map do |programme|
           association(
             :consent,
             :refused,
@@ -216,13 +218,13 @@ FactoryBot.define do
             organisation:,
             programme:
           )
-        ]
+        end
       end
     end
 
     trait :consent_refused_with_notes do
       consents do
-        [
+        programmes.map do |programme|
           association(
             :consent,
             :refused,
@@ -233,36 +235,38 @@ FactoryBot.define do
             reason_for_refusal: "already_vaccinated",
             notes: "Already had the vaccine at the GP"
           )
-        ]
+        end
       end
     end
 
     trait :consent_conflicting do
       consents do
-        [
-          association(
-            :consent,
-            :refused,
-            :from_mum,
-            patient: instance,
-            organisation:,
-            programme:
-          ),
-          association(
-            :consent,
-            :given,
-            :from_dad,
-            patient: instance,
-            organisation:,
-            programme:
-          )
-        ]
+        programmes.flat_map do |programme|
+          [
+            association(
+              :consent,
+              :refused,
+              :from_mum,
+              patient: instance,
+              organisation:,
+              programme:
+            ),
+            association(
+              :consent,
+              :given,
+              :from_dad,
+              patient: instance,
+              organisation:,
+              programme:
+            )
+          ]
+        end
       end
     end
 
     trait :consent_not_provided do
       consents do
-        [
+        programmes.map do |programme|
           association(
             :consent,
             :not_provided,
@@ -271,7 +275,7 @@ FactoryBot.define do
             organisation:,
             programme:
           )
-        ]
+        end
       end
     end
 
@@ -279,7 +283,7 @@ FactoryBot.define do
       consent_given_triage_needed
 
       triages do
-        [
+        programmes.map do |programme|
           association(
             :triage,
             :ready_to_vaccinate,
@@ -289,13 +293,13 @@ FactoryBot.define do
             organisation:,
             notes: "Okay to vaccinate"
           )
-        ]
+        end
       end
     end
 
     trait :triage_do_not_vaccinate do
       triages do
-        [
+        programmes.map do |programme|
           association(
             :triage,
             :do_not_vaccinate,
@@ -305,13 +309,13 @@ FactoryBot.define do
             organisation:,
             notes: "Do not vaccinate"
           )
-        ]
+        end
       end
     end
 
     trait :triage_needs_follow_up do
       triages do
-        [
+        programmes.map do |programme|
           association(
             :triage,
             :needs_follow_up,
@@ -321,13 +325,13 @@ FactoryBot.define do
             organisation:,
             notes: "Needs follow up"
           )
-        ]
+        end
       end
     end
 
     trait :triage_delay_vaccination do
       triages do
-        [
+        programmes.map do |programme|
           association(
             :triage,
             :delay_vaccination,
@@ -337,13 +341,13 @@ FactoryBot.define do
             organisation:,
             notes: "Delay vaccination"
           )
-        ]
+        end
       end
     end
 
     trait :vaccinated do
       vaccination_records do
-        [
+        programmes.map do |programme|
           if session
             association(
               :vaccination_record,
@@ -355,7 +359,7 @@ FactoryBot.define do
           else
             association(:vaccination_record, patient: instance, programme:)
           end
-        ]
+        end
       end
     end
   end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -153,7 +153,9 @@ FactoryBot.define do
           :consent_notification,
           :request,
           patient:,
-          programme: context.programme,
+          session:
+            context.session || create(:session, programme: context.programme),
+          programmes: [context.programme],
           sent_at: 1.week.ago
         )
       end
@@ -165,7 +167,9 @@ FactoryBot.define do
           :consent_notification,
           :initial_reminder,
           patient:,
-          programme: context.programme
+          session:
+            context.session || create(:session, programme: context.programme),
+          programmes: [context.programme]
         )
       end
     end

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -105,7 +105,7 @@ describe "Delete vaccination record" do
         :session,
         date: Date.yesterday,
         organisation: @organisation,
-        programme: @programme
+        programmes: [@programme]
       )
 
     @patient =
@@ -116,7 +116,7 @@ describe "Delete vaccination record" do
         given_name: "John",
         family_name: "Smith",
         year_group: 8,
-        programme: @programme,
+        programmes: [@programme],
         organisation: @organisation
       )
 

--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -36,7 +36,7 @@ describe "Download vaccination reports" do
     @programme = create(:programme, :hpv, organisations: [@organisation])
 
     @session =
-      create(:session, organisation: @organisation, programme: @programme)
+      create(:session, organisation: @organisation, programmes: [@programme])
 
     @patient =
       create(
@@ -44,7 +44,7 @@ describe "Download vaccination reports" do
         :triage_ready_to_vaccinate,
         given_name: "John",
         family_name: "Smith",
-        programme: @programme,
+        programmes: [@programme],
         organisation: @organisation
       )
 

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -277,7 +277,7 @@ describe "Edit vaccination record" do
         given_name: "John",
         family_name: "Smith",
         organisation: @organisation,
-        programme: @programme
+        programmes: [@programme]
       )
 
     @patient_session =

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -41,9 +41,9 @@ describe "Manage attendance" do
   end
 
   def given_my_organisation_is_running_an_hpv_vaccination_programme
-    @programme = create(:programme, :hpv_all_vaccines)
+    @programmes = [create(:programme, :hpv_all_vaccines)]
     @organisation =
-      create(:organisation, :with_one_nurse, programmes: [@programme])
+      create(:organisation, :with_one_nurse, programmes: @programmes)
   end
 
   def and_there_is_a_vaccination_session_today_with_a_patient_ready_to_vaccinate
@@ -52,7 +52,7 @@ describe "Manage attendance" do
       create(
         :session,
         :today,
-        programme: @programme,
+        programmes: @programmes,
         organisation: @organisation,
         location:
       )
@@ -61,7 +61,7 @@ describe "Manage attendance" do
       :patient_session,
       3,
       :consent_given_triage_not_needed,
-      programme: @programme,
+      programmes: @programmes,
       session: @session
     )
   end

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -28,19 +28,19 @@ describe "Manage batches" do
   end
 
   def given_my_organisation_is_running_an_hpv_vaccination_programme
-    @programme = create(:programme, :hpv_all_vaccines)
+    @programmes = [create(:programme, :hpv_all_vaccines)]
     @organisation =
-      create(:organisation, :with_one_nurse, programmes: [@programme])
+      create(:organisation, :with_one_nurse, programmes: @programmes)
   end
 
   def and_there_is_a_vaccination_session_today_with_one_patient_ready_to_vaccinate
     location = create(:school)
-    session = create(:session, :today, programme: @programme, location:)
+    session = create(:session, :today, programmes: @programmes, location:)
 
     create(
       :patient_session,
       :consent_given_triage_not_needed,
-      programme: @programme,
+      programmes: @programmes,
       session:
     )
 

--- a/spec/features/scheduled_consent_requests_spec.rb
+++ b/spec/features/scheduled_consent_requests_spec.rb
@@ -116,10 +116,26 @@ describe "Scheduled consent requests" do
   def then_all_four_parents_received_consent_requests
     SchoolConsentRequestsJob.perform_now
 
-    expect_email_to("parent1.child1@example.com", :consent_school_request, :any)
-    expect_email_to("parent2.child1@example.com", :consent_school_request, :any)
-    expect_email_to("parent1.child2@example.com", :consent_school_request, :any)
-    expect_email_to("parent2.child2@example.com", :consent_school_request, :any)
+    expect_email_to(
+      "parent1.child1@example.com",
+      :consent_school_request_hpv,
+      :any
+    )
+    expect_email_to(
+      "parent2.child1@example.com",
+      :consent_school_request_hpv,
+      :any
+    )
+    expect_email_to(
+      "parent1.child2@example.com",
+      :consent_school_request_hpv,
+      :any
+    )
+    expect_email_to(
+      "parent2.child2@example.com",
+      :consent_school_request_hpv,
+      :any
+    )
 
     expect_sms_to("07700 900000", :consent_school_request, :any)
     expect_sms_to("07700 900001", :consent_school_request, :any)

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -23,15 +23,14 @@ describe "Triage" do
   end
 
   def given_a_programme_with_a_running_session
-    programme = create(:programme, :hpv)
-    @organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv)]
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
     @school = create(:school)
     session =
       create(
         :session,
         organisation: @organisation,
-        programme:,
+        programmes:,
         location: @school,
         date: Time.zone.today
       )
@@ -40,7 +39,7 @@ describe "Triage" do
         :patient_session,
         :consent_given_triage_needed,
         :in_attendance,
-        programme:,
+        programmes:,
         session:
       ).patient
   end

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -48,7 +48,7 @@ describe "Triage" do
       create(
         :patient_session,
         :consent_given_triage_needed,
-        programme: @programme,
+        programmes: [@programme],
         session: @session
       ).patient
     create(

--- a/spec/features/triage_then_parental_consent_refused_spec.rb
+++ b/spec/features/triage_then_parental_consent_refused_spec.rb
@@ -36,7 +36,7 @@ describe "Triage" do
       create(
         :patient_session,
         :consent_given_triage_needed,
-        programme: @programme,
+        programmes: [@programme],
         session: @session
       ).patient
   end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -32,7 +32,7 @@ feature "Verbal consent" do
       create(
         :patient_session,
         :consent_refused,
-        programme: @programme,
+        programmes: [@programme],
         session: @session
       ).patient
   end

--- a/spec/jobs/patient_nhs_number_lookup_job_spec.rb
+++ b/spec/jobs/patient_nhs_number_lookup_job_spec.rb
@@ -67,7 +67,9 @@ describe PatientNHSNumberLookupJob do
 
       let!(:existing_patient) { create(:patient, nhs_number: "9449306168") }
 
-      let(:patient_session) { create(:patient_session, patient:, programme:) }
+      let(:patient_session) do
+        create(:patient_session, patient:, programmes: [programme])
+      end
       let(:gillick_assessment) do
         create(:gillick_assessment, :competent, patient_session:)
       end

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -3,7 +3,7 @@
 describe SchoolConsentRemindersJob do
   subject(:perform_now) { described_class.perform_now }
 
-  let(:programme) { create(:programme) }
+  let(:programmes) { [create(:programme)] }
 
   let(:parents) { create_list(:parent, 2) }
 
@@ -13,15 +13,26 @@ describe SchoolConsentRemindersJob do
       :consent_request_sent,
       :initial_consent_reminder_sent,
       parents:,
-      programme:
+      programme: programmes.first
     )
   end
   let(:patient_not_sent_reminder) do
-    create(:patient, :consent_request_sent, parents:, programme:)
+    create(
+      :patient,
+      :consent_request_sent,
+      parents:,
+      programme: programmes.first
+    )
   end
-  let(:patient_not_sent_request) { create(:patient, parents:, programme:) }
+  let(:patient_not_sent_request) do
+    create(:patient, parents:, programme: programmes.first)
+  end
   let(:patient_with_consent) do
-    create(:patient, :consent_given_triage_not_needed, programme:)
+    create(
+      :patient,
+      :consent_given_triage_not_needed,
+      programme: programmes.first
+    )
   end
   let(:deceased_patient) { create(:patient, :deceased) }
   let(:invalid_patient) { create(:patient, :invalidated) }
@@ -41,7 +52,7 @@ describe SchoolConsentRemindersJob do
 
   let(:dates) { [Date.new(2024, 1, 12), Date.new(2024, 1, 15)] }
 
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:location) { create(:school, organisation:) }
 
   let!(:session) do
@@ -52,7 +63,7 @@ describe SchoolConsentRemindersJob do
       days_before_consent_reminders: 7,
       location:,
       patients:,
-      programme:,
+      programme: programmes.first,
       organisation:
     )
   end
@@ -74,7 +85,7 @@ describe SchoolConsentRemindersJob do
     it "sends notifications to one patient" do
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_not_sent_reminder,
-        programme:,
+        programmes:,
         session:,
         type: :initial_reminder
       )
@@ -103,7 +114,7 @@ describe SchoolConsentRemindersJob do
         :consent_notification,
         :initial_reminder,
         patient: patient_not_sent_reminder,
-        programme:
+        session:
       )
     end
 
@@ -119,14 +130,14 @@ describe SchoolConsentRemindersJob do
     it "sends notifications to two patients" do
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_not_sent_reminder,
-        programme:,
+        programmes:,
         session:,
         type: :initial_reminder
       )
 
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_with_initial_reminder_sent,
-        programme:,
+        programmes:,
         session:,
         type: :subsequent_reminder
       )

--- a/spec/jobs/school_consent_reminders_job_spec.rb
+++ b/spec/jobs/school_consent_reminders_job_spec.rb
@@ -13,26 +13,15 @@ describe SchoolConsentRemindersJob do
       :consent_request_sent,
       :initial_consent_reminder_sent,
       parents:,
-      programme: programmes.first
+      programmes:
     )
   end
   let(:patient_not_sent_reminder) do
-    create(
-      :patient,
-      :consent_request_sent,
-      parents:,
-      programme: programmes.first
-    )
+    create(:patient, :consent_request_sent, parents:, programmes:)
   end
-  let(:patient_not_sent_request) do
-    create(:patient, parents:, programme: programmes.first)
-  end
+  let(:patient_not_sent_request) { create(:patient, parents:, programmes:) }
   let(:patient_with_consent) do
-    create(
-      :patient,
-      :consent_given_triage_not_needed,
-      programme: programmes.first
-    )
+    create(:patient, :consent_given_triage_not_needed, programmes:)
   end
   let(:deceased_patient) { create(:patient, :deceased) }
   let(:invalid_patient) { create(:patient, :invalidated) }
@@ -63,7 +52,7 @@ describe SchoolConsentRemindersJob do
       days_before_consent_reminders: 7,
       location:,
       patients:,
-      programme: programmes.first,
+      programmes:,
       organisation:
     )
   end

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -8,7 +8,7 @@ describe SchoolConsentRequestsJob do
   let(:parents) { create_list(:parent, 2) }
 
   let(:patient_with_request_sent) do
-    create(:patient, :consent_request_sent, :consent_request_sent, programmes:)
+    create(:patient, :consent_request_sent, programmes:)
   end
   let(:patient_not_sent_request) { create(:patient, parents:, programmes:) }
   let(:patient_with_consent) do
@@ -73,6 +73,22 @@ describe SchoolConsentRequestsJob do
         type: :request
       )
       perform_now
+    end
+
+    context "with Td/IPV and MenACWY" do
+      let(:programmes) do
+        [create(:programme, :menacwy), create(:programme, :td_ipv)]
+      end
+
+      it "sends one notification to one patient" do
+        expect(ConsentNotification).to receive(:create_and_send!).once.with(
+          patient: patient_not_sent_request,
+          programmes:,
+          session:,
+          type: :request
+        )
+        perform_now
+      end
     end
 
     context "when location is a generic clinic" do

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -8,22 +8,11 @@ describe SchoolConsentRequestsJob do
   let(:parents) { create_list(:parent, 2) }
 
   let(:patient_with_request_sent) do
-    create(
-      :patient,
-      :consent_request_sent,
-      :consent_request_sent,
-      programme: programmes.first
-    )
+    create(:patient, :consent_request_sent, :consent_request_sent, programmes:)
   end
-  let(:patient_not_sent_request) do
-    create(:patient, parents:, programme: programmes.first)
-  end
+  let(:patient_not_sent_request) { create(:patient, parents:, programmes:) }
   let(:patient_with_consent) do
-    create(
-      :patient,
-      :consent_given_triage_not_needed,
-      programme: programmes.first
-    )
+    create(:patient, :consent_given_triage_not_needed, programmes:)
   end
   let(:deceased_patient) { create(:patient, :deceased) }
   let(:invalid_patient) { create(:patient, :invalidated) }
@@ -41,9 +30,7 @@ describe SchoolConsentRequestsJob do
   end
 
   context "when session is unscheduled" do
-    let(:session) do
-      create(:session, :unscheduled, patients:, programme: programmes.first)
-    end
+    let(:session) { create(:session, :unscheduled, patients:, programmes:) }
 
     it "doesn't send any notifications" do
       expect(ConsentNotification).not_to receive(:create_and_send!)
@@ -56,7 +43,7 @@ describe SchoolConsentRequestsJob do
       create(
         :session,
         patients:,
-        programme: programmes.first,
+        programmes:,
         send_consent_requests_at: 2.days.from_now
       )
     end
@@ -72,7 +59,7 @@ describe SchoolConsentRequestsJob do
       create(
         :session,
         patients:,
-        programme: programmes.first,
+        programmes:,
         date: 3.weeks.from_now.to_date,
         send_consent_requests_at: Date.current
       )
@@ -95,7 +82,7 @@ describe SchoolConsentRequestsJob do
         create(
           :session,
           patients:,
-          programme: programmes.first,
+          programmes:,
           send_consent_requests_at: Date.current,
           organisation:
         )

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -3,16 +3,27 @@
 describe SchoolConsentRequestsJob do
   subject(:perform_now) { described_class.perform_now }
 
-  let(:programme) { create(:programme) }
+  let(:programmes) { [create(:programme)] }
 
   let(:parents) { create_list(:parent, 2) }
 
   let(:patient_with_request_sent) do
-    create(:patient, :consent_request_sent, :consent_request_sent, programme:)
+    create(
+      :patient,
+      :consent_request_sent,
+      :consent_request_sent,
+      programme: programmes.first
+    )
   end
-  let(:patient_not_sent_request) { create(:patient, parents:, programme:) }
+  let(:patient_not_sent_request) do
+    create(:patient, parents:, programme: programmes.first)
+  end
   let(:patient_with_consent) do
-    create(:patient, :consent_given_triage_not_needed, programme:)
+    create(
+      :patient,
+      :consent_given_triage_not_needed,
+      programme: programmes.first
+    )
   end
   let(:deceased_patient) { create(:patient, :deceased) }
   let(:invalid_patient) { create(:patient, :invalidated) }
@@ -30,7 +41,9 @@ describe SchoolConsentRequestsJob do
   end
 
   context "when session is unscheduled" do
-    let(:session) { create(:session, :unscheduled, patients:, programme:) }
+    let(:session) do
+      create(:session, :unscheduled, patients:, programme: programmes.first)
+    end
 
     it "doesn't send any notifications" do
       expect(ConsentNotification).not_to receive(:create_and_send!)
@@ -43,7 +56,7 @@ describe SchoolConsentRequestsJob do
       create(
         :session,
         patients:,
-        programme:,
+        programme: programmes.first,
         send_consent_requests_at: 2.days.from_now
       )
     end
@@ -59,7 +72,7 @@ describe SchoolConsentRequestsJob do
       create(
         :session,
         patients:,
-        programme:,
+        programme: programmes.first,
         date: 3.weeks.from_now.to_date,
         send_consent_requests_at: Date.current
       )
@@ -68,7 +81,7 @@ describe SchoolConsentRequestsJob do
     it "sends notifications to one patient" do
       expect(ConsentNotification).to receive(:create_and_send!).once.with(
         patient: patient_not_sent_request,
-        programme:,
+        programmes:,
         session:,
         type: :request
       )
@@ -76,13 +89,13 @@ describe SchoolConsentRequestsJob do
     end
 
     context "when location is a generic clinic" do
-      let(:organisation) { create(:organisation, programmes: [programme]) }
+      let(:organisation) { create(:organisation, programmes:) }
       let(:location) { create(:generic_clinic, organisation:) }
       let(:session) do
         create(
           :session,
           patients:,
-          programme:,
+          programme: programmes.first,
           send_consent_requests_at: Date.current,
           organisation:
         )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -38,7 +38,7 @@ describe PatientMerger do
         :consent_notification,
         :request,
         patient: patient_to_destroy,
-        programme:
+        session:
       )
     end
     let(:gillick_assessment) do

--- a/spec/lib/programme_grouper_spec.rb
+++ b/spec/lib/programme_grouper_spec.rb
@@ -11,19 +11,19 @@ describe ProgrammeGrouper do
     context "with only HPV" do
       let(:programmes) { [hpv] }
 
-      it { should eq([[hpv]]) }
+      it { should eq({ hpv: [hpv] }) }
     end
 
     context "with Td/IPV and MenACWY" do
       let(:programmes) { [menacwy, td_ipv] }
 
-      it { should eq([[menacwy, td_ipv]]) }
+      it { should eq({ doubles: [menacwy, td_ipv] }) }
     end
 
     context "with HPV, Td/IPV and MenACWY" do
       let(:programmes) { [hpv, menacwy, td_ipv] }
 
-      it { should eq([[hpv], [menacwy, td_ipv]]) }
+      it { should eq({ hpv: [hpv], doubles: [menacwy, td_ipv] }) }
     end
   end
 end

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -21,7 +21,9 @@ describe Reports::CareplusExporter do
       gias_establishment_number: 456
     )
   end
-  let(:session) { create(:session, organisation:, programme:, location:) }
+  let(:session) do
+    create(:session, organisation:, programmes: [programme], location:)
+  end
   let(:parsed_csv) { CSV.parse(csv) }
   let(:headers) { parsed_csv.first }
   let(:data_rows) { parsed_csv[1..] }
@@ -69,7 +71,7 @@ describe Reports::CareplusExporter do
       create(
         :patient_session,
         :consent_given_triage_not_needed,
-        programme:,
+        programmes: [programme],
         session:
       )
     vaccination_record =
@@ -112,7 +114,7 @@ describe Reports::CareplusExporter do
       create(
         :patient_session,
         :consent_given_triage_not_needed,
-        programme:,
+        programmes: [programme],
         patient:,
         session:
       )

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -317,7 +317,7 @@ describe Reports::ProgrammeVaccinationsExporter do
           :deceased,
           date_of_death: Date.new(2010, 1, 1),
           session:,
-          programme:
+          programmes: [programme]
         )
       end
 
@@ -337,7 +337,7 @@ describe Reports::ProgrammeVaccinationsExporter do
           :vaccinated,
           updated_from_pds_at: Time.current,
           session:,
-          programme:
+          programmes: [programme]
         )
       end
 
@@ -350,10 +350,16 @@ describe Reports::ProgrammeVaccinationsExporter do
       let(:gp_practice) do
         create(:gp_practice, name: "Practice", ods_code: "GP")
       end
-      let(:session) { create(:session, programme:, organisation:) }
+      let(:session) { create(:session, programmes: [programme], organisation:) }
 
       before do
-        create(:patient, :vaccinated, gp_practice:, session:, programme:)
+        create(
+          :patient,
+          :vaccinated,
+          gp_practice:,
+          session:,
+          programmes: [programme]
+        )
       end
 
       it "includes the information" do
@@ -366,7 +372,9 @@ describe Reports::ProgrammeVaccinationsExporter do
 
     context "with consent" do
       let(:session) { create(:session, programme:, organisation:) }
-      let(:patient) { create(:patient, :vaccinated, session:, programme:) }
+      let(:patient) do
+        create(:patient, :vaccinated, session:, programmes: [programme])
+      end
 
       before do
         parent = create(:parent, full_name: "John Smith")
@@ -393,7 +401,7 @@ describe Reports::ProgrammeVaccinationsExporter do
     context "with a gillick assessment" do
       let(:session) { create(:session, programme:, organisation:) }
       let(:patient_session) do
-        create(:patient_session, :vaccinated, programme:, session:)
+        create(:patient_session, :vaccinated, programmes: [programme], session:)
       end
       let(:patient) { patient_session.patient }
 
@@ -466,7 +474,7 @@ describe Reports::ProgrammeVaccinationsExporter do
         create(
           :patient_session,
           :vaccinated,
-          programme:,
+          programmes: [programme],
           session:,
           user: performed_by
         )

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -41,7 +41,7 @@ describe ConsentNotification do
 
     let(:parents) { create_list(:parent, 2) }
     let(:patient) { create(:patient, parents:) }
-    let(:programmes) { [create(:programme)] }
+    let(:programmes) { [create(:programme, :hpv)] }
     let(:organisation) { create(:organisation, programmes:) }
     let(:location) { create(:school, organisation:) }
     let(:session) do
@@ -70,20 +70,38 @@ describe ConsentNotification do
 
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_delivered_email(
-          :consent_school_request
+          :consent_school_request_hpv
         ).with(
           parent: parents.first,
           patient:,
           programmes:,
           session:,
           sent_by: current_user
-        ).and have_delivered_email(:consent_school_request).with(
+        ).and have_delivered_email(:consent_school_request_hpv).with(
                 parent: parents.second,
                 patient:,
                 programmes:,
                 session:,
                 sent_by: current_user
               )
+      end
+
+      context "with Td/IPV and MenACWY programmes" do
+        let(:programmes) do
+          [create(:programme, :menacwy), create(:programme, :td_ipv)]
+        end
+
+        it "enqueues an email per parent" do
+          expect { create_and_send! }.to have_delivered_email(
+            :consent_school_request_doubles
+          ).with(
+            parent: parents.first,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
+        end
       end
 
       it "enqueues a text per parent" do
@@ -207,20 +225,38 @@ describe ConsentNotification do
 
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_delivered_email(
-          :consent_school_initial_reminder
+          :consent_school_initial_reminder_hpv
         ).with(
           parent: parents.first,
           patient:,
           programmes:,
           session:,
           sent_by: current_user
-        ).and have_delivered_email(:consent_school_initial_reminder).with(
+        ).and have_delivered_email(:consent_school_initial_reminder_hpv).with(
                 parent: parents.second,
                 patient:,
                 programmes:,
                 session:,
                 sent_by: current_user
               )
+      end
+
+      context "with Td/IPV and MenACWY programmes" do
+        let(:programmes) do
+          [create(:programme, :menacwy), create(:programme, :td_ipv)]
+        end
+
+        it "enqueues an email per parent" do
+          expect { create_and_send! }.to have_delivered_email(
+            :consent_school_initial_reminder_doubles
+          ).with(
+            parent: parents.first,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
+        end
       end
 
       it "enqueues a text per parent" do
@@ -275,20 +311,40 @@ describe ConsentNotification do
 
       it "enqueues an email per parent" do
         expect { create_and_send! }.to have_delivered_email(
-          :consent_school_subsequent_reminder
+          :consent_school_subsequent_reminder_hpv
         ).with(
           parent: parents.first,
           patient:,
           programmes:,
           session:,
           sent_by: current_user
-        ).and have_delivered_email(:consent_school_subsequent_reminder).with(
+        ).and have_delivered_email(
+                :consent_school_subsequent_reminder_hpv
+              ).with(
                 parent: parents.second,
                 patient:,
                 programmes:,
                 session:,
                 sent_by: current_user
               )
+      end
+
+      context "with Td/IPV and MenACWY programmes" do
+        let(:programmes) do
+          [create(:programme, :menacwy), create(:programme, :td_ipv)]
+        end
+
+        it "enqueues an email per parent" do
+          expect { create_and_send! }.to have_delivered_email(
+            :consent_school_subsequent_reminder_doubles
+          ).with(
+            parent: parents.first,
+            patient:,
+            programmes:,
+            session:,
+            sent_by: current_user
+          )
+        end
       end
 
       it "enqueues a text per parent" do

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -8,22 +8,18 @@
 #  sent_at         :datetime         not null
 #  type            :integer          not null
 #  patient_id      :bigint           not null
-#  programme_id    :bigint           not null
 #  sent_by_user_id :bigint
 #  session_id      :bigint           not null
 #
 # Indexes
 #
-#  index_consent_notifications_on_patient_id                   (patient_id)
-#  index_consent_notifications_on_patient_id_and_programme_id  (patient_id,programme_id)
-#  index_consent_notifications_on_programme_id                 (programme_id)
-#  index_consent_notifications_on_sent_by_user_id              (sent_by_user_id)
-#  index_consent_notifications_on_session_id                   (session_id)
+#  index_consent_notifications_on_patient_id       (patient_id)
+#  index_consent_notifications_on_sent_by_user_id  (sent_by_user_id)
+#  index_consent_notifications_on_session_id       (session_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_id => patients.id)
-#  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (sent_by_user_id => users.id)
 #  fk_rails_...  (session_id => sessions.id)
 #
@@ -33,7 +29,7 @@ describe ConsentNotification do
       travel_to(today) do
         described_class.create_and_send!(
           patient:,
-          programme: programmes.first,
+          programmes:,
           session:,
           type:,
           current_user:
@@ -67,7 +63,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).not_to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -136,7 +132,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).not_to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -204,7 +200,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end
@@ -272,7 +268,7 @@ describe ConsentNotification do
 
         consent_notification = described_class.last
         expect(consent_notification).to be_reminder
-        expect(consent_notification.programme).to eq(programmes.first)
+        expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
         expect(consent_notification.sent_at).to be_today
       end

--- a/spec/models/draft_consent_spec.rb
+++ b/spec/models/draft_consent_spec.rb
@@ -12,8 +12,10 @@ describe DraftConsent do
   let(:request_session) { {} }
   let(:current_user) { organisation.users.first }
 
-  let(:patient_session) { create(:patient_session, programme:) }
   let(:programme) { create(:programme, :hpv) }
+  let(:session) { create(:session, programmes: [programme]) }
+
+  let(:patient_session) { create(:patient_session, session:) }
 
   let(:valid_given_attributes) do
     {

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -23,9 +23,10 @@
 #
 
 describe PatientSession do
-  subject(:patient_session) { create(:patient_session, programme:) }
+  subject(:patient_session) { create(:patient_session, session:) }
 
   let(:programme) { create(:programme) }
+  let(:session) { create(:session, programmes: [programme]) }
 
   it { should have_many(:gillick_assessments).order(:created_at) }
 
@@ -206,7 +207,9 @@ describe PatientSession do
   describe "#latest_consents" do
     subject(:latest_consents) { patient_session.latest_consents(programme:) }
 
-    let(:patient_session) { create(:patient_session, programme:, patient:) }
+    let(:patient_session) do
+      create(:patient_session, programmes: [programme], patient:)
+    end
 
     before { patient_session.strict_loading!(false) }
 
@@ -263,9 +266,8 @@ describe PatientSession do
   describe "#safe_to_destroy?" do
     subject(:safe_to_destroy?) { patient_session.safe_to_destroy? }
 
-    let(:patient_session) { create(:patient_session, programme:) }
+    let(:patient_session) { create(:patient_session, session:) }
     let(:patient) { patient_session.patient }
-    let(:session) { patient_session.session }
 
     context "when safe to destroy" do
       it { should be true }

--- a/spec/models/patient_session_stats_spec.rb
+++ b/spec/models/patient_session_stats_spec.rb
@@ -5,12 +5,12 @@ describe PatientSessionStats do
     subject(:to_h) do
       described_class.new(
         session.patient_sessions.preload_for_status,
-        programme:
+        programme: programmes.first
       ).to_h
     end
 
-    let(:programme) { create(:programme) }
-    let(:session) { create(:session, programme:) }
+    let(:programmes) { [create(:programme)] }
+    let(:session) { create(:session, programmes:) }
 
     it "returns a hash of session stats" do
       expect(to_h).to eq(
@@ -32,45 +32,50 @@ describe PatientSessionStats do
           create(
             :patient_session,
             :consent_refused,
-            programme:,
+            programmes:,
             session:
           ).patient # consent refused
-        create(:patient_session, :consent_refused, programme:, patient:) # duplicate is ignored
+        create(:patient_session, :consent_refused, programmes:, patient:) # duplicate is ignored
 
-        create(:patient_session, :added_to_session, programme:, session:) # without a response
+        create(:patient_session, :added_to_session, programmes:, session:) # without a response
         create(
           :patient_session,
           :consent_given_triage_needed,
-          programme:,
+          programmes:,
           session:
         ) # needing triage, consent given
-        create(:patient_session, :triaged_kept_in_triage, programme:, session:) # needing triage, consent given
+        create(:patient_session, :triaged_kept_in_triage, programmes:, session:) # needing triage, consent given
         create(
           :patient_session,
           :triaged_ready_to_vaccinate,
-          programme:,
+          programmes:,
           session:
         ) # ready to vaccinate, consent given
         create(
           :patient_session,
           :consent_given_triage_not_needed,
-          programme:,
+          programmes:,
           session:
         ) # ready to vaccinate, consent given
 
         create(:consent_form, :recorded, session:, consent_id: nil) # => unmatched response
         create(:consent_form, :draft, session:, consent_id: nil) # => still draft, should not be counted
 
-        create(:patient_session, :consent_conflicting, programme:, session:) # conflicting consent
+        create(:patient_session, :consent_conflicting, programmes:, session:) # conflicting consent
 
         gillick_patient =
           create(
             :patient_session,
             :consent_conflicting,
-            programme:,
+            programmes:,
             session:
           ).patient
-        create(:consent, :self_consent, patient: gillick_patient, programme:) # conflicting consent with gillick
+        create(
+          :consent,
+          :self_consent,
+          patient: gillick_patient,
+          programme: programmes.first
+        ) # conflicting consent with gillick
       end
 
       it "returns a hash of session stats" do

--- a/spec/policies/patient_session_policy_spec.rb
+++ b/spec/policies/patient_session_policy_spec.rb
@@ -1,20 +1,19 @@
 # frozen_string_literal: true
 
 describe PatientSessionPolicy do
-  let(:programme) { create(:programme) }
+  let(:programmes) { [create(:programme)] }
 
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:user) { create(:user, organisation:) }
 
   let(:patient_session) do
     create(
       :patient_session,
-      programme:,
-      session: create(:session, organisation:, programme:)
+      session: create(:session, organisation:, programmes:)
     )
   end
   let(:another_organisations_patient_session) do
-    create(:patient_session, programme:)
+    create(:patient_session, programmes:)
   end
 
   describe "Scope#resolve" do


### PR DESCRIPTION
This makes it possible to send custom email templates based on the programme groups. This has no effect on HPV, but for Td/IPV and MenACWY we send a single template for both vaccines under the name "doubles".

I haven't added the templates for doubles in this PR, but once they are in GOV.UK Notify we can add the template IDs here.