### PR TITLE
Update check answers page for doubles

### DIFF
--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -16,48 +16,125 @@
 
 <%= h1 "Check and confirm" %>
 
-<%= render AppCardComponent.new do |c| %>
-  <% c.with_heading { t("consent_forms.confirm.consent_card_title.#{@consent_form.programmes.first.type}") } %>
-  <%= govuk_summary_list do |summary_list|
-        summary_list.with_row do |row|
-          row.with_key { "Do you agree?" }
-          row.with_value {
-            @consent_form.consent_given? ?
-              t("consent_forms.confirm.i_agree.#{@consent_form.programmes.first.type}") :
-              "No"
-          }
-          row.with_action(text: "Change",
-                          href: change_link[:consent],
-                          visually_hidden_text: "consent")
-        end
-      
-        reason_notes = @consent_form.reason_notes.present? ? "<br>".html_safe + @consent_form.reason_notes : ""
-        reason_for_refusal_text = @consent_form.human_enum_name(:reason) + reason_notes
-      
-        if @consent_form.consent_refused?
-          summary_list.with_row do |row|
-            row.with_key { "Reason" }
-            row.with_value { reason_for_refusal_text.html_safe }
-            row.with_action(text: "Change",
-                            href: change_link[:reason],
-                            visually_hidden_text: "reason for refusal")
-          end
-      
-          if !@consent_form.contact_injection.nil?
+<% if @consent_form.consent_given_one? %>
+  <% if @consent_form.chosen_vaccine == "menacwy" %>
+    <%= render AppCardComponent.new do |c| %>
+      <% c.with_heading { t("consent_forms.confirm.consent_card_title.menacwy") } %>
+      <%= govuk_summary_list do |summary_list|
             summary_list.with_row do |row|
-              row.with_key { "Alternative option" }
-              row.with_value {
-                @consent_form.contact_injection? ?
-                  "Someone can contact me about an injection" :
-                  "No"
-              }
+              row.with_key { "Decision" }
+              row.with_value { "Consent given" }
               row.with_action(text: "Change",
-                              href: change_link[:injection],
-                              visually_hidden_text: "alternative option")
+                              href: change_link[:consent],
+                              visually_hidden_text: "consent")
+            end
+          end %>
+    <% end %>
+
+    <%= render AppCardComponent.new do |c| %>
+      <% c.with_heading { t("consent_forms.confirm.consent_card_title.td_ipv") } %>
+      <%= govuk_summary_list do |summary_list|
+            summary_list.with_row do |row|
+              row.with_key { "Decision" }
+              row.with_value { "Consent refused" }
+              row.with_action(text: "Change",
+                              href: change_link[:consent],
+                              visually_hidden_text: "consent")
+            end
+          
+            reason_notes = @consent_form.reason_notes.present? ? "<br>".html_safe + @consent_form.reason_notes : ""
+            reason_for_refusal_text = @consent_form.human_enum_name(:reason) + reason_notes
+          
+            summary_list.with_row do |row|
+              row.with_key { "Reason" }
+              row.with_value { reason_for_refusal_text.html_safe }
+              row.with_action(text: "Change",
+                              href: change_link[:reason],
+                              visually_hidden_text: "reason for refusal")
+            end
+          end %>
+    <% end %>
+  <% else %>
+    <%= render AppCardComponent.new do |c| %>
+      <% c.with_heading { t("consent_forms.confirm.consent_card_title.td_ipv") } %>
+      <%= govuk_summary_list do |summary_list|
+            summary_list.with_row do |row|
+              row.with_key { "Decision" }
+              row.with_value { "Consent given" }
+              row.with_action(text: "Change",
+                              href: change_link[:consent],
+                              visually_hidden_text: "consent")
+            end
+          end %>
+    <% end %>
+
+    <%= render AppCardComponent.new do |c| %>
+      <% c.with_heading { t("consent_forms.confirm.consent_card_title.menacwy") } %>
+      <%= govuk_summary_list do |summary_list|
+            summary_list.with_row do |row|
+              row.with_key { "Decision" }
+              row.with_value { "Consent refused" }
+              row.with_action(text: "Change",
+                              href: change_link[:consent],
+                              visually_hidden_text: "consent")
+            end
+          
+            reason_notes = @consent_form.reason_notes.present? ? "<br>".html_safe + @consent_form.reason_notes : ""
+            reason_for_refusal_text = @consent_form.human_enum_name(:reason) + reason_notes
+          
+            summary_list.with_row do |row|
+              row.with_key { "Reason" }
+              row.with_value { reason_for_refusal_text.html_safe }
+              row.with_action(text: "Change",
+                              href: change_link[:reason],
+                              visually_hidden_text: "reason for refusal")
+            end
+          end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render AppCardComponent.new do |c| %>
+    <% programme_type = @consent_form.programmes.first.type.in?(["menacwy", "td_ipv"]) ? "menacwy_td_ipv" : @consent_form.programmes.first.type %>
+    <% c.with_heading { t("consent_forms.confirm.consent_card_title.#{programme_type}") } %>
+    <%= govuk_summary_list do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { "Decision" }
+            row.with_value {
+              @consent_form.consent_given? ? "Consent given" : "Consent refused"
+            }
+            row.with_action(text: "Change",
+                            href: change_link[:consent],
+                            visually_hidden_text: "consent")
+          end
+        
+          if @consent_form.consent_refused?
+            reason_notes = @consent_form.reason_notes.present? ? "<br>".html_safe + @consent_form.reason_notes : ""
+            reason_for_refusal_text = @consent_form.human_enum_name(:reason) + reason_notes
+        
+            summary_list.with_row do |row|
+              row.with_key { "Reason" }
+              row.with_value { reason_for_refusal_text.html_safe }
+              row.with_action(text: "Change",
+                              href: change_link[:reason],
+                              visually_hidden_text: "reason for refusal")
+            end
+        
+            if !@consent_form.contact_injection.nil?
+              summary_list.with_row do |row|
+                row.with_key { "Alternative option" }
+                row.with_value {
+                  @consent_form.contact_injection? ?
+                    "Someone can contact me about an injection" :
+                    "No"
+                }
+                row.with_action(text: "Change",
+                                href: change_link[:injection],
+                                visually_hidden_text: "alternative option")
+              end
             end
           end
