### PR TITLE
Update content when refusing consent

### DIFF
--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -2,7 +2,9 @@
   <%= render AppBacklinkComponent.new(backlink_path) %>
 <% end %>
 
-<% title = "Why are you refusing to give consent?" %>
+<% title = "Please tell us why you do not agree to your child having the " \
+   "#{@consent_form.not_chosen_programmes.map(&:name).to_sentence} " \
+   "#{"vaccination".pluralize(@consent_form.not_chosen_programmes.count)}" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @consent_form, url: wizard_path, method: :put do |f| %>

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -170,6 +170,10 @@ describe "Parental consent" do
   end
 
   def and_i_give_a_reason_for_refusal
+    expect(page).to have_content(
+      "Please tell us why you do not agree to your child having the Td/IPV vaccination"
+    )
+
     choose "Vaccine already received"
     click_on "Continue"
 

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -53,7 +53,9 @@ describe "Parental consent" do
     choose "No"
     click_on "Continue"
 
-    expect(page).to have_content("Why are you refusing to give consent?")
+    expect(page).to have_content(
+      "Please tell us why you do not agree to your child having the HPV vaccination"
+    )
     choose "Medical reasons"
     click_on "Continue"
 

--- a/spec/features/triage_then_parental_consent_refused_spec.rb
+++ b/spec/features/triage_then_parental_consent_refused_spec.rb
@@ -96,7 +96,9 @@ describe "Triage" do
     choose "No"
     click_on "Continue"
 
-    expect(page).to have_content("Why are you refusing to give consent?")
+    expect(page).to have_content(
+      "Please tell us why you do not agree to your child having the HPV vaccination"
+    )
     choose "Medical reasons"
     click_on "Continue"
 


### PR DESCRIPTION
This updates the content shown on one of the questions when refusing consent to ask specifically which programme the parent is refusing consent for. For HPV this doesn't change much, but for doubles it makes clear that we're only asking about the vaccination that the parent doesn't want to consent to.

## Screenshots

<img width="773" alt="Screenshot 2025-02-25 at 15 13 32" src="https://github.com/user-attachments/assets/f98f40c0-2648-4ec5-8c97-d3bac490efc6" />
<img width="727" alt="Screenshot 2025-02-25 at 15 09 29" src="https://github.com/user-attachments/assets/96286bd5-a1c5-4726-a455-9d1d0406585c" />
<img width="771" alt="Screenshot 2025-02-25 at 15 08 40" src="https://github.com/user-attachments/assets/cc2963d2-15fd-4887-a740-cac185fed22d" />
