### PR TITLE
Add vaccine to vaccination records

### DIFF
--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -185,10 +185,6 @@ class DraftVaccinationRecord
 
   private
 
-  def writable_attribute_names
-    super - %w[vaccine_id]
-  end
-
   def reset_unused_fields
     if administered?
       if vaccine_id.nil? && programme &&

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -152,7 +152,8 @@ class ImmunisationImportRow
         batch_id: batch&.id,
         delivery_method:,
         delivery_site:,
-        notes:
+        notes:,
+        vaccine_id: vaccine&.id
       )
     else
       # Postgres UUID generation is skipped in bulk import
@@ -162,6 +163,7 @@ class ImmunisationImportRow
       vaccination_record.delivery_method = delivery_method
       vaccination_record.delivery_site = delivery_site
       vaccination_record.notes = notes
+      vaccination_record.vaccine = vaccine
     end
 
     vaccination_record

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -26,6 +26,7 @@
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
 #  session_id               :bigint
+#  vaccine_id               :bigint
 #
 # Indexes
 #
@@ -36,6 +37,7 @@
 #  index_vaccination_records_on_programme_id          (programme_id)
 #  index_vaccination_records_on_session_id            (session_id)
 #  index_vaccination_records_on_uuid                  (uuid) UNIQUE
+#  index_vaccination_records_on_vaccine_id            (vaccine_id)
 #
 # Foreign Keys
 #
@@ -44,6 +46,7 @@
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (session_id => sessions.id)
+#  fk_rails_...  (vaccine_id => vaccines.id)
 #
 class VaccinationRecord < ApplicationRecord
   include Discard::Model
@@ -75,6 +78,7 @@ class VaccinationRecord < ApplicationRecord
   }.with_indifferent_access
 
   belongs_to :batch, optional: true
+  belongs_to :vaccine, optional: true
   belongs_to :performed_by_user, class_name: "User", optional: true
   belongs_to :programme
 
@@ -87,7 +91,6 @@ class VaccinationRecord < ApplicationRecord
   has_one :location, through: :session
   has_one :organisation, through: :session
   has_one :team, through: :session
-  has_one :vaccine, through: :batch
 
   scope :unexported, -> { where.missing(:dps_exports) }
 
@@ -177,19 +180,6 @@ class VaccinationRecord < ApplicationRecord
 
   def academic_year
     performed_at.to_date.academic_year
-  end
-
-  def vaccine_id
-    vaccine&.id
-  end
-
-  def vaccine_id_changed?
-    vaccine_id_was != vaccine_id
-  end
-
-  def vaccine_id_was
-    return nil if batch_id_was.nil?
-    Batch.find(batch_id_was).vaccine_id
   end
 
   private

--- a/db/migrate/20250224173345_add_vaccine_to_vaccination_records.rb
+++ b/db/migrate/20250224173345_add_vaccine_to_vaccination_records.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddVaccineToVaccinationRecords < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :vaccination_records, :vaccine, foreign_key: true
+
+    reversible do |dir|
+      dir.up do
+        VaccinationRecord
+          .where.not(batch_id: nil)
+          .eager_load(:batch)
+          .find_each { it.update_column(:vaccine_id, it.batch.vaccine_id) }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_21_155425) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_24_173345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -763,6 +763,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_155425) do
     t.bigint "patient_id"
     t.bigint "session_id"
     t.string "performed_ods_code", null: false
+    t.bigint "vaccine_id"
     t.index ["batch_id"], name: "index_vaccination_records_on_batch_id"
     t.index ["discarded_at"], name: "index_vaccination_records_on_discarded_at"
     t.index ["patient_id"], name: "index_vaccination_records_on_patient_id"
@@ -770,6 +771,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_155425) do
     t.index ["programme_id"], name: "index_vaccination_records_on_programme_id"
     t.index ["session_id"], name: "index_vaccination_records_on_session_id"
     t.index ["uuid"], name: "index_vaccination_records_on_uuid", unique: true
+    t.index ["vaccine_id"], name: "index_vaccination_records_on_vaccine_id"
   end
 
   create_table "vaccines", force: :cascade do |t|
@@ -888,5 +890,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_21_155425) do
   add_foreign_key "vaccination_records", "programmes"
   add_foreign_key "vaccination_records", "sessions"
   add_foreign_key "vaccination_records", "users", column: "performed_by_user_id"
+  add_foreign_key "vaccination_records", "vaccines"
   add_foreign_key "vaccines", "programmes"
 end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -26,6 +26,7 @@
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
 #  session_id               :bigint
+#  vaccine_id               :bigint
 #
 # Indexes
 #
@@ -36,6 +37,7 @@
 #  index_vaccination_records_on_programme_id          (programme_id)
 #  index_vaccination_records_on_session_id            (session_id)
 #  index_vaccination_records_on_uuid                  (uuid) UNIQUE
+#  index_vaccination_records_on_vaccine_id            (vaccine_id)
 #
 # Foreign Keys
 #
@@ -44,6 +46,7 @@
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (session_id => sessions.id)
+#  fk_rails_...  (vaccine_id => vaccines.id)
 #
 FactoryBot.define do
   factory :vaccination_record do
@@ -51,9 +54,6 @@ FactoryBot.define do
       organisation do
         programme.organisations.first ||
           association(:organisation, programmes: [programme])
-      end
-      vaccine do
-        programme.vaccines.active.first || association(:vaccine, programme:)
       end
     end
 
@@ -68,6 +68,10 @@ FactoryBot.define do
 
     delivery_site { "left_arm_upper_position" }
     delivery_method { "intramuscular" }
+
+    vaccine do
+      programme.vaccines.active.first || association(:vaccine, programme:)
+    end
 
     batch do
       association :batch, organisation:, vaccine:, strategy: :create if vaccine

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -26,6 +26,7 @@
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
 #  session_id               :bigint
+#  vaccine_id               :bigint
 #
 # Indexes
 #
@@ -36,6 +37,7 @@
 #  index_vaccination_records_on_programme_id          (programme_id)
 #  index_vaccination_records_on_session_id            (session_id)
 #  index_vaccination_records_on_uuid                  (uuid) UNIQUE
+#  index_vaccination_records_on_vaccine_id            (vaccine_id)
 #
 # Foreign Keys
 #
@@ -44,6 +46,7 @@
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
 #  fk_rails_...  (session_id => sessions.id)
+#  fk_rails_...  (vaccine_id => vaccines.id)
 #
 
 describe VaccinationRecord do


### PR DESCRIPTION
At the moment the vaccine for a vaccination record comes from the batch, but we need to be able to support uploading historical vaccination records where we don't necessarily know the batch, but we do know the vaccine. To record these we need to be able to store the vaccine on the vaccination record separately to the batch.