### PR TITLE
Avoid duplicate TIME_OF_VACCINATION errors

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -106,10 +106,8 @@ class ImmunisationImportRow
             },
             comparison: {
               less_than_or_equal_to: -> { Time.current },
-              if: -> do
-                @data["TIME_OF_VACCINATION"]&.strip.present? &&
-                  date_of_vaccination == Date.current
-              end
+              if: -> { date_of_vaccination == Date.current },
+              allow_nil: true
             }
   validate :date_matches_session
   validate :uuid_exists


### PR DESCRIPTION
The comparison check is also checking for the presence of a value, but since the conditions are the same, we can split them up in to two separate checks, and only perform the comparison check if there's a value.