### PR TITLE
Show notify log entry programmes in activity log 

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -99,7 +99,7 @@ class AppActivityLogComponent < ViewComponent::Base
           at: consent_form.recorded_at,
           by:
             "#{consent_form.parent_full_name} (#{consent_form.parent_relationship_label})",
-          programme: consent.programme
+          programmes: [consent.programme]
         }
       else
         {
@@ -107,7 +107,7 @@ class AppActivityLogComponent < ViewComponent::Base
             "Consent #{original_response} by #{consent.name} (#{consent.who_responded})",
           at: consent.created_at,
           by: consent.recorded_by,
-          programme: consent.programme
+          programmes: [consent.programme]
         }
       end
 
@@ -116,7 +116,7 @@ class AppActivityLogComponent < ViewComponent::Base
           title: "Consent response manually matched with child record",
           at: consent.created_at,
           by: consent.recorded_by,
-          programme: consent.programme
+          programmes: [consent.programme]
         }
       end
 
@@ -124,7 +124,7 @@ class AppActivityLogComponent < ViewComponent::Base
         events << {
           title: "Consent from #{consent.name} invalidated",
           at: consent.invalidated_at,
-          programme: consent.programme
+          programmes: [consent.programme]
         }
       end
 
@@ -132,7 +132,7 @@ class AppActivityLogComponent < ViewComponent::Base
         events << {
           title: "Consent from #{consent.name} withdrawn",
           at: consent.withdrawn_at,
-          programme: consent.programme
+          programmes: [consent.programme]
         }
       end
 
@@ -157,7 +157,7 @@ class AppActivityLogComponent < ViewComponent::Base
         body: gillick_assessment.notes,
         at: gillick_assessment.created_at,
         by: gillick_assessment.performed_by,
-        programme: gillick_assessment.programme
+        programmes: [gillick_assessment.programme]
       }
     end
   end
@@ -203,7 +203,7 @@ class AppActivityLogComponent < ViewComponent::Base
         body: triage.notes,
         at: triage.created_at,
         by: triage.performed_by,
-        programme: triage.programme
+        programmes: [triage.programme]
       }
     end
   end
@@ -222,7 +222,7 @@ class AppActivityLogComponent < ViewComponent::Base
         body: vaccination_record.notes,
         at: vaccination_record.performed_at,
         by: vaccination_record.performed_by,
-        programme: vaccination_record.programme
+        programmes: [vaccination_record.programme]
       }
 
       discarded =
@@ -231,7 +231,7 @@ class AppActivityLogComponent < ViewComponent::Base
             title:
               "#{vaccination_record.programme.name} vaccination record deleted",
             at: vaccination_record.discarded_at,
-            programme: vaccination_record.programme
+            programmes: [vaccination_record.programme]
           }
         end
 

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -31,16 +31,12 @@ class AppActivityLogComponent < ViewComponent::Base
       @patient.consents.includes(
         :consent_form,
         :parent,
-        :programme,
         :recorded_by,
         patient: :parent_relationships
       )
 
     @gillick_assessments =
-      (patient || patient_session).gillick_assessments.includes(
-        :performed_by,
-        :programme
-      )
+      (patient || patient_session).gillick_assessments.includes(:performed_by)
 
     @notify_log_entries = @patient.notify_log_entries.includes(:sent_by)
 
@@ -50,12 +46,11 @@ class AppActivityLogComponent < ViewComponent::Base
     @session_attendances =
       (patient || patient_session).session_attendances.includes(:location)
 
-    @triages = @patient.triages.includes(:performed_by, :programme)
+    @triages = @patient.triages.includes(:performed_by)
 
     @vaccination_records =
       @patient.vaccination_records.with_discarded.includes(
         :performed_by_user,
-        :programme,
         :vaccine
       )
   end
@@ -99,7 +94,7 @@ class AppActivityLogComponent < ViewComponent::Base
           at: consent_form.recorded_at,
           by:
             "#{consent_form.parent_full_name} (#{consent_form.parent_relationship_label})",
