### PR TITLE
Pluralise GOV.UK Notify vaccination personalisation

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -266,6 +266,9 @@ class GovukNotifyPersonalisation
   end
 
   def vaccination
-    "#{programme_name} vaccination"
+    [
+      programme_name,
+      programmes.count == 1 ? "vaccination" : "vaccinations"
+    ].join(" ")
   end
 end

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -87,6 +87,14 @@ describe GovukNotifyPersonalisation do
     it { should include(catch_up: "yes", not_catch_up: "no") }
   end
 
+  context "with multiple programmes" do
+    let(:programmes) do
+      [create(:programme, :menacwy), create(:programme, :td_ipv)]
+    end
+
+    it { should include(vaccination: "MenACWY and Td/IPV vaccinations") }
+  end
+
   context "with multiple dates" do
     before { session.session_dates.create!(value: Date.new(2026, 1, 2)) }
 


### PR DESCRIPTION
So that the emails and texts read better we want this variable to be pluralised when we're talking about more than one vaccine.