### PR TITLE
Make CARE_SETTING optional for all programmes

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -282,8 +282,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
       {
         name: "CARE_SETTING",
         notes:
-          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}, must be " \
-            "#{tag.i("1")} (school) or #{tag.i("2")} (clinic)"
+          "Optional, must be #{tag.i("1")} (school) or #{tag.i("2")} (clinic)"
       },
       {
         name: "CLINIC_NAME",

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -106,7 +106,6 @@ class ImmunisationImportRow
   validates :care_setting,
             inclusion: [CARE_SETTING_SCHOOL, CARE_SETTING_COMMUNITY],
             allow_nil: true
-  validates :care_setting, presence: true, if: :requires_care_setting?
   validates :clinic_name,
             inclusion: {
               if: -> do
@@ -486,10 +485,6 @@ class ImmunisationImportRow
 
   def offline_recording?
     session_id.present?
-  end
-
-  def requires_care_setting?
-    programme&.hpv?
   end
 
   def performed_by_details_present_where_required


### PR DESCRIPTION
This value was currently only required for HPV, but we want it to be optional across all programmes as it won't always be available when uploading the file.