### PR TITLE
Show programme separate to vaccine

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -14,9 +14,9 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
     @change_links = change_links
     @show_notes = show_notes
 
+    @batch = vaccination_record.batch
     @patient = vaccination_record.patient
     @vaccine = vaccination_record.vaccine
-    @batch = vaccination_record.batch
   end
 
   def call
@@ -37,6 +37,11 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
             visually_hidden_text: "outcome"
           )
         end
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Programme" }
+        row.with_value { programme_value }
       end
 
       if @vaccination_record.administered?
@@ -212,11 +217,15 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
     )
   end
 
-  def vaccine_value
+  def programme_value
     highlight_if(
-      helpers.vaccine_heading(@vaccine),
-      @vaccination_record.vaccine_id_changed?
+      @vaccination_record.programme.name,
+      @vaccination_record.programme_id_changed?
     )
+  end
+
+  def vaccine_value
+    highlight_if(@vaccine.brand, @vaccination_record.vaccine_id_changed?)
   end
 
   def delivery_method_value

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -65,11 +65,20 @@ describe AppVaccinationRecordSummaryComponent do
     end
   end
 
+  describe "programme row" do
+    it do
+      expect(rendered).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Programme\nHPV"
+      )
+    end
+  end
+
   describe "vaccine row" do
     it do
       expect(rendered).to have_css(
         ".nhsuk-summary-list__row",
-        text: "Vaccine\nGardasil 9 (HPV)"
+        text: "Vaccine\nGardasil 9"
       )
     end
 


### PR DESCRIPTION
When showing the summary of a vaccination record we need to highlight the programme separately to the vaccine or batch because some historical records won't have a vaccine associated with them.

## Screenshot

![Screenshot 2025-02-24 at 17 31 35](https://github.com/user-attachments/assets/a961a186-973b-4765-988a-bfeb43715b12)
