### PR TITLE
Allow performed_ods_code to be optional

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -68,8 +68,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
       {
         name: "ORGANISATION_CODE",
         notes:
-          "#{tag.strong("Required")}, must be a valid " \
-            "#{govuk_link_to("ODS code", "https://odsportal.digital.nhs.uk/")}"
+          "Optional, must be a valid #{link_to("ODS code", "https://odsportal.digital.nhs.uk/")}"
       },
       {
         name: "SCHOOL_URN",

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -82,9 +82,6 @@ class ImmunisationImportRow
             }
 
   validates :performed_ods_code,
-            presence: {
-              unless: :offline_recording?
-            },
             comparison: {
               equal_to: :organisation_ods_code,
               if: :offline_recording?
@@ -355,7 +352,7 @@ class ImmunisationImportRow
   end
 
   def performed_ods_code
-    @data["ORGANISATION_CODE"]&.strip&.upcase
+    @data["ORGANISATION_CODE"]&.strip&.upcase&.presence
   end
 
   def programme_name

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -17,7 +17,7 @@
 #  performed_at             :datetime         not null
 #  performed_by_family_name :string
 #  performed_by_given_name  :string
-#  performed_ods_code       :string           not null
+#  performed_ods_code       :string
 #  uuid                     :uuid             not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null

--- a/db/migrate/20250224221219_make_vaccination_record_performed_ods_code_null.rb
+++ b/db/migrate/20250224221219_make_vaccination_record_performed_ods_code_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeVaccinationRecordPerformedODSCodeNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :vaccination_records, :performed_ods_code, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_24_200603) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_24_221219) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -763,7 +763,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_24_200603) do
     t.datetime "confirmation_sent_at"
     t.bigint "patient_id"
     t.bigint "session_id"
-    t.string "performed_ods_code", null: false
+    t.string "performed_ods_code"
     t.bigint "vaccine_id"
     t.index ["batch_id"], name: "index_vaccination_records_on_batch_id"
     t.index ["discarded_at"], name: "index_vaccination_records_on_discarded_at"

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -17,7 +17,7 @@
 #  performed_at             :datetime         not null
 #  performed_by_family_name :string
 #  performed_by_given_name  :string
-#  performed_ods_code       :string           not null
+#  performed_ods_code       :string
 #  uuid                     :uuid             not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -3,11 +3,11 @@ R1L,110158,Eton College,7420180008,Chyna,Pickle,20100912,Not Specified,LE3 2DA,2
 R1L,110158,Eton College,,Renie,Parrish,20100913,Not Specified,LE1 2DA,20240514,HPV,Gardasil,123013325,20220730,Right Buttock,1,LocalPatient2,www.LocalPatient2,1
 R1L,110158,Eton College,4146825652,Caden,Attwater,20100914,Male,LE1 2DA,20240514,HPV,Gardasil9,123013325,20220730,Left Thigh,1,LocalPatient3,www.LocalPatient3,1
 R1L,110158,Eton College,2675725722,Berry,Hamilton,20100915,Female,LE8 2DA,20240514,HPV,Cervarix,123013325,20220730,Nasal,1,LocalPatient4,www.LocalPatient4,1
-R1L,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,HPV,Gardasil,123013325,20220730,,1,LocalPatient5,www.LocalPatient5,1
+,110158,Eton College,1108533868,Jordin,Mould,20100916,Male,LE2 2PX,20240514,HPV,Gardasil,123013325,20220730,,1,LocalPatient5,www.LocalPatient5,1
 R1L,110158,Eton College,8160442742,Oliver,Bowers,20100917,Male,LE5 2RP,20240514,HPV,Gardasil9,123013326,20220730,Right Upper Arm,1,LocalPatient6,www.LocalPatient6,1
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,HPV,Cervarix,123013326,20220730,Right Thigh,2,LocalPatient7,www.LocalPatient7,1
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20230410,HPV,Cervarix,123013325,20250730,,1,LocalPatient7,www.LocalPatient7,1
-R1L,110158,,9999148581,Harold,Andrew,20101002,Not known,SW11 1AA,20230113,HPV,Gardasil,OU1731,20241015,left upper arm,1,LocalPatient7,www.LocalPatient7,1
+,110158,,9999148581,Harold,Andrew,20101002,Not known,SW11 1AA,20230113,HPV,Gardasil,OU1731,20241015,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525156,Martial,Dare,20101002,Not known,SW11 1AA,20230126,HPV,Gardasil,OZ2022,20241010,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525157,Harold,Dare,20101002,Not known,SW11 1AA,20220126,HPV,Gardasil,SA6880,20241012,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 ,,,,,,,,,,,,,,,,,

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -64,9 +64,6 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row.errors[:administered]).to include(
           /You need to record whether the child was vaccinated or not/
         )
-        expect(immunisation_import_row.errors[:performed_ods_code]).to include(
-          "Enter an organisation code."
-        )
         expect(immunisation_import_row.errors[:programme_name]).to include(
           "is not included in the list"
         )
@@ -86,9 +83,6 @@ describe ImmunisationImportRow do
         )
         expect(immunisation_import_row.errors[:patient_postcode]).to eq(
           ["Enter a valid postcode, such as SW1A 1AA"]
-        )
-        expect(immunisation_import_row.errors[:performed_ods_code]).to eq(
-          ["Enter an organisation code."]
         )
       end
 
@@ -305,10 +299,10 @@ describe ImmunisationImportRow do
       end
     end
 
-    context "vaccination in this academic year and no organisation provided" do
-      let(:data) do
-        { "DATE_OF_VACCINATION" => "#{Date.current.academic_year}0901" }
-      end
+    context "vaccination in a session and no organisation provided" do
+      let(:data) { { "SESSION_ID" => session.id.to_s } }
+
+      let(:session) { create(:session, organisation:, programme:) }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -17,7 +17,7 @@
 #  performed_at             :datetime         not null
 #  performed_by_family_name :string
 #  performed_by_given_name  :string
-#  performed_ods_code       :string           not null
+#  performed_ods_code       :string
 #  uuid                     :uuid             not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null


### PR DESCRIPTION
In some cases this value won't be available when importing the historical vaccinations so we need to allow files to be uploaded that don't contain an ODS code.