-          programmes: [consent.programme]
+          programmes: programmes_for(consent)
         }
       else
         {
@@ -107,7 +102,7 @@ class AppActivityLogComponent < ViewComponent::Base
             "Consent #{original_response} by #{consent.name} (#{consent.who_responded})",
           at: consent.created_at,
           by: consent.recorded_by,
-          programmes: [consent.programme]
+          programmes: programmes_for(consent)
         }
       end
 
@@ -116,7 +111,7 @@ class AppActivityLogComponent < ViewComponent::Base
           title: "Consent response manually matched with child record",
           at: consent.created_at,
           by: consent.recorded_by,
-          programmes: [consent.programme]
+          programmes: programmes_for(consent)
         }
       end
 
@@ -124,7 +119,7 @@ class AppActivityLogComponent < ViewComponent::Base
         events << {
           title: "Consent from #{consent.name} invalidated",
           at: consent.invalidated_at,
-          programmes: [consent.programme]
+          programmes: programmes_for(consent)
         }
       end
 
@@ -132,7 +127,7 @@ class AppActivityLogComponent < ViewComponent::Base
         events << {
           title: "Consent from #{consent.name} withdrawn",
           at: consent.withdrawn_at,
-          programmes: [consent.programme]
+          programmes: programmes_for(consent)
         }
       end
 
@@ -157,7 +152,7 @@ class AppActivityLogComponent < ViewComponent::Base
         body: gillick_assessment.notes,
         at: gillick_assessment.created_at,
         by: gillick_assessment.performed_by,
-        programmes: [gillick_assessment.programme]
+        programmes: programmes_for(gillick_assessment)
       }
     end
   end
@@ -169,7 +164,8 @@ class AppActivityLogComponent < ViewComponent::Base
         body:
           patient.restricted? ? "" : notify_log_entry.recipient_deterministic,
         at: notify_log_entry.created_at,
-        by: notify_log_entry.sent_by
+        by: notify_log_entry.sent_by,
+        programmes: programmes_for(notify_log_entry)
       }
     end
   end
@@ -203,7 +199,7 @@ class AppActivityLogComponent < ViewComponent::Base
         body: triage.notes,
         at: triage.created_at,
         by: triage.performed_by,
-        programmes: [triage.programme]
+        programmes: programmes_for(triage)
       }
     end
   end
@@ -222,7 +218,7 @@ class AppActivityLogComponent < ViewComponent::Base
         body: vaccination_record.notes,
         at: vaccination_record.performed_at,
         by: vaccination_record.performed_by,
-        programmes: [vaccination_record.programme]
+        programmes: programmes_for(vaccination_record)
       }
 
       discarded =
@@ -230,7 +226,7 @@ class AppActivityLogComponent < ViewComponent::Base
           {
             title: "Vaccination record deleted",
             at: vaccination_record.discarded_at,
-            programmes: [vaccination_record.programme]
+            programmes: programmes_for(vaccination_record)
           }
         end
 
@@ -253,5 +249,14 @@ class AppActivityLogComponent < ViewComponent::Base
 
       { title:, at: session_attendance.created_at }
     end
+  end
+
+  def programmes_for(object)
+    ids = object.try(:programme_ids) || [object.try(:programme_id)].compact
+    ids.map { programmes_by_id.fetch(it) }
+  end
+
+  def programmes_by_id
+    @programmes_by_id ||= Programme.all.index_by(&:id)
   end
 end

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -212,9 +212,9 @@ class AppActivityLogComponent < ViewComponent::Base
     vaccination_records.flat_map do |vaccination_record|
       title =
         if vaccination_record.administered?
-          "Vaccinated with #{helpers.vaccine_heading(vaccination_record.vaccine)}"
+          "Vaccinated with #{vaccination_record.vaccine.brand}"
         else
