### PR TITLE
Add missing doubles translation strings

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -772,6 +772,8 @@ en:
       title:
         flu: Do they agree to them having the flu vaccination?
         hpv: Do they agree to them having the HPV vaccination?
+        menacwy: Do they agree to them having the MenACWY vaccination?
+        td_ipv: Do they agree to them having the Td/IPV vaccination?
     notes:
       title:
         already_vaccinated: Where did their child get their vaccination?


### PR DESCRIPTION
When getting verbal consent these strings were missing and was causing an error.