### PR TITLE
Fix errant space in navigation links that contain a count

### DIFF
--- a/app/components/app_header_navigation_item_component.rb
+++ b/app/components/app_header_navigation_item_component.rb
@@ -18,7 +18,7 @@ class AppHeaderNavigationItemComponent < ViewComponent::Base
         aria: {
           current: current? ? "true" : nil
         }
-      ) { safe_join([@title, count_tag], " ") }
+      ) { safe_join([@title, count_tag], "") }
     end
   end
 
@@ -42,7 +42,7 @@ class AppHeaderNavigationItemComponent < ViewComponent::Base
     return "" unless show_count?
 
     tag.span(class: "app-count") do
-      tag.span("(", class: "nhsuk-u-visually-hidden") + @count.to_s +
+      tag.span(" (", class: "nhsuk-u-visually-hidden") + @count.to_s +
         tag.span(")", class: "nhsuk-u-visually-hidden")
     end
   end


### PR DESCRIPTION
Before:

<img width="1100" alt="Screenshot 2025-02-25 at 12 01 51" src="https://github.com/user-attachments/assets/b2308292-88e9-4478-b0bc-8e0b9e1edede" />

After:

<img width="1100" alt="Screenshot 2025-02-25 at 12 02 05" src="https://github.com/user-attachments/assets/980b630a-dbd9-42da-8e19-f2516ff2b863" />