-          "#{vaccination_record.programme.name} vaccination not given: #{vaccination_record.human_enum_name(:outcome)}"
+          "Vaccination not given: #{vaccination_record.human_enum_name(:outcome)}"
         end
 
       kept = {
@@ -228,8 +228,7 @@ class AppActivityLogComponent < ViewComponent::Base
       discarded =
         if vaccination_record.discarded?
           {
-            title:
-              "#{vaccination_record.programme.name} vaccination record deleted",
+            title: "Vaccination record deleted",
             at: vaccination_record.discarded_at,
             programmes: [vaccination_record.programme]
           }

--- a/app/components/app_log_event_component.rb
+++ b/app/components/app_log_event_component.rb
@@ -17,8 +17,8 @@ class AppLogEventComponent < ViewComponent::Base
     <% end %>
     
     <p class="nhsuk-body-s nhsuk-u-margin-0 nhsuk-u-secondary-text-color">
-      <% if programme %>
-        <%= render AppProgrammeTagsComponent.new([programme]) %>
+      <% if programmes.any? %>
+        <%= render AppProgrammeTagsComponent.new(programmes) %>
         &nbsp;
       <% end %>
       <%= invalidated ? tag.s(subtitle) : subtitle %>
@@ -34,7 +34,7 @@ class AppLogEventComponent < ViewComponent::Base
     at:,
     body: nil,
     by: nil,
-    programme: nil,
+    programmes: [],
     invalidated: false,
     card: false
   )
@@ -44,14 +44,14 @@ class AppLogEventComponent < ViewComponent::Base
     @body = body
     @at = at.to_fs(:long)
     @by = by.respond_to?(:full_name) ? by.full_name : by
-    @programme = programme
+    @programmes = programmes
     @invalidated = invalidated
     @card = card
   end
 
   private
 
-  attr_reader :title, :body, :programme, :invalidated, :card
+  attr_reader :title, :body, :programmes, :invalidated, :card
 
   def subtitle
     safe_join([@at, @by].compact, " &middot; ".html_safe)

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -61,6 +61,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
       delivery_id:,
       parent: personalisation.parent,
       patient: personalisation.patient,
+      programme_ids: personalisation.programmes.map(&:id),
       recipient: email_address,
       recipient_deterministic: email_address,
       sent_by:,

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -53,6 +53,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
       delivery_id:,
       parent: personalisation.parent,
       patient: personalisation.patient,
+      programme_ids: personalisation.programmes.map(&:id),
       recipient: phone_number,
       recipient_deterministic: phone_number,
       sent_by:,

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -15,22 +15,27 @@ class SMSDeliveryJob < NotifyDeliveryJob
     template_id = GOVUK_NOTIFY_SMS_TEMPLATES[template_name.to_sym]
     raise UnknownTemplate if template_id.nil?
 
-    parent ||= consent&.parent
-
-    phone_number = consent_form&.parent_phone || parent&.phone
-    return if phone_number.nil?
-
     personalisation =
