### PR TITLE
Fetch programmes from patient session

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -24,7 +24,7 @@ class AppConsentComponent < ViewComponent::Base
       patient
         .consent_notifications
         .request
-        .has_programme(session.programmes)
+        .has_programme(programme)
         .order(sent_at: :desc)
         .first
   end

--- a/app/components/app_session_patient_table_component.rb
+++ b/app/components/app_session_patient_table_component.rb
@@ -116,7 +116,7 @@ class AppSessionPatientTableComponent < ViewComponent::Base
     tab = params[:tab]
 
     session = patient_session.session
-    programme = @programme || session.programmes.first
+    programme = @programme || patient_session.programmes.first
 
     # TODO: Remove this once "Record session outcomes" exists.
     # We have to guess the section and tab if it's not provided, this

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -32,6 +32,12 @@ class ConsentFormsController < ApplicationController
       @patient.sessions_for_current_academic_year.first ||
         @consent_form.original_session
 
+    patient_session =
+      PatientSession.includes(session: :programmes).find_by!(
+        patient: @patient,
+        session:
+      )
+
     flash[:success] = {
       heading: "Consent matched for",
       heading_link_text: @patient.full_name,
@@ -39,7 +45,7 @@ class ConsentFormsController < ApplicationController
         session_patient_programme_path(
           session,
           @patient,
-          session.programmes.first,
+          patient_session.programmes.first,
           section: "triage",
           tab: "given"
         )

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -9,8 +9,8 @@ class ConsentsController < ApplicationController
   include PatientSortingConcern
 
   before_action :set_session
-  before_action :set_programme
   before_action :set_patient_session, except: :index
+  before_action :set_programme, except: :index
   before_action :set_patient, except: :index
   before_action :set_consent, except: %i[index create send_request]
   before_action :ensure_can_withdraw, only: %i[edit_withdraw update_withdraw]
@@ -18,6 +18,10 @@ class ConsentsController < ApplicationController
                 only: %i[edit_invalidate update_invalidate]
 
   def index
+    @programme =
+      @session.programmes.find_by(type: params[:programme_type]) ||
+        @session.programmes.first
+
     all_patient_sessions =
       @session
         .patient_sessions
@@ -146,25 +150,24 @@ class ConsentsController < ApplicationController
 
   def set_session
     @session =
-      policy_scope(Session).includes(
-        :location,
-        :organisation,
-        :programmes
-      ).find_by!(slug: params[:session_slug])
-  end
-
-  def set_programme
-    @programme =
-      @session.programmes.find_by(type: params[:programme_type]) ||
-        @session.programmes.first
+      policy_scope(Session).includes(:location, :organisation).find_by!(
+        slug: params[:session_slug]
+      )
   end
 
   def set_patient_session
     @patient_session =
-      policy_scope(PatientSession).find_by!(
+      policy_scope(PatientSession).includes(session: :programmes).find_by!(
         session: @session,
         patient_id: params[:patient_id]
       )
+  end
+
+  def set_programme
+    @programme =
+      @patient_session.programmes.find { it.type == params[:programme_type] }
+
+    raise ActiveRecord::RecordNotFound if @programme.nil?
   end
 
   def set_patient

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -75,7 +75,6 @@ class DevController < ApplicationController
     Faker::Config.locale = "en-GB"
 
     session = Session.includes(programmes: :vaccines).find(params[:session_id])
-    programme = session.programmes.first
 
     attributes =
       if ActiveModel::Type::Boolean.new.cast(params[:parent_phone])
@@ -87,7 +86,7 @@ class DevController < ApplicationController
     consent_form =
       FactoryBot.build(:consent_form, :draft, session:, **attributes)
 
-    vaccine = programme.vaccines.first
+    vaccine = consent_form.programmes.first.vaccines.first
     consent_form.health_answers = vaccine.health_questions.to_health_answers
     consent_form.save!
 

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -24,7 +24,6 @@ class PatientSessionsController < ApplicationController
         .eager_load(:location, :session, patient: %i[gp_practice school])
         .preload(
           :gillick_assessments,
-          :programmes,
           :session_attendances,
           patient: {
             consents: %i[parent],
@@ -33,7 +32,8 @@ class PatientSessionsController < ApplicationController
             vaccination_records: {
               vaccine: :programme
             }
-          }
+          },
+          session: :programmes
         )
         .find_by!(
           session: {
@@ -45,7 +45,9 @@ class PatientSessionsController < ApplicationController
 
   def set_programme
     @programme =
-      @patient_session.programmes.find_by!(type: params[:programme_type])
+      @patient_session.programmes.find { it.type == params[:programme_type] }
+
+    raise ActiveRecord::RecordNotFound if @programme.nil?
   end
 
   def set_session

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -59,7 +59,7 @@ class PatientsController < ApplicationController
       if organisation_id.nil?
         @patient
           .patient_sessions
-          .includes(:programmes, :session_attendances)
+          .preload_for_status
           .where(session: old_organisation.sessions)
           .find_each(&:destroy_if_safe!)
       end

--- a/app/controllers/session_attendances_controller.rb
+++ b/app/controllers/session_attendances_controller.rb
@@ -48,7 +48,10 @@ class SessionAttendancesController < ApplicationController
     @patient_session =
       policy_scope(PatientSession)
         .eager_load(:patient, :session)
-        .preload(:programmes, patient: %i[consents triages vaccination_records])
+        .preload(
+          patient: %i[consents triages vaccination_records],
+          session: :programmes
+        )
         .find_by!(
           session: {
             slug: params.fetch(:session_slug)

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -10,13 +10,13 @@ class SchoolSessionRemindersJob < ApplicationJob
       PatientSession
         .includes(
           :gillick_assessments,
-          :programmes,
           patient: [
             :parents,
             :triages,
             :vaccination_records,
             { consents: %i[parent patient] }
-          ]
+          ],
+          session: :programmes
         )
         .eager_load(:session)
         .joins(:location)

--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -74,12 +74,12 @@ class Reports::CareplusExporter
         .patient_sessions
         .includes(
           :location,
-          :programmes,
           patient: [
             :school,
             :vaccination_records,
             { consents: %i[parent patient] }
-          ]
+          ],
+          session: :programmes
         )
         .where.not(vaccination_records: { id: nil })
         .merge(VaccinationRecord.administered)

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -129,19 +129,19 @@ class Reports::OfflineSessionExporter
       .patient_sessions
       .eager_load(patient: :school)
       .preload(
-        :programmes,
         patient: {
           consents: [:parent, { patient: :parent_relationships }],
           triages: :performed_by,
           vaccination_records: %i[batch performed_by_user vaccine]
         },
+        session: :programmes,
         gillick_assessments: :performed_by
       )
       .order_by_name
   end
 
   def rows(patient_session:)
-    session.programmes.flat_map do |programme|
+    patient_session.programmes.flat_map do |programme|
       bg_color =
         if patient_session.consent_refused?(programme:)
           "F7D4D1"

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -238,10 +238,6 @@ class Patient < ApplicationRecord
     birth_academic_year_changed?
   end
 
-  def eligible_for?(programme:)
-    year_group.in?(programme.year_groups)
-  end
-
   def has_consent?(programme)
     consents.any? { _1.programme_id == programme.id }
   end
@@ -373,12 +369,7 @@ class Patient < ApplicationRecord
 
   def clear_sessions_for_current_academic_year!
     patient_sessions
-      .includes(
-        :programmes,
-        :gillick_assessments,
-        :session_attendances,
-        patient: :vaccination_records
-      )
+      .preload_for_status
       .where(session: sessions_for_current_academic_year)
       .find_each(&:destroy_if_safe!)
   end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -33,7 +33,6 @@ class PatientSession < ApplicationRecord
   has_one :location, through: :session
   has_one :team, through: :session
   has_one :organisation, through: :session
-  has_many :programmes, through: :session
   has_many :session_attendances, dependent: :destroy
 
   has_many :gillick_assessments, -> { order(:created_at) }
@@ -65,9 +64,9 @@ class PatientSession < ApplicationRecord
         -> do
           preload(
             :gillick_assessments,
-            :programmes,
             :session_attendances,
-            patient: [:triages, { consents: :parent }, :vaccination_records]
+            patient: [:triages, { consents: :parent }, :vaccination_records],
+            session: :programmes
           )
         end
 
@@ -95,6 +94,10 @@ class PatientSession < ApplicationRecord
 
   def destroy_if_safe!
     destroy! if safe_to_destroy?
+  end
+
+  def programmes
+    session.programmes.select { it.year_groups.include?(patient.year_group) }
   end
 
   def consents(programme:)

--- a/app/models/patient_session_stats.rb
+++ b/app/models/patient_session_stats.rb
@@ -7,7 +7,7 @@ class PatientSessionStats
         .sort_by(&:created_at)
         .reverse
         .uniq(&:patient_id)
-        .select { it.patient.eligible_for?(programme:) }
+        .select { it.programmes.include?(programme) }
     @programme = programme
     @keys =
       keys ||

--- a/app/views/patient_sessions/_secondary_navigation.html.erb
+++ b/app/views/patient_sessions/_secondary_navigation.html.erb
@@ -1,12 +1,10 @@
 <%= render AppSecondaryNavigationComponent.new(classes: "app-secondary-navigation--sticky") do |nav|
-     @session.programmes.each do |programme|
-       if @patient.eligible_for?(programme:)
-         nav.with_item(
-           href: session_patient_programme_path(patient_id: @patient.id, programme_type: programme),
-           text: programme.name,
-           selected: @programme == programme,
-         )
-       end
+     @patient_session.programmes.each do |programme|
+       nav.with_item(
+         href: session_patient_programme_path(patient_id: @patient.id, programme_type: programme),
+         text: programme.name,
+         selected: @programme == programme,
+       )
      end
      nav.with_item(
        href: session_patient_log_path(patient_id: @patient.id),

--- a/app/views/session_attendances/edit.html.erb
+++ b/app/views/session_attendances/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-        session_patient_programme_path(patient_id: @patient.id, programme_type: @session.programmes.first.type),
+        session_patient_programme_path(patient_id: @patient.id, programme_type: @patient_session.programmes.first.type),
         name: "#{@section.pluralize} page",
       ) %>
 <% end %>

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -110,7 +110,7 @@ describe Reports::CareplusExporter do
     let(:location) { create(:generic_clinic, organisation:) }
 
     it "includes clinic location details" do
-      patient = create(:patient)
+      patient = create(:patient, year_group: 8)
       create(
         :patient_session,
         :consent_given_triage_not_needed,

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -98,7 +98,7 @@ describe Reports::OfflineSessionExporter do
       let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
       let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
       let(:patient_session) { create(:patient_session, patient:, session:) }
-      let(:patient) { create(:patient) }
+      let(:patient) { create(:patient, year_group: 8) }
 
       it { should be_empty }
 
@@ -516,6 +516,7 @@ describe Reports::OfflineSessionExporter do
         let(:patient) do
           create(
             :patient,
+            year_group: 8,
             school: create(:school, urn: "123456", name: "Waterloo Road")
           )
         end


### PR DESCRIPTION
Where we display a list of programmes, or where we select a single programme, we now ensure that we're only selecting programmes that the patient is eligible for, by selecting from the patient session rather than the session.

This is possible by removing the `has_many :programmes` on the patient session, and instead fetching all the programmes for a particular session and then filtering by eligible year groups. We can be confident that this change has been applied across the service as we're forced to update the strict loading rules for everything.

In the future, this approach might be reworked such that patients belong to multiple cohorts and we fetch the programmes via that model. This is necessary to make it possible to easily remove patients from a cohort even if we don't have the vaccination records for them.