### PR TITLE
Ensure consent requests are only sent to eligible patients

### DIFF
--- a/app/jobs/concerns/send_clinic_invitations_concern.rb
+++ b/app/jobs/concerns/send_clinic_invitations_concern.rb
@@ -17,8 +17,12 @@ module SendClinicInvitationsConcern
   def should_send_notification?(patient_session:, programmes:, session_date:)
     return false unless patient_session.send_notifications?
 
+    eligible_programmes = patient_session.programmes & programmes
+
+    return false if eligible_programmes.empty?
+
     all_vaccinated =
-      programmes.all? do |programme|
+      eligible_programmes.all? do |programme|
         patient_session.vaccination_administered?(programme:)
       end
 
@@ -32,7 +36,7 @@ module SendClinicInvitationsConcern
     return false if already_sent_notification
 
     all_consent_refused =
-      programmes.all? do |programme|
+      eligible_programmes.all? do |programme|
         patient_session.consent_refused?(programme:)
       end
 

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -30,7 +30,8 @@ class SendClinicInitialInvitationsJob < ApplicationJob
       .eager_load(:patient)
       .preload(
         :session_notifications,
-        patient: %i[consents parents vaccination_records]
+        patient: %i[consents parents vaccination_records],
+        session: :programmes
       )
       .where(patient: { school: })
       .reject { it.session_notifications.any? }

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -56,7 +56,7 @@ class SessionNotification < ApplicationRecord
 
     parents =
       if type == :school_reminder
-        session.programmes.flat_map do |programme|
+        patient_session.programmes.flat_map do |programme|
           patient_session
             .latest_consents(programme:)
             .select(&:response_given?)

--- a/spec/jobs/clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/clinic_session_invitations_job_spec.rb
@@ -3,10 +3,10 @@
 describe ClinicSessionInvitationsJob do
   subject(:perform_now) { described_class.perform_now }
 
-  let(:programme) { create(:programme) }
+  let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:parents) { create_list(:parent, 2) }
-  let(:patient) { create(:patient, parents:) }
+  let(:patient) { create(:patient, parents:, year_group: 8) }
   let(:location) { create(:generic_clinic, organisation:) }
 
   context "for a scheduled clinic session in 3 weeks" do

--- a/spec/jobs/school_consent_requests_job_spec.rb
+++ b/spec/jobs/school_consent_requests_job_spec.rb
@@ -91,6 +91,52 @@ describe SchoolConsentRequestsJob do
       end
     end
 
+    context "with HPV, Td/IPV and MenACWY" do
+      let(:hpv_programme) { create(:programme, :hpv) }
+      let(:menacwy_programme) { create(:programme, :menacwy) }
+      let(:td_ipv_programme) { create(:programme, :td_ipv) }
+
+      let(:programmes) { [hpv_programme, menacwy_programme, td_ipv_programme] }
+
+      context "when the patient is in Year 8" do
+        let(:patient_not_sent_request) do
+          create(:patient, year_group: 8, parents:, programmes:)
+        end
+
+        it "sends only one notification for HPV" do
+          expect(ConsentNotification).to receive(:create_and_send!).once.with(
+            patient: patient_not_sent_request,
+            programmes: [hpv_programme],
+            session:,
+            type: :request
+          )
+          perform_now
+        end
+      end
+
+      context "when the patient is in Year 9" do
+        let(:patient_not_sent_request) do
+          create(:patient, year_group: 9, parents:, programmes:)
+        end
+
+        it "sends two notifications for HPV, and MenACWY and Td/IPV" do
+          expect(ConsentNotification).to receive(:create_and_send!).with(
+            patient: patient_not_sent_request,
+            programmes: [hpv_programme],
+            session:,
+            type: :request
+          )
+          expect(ConsentNotification).to receive(:create_and_send!).with(
+            patient: patient_not_sent_request,
+            programmes: [menacwy_programme, td_ipv_programme],
+            session:,
+            type: :request
+          )
+          perform_now
+        end
+      end
+    end
+
     context "when location is a generic clinic" do
       let(:organisation) { create(:organisation, programmes:) }
       let(:location) { create(:generic_clinic, organisation:) }

--- a/spec/jobs/send_clinic_initial_invitations_job_spec.rb
+++ b/spec/jobs/send_clinic_initial_invitations_job_spec.rb
@@ -5,10 +5,10 @@ describe SendClinicInitialInvitationsJob do
     described_class.perform_now(session, school: nil, programmes:)
   end
 
-  let(:programmes) { [create(:programme)] }
+  let(:programmes) { [create(:programme, :hpv)] }
   let(:organisation) { create(:organisation, programmes:) }
   let(:parents) { create_list(:parent, 2) }
-  let(:patient) { create(:patient, parents:) }
+  let(:patient) { create(:patient, parents:, year_group: 8) }
   let(:location) { create(:generic_clinic, organisation:) }
 
   let(:session) do

--- a/spec/jobs/send_clinic_subsequent_invitations_job_spec.rb
+++ b/spec/jobs/send_clinic_subsequent_invitations_job_spec.rb
@@ -3,10 +3,10 @@
 describe SendClinicSubsequentInvitationsJob do
   subject(:perform_now) { described_class.perform_now(session) }
 
-  let(:programme) { create(:programme) }
+  let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:parents) { create_list(:parent, 2) }
-  let(:patient) { create(:patient, parents:) }
+  let(:patient) { create(:patient, parents:, year_group: 8) }
   let(:location) { create(:generic_clinic, organisation:) }
 
   let(:session) do

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -41,11 +41,13 @@ describe SessionNotification do
     let(:today) { Date.new(2024, 1, 1) }
 
     let(:parents) { create_list(:parent, 2) }
-    let(:patient) { create(:patient, parents:) }
-    let(:programme) { create(:programme) }
+    let(:patient) { create(:patient, parents:, year_group: 10) }
+    let(:programme) { create(:programme, :td_ipv) }
     let(:organisation) { create(:organisation, programmes: [programme]) }
     let(:location) { create(:school, organisation:) }
-    let(:session) { create(:session, location:, programme:, organisation:) }
+    let(:session) do
+      create(:session, location:, programmes: [programme], organisation:)
+    end
     let(:session_date) { session.dates.min }
     let(:patient_session) { create(:patient_session, patient:, session:) }
     let(:current_user) { create(:user) }


### PR DESCRIPTION
This is necessary for the MenACWY and Td/IPV programmes which aren't administered to Year 8s, however the HPV programme is administered for Year 8s.

As all three vaccines might be administered at the same time as a single session, there might be Year 8 patients in a session, and we have to make sure that only consent requests for HPV are sent out for these patients, not ones for Td/IPV and MenACWY as well.