### PR TITLE
Validate vaccine for programme

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -493,7 +493,7 @@ class ImmunisationImportRow
   end
 
   def valid_given_vaccines
-    organisation.vaccines.pluck(:nivs_name)
+    organisation.vaccines.where(programme:).pluck(:nivs_name)
   end
 
   delegate :maximum_dose_sequence, to: :programme, allow_nil: true


### PR DESCRIPTION
When importing vaccination records, we need to ensure that the vaccine is approriate for the programme. It shouldn't be possible to, for example, set the programme to HPV and then specify a vaccine from Td/IPV.