### PR TITLE
Add vaccination criteria for doubles

### DIFF
--- a/app/lib/programme_grouper.rb
+++ b/app/lib/programme_grouper.rb
@@ -27,8 +27,8 @@ class ProgrammeGrouper
       :flu
     elsif programme.hpv?
       :hpv
-    elsif programme.td_ipv? || programme.menacwy?
-      :doubles # Td/IPV and MenACWY is administered together
+    elsif programme.doubles?
+      :doubles
     else
       raise "Unknown programme type #{programme.type}"
     end

--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class VaccinatedCriteria
+  def initialize(programme, patient:, vaccination_records:)
+    @programme = programme
+    @patient = patient
+    @vaccination_records = vaccination_records
+  end
+
+  def call
+    if vaccination_records.any? { it.programme_id != programme.id }
+      raise "Vaccination records provided for different programme."
+    end
+
+    if programme.doubles?
+      vaccination_records.any? do
+        it.administered? &&
+          it.dose_sequence == programme.vaccinated_dose_sequence &&
+          patient.age(now: it.performed_at) >= 10
+      end
+    else
+      vaccination_records.any?(&:administered?)
+    end
+  end
+
+  def self.call(*args, **kwargs)
+    new(*args, **kwargs).call
+  end
+
+  private_class_method :new
+
+  private
+
+  attr_reader :programme, :patient, :vaccination_records
+end

--- a/app/models/concerns/age_concern.rb
+++ b/app/models/concerns/age_concern.rb
@@ -14,9 +14,9 @@ module AgeConcern
   included do
     date_of_birth_field_for_age :date_of_birth
 
-    def age
+    def age(now: nil)
       date_of_birth_value = __send__(self.class.date_of_birth_field_for_age)
-      now = Time.zone.now.to_date
+      now ||= Time.current
 
       month_is_greater = now.month > date_of_birth_value.month
       month_matches = now.month == date_of_birth_value.month

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -123,10 +123,11 @@ module PatientSessionStatusConcern
     end
 
     def vaccination_administered?(programme:)
-      vaccination_records(programme:).any? do
-        it.administered? &&
-          it.dose_sequence >= programme.vaccinated_dose_sequence
-      end
+      VaccinatedCriteria.call(
+        programme,
+        patient:,
+        vaccination_records: vaccination_records(programme:)
+      )
     end
 
     def vaccination_not_administered?(programme:)

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -46,6 +46,10 @@ class Programme < ApplicationRecord
     type
   end
 
+  def doubles?
+    menacwy? || td_ipv?
+  end
+
   def name
     human_enum_name(:type)
   end

--- a/spec/lib/vaccinated_criteria_spec.rb
+++ b/spec/lib/vaccinated_criteria_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+describe VaccinatedCriteria do
+  describe "#call" do
+    subject(:call) do
+      described_class.call(programme, patient:, vaccination_records:)
+    end
+
+    let(:patient) { create(:patient, date_of_birth: 15.years.ago.to_date) }
+    let(:vaccination_records) { [] }
+
+    context "with a Flu programme" do
+      let(:programme) { create(:programme, :flu) }
+
+      it { should be(false) }
+
+      context "with an unadministered vaccination record" do
+        let(:vaccination_records) do
+          [build(:vaccination_record, :not_administered, patient:, programme:)]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with an administered vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :administered, patient:, programme:)]
+        end
+
+        it { should be(true) }
+      end
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { create(:programme, :hpv) }
+
+      it { should be(false) }
+
+      context "with an unadministered vaccination record" do
+        let(:vaccination_records) do
+          [build(:vaccination_record, :not_administered, patient:, programme:)]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with an administered vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :administered, patient:, programme:)]
+        end
+
+        it { should be(true) }
+      end
+    end
+
+    context "with a MenACWY programme" do
+      let(:programme) { create(:programme, :menacwy) }
+
+      it { should be(false) }
+
+      context "with an unadministered vaccination record" do
+        let(:vaccination_records) do
+          [build(:vaccination_record, :not_administered, patient:, programme:)]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with an administered vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :administered, patient:, programme:)]
+        end
+
+        it { should be(true) }
+      end
+
+      context "with an administered vaccination record when the patient was younger than 10 years old" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              patient:,
+              programme:,
+              performed_at: 6.years.ago
+            )
+          ]
+        end
+
+        it { should be(false) }
+      end
+    end
+
+    context "with an Td/IPV programme" do
+      let(:programme) { create(:programme, :td_ipv) }
+
+      it { should be(false) }
+
+      context "with an unadministered vaccination record" do
+        let(:vaccination_records) do
+          [build(:vaccination_record, :not_administered, patient:, programme:)]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with a first dose administered vaccination record" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: 1,
+              patient:,
+              programme:
+            )
+          ]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with a first dose administered vaccination record when the patient was younger than 10 years old" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: 1,
+              patient:,
+              programme:,
+              performed_at: 6.years.ago
+            )
+          ]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with a fifth dose administered vaccination record" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: 5,
+              patient:,
+              programme:
+            )
+          ]
+        end
+
+        it { should be(true) }
+      end
+
+      context "with a fifth dose administered vaccination record when the patient was younger than 10 years old" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: 5,
+              patient:,
+              programme:,
+              performed_at: 6.years.ago
+            )
+          ]
+        end
+
+        it { should be(false) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
For the MenACWY and Td/IPV programmes, a patient is only considered vaccinated if a vaccination record exists with the required dose sequence (1 for MenACWY and 5 for Td/IPV), and the vaccination was administered after the patient was 10 years old.