### PR TITLE
Add custom dose sequence values per programme

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -259,7 +259,12 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
 
   def dose_sequence
     special_values =
-      ImmunisationImportRow::DOSE_SEQUENCES.keys.map { tag.i(_1) }
+      ImmunisationImportRow::DOSE_SEQUENCES
+        .values
+        .flat_map(&:keys)
+        .sort
+        .uniq
+        .map { tag.i(it) }
 
     special_values_sentence =
       special_values.to_sentence(

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -82,7 +82,8 @@ class Programme < ApplicationRecord
 
   def maximum_dose_sequence
     # HPV is given 3 times to patients with a weakened immune system.
-    hpv? ? 3 : vaccinated_dose_sequence
+    # MenACWY is sometimes given more frequently.
+    hpv? || menacwy? ? 3 : vaccinated_dose_sequence
   end
 
   IMPORT_NAMES = {

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1065,28 +1065,48 @@ describe ImmunisationImportRow do
     let(:programme) { create(:programme, :hpv) }
 
     context "without a value" do
-      let(:data) { { "VACCINE_GIVEN" => "Gardasil9" } }
+      let(:data) { { "PROGRAMME" => "HPV" } }
 
       it { should be_nil }
     end
 
     context "with an invalid value" do
-      let(:data) do
-        { "VACCINE_GIVEN" => "Gardasil9", "DOSE_SEQUENCE" => "abc" }
-      end
+      let(:data) { { "PROGRAMME" => "HPV", "DOSE_SEQUENCE" => "abc" } }
 
       it { should be_nil }
     end
 
     context "with a valid value" do
-      let(:data) { { "VACCINE_GIVEN" => "Gardasil9", "DOSE_SEQUENCE" => "1" } }
+      let(:data) { { "PROGRAMME" => "HPV", "DOSE_SEQUENCE" => "1" } }
 
       it { should eq(1) }
     end
 
+    %w[1P 2P 3P].each_with_index do |value, index|
+      context "with an HPV special value of #{value}" do
+        let(:programme) { create(:programme, :hpv) }
+
+        let(:data) { { "PROGRAMME" => "HPV", "DOSE_SEQUENCE" => value } }
+
+        it { should eq(index + 1) }
+      end
+    end
+
+    %w[1P 1B 2B].each_with_index do |value, index|
+      context "with a MenACWY special value of #{value}" do
+        let(:programme) { create(:programme, :menacwy) }
+
+        let(:data) { { "PROGRAMME" => "MenACWY", "DOSE_SEQUENCE" => value } }
+
+        it { should eq(index + 1) }
+      end
+    end
+
     %w[1P 2P 3P 1B 2B].each_with_index do |value, index|
-      context "with a special value of #{value}" do
-        let(:data) { { "DOSE_SEQUENCE" => value } }
+      context "with a Td/IPV special value of #{value}" do
+        let(:programme) { create(:programme, :td_ipv) }
+
+        let(:data) { { "PROGRAMME" => "Td/IPV", "DOSE_SEQUENCE" => value } }
 
         it { should eq(index + 1) }
       end

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -100,7 +100,7 @@ describe Programme do
     context "with a MenACWY programme" do
       let(:programme) { build(:programme, :menacwy) }
 
-      it { should eq(1) }
+      it { should eq(3) }
     end
 
     context "with an Td/IPV programme" do


### PR DESCRIPTION
The special values for dose sequences are different per programme so we need to customise the functionality to allow this. At the same time, we only require dose sequence to be present if we're uploading a file for a current session.