### PR TITLE
Add "Record as already vaccinated" functionality

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -267,6 +267,8 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
     if (location = @vaccination_record.location)
       if location.generic_clinic?
         @vaccination_record.location_name
+      elsif @vaccination_record.already_had?
+        "Unknown"
       else
         location.name
       end

--- a/app/jobs/school_consent_requests_job.rb
+++ b/app/jobs/school_consent_requests_job.rb
@@ -44,13 +44,14 @@ class SchoolConsentRequestsJob < ApplicationJob
   def should_send_notification?(patient_session:, programmes:)
     return false unless patient_session.send_notifications?
 
-    has_consent_or_triage =
+    has_consent_or_vaccinated =
       programmes.all? do |programme|
         patient_session.consents(programme:).any? ||
-          patient_session.triaged_do_not_vaccinate?(programme:)
+          patient_session.vaccinated?(programme:) ||
+          patient_session.unable_to_vaccinate?(programme:)
       end
 
-    return false if has_consent_or_triage
+    return false if has_consent_or_vaccinated
 
     patient = patient_session.patient
 

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -152,8 +152,7 @@ module PatientSessionStatusConcern
     end
 
     def next_step(programme:)
-      if added_to_session?(programme:) ||
-           consent_given_triage_needed?(programme:) ||
+      if consent_given_triage_needed?(programme:) ||
            triaged_kept_in_triage?(programme:)
         :triage
       elsif consent_given_triage_not_needed?(programme:) ||

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -37,7 +37,7 @@ class DraftVaccinationRecord
     [
       :notes,
       :date_and_time,
-      :outcome,
+      (:outcome if can_change_outcome?),
       (:delivery if administered?),
       (:vaccine if administered?),
       (:batch if administered?),
@@ -102,6 +102,11 @@ class DraftVaccinationRecord
   def administered?
     return nil if outcome.nil?
     outcome == "administered"
+  end
+
+  def already_had?
+    return nil if outcome.nil?
+    outcome == "already_had"
   end
 
   # So that a form error matches to a field in this model
@@ -198,6 +203,10 @@ class DraftVaccinationRecord
       self.delivery_site = nil
       self.vaccine_id = nil
     end
+  end
+
+  def can_change_outcome?
+    outcome != "already_had" || editing? || session.nil? || session.today?
   end
 
   def batch_vaccine_matches_vaccine

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -77,10 +77,6 @@ class PatientSession < ApplicationRecord
 
   delegate :send_notifications?, to: :patient
 
-  def able_to_vaccinate?
-    !unable_to_vaccinate?
-  end
-
   def safe_to_destroy?
     any_vaccination_records =
       programmes.any? do |programme|
@@ -94,6 +90,11 @@ class PatientSession < ApplicationRecord
 
   def destroy_if_safe!
     destroy! if safe_to_destroy?
+  end
+
+  def can_record_as_already_vaccinated?(programme:)
+    !session.today? && !vaccinated?(programme:) &&
+      !unable_to_vaccinate?(programme:)
   end
 
   def programmes

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -20,7 +20,7 @@
      delivery_site: wizard_path("delivery"),
      location: @draft_vaccination_record.wizard_steps.include?(:location) ? wizard_path("location") : nil,
      notes: wizard_path("notes"),
-     outcome: wizard_path("outcome"),
+     outcome: @draft_vaccination_record.wizard_steps.include?(:outcome) ? wizard_path("outcome") : nil,
      performed_at: wizard_path("date-and-time"),
      vaccine: wizard_path("vaccine"),
    } %>

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -10,8 +10,8 @@
   <%= @patient.full_name %>
 <% end %>
 
-<% if (session_attendance = @patient_session.todays_attendance) %>
-  <ul class="app-action-list">
+<ul class="app-action-list">
+  <% if (session_attendance = @patient_session.todays_attendance) %>
     <li class="app-action-list__item">
       <% if session_attendance.attending %>
         <%= govuk_tag(text: "Attending today’s session") %>
@@ -29,8 +29,17 @@
             ) %>
       <% end %>
     </li>
-  </ul>
-<% end %>
+  <% end %>
+
+  <li class="app-action-list__item">
+    <% if @patient_session.can_record_as_already_vaccinated?(programme: @programme) %>
+      <%= link_to(
+            "Record as already vaccinated",
+            session_patient_record_already_vaccinated_path(programme_type: @programme),
+          ) %>
+    <% end %>
+  </li>
+</ul>
 
 <%= render "patient_sessions/secondary_navigation" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,7 @@ Rails.application.routes.draw do
     scope ":tab" do
       resources :patient_sessions, path: "patients", as: :patient, only: [] do
         get "log"
+        get "record-already-vaccinated"
 
         resource :attendance,
                  controller: "session_attendances",

--- a/spec/features/td_ipv_already_had_spec.rb
+++ b/spec/features/td_ipv_already_had_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-describe "Triage" do
-  scenario "nurse can triage after importing cohort to remove from programme" do
+describe "Td/IPV" do
+  scenario "record a patient as already vaccinated outside the session" do
     given_a_menacwy_programme_with_a_session
     and_i_am_signed_in_as_a_nurse
 
@@ -17,7 +17,7 @@ describe "Triage" do
     and_i_click_on_the_patient
     then_i_see_the_patient_needs_consent
 
-    when_i_mark_the_patient_as_not_safe_to_vaccinate
+    when_i_record_the_patient_as_already_vaccinated
     and_the_consent_requests_are_sent
     then_the_parent_doesnt_receive_a_consent_request
   end
@@ -86,9 +86,9 @@ describe "Triage" do
     expect(page).to have_content("No response")
   end
 
-  def when_i_mark_the_patient_as_not_safe_to_vaccinate
-    choose "No, do not vaccinate"
-    click_on "Save triage"
+  def when_i_record_the_patient_as_already_vaccinated
+    click_on "Record as already vaccinated"
+    click_on "Confirm"
   end
 
   def and_the_consent_requests_are_sent


### PR DESCRIPTION
This replaces the ability to triage a patient the moment they're in a session with a feature that instead allows a patient to be marked as having already had the vaccine, which records a vaccination record against the patient for that programme, and prevents any consent request emails from going out if they haven't already.

## Screenshots

![Screenshot 2025-02-24 at 22 54 30](https://github.com/user-attachments/assets/e61c22e9-5c92-4aff-b8e2-e66dfd55c87d)
![Screenshot 2025-02-24 at 22 54 35](https://github.com/user-attachments/assets/62b17b2b-cba5-47a3-a548-2cc3effac3a4)
![Screenshot 2025-02-24 at 22 54 40](https://github.com/user-attachments/assets/8b152d5c-29bb-401f-9d1e-2e9eb32a5e39)
![Screenshot 2025-02-24 at 22 54 44](https://github.com/user-attachments/assets/759cb06f-48b7-458e-8ce9-732e2d13450e)