-      GovukNotifyPersonalisation.call(
+      GovukNotifyPersonalisation.new(
         session:,
         consent:,
         consent_form:,
+        parent:,
         patient:,
         programmes:,
         vaccination_record:
       )
 
-    args = { personalisation:, phone_number:, template_id: }
+    phone_number =
+      personalisation.consent_form&.parent_phone ||
+        personalisation.parent&.phone
+    return if phone_number.nil?
+
+    args = {
+      personalisation: personalisation.to_h,
+      phone_number:,
+      template_id:
+    }
 
     delivery_id =
       if self.class.send_via_notify?
@@ -43,13 +48,11 @@ class SMSDeliveryJob < NotifyDeliveryJob
         nil
       end
 
-    patient ||= consent&.patient || vaccination_record&.patient
-
     NotifyLogEntry.create!(
-      consent_form:,
+      consent_form: personalisation.consent_form,
       delivery_id:,
-      parent:,
-      patient:,
+      parent: personalisation.parent,
+      patient: personalisation.patient,
       recipient: phone_number,
       recipient_deterministic: phone_number,
       sent_by:,

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -6,6 +6,7 @@ class GovukNotifyPersonalisation
   def initialize(
     consent: nil,
     consent_form: nil,
+    parent: nil,
     patient: nil,
     programmes: nil,
     session: nil,
@@ -13,10 +14,11 @@ class GovukNotifyPersonalisation
   )
     @consent = consent
     @consent_form = consent_form
+    @parent = parent || consent&.parent
     @patient = patient || consent&.patient || vaccination_record&.patient
     @programmes =
-      programmes || [vaccination_record&.programme] ||
-        consent_form&.programmes || [consent&.programme]
+      programmes.presence || consent_form&.programmes.presence ||
+        [consent&.programme || vaccination_record&.programme].compact
     @session =
       session || consent_form&.actual_session ||
         consent_form&.original_session || vaccination_record&.session
@@ -27,7 +29,7 @@ class GovukNotifyPersonalisation
     @vaccination_record = vaccination_record
   end
 
-  def call
+  def to_h
     {
       batch_name:,
       catch_up:,
@@ -61,22 +63,17 @@ class GovukNotifyPersonalisation
     }.compact
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
-  end
-
-  private_class_method :new
-
-  private
-
   attr_reader :consent,
               :consent_form,
+              :parent,
               :patient,
               :programmes,
               :session,
               :team,
               :organisation,
               :vaccination_record
+
+  private
 
   def batch_name
     vaccination_record&.batch&.name

--- a/app/models/notify_log_entry.rb
+++ b/app/models/notify_log_entry.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  delivery_status         :integer          default("sending"), not null
+#  programme_ids           :integer          default([]), not null, is an Array
 #  recipient               :string
 #  recipient_deterministic :string
 #  type                    :integer          not null

--- a/db/migrate/20250225161342_add_programme_i_ds_to_notify_log_entries.rb
+++ b/db/migrate/20250225161342_add_programme_i_ds_to_notify_log_entries.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddProgrammeIDsToNotifyLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notify_log_entries,
+               :programme_ids,
+               :integer,
+               array: true,
+               default: [],
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_24_221219) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_25_161342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -476,6 +476,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_24_221219) do
     t.bigint "parent_id"
     t.string "recipient_deterministic"
     t.string "recipient"
+    t.integer "programme_ids", default: [], null: false, array: true
     t.index ["consent_form_id"], name: "index_notify_log_entries_on_consent_form_id"
     t.index ["delivery_id"], name: "index_notify_log_entries_on_delivery_id"
     t.index ["parent_id"], name: "index_notify_log_entries_on_parent_id"

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -105,7 +105,7 @@ describe AppActivityLogComponent do
         performed_at: Time.zone.parse("2024-05-31 13:00"),
         performed_by: nil,
         notes: "Some notes",
