### PR TITLE
Send consent confirmation emails per programme 

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -10,34 +10,57 @@ module ConsentFormMailerConcern
         consent_form:
       )
     elsif consent_form.consent_refused?
-      EmailDeliveryJob.perform_later(
-        :consent_confirmation_refused,
-        consent_form:
-      )
-
-      if consent_form.parent_phone_receive_updates
-        SMSDeliveryJob.perform_later(
-          :consent_confirmation_refused,
-          consent_form:
-        )
-      end
-    elsif consent_form.needs_triage?
-      EmailDeliveryJob.perform_later(
-        :consent_confirmation_triage,
-        consent_form:
-      )
-    elsif consent_form.actual_session.clinic? ||
-          consent_form.actual_session.completed?
-      EmailDeliveryJob.perform_later(
-        :consent_confirmation_clinic,
-        consent_form:
-      )
+      send_consent_form_confirmation_refused(consent_form)
     else
-      EmailDeliveryJob.perform_later(:consent_confirmation_given, consent_form:)
+      ProgrammeGrouper
+        .call(consent_form.chosen_programmes)
+        .each_value do |programmes|
+          if consent_form.needs_triage?
+            EmailDeliveryJob.perform_later(
+              :consent_confirmation_triage,
+              consent_form:,
+              programmes:
+            )
+          elsif consent_form.actual_session.clinic? ||
+                consent_form.actual_session.completed?
+            EmailDeliveryJob.perform_later(
+              :consent_confirmation_clinic,
+              consent_form:,
+              programmes:
+            )
+          else
+            EmailDeliveryJob.perform_later(
+              :consent_confirmation_given,
+              consent_form:,
+              programmes:
+            )
 
-      if consent_form.parent_phone_receive_updates
-        SMSDeliveryJob.perform_later(:consent_confirmation_given, consent_form:)
-      end
+            if consent_form.parent_phone_receive_updates
+              SMSDeliveryJob.perform_later(
+                :consent_confirmation_given,
+                consent_form:,
+                programmes:
+              )
+            end
+          end
+        end
+
+      ProgrammeGrouper
+        .call(consent_form.not_chosen_programmes)
+        .each_value do |programmes|
+          send_consent_form_confirmation_refused(consent_form, programmes:)
+        end
+    end
+  end
+
+  def send_consent_form_confirmation_refused(consent_form, programmes: nil)
+    params = { consent_form: }
+    params[:programmes] = programmes if programmes
+
+    EmailDeliveryJob.perform_later(:consent_confirmation_refused, **params)
+
+    if consent_form.parent_phone_receive_updates
+      SMSDeliveryJob.perform_later(:consent_confirmation_refused, **params)
     end
   end
 end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -431,7 +431,23 @@ class ConsentForm < ApplicationRecord
     education_setting_home?
   end
 
+  def chosen_programmes
+    return [] if consent_refused?
+
+    if chosen_vaccine.present?
+      programmes.where(type: chosen_vaccine)
+    else
+      programmes
+    end
+  end
+
+  def not_chosen_programmes
+    programmes - chosen_programmes
+  end
+
   def chosen_vaccines
+    return [] if consent_refused?
+
     if chosen_vaccine.present?
       programmes.find_by(type: chosen_vaccine).vaccines.active
     else


### PR DESCRIPTION
If a user has consent to one vaccine programme, but not the other, we need to make sure we sent them two emails, confirming the consent given and the consent refused on each.