### PR TITLE
Get the programmes from the consent form

### DIFF
--- a/app/views/parent_interface/consent_forms/edit/consent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/consent.html.erb
@@ -14,7 +14,7 @@
     <%= f.govuk_radio_button :response, "given",
                              label: { text: t("consent_forms.consent.i_agree.#{@consent_form.programmes.first.type}") },
                              link_errors: true %>
-    <% if @session.programmes.count > 1 %>
+    <% if @consent_form.programmes.count > 1 %>
       <%= f.govuk_radio_button :response, "given_one",
                                label: { text: "I agree to them having one of the vaccinations" } do %>
         <%= f.govuk_radio_buttons_fieldset :chosen_vaccine,
@@ -22,15 +22,15 @@
                                              size: "s",
                                              text: "Which vaccinations do you give consent for?",
                                            } do %>
-          <% @session.programmes.each do |programme| %>
+          <% @consent_form.programmes.each do |programme| %>
             <%= f.govuk_radio_button :chosen_vaccine, programme.type,
                                      label: { text: programme.name } %>
           <% end %>
         <% end %>
       <% end %>
     <% end %>
-    <%= f.govuk_radio_button :response, "refused",
-                             label: { text: "No" } %>
+
+    <%= f.govuk_radio_button :response, "refused", label: { text: "No" } %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">


### PR DESCRIPTION
The session might have more programmes than the consent form, and we don't want to show "HPV" next to doubles, for example.