-        vaccine: create(:vaccine, :gardasil, programme:)
+        vaccine: create(:vaccine, :cervarix, programme:)
       )
 
       create(
@@ -139,14 +139,14 @@ describe AppActivityLogComponent do
     end
 
     include_examples "card",
-                     title: "Vaccinated with Gardasil 9 (HPV)",
+                     title: "Vaccinated with Gardasil 9",
                      date: "31 May 2024 at 12:00pm",
                      notes: "Some notes",
                      by: "Nurse Joy",
                      programme: "HPV"
 
     include_examples "card",
-                     title: "Vaccinated with Gardasil (HPV)",
+                     title: "Vaccinated with Cervarix",
                      date: "31 May 2024 at 1:00pm",
                      notes: "Some notes",
                      programme: "HPV"
@@ -202,7 +202,7 @@ describe AppActivityLogComponent do
     end
 
     include_examples "card",
-                     title: "HPV vaccination not given: Unwell",
+                     title: "Vaccination not given: Unwell",
                      date: "31 May 2024 at 1:00pm",
                      notes: "Some notes.",
                      by: "Nurse Joy",
@@ -224,13 +224,13 @@ describe AppActivityLogComponent do
     end
 
     include_examples "card",
-                     title: "Vaccinated with Gardasil 9 (HPV)",
+                     title: "Vaccinated with Gardasil 9",
                      date: "31 May 2024 at 1:00pm",
                      by: "Nurse Joy",
                      programme: "HPV"
 
     include_examples "card",
-                     title: "HPV vaccination record deleted",
+                     title: "Vaccination record deleted",
                      date: "31 May 2024 at 2:00pm",
                      programme: "HPV"
   end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -112,8 +112,9 @@ describe AppActivityLogComponent do
         :notify_log_entry,
         :email,
         template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[:consent_school_request_hpv],
-        patient:,
         consent_form: nil,
+        patient:,
+        programme_ids: [programme.id],
         recipient: "test@example.com",
         created_at: Date.new(2024, 5, 10),
         sent_by: user
@@ -183,7 +184,8 @@ describe AppActivityLogComponent do
                      title: "Consent school request hpv sent",
                      date: "10 May 2024 at 12:00am",
                      notes: "test@example.com",
-                     by: "Nurse Joy"
+                     by: "Nurse Joy",
+                     programme: "HPV"
   end
 
   describe "vaccination not administered" do

--- a/spec/factories/notify_log_entries.rb
+++ b/spec/factories/notify_log_entries.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  delivery_status         :integer          default("sending"), not null
+#  programme_ids           :integer          default([]), not null, is an Array
 #  recipient               :string
 #  recipient_deterministic :string
 #  type                    :integer          not null

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -208,7 +208,7 @@ describe "Delete vaccination record" do
 
   def then_i_see_the_delete_vaccination
     expect(page).to have_content("Vaccinated with Gardasil 9")
-    expect(page).to have_content("HPV vaccination record deleted")
+    expect(page).to have_content("Vaccination record deleted")
   end
 
   def and_the_parent_receives_an_email

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -80,7 +80,7 @@ describe "Parental consent" do
     click_on "Activity log"
     expect(page).to have_content(
       "Consent clinic request sent\n#{@parent.email}\n" \
-        "1 January 2024 at 12:00am · Test User"
+        "HPV   1 January 2024 at 12:00am · Test User"
     )
   end
 
@@ -88,7 +88,7 @@ describe "Parental consent" do
     click_on "Activity log"
     expect(page).to have_content(
       "Consent clinic request sent\n#{@parent.phone}\n" \
-        "1 January 2024 at 12:00am · Test User"
+        "HPV   1 January 2024 at 12:00am · Test User"
     )
   end
 end

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -60,14 +60,15 @@ describe EmailDeliveryJob do
     let(:vaccination_record) { nil }
 
     it "generates personalisation" do
-      expect(GovukNotifyPersonalisation).to receive(:call).with(
+      expect(GovukNotifyPersonalisation).to receive(:new).with(
         session:,
         consent:,
         consent_form:,
+        parent:,
         patient:,
         programmes:,
         vaccination_record:
-      )
+      ).and_call_original
       perform_now
     end
 

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -49,9 +49,7 @@ describe EmailDeliveryJob do
         programmes:
       )
     end
-    let(:session) do
-      create(:session, programme: programmes.first, organisation:)
-    end
+    let(:session) { create(:session, programmes:, organisation:) }
     let(:parent) { create(:parent, email: "test@example.com") }
     let(:consent) { nil }
     let(:consent_form) { nil }
@@ -108,6 +106,7 @@ describe EmailDeliveryJob do
       )
       expect(notify_log_entry.parent).to eq(parent)
       expect(notify_log_entry.patient).to eq(patient)
+      expect(notify_log_entry.programme_ids).to eq(programmes.map(&:id))
       expect(notify_log_entry.sent_by).to eq(sent_by)
     end
 
@@ -164,6 +163,7 @@ describe EmailDeliveryJob do
           GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name]
         )
         expect(notify_log_entry.consent_form).to eq(consent_form)
+        expect(notify_log_entry.programme_ids).to eq(programmes.map(&:id))
       end
 
       context "when the parent doesn't have a phone number" do

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -85,6 +85,7 @@ describe SMSDeliveryJob do
       )
       expect(notify_log_entry.parent).to eq(parent)
       expect(notify_log_entry.patient).to eq(patient)
