### PR TITLE
Add SESSION_ID column when importing vaccination records

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -118,6 +118,7 @@ class Reports::OfflineSessionExporter
         dose_sequence
         reason_not_vaccinated
         notes
+        session_id
         uuid
       ].tap do |values|
         values.insert(6, :clinic_name) if location.generic_clinic?
@@ -172,7 +173,7 @@ class Reports::OfflineSessionExporter
         [
           Row.new(columns, style: row_style) do |row|
             add_patient_cells(row, patient_session:, programme:)
-            add_new_row_cells(row, programme:)
+            add_new_row_cells(row, session: patient_session.session, programme:)
           end
         ]
       end
@@ -232,6 +233,7 @@ class Reports::OfflineSessionExporter
   def add_existing_row_cells(row, vaccination_record:)
     batch = vaccination_record.batch
     programme = vaccination_record.programme
+    session = vaccination_record.session
     vaccine = vaccination_record.vaccine
 
     row[:vaccinated] = Cell.new(
@@ -266,6 +268,7 @@ class Reports::OfflineSessionExporter
       allowed_values: ImmunisationImportRow::REASONS.keys
     )
     row[:notes] = vaccination_record.notes
+    row[:session_id] = session.id
     row[:uuid] = vaccination_record.uuid
 
     if location.generic_clinic?
@@ -276,7 +279,7 @@ class Reports::OfflineSessionExporter
     end
   end
 
-  def add_new_row_cells(row, programme:)
+  def add_new_row_cells(row, session:, programme:)
     row[:vaccinated] = Cell.new(allowed_values: %w[Y N])
     row[:date_of_vaccination] = Cell.new(type: :date)
     row[:programme] = programme.import_names.first
@@ -297,6 +300,8 @@ class Reports::OfflineSessionExporter
     row[:reason_not_vaccinated] = Cell.new(
       allowed_values: ImmunisationImportRow::REASONS.keys
     )
+
+    row[:session_id] = session.id
 
     if location.generic_clinic?
       row[:clinic_name] = Cell.new(allowed_values: clinic_name_values)

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -117,7 +117,6 @@ describe "Immunisation imports duplicates" do
         delivery_site: :nose,
         dose_sequence: 1,
         patient: @already_vaccinated_patient,
-        session: @session,
         vaccine: @vaccine,
         performed_by_user: nil
       )
@@ -133,7 +132,6 @@ describe "Immunisation imports duplicates" do
         delivery_site: :left_arm_upper_position,
         dose_sequence: 1,
         patient: @third_patient,
-        session: @session,
         vaccine: @other_vaccine,
         performed_by_user: nil
       )

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -86,6 +86,7 @@ describe Reports::OfflineSessionExporter do
             DOSE_SEQUENCE
             REASON_NOT_VACCINATED
             NOTES
+            SESSION_ID
             UUID
           ]
         )
@@ -135,6 +136,7 @@ describe Reports::OfflineSessionExporter do
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
+              "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "",
               "TRIAGED_BY" => nil,
               "TRIAGE_DATE" => nil,
@@ -210,6 +212,7 @@ describe Reports::OfflineSessionExporter do
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
+              "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,
               "TRIAGE_DATE" => nil,
@@ -292,6 +295,7 @@ describe Reports::OfflineSessionExporter do
               "REASON_NOT_VACCINATED" => "unwell",
               "SCHOOL_NAME" => location.name,
               "SCHOOL_URN" => location.urn,
+              "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,
               "TRIAGE_DATE" => nil,
@@ -452,6 +456,7 @@ describe Reports::OfflineSessionExporter do
             DOSE_SEQUENCE
             REASON_NOT_VACCINATED
             NOTES
+            SESSION_ID
             UUID
           ]
         )
@@ -497,6 +502,7 @@ describe Reports::OfflineSessionExporter do
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "",
               "SCHOOL_URN" => "888888",
+              "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "",
               "TRIAGED_BY" => nil,
               "TRIAGE_DATE" => nil,
@@ -573,6 +579,7 @@ describe Reports::OfflineSessionExporter do
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "Waterloo Road",
               "SCHOOL_URN" => "123456",
+              "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,
               "TRIAGE_DATE" => nil,

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -178,23 +178,6 @@ describe ImmunisationImport do
           .times
           .on_queue(:imports)
       end
-
-      it "adds patients to the session if it exists" do
-        # must match a session in valid_flu.csv
-        location = Location.school.find_by!(urn: "120026")
-        create(
-          :session,
-          location:,
-          organisation:,
-          programme:,
-          date: Date.new(2024, 5, 14)
-        )
-
-        expect { process! }.to change(
-          immunisation_import.patient_sessions,
-          :count
-        ).by(8)
-      end
     end
 
     context "with valid HPV rows" do
@@ -248,23 +231,6 @@ describe ImmunisationImport do
           .exactly(9)
           .times
           .on_queue(:imports)
-      end
-
-      it "adds patients to the session if it exists" do
-        # must match a session in valid_hpv.csv
-        location = Location.school.find_by!(urn: "110158")
-        create(
-          :session,
-          location:,
-          organisation:,
-          programme:,
-          date: Date.new(2024, 5, 14)
-        )
-
-        expect { process! }.to change(
-          immunisation_import.patient_sessions,
-          :count
-        ).by(6)
       end
     end
 


### PR DESCRIPTION
This adds a new column used when importing offline vaccination records, to tell Mavis which session the offline records are being imported for, ensuring that we associate them within Mavis to the correct session.

We can use the presence of this value to know if the file is being uploaded from an offline recording and therefore the validation is stricter than in other cases.

This is necessary because we want to be able to import vaccination records in the current academic year that happened outside Mavis, and currently we use that to determine whether the upload is from offline recording or not.