### PR TITLE
Allow dose_sequence to be optional

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -316,7 +316,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   end
 
   def dose_number
-    return nil if @vaccine.nil? || @vaccine.seasonal?
+    return nil if @vaccine&.seasonal? || @vaccination_record.dose_sequence.nil?
 
     numbers_to_words = {
       1 => "First",

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -83,6 +83,10 @@ class DraftVaccinationRecordsController < ApplicationController
   def handle_outcome
     # If not administered we can skip the remaining steps as they're not relevant.
     jump_to("confirm") unless @draft_vaccination_record.administered?
+
+    # TODO: Require the nurse to specify the dose sequence.
+    @draft_vaccination_record.dose_sequence ||=
+      1 if @draft_vaccination_record.administered?
   end
 
   def handle_confirm

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -93,6 +93,7 @@ class DraftVaccinationRecord
     validates :batch_id,
               :delivery_method,
               :delivery_site,
+              :dose_sequence,
               :performed_at,
               :vaccine_id,
               presence: true

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -285,7 +285,7 @@ class ImmunisationImportRow
   def dose_sequence
     value = @data["DOSE_SEQUENCE"]&.gsub(/\s/, "")&.presence&.upcase
 
-    return 1 if value.blank? && (!administered || maximum_dose_sequence == 1)
+    return 1 if value.blank? && maximum_dose_sequence == 1
 
     return DOSE_SEQUENCES[value] if DOSE_SEQUENCES.include?(value)
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -9,7 +9,7 @@
 #  delivery_method          :integer
 #  delivery_site            :integer
 #  discarded_at             :datetime
-#  dose_sequence            :integer          not null
+#  dose_sequence            :integer
 #  location_name            :string
 #  notes                    :text
 #  outcome                  :integer          not null
@@ -147,11 +147,11 @@ class VaccinationRecord < ApplicationRecord
               if: :requires_location_name?
             }
 
-  validates :dose_sequence, presence: true
   validates :dose_sequence,
             comparison: {
               greater_than_or_equal_to: 1,
-              less_than_or_equal_to: :maximum_dose_sequence
+              less_than_or_equal_to: :maximum_dose_sequence,
+              allow_nil: true
             }
 
   validates :performed_at,

--- a/db/migrate/20250224200603_make_vaccination_record_dose_sequence_null.rb
+++ b/db/migrate/20250224200603_make_vaccination_record_dose_sequence_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeVaccinationRecordDoseSequenceNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :vaccination_records, :dose_sequence, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_24_173345) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_24_200603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -750,7 +750,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_24_173345) do
     t.integer "delivery_method"
     t.bigint "performed_by_user_id"
     t.text "notes"
-    t.integer "dose_sequence", null: false
+    t.integer "dose_sequence"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.datetime "performed_at", null: false
     t.string "performed_by_given_name"

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -9,7 +9,7 @@
 #  delivery_method          :integer
 #  delivery_site            :integer
 #  discarded_at             :datetime
-#  dose_sequence            :integer          not null
+#  dose_sequence            :integer
 #  location_name            :string
 #  notes                    :text
 #  outcome                  :integer          not null
@@ -92,6 +92,7 @@ FactoryBot.define do
       delivery_method { nil }
       outcome { "not_well" }
       vaccine { nil }
+      dose_sequence { nil }
     end
 
     trait :performed_by_not_user do

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -9,7 +9,7 @@
 #  delivery_method          :integer
 #  delivery_site            :integer
 #  discarded_at             :datetime
-#  dose_sequence            :integer          not null
+#  dose_sequence            :integer
 #  location_name            :string
 #  notes                    :text
 #  outcome                  :integer          not null


### PR DESCRIPTION
When importing historical records or when uploading not administered records, the dose sequence can be unknown and therefore isn't required in all cases, so the column must be nullable.