### PR TITLE
Allow delivery site to be optional

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -6,7 +6,6 @@ class ImmunisationImportRow
   validates :administered, inclusion: [true, false]
 
   with_options if: :administered do
-    validates :delivery_site, presence: true
     validates :reason, absence: true
   end
 
@@ -18,9 +17,9 @@ class ImmunisationImportRow
   end
 
   with_options if: -> { administered && offline_recording? } do
-    validates :vaccine_given, presence: true
     validates :batch_expiry_date, presence: true
     validates :batch_number, presence: true
+    validates :delivery_site, presence: true
   end
 
   validates :vaccine_given,
@@ -41,8 +40,7 @@ class ImmunisationImportRow
               allow_nil: true
             }
 
-  validate :delivery_site_appropriate_for_vaccine,
-           if: -> { administered && delivery_site.present? && vaccine.present? }
+  validate :delivery_site_appropriate_for_vaccine
 
   validates :dose_sequence,
             presence: {

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -103,10 +103,7 @@ class VaccinationRecord < ApplicationRecord
 
   enum :delivery_method,
        { intramuscular: 0, subcutaneous: 1, nasal_spray: 2 },
-       prefix: true,
-       validate: {
-         if: :administered?
-       }
+       prefix: true
   enum :delivery_site,
        {
          left_arm_upper_position: 2,
@@ -119,10 +116,8 @@ class VaccinationRecord < ApplicationRecord
          right_buttock: 9,
          nose: 10
        },
-       prefix: true,
-       validate: {
-         if: :administered?
-       }
+       prefix: true
+
   enum :outcome,
        {
          administered: 0,

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -111,7 +111,6 @@ describe "Immunisation imports" do
 
     expect(page).to have_content("Row 2")
     expect(page).to have_content("BATCH_EXPIRY_DATE:")
-    expect(page).to have_content("ANATOMICAL_SITE:")
     expect(page).to have_content("VACCINE_GIVEN:")
   end
 

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -3,10 +3,10 @@ R1L,110158,Eton College,7420180008,Chyna,Pickle,20100912,Not Specified,LE3 2DA,2
 R1L,110158,Eton College,,Renie,Parrish,20100913,Not Specified,LE1 2DA,20240514,HPV,Gardasil,123013325,20220730,Right Buttock,1,LocalPatient2,www.LocalPatient2,1
 R1L,110158,Eton College,4146825652,Caden,Attwater,20100914,Male,LE1 2DA,20240514,HPV,Gardasil9,123013325,20220730,Left Thigh,1,LocalPatient3,www.LocalPatient3,1
 R1L,110158,Eton College,2675725722,Berry,Hamilton,20100915,Female,LE8 2DA,20240514,HPV,Cervarix,123013325,20220730,Nasal,1,LocalPatient4,www.LocalPatient4,1
-R1L,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,HPV,Gardasil,123013325,20220730,Left Upper Arm,1,LocalPatient5,www.LocalPatient5,1
+R1L,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,HPV,Gardasil,123013325,20220730,,1,LocalPatient5,www.LocalPatient5,1
 R1L,110158,Eton College,8160442742,Oliver,Bowers,20100917,Male,LE5 2RP,20240514,HPV,Gardasil9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,HPV,Cervarix,123013326,20220730,Right Thigh,2,LocalPatient7,www.LocalPatient7,1
-R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20230410,HPV,Cervarix,123013325,20250730,Right Thigh,1,LocalPatient7,www.LocalPatient7,1
+R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20230410,HPV,Cervarix,123013325,20250730,,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999148581,Harold,Andrew,20101002,Not known,SW11 1AA,20230113,HPV,Gardasil,OU1731,20241015,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525156,Martial,Dare,20101002,Not known,SW11 1AA,20230126,HPV,Gardasil,OZ2022,20241010,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525157,Harold,Dare,20101002,Not known,SW11 1AA,20220126,HPV,Gardasil,SA6880,20241012,left upper arm,1,LocalPatient7,www.LocalPatient7,1

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -78,9 +78,6 @@ describe ImmunisationImportRow do
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
-        expect(immunisation_import_row.errors[:delivery_site]).to eq(
-          ["Enter an anatomical site."]
-        )
         expect(immunisation_import_row.errors[:patient_date_of_birth]).to eq(
           ["Enter a date of birth in the correct format."]
         )
@@ -498,6 +495,28 @@ describe ImmunisationImportRow do
         )
         expect(immunisation_import_row.errors[:batch_number]).to eq(
           ["Enter a batch number."]
+        )
+      end
+    end
+
+    context "vaccination in a session without a delivery site" do
+      let(:programme) { create(:programme, :flu) }
+
+      let(:data) do
+        {
+          "VACCINATED" => "Y",
+          "PROGRAMME" => "Flu",
+          "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901",
+          "SESSION_ID" => session.id.to_s
+        }
+      end
+
+      let(:session) { create(:session, organisation:, programme:) }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:delivery_site]).to eq(
+          ["Enter an anatomical site."]
         )
       end
     end


### PR DESCRIPTION
When uploading historical vaccination records, or those that happened outside of Mavis, we may not always know the delivery site so we need to allow it to be optional.