### PR TITLE
Combine health questions when giving consent

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -528,9 +528,7 @@ class ConsentForm < ApplicationRecord
   def seed_health_questions
     return unless health_answers.empty?
 
-    # TODO: handle multiple active vaccines
-    vaccine = vaccines.select(&:active?).first
-
-    self.health_answers = vaccine.health_questions.to_health_answers
+    self.health_answers =
+      vaccines.active.flat_map { it.health_questions.to_health_answers }
   end
 end

--- a/config/vaccines.yml
+++ b/config/vaccines.yml
@@ -101,7 +101,6 @@ gardasil_9:
 menquadfi:
   brand: MenQuadfi
   type: menacwy
-  discontinued: true
   method: injection
   manufacturer: Sanofi
   nivs_name: MenQuadfi

--- a/config/vaccines.yml
+++ b/config/vaccines.yml
@@ -124,6 +124,7 @@ menveo:
 nimenrix:
   brand: Nimenrix
   type: menacwy
+  discontinued: true
   method: injection
   manufacturer: Pfizer
   nivs_name: Nimenrix

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -636,10 +636,6 @@ describe ConsentForm do
 
   it "combines health questions from multiple active vaccines" do
     programme1 = create(:programme, :menacwy)
-
-    # Menacwy vaccine is discontinued in yml, we need >1 active vaccines to test
-    programme1.vaccines.first.update!(discontinued: false)
-
     programme2 = create(:programme, :td_ipv)
     consent_form =
       create(

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -634,6 +634,35 @@ describe ConsentForm do
     expect(consent_form.health_answers).to be_empty
   end
 
+  it "combines health questions from multiple active vaccines" do
+    programme1 = create(:programme, :menacwy)
+
+    # Menacwy vaccine is discontinued in yml, we need >1 active vaccines to test
+    programme1.vaccines.first.update!(discontinued: false)
+
+    programme2 = create(:programme, :td_ipv)
+    consent_form =
+      create(
+        :consent_form,
+        session: create(:session, programmes: [programme1, programme2]),
+        programmes: [programme1, programme2],
+        response: "refused"
+      )
+
+    consent_form.update!(
+      response: "given",
+      address_line_1: "123 Fake St",
+      address_town: "London",
+      address_postcode: "SW1A 1AA"
+    )
+    consent_form.reload
+
+    expect(consent_form.health_answers.count).to eq(
+      programme1.vaccines.first.health_questions.count +
+        programme2.vaccines.first.health_questions.count
+    )
+  end
+
   it "removes the health questions when the parent refuses consent for HPV" do
     consent_form =
       create(


### PR DESCRIPTION
If there are multiple vaccines, this ensures that we use all the available health questions.