### PR TITLE
Show patients if we have a vaccination record

### DIFF
--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -11,7 +11,7 @@ class CohortsController < ApplicationController
     birth_academic_years = @programme.birth_academic_years
 
     @patient_count_by_birth_academic_year =
-      policy_scope(Patient)
+      patients_in_cohort
         .where(birth_academic_year: birth_academic_years)
         .group(:birth_academic_year)
         .count
@@ -25,7 +25,7 @@ class CohortsController < ApplicationController
     @birth_academic_year = Integer(params[:id])
 
     patients =
-      policy_scope(Patient)
+      patients_in_cohort
         .where(birth_academic_year: @birth_academic_year)
         .not_deceased
         .includes(:school)
@@ -38,5 +38,9 @@ class CohortsController < ApplicationController
 
   def set_programme
     @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+
+  def patients_in_cohort
+    Patient.where(organisation: current_user.selected_organisation)
   end
 end

--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -12,9 +12,26 @@ class PatientPolicy < ApplicationPolicy
           SchoolMove.where(school: organisation.schools)
         )
 
-      scope.where(organisation:).or(
-        scope.where(school_moves.where("patient_id = patients.id").arel.exists)
-      )
+      vaccination_records =
+        VaccinationRecord
+          .left_outer_joins(:session)
+          .where(session: { organisation: })
+          .or(
+            VaccinationRecord.where(performed_ods_code: organisation.ods_code)
+          )
+
+      scope
+        .where(organisation:)
+        .or(
+          scope.where(
+            school_moves.where("patient_id = patients.id").arel.exists
+          )
+        )
+        .or(
+          scope.where(
+            vaccination_records.where("patient_id = patients.id").arel.exists
+          )
+        )
     end
   end
 end

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -24,19 +24,13 @@ class VaccinationRecordPolicy < ApplicationPolicy
 
   class Scope < ApplicationPolicy::Scope
     def resolve
+      organisation = user.selected_organisation
+
       scope
         .kept
-        .where(patient: PatientPolicy::Scope.new(user, Patient).resolve)
-        .or(
-          scope.kept.where(
-            session: SessionPolicy::Scope.new(user, Session).resolve
-          )
-        )
-        .or(
-          scope.kept.where(
-            performed_ods_code: user.selected_organisation.ods_code
-          )
-        )
+        .where(patient: organisation.patients)
+        .or(scope.kept.where(session: organisation.sessions))
+        .or(scope.kept.where(performed_ods_code: organisation.ods_code))
     end
   end
 end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -60,5 +60,29 @@ describe PatientPolicy do
       it { should include(patient_with_move_in_school) }
       it { should_not include(patient_with_move_in_another_school) }
     end
+
+    context "when the patient not in the org but was vaccinated by them" do
+      let(:patient_with_vaccination_record) { create(:patient) }
+      let(:patient_with_another_vaccination_record) { create(:patient) }
+
+      let(:programme) { create(:programme) }
+
+      before do
+        create(
+          :vaccination_record,
+          patient: patient_with_vaccination_record,
+          performed_ods_code: organisation.ods_code,
+          programme:
+        )
+        create(
+          :vaccination_record,
+          patient: patient_with_another_vaccination_record,
+          programme:
+        )
+      end
+
+      it { should include(patient_with_vaccination_record) }
+      it { should_not include(patient_with_another_vaccination_record) }
+    end
   end
 end


### PR DESCRIPTION
If a patient was vaccinated by the organisation, even if that happened historically and the patient is no longer part of the organisation cohort, we still want the organisation to have visibility of the patients so they can be searched for.