-        end
-      end %>
+        end %>
+  <% end %>
 <% end %>
 
 <%= render AppCardComponent.new do |c| %>
@@ -91,7 +168,7 @@
           )
         end
       
-        if @consent_form.consent_given?
+        if @consent_form.consent_given? || @consent_form.consent_given_one?
           summary_list.with_row do |row|
             row.with_key { "Address" }
             row.with_value { format_address_multi_line(@consent_form) }
@@ -180,7 +257,7 @@
       end %>
 <% end %>
 
-<% if @consent_form.consent_given? %>
+<% if @consent_form.consent_given? || @consent_form.consent_given_one? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Health questions" } %>
     <%= govuk_summary_list classes: "app-summary-list--full-width" do |summary_list|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -664,13 +664,10 @@ en:
       consent_card_title:
         flu: Consent for the flu vaccination
         hpv: Consent for the HPV vaccination
-        menacwy: Consent for the MenACWY and Td/IPV vaccinations
-        td_ipv: Consent for the MenACWY and Td/IPV vaccinations
-      i_agree:
-        flu: Yes, I agree to them having a nasal flu vaccination
-        hpv: Yes, I agree
-        menacwy: Yes, I agree to them having both vaccinations
-        td_ipv: Yes, I agree to them having both vaccinations
+        menacwy: Consent for the MenACWY vaccination
+        td_ipv: Consent for the Td/IPV vaccination
+        menacwy_td_ipv: Consent for the MenACWY and Td/IPV vaccinations
+      i_agree: Consent given
     confirmation_agreed:
       title:
         flu: " %{full_name} will get their nasal flu vaccination at school"


### PR DESCRIPTION
This adds new cards for the cases where users choose to consent to only one vaccine.

The refusal reason step is missing - that's coming in a follow-up PR.

Review without whitespace.

### Screenshots

<img width="808" alt="Screenshot 2025-02-24 at 23 45 46" src="https://github.com/user-attachments/assets/be4ac2a6-078b-463c-9a4b-1bd0482632cc" />
<img width="788" alt="Screenshot 2025-02-24 at 23 45 56" src="https://github.com/user-attachments/assets/54c7c148-e9e4-4069-8c75-94cc968af4a7" />
<img width="771" alt="Screenshot 2025-02-24 at 23 46 18" src="https://github.com/user-attachments/assets/d2e6ac7a-c818-4216-a824-649c3854bba3" />
