### PR TITLE
Use location_name when there's no session

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -271,7 +271,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
         location.name
       end
     else
-      "Unknown"
+      @vaccination_record.location_name
     end
   end
 


### PR DESCRIPTION
This is necessary when uploading historical vaccination records not tied to a session, the school name will be present in the `location_name` column, and we should display it to the nurses.