### PR TITLE
Ask for reason when parent consents to one vaccine

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -273,7 +273,9 @@ class ConsentForm < ApplicationRecord
       (:reason_notes if consent_refused? && reason_notes_must_be_provided?),
       (:injection if injection_offered_as_alternative?),
       (:address if consent_given? || consent_given_one?),
-      (:health_question if consent_given? || consent_given_one?)
+      (:health_question if consent_given? || consent_given_one?),
+      (:reason if consent_given_one?),
+      (:reason_notes if consent_given_one? && reason_notes_must_be_provided?)
     ].compact
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -508,11 +508,13 @@ class ConsentForm < ApplicationRecord
 
     self.parent_relationship_other_name = nil unless parent_relationship_other?
 
-    if consent_given? || consent_given_one?
-      self.contact_injection = nil
-
+    if consent_given?
       self.reason = nil
       self.reason_notes = nil
+    end
+
+    if consent_given? || consent_given_one?
+      self.contact_injection = nil
 
       seed_health_questions
     end

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -13,7 +13,7 @@ describe "Parental consent" do
 
     when_i_give_consent_to_both_programmes
     and_i_fill_in_my_address
-    and_i_answer_no_to_all_the_medical_questions
+    and_i_answer_no_until_the_check_answers_page
     then_i_can_check_my_answers
   end
 
@@ -29,7 +29,8 @@ describe "Parental consent" do
 
     when_i_give_consent_to_one_programme
     and_i_fill_in_my_address
-    and_i_answer_no_to_all_the_medical_questions
+    and_i_answer_no_until_the_reason_for_refusal_page
+    and_i_give_a_reason_for_refusal
     then_i_can_check_my_answers
   end
 
@@ -111,8 +112,15 @@ describe "Parental consent" do
     click_on "Continue"
   end
 
-  def and_i_answer_no_to_all_the_medical_questions
+  def and_i_answer_no_until_the_check_answers_page
     until page.has_content?("Check and confirm")
+      choose "No"
+      click_on "Continue"
+    end
+  end
+
+  def and_i_answer_no_until_the_reason_for_refusal_page
+    until page.has_content?("Why are you refusing")
       choose "No"
       click_on "Continue"
     end
@@ -132,6 +140,11 @@ describe "Parental consent" do
     expect(page).to have_field("Td/IPV", type: "radio")
     choose "I agree to them having one of the vaccinations"
     choose "MenACWY"
+    click_on "Continue"
+  end
+
+  def and_i_give_a_reason_for_refusal
+    choose "Vaccine already received"
     click_on "Continue"
   end
 end

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -146,5 +146,8 @@ describe "Parental consent" do
   def and_i_give_a_reason_for_refusal
     choose "Vaccine already received"
     click_on "Continue"
+
+    fill_in "Give details", with: "At a hospital"
+    click_on "Continue"
   end
 end


### PR DESCRIPTION
When parents only give consent to one vaccine in a doubles campaign, we need to ask them for a reason.