+      expect(notify_log_entry.programme_ids).to eq(programmes.map(&:id))
       expect(notify_log_entry.sent_by).to eq(sent_by)
     end
 
@@ -125,6 +126,7 @@ describe SMSDeliveryJob do
           GOVUK_NOTIFY_SMS_TEMPLATES[template_name]
         )
         expect(notify_log_entry.consent_form).to eq(consent_form)
+        expect(notify_log_entry.programme_ids).to eq(programmes.map(&:id))
       end
 
       context "when the parent doesn't have a phone number" do

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -51,14 +51,15 @@ describe SMSDeliveryJob do
     let(:vaccination_record) { nil }
 
     it "generates personalisation" do
-      expect(GovukNotifyPersonalisation).to receive(:call).with(
+      expect(GovukNotifyPersonalisation).to receive(:new).with(
         session:,
         consent:,
         consent_form:,
+        parent:,
         patient:,
         programmes:,
         vaccination_record:
-      )
+      ).and_call_original
       perform_now
     end
 

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 describe GovukNotifyPersonalisation do
-  subject(:personalisation) do
-    described_class.call(
+  subject(:to_h) do
+    described_class.new(
       patient:,
       session:,
       consent:,
       consent_form:,
       programmes:,
       vaccination_record:
-    )
+    ).to_h
   end
 
   let(:programmes) { [create(:programme, :hpv)] }
@@ -47,7 +47,7 @@ describe GovukNotifyPersonalisation do
   let(:vaccination_record) { nil }
 
   it do
-    expect(personalisation).to eq(
+    expect(to_h).to eq(
       {
         catch_up: "no",
         consent_deadline: "Wednesday 31 December",
@@ -99,7 +99,7 @@ describe GovukNotifyPersonalisation do
     before { session.session_dates.create!(value: Date.new(2026, 1, 2)) }
 
     it do
-      expect(personalisation).to match(
+      expect(to_h).to match(
         hash_including(
           consent_deadline: "Wednesday 31 December",
           next_session_date: "Thursday 1 January",
@@ -115,7 +115,7 @@ describe GovukNotifyPersonalisation do
       around { |example| travel_to(Date.new(2026, 1, 1)) { example.run } }
 
       it do
-        expect(personalisation).to match(
+        expect(to_h).to match(
           hash_including(consent_deadline: "Thursday 1 January")
         )
       end
@@ -133,7 +133,7 @@ describe GovukNotifyPersonalisation do
     end
 
     it do
-      expect(personalisation).to match(
+      expect(to_h).to match(
         hash_including(
           reason_for_refusal: "of personal choice",
           survey_deadline_date: "8 January 2024"
@@ -153,7 +153,7 @@ describe GovukNotifyPersonalisation do
     end
 
     it do
-      expect(personalisation).to include(
+      expect(to_h).to include(
         reason_for_refusal: "of personal choice",
         survey_deadline_date: "8 January 2024",
         location_name: "Hogwarts"
@@ -205,7 +205,7 @@ describe GovukNotifyPersonalisation do
     end
 
     it do
-      expect(personalisation).to match(
+      expect(to_h).to match(
         hash_including(
           day_month_year_of_vaccination: "01/01/2024",
           reason_did_not_vaccinate: "the nurse decided John was not well",

--- a/spec/models/notify_log_entry_spec.rb
+++ b/spec/models/notify_log_entry_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                      :bigint           not null, primary key
 #  delivery_status         :integer          default("sending"), not null
+#  programme_ids           :integer          default([]), not null, is an Array
 #  recipient               :string
 #  recipient_deterministic :string
 #  type                    :integer          not null


### PR DESCRIPTION
When rendering the emails and text messages that have been sent for a particular patient, we can now show the programmes associated with that email or text message.

To implement this I've created a cache of programmes which can be used across all the activity log entries to avoid needing multiple queries each time and for each type of record.