### PR TITLE
Create consent responses per programme

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -159,17 +159,45 @@ class Consent < ApplicationRecord
         consent_form.find_or_create_parent_with_relationship_to!(patient:)
 
       consent_form.programmes.map do |programme|
+        given_one_and_this_refused =
+          consent_form.consent_given_one? &&
+            consent_form.chosen_vaccines.none? do
+              it.programme_id == programme.id
+            end
+
+        reason_for_refusal =
+          if given_one_and_this_refused || consent_form.consent_refused?
+            consent_form.reason
+          end
+
+        notes =
+          if given_one_and_this_refused || consent_form.consent_refused?
+            consent_form.reason_notes
+          end
+
+        response =
+          if given_one_and_this_refused
+            "refused"
+          elsif consent_form.consent_given_one?
+            "given"
+          else
+            consent_form.response
+          end
+
+        # TODO: Unpick health answers from different programmes.
+        health_answers = consent_form.health_answers
+
         create!(
           consent_form:,
           organisation: consent_form.organisation,
           programme:,
           patient:,
           parent:,
-          reason_for_refusal: consent_form.reason,
-          notes: consent_form.reason_notes.presence || "",
-          response: consent_form.response,
+          reason_for_refusal:,
+          notes: notes.presence || "",
+          response:,
           route: "website",
-          health_answers: consent_form.health_answers,
+          health_answers:,
           recorded_by: current_user
         )
       end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -431,6 +431,14 @@ class ConsentForm < ApplicationRecord
     education_setting_home?
   end
 
+  def chosen_vaccines
+    if chosen_vaccine.present?
+      programmes.find_by(type: chosen_vaccine).vaccines.active
+    else
+      vaccines.active
+    end
+  end
+
   private
 
   def academic_year
@@ -549,13 +557,5 @@ class ConsentForm < ApplicationRecord
 
         health_answer
       end
-  end
-
-  def chosen_vaccines
-    if chosen_vaccine.present?
-      programmes.find_by(type: chosen_vaccine).vaccines.active
-    else
-      vaccines.active
-    end
   end
 end


### PR DESCRIPTION
When submitting a consent form it's possible to consent to only one vaccination programme, so we need to make sure the generated `Consent` objects reflect that.