### PR TITLE
Prevent removing programmes once added

### DIFF
--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -4,11 +4,19 @@ class Sessions::EditController < ApplicationController
   before_action :set_session
 
   def edit_programmes
+    @form =
+      SessionProgrammesForm.new(
+        session: @session,
+        programme_ids: @session.programme_ids
+      )
+
     render :programmes
   end
 
   def update_programmes
-    if @session.update(programmes_params)
+    @form = SessionProgrammesForm.new(session: @session, **programmes_params)
+
+    if @form.save
       redirect_to edit_session_path(@session)
     else
       render :programmes, status: :unprocessable_entity
@@ -66,7 +74,7 @@ class Sessions::EditController < ApplicationController
   end
 
   def programmes_params
-    params.expect(session: { programme_ids: [] })
+    params.expect(session_programmes_form: { programme_ids: [] })
   end
 
   def send_consent_requests_at_validator

--- a/app/forms/session_programmes_form.rb
+++ b/app/forms/session_programmes_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SessionProgrammesForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :session
+
+  attribute :programme_ids, array: true, default: []
+
+  validates :programme_ids, presence: true
+  validate :cannot_remove_programmes
+
+  def save
+    session.programme_ids = programme_ids if valid?
+  end
+
+  def programme_ids=(values)
+    super(values&.compact_blank&.map(&:to_i) || [])
+  end
+
+  private
+
+  def cannot_remove_programmes
+    if (session.programme_ids - programme_ids).present?
+      errors.add(:programme_ids, :inclusion)
+    end
+  end
+end

--- a/app/views/sessions/edit/programmes.html.erb
+++ b/app/views/sessions/edit/programmes.html.erb
@@ -5,7 +5,7 @@
 <% legend = "Which programmes is this session part of?" %>
 <% content_for :page_title, legend %>
 
-<%= form_with model: @session, url: edit_programmes_session_path(@session), method: :put do |f| %>
+<%= form_with model: @form, url: edit_programmes_session_path(@session), method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_collection_check_boxes :programme_ids, policy_scope(Programme), :id, :name,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -310,6 +310,11 @@ en:
           attributes:
             action:
               inclusion: Choose whether to update the child’s record with this new information
+        session_programmes_form:
+          attributes:
+            programme_ids:
+              blank: Choose which programmes this session is part of
+              inclusion: You cannot remove a program from the session once it has been added
         vaccinate_form:
           attributes:
             delivery_site:
@@ -584,8 +589,6 @@ en:
               match_type: Vaccines must be suitable for the programme type
         session:
           attributes:
-            programme_ids:
-              blank: Choose which programmes this session is part of
             send_consent_requests_at:
               blank: Enter a date
               missing_day: Enter a day

--- a/spec/forms/session_programmes_form_spec.rb
+++ b/spec/forms/session_programmes_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe SessionProgrammesForm do
+  subject(:form) { described_class.new(session:, programme_ids:) }
+
+  let(:programmes) do
+    [create(:programme, :menacwy), create(:programme, :td_ipv)]
+  end
+
+  let(:session) { create(:session, programmes:) }
+  let(:programme_ids) { programmes.map(&:id) }
+
+  it { should be_valid }
+
+  it { should validate_presence_of(:programme_ids) }
+
+  context "when attempting to remove a programme" do
+    let(:programme_ids) { [programmes.first.id] }
+
+    it "is invalid" do
+      expect(form).to be_invalid
+      expect(form.errors[:programme_ids]).to include(
+        "You cannot remove a program from the session once it has been added"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Once a programme has been added to a session, it shouldn't be possible to remove the programme, to prevent a clinic risk where a programme is removed leading to double vaccination.

Although no data is lost when removing programmes, the data will stop appearing in the UI and in reports.