### PR TITLE
Refactor session factory

### DIFF
--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -5,8 +5,8 @@ describe AppActivityLogComponent do
 
   let(:component) { described_class.new(patient_session:) }
 
-  let(:programme) { create(:programme, :hpv) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme, :hpv)] }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:patient_session) do
     create(
       :patient_session,
@@ -19,7 +19,7 @@ describe AppActivityLogComponent do
     create(:user, organisation:, family_name: "Joy", given_name: "Nurse")
   end
   let(:location) { create(:school, name: "Hogwarts") }
-  let(:session) { create(:session, programme:, location:) }
+  let(:session) { create(:session, programmes:, location:) }
   let(:patient) do
     create(:patient, school: location, given_name: "Sarah", family_name: "Doe")
   end
@@ -54,7 +54,7 @@ describe AppActivityLogComponent do
       create(
         :consent,
         :given,
-        programme:,
+        programme: programmes.first,
         patient:,
         parent: mum,
         created_at: Time.zone.parse("2024-05-30 12:00"),
@@ -63,7 +63,7 @@ describe AppActivityLogComponent do
       create(
         :consent,
         :refused,
-        programme:,
+        programme: programmes.first,
         patient:,
         parent: dad,
         created_at: Time.zone.parse("2024-05-30 13:00")
@@ -72,7 +72,7 @@ describe AppActivityLogComponent do
       create(
         :triage,
         :needs_follow_up,
-        programme:,
+        programme: programmes.first,
         patient:,
         created_at: Time.zone.parse("2024-05-30 14:00"),
         notes: "Some notes",
@@ -81,7 +81,7 @@ describe AppActivityLogComponent do
       create(
         :triage,
         :ready_to_vaccinate,
-        programme:,
+        programme: programmes.first,
         patient:,
         created_at: Time.zone.parse("2024-05-30 14:30"),
         performed_by: user
@@ -89,7 +89,7 @@ describe AppActivityLogComponent do
 
       create(
         :vaccination_record,
-        programme:,
+        programme: programmes.first,
         patient:,
         session:,
         performed_at: Time.zone.parse("2024-05-31 12:00"),
@@ -99,13 +99,13 @@ describe AppActivityLogComponent do
 
       create(
         :vaccination_record,
-        programme:,
+        programme: programmes.first,
         patient:,
         session:,
         performed_at: Time.zone.parse("2024-05-31 13:00"),
         performed_by: nil,
         notes: "Some notes",
-        vaccine: create(:vaccine, :cervarix, programme:)
+        vaccine: create(:vaccine, :cervarix, programme: programmes.first)
       )
 
       create(
@@ -114,7 +114,7 @@ describe AppActivityLogComponent do
         template_id: GOVUK_NOTIFY_EMAIL_TEMPLATES[:consent_school_request_hpv],
         consent_form: nil,
         patient:,
-        programme_ids: [programme.id],
+        programme_ids: programmes.map(&:id),
         recipient: "test@example.com",
         created_at: Date.new(2024, 5, 10),
         sent_by: user
@@ -193,13 +193,13 @@ describe AppActivityLogComponent do
       create(
         :vaccination_record,
         :not_administered,
-        programme:,
+        programme: programmes.first,
         patient:,
         session:,
         performed_at: Time.zone.local(2024, 5, 31, 13),
         performed_by: user,
         notes: "Some notes.",
-        vaccine: create(:vaccine, :gardasil, programme:)
+        vaccine: create(:vaccine, :gardasil, programme: programmes.first)
       )
     end
 
@@ -216,7 +216,7 @@ describe AppActivityLogComponent do
       create(
         :vaccination_record,
         :discarded,
-        programme:,
+        programme: programmes.first,
         patient:,
         session:,
         performed_at: Time.zone.local(2024, 5, 31, 13),
@@ -243,7 +243,7 @@ describe AppActivityLogComponent do
         :consent,
         :given,
         :self_consent,
-        programme:,
+        programme: programmes.first,
         patient:,
         created_at: Time.zone.parse("2024-05-30 12:00")
       )
@@ -271,7 +271,7 @@ describe AppActivityLogComponent do
         :consent,
         :given,
         :invalidated,
-        programme:,
+        programme: programmes.first,
         patient:,
         parent: mum,
         consent_form:,
@@ -299,7 +299,7 @@ describe AppActivityLogComponent do
         :consent,
         :given,
         :withdrawn,
-        programme:,
+        programme: programmes.first,
         patient:,
         parent: mum,
         created_at: Time.zone.local(2024, 5, 30, 12),
@@ -324,7 +324,7 @@ describe AppActivityLogComponent do
         :consent,
         :given,
         :invalidated,
-        programme:,
+        programme: programmes.first,
         patient:,
         parent: mum,
         created_at: Time.zone.local(2024, 5, 30, 12),
@@ -344,10 +344,8 @@ describe AppActivityLogComponent do
   end
 
   describe "gillick assessments" do
-    let(:programme) { create(:programme, :td_ipv) }
-    let(:patient_session) do
-      create(:patient_session, patient:, programmes: [programme])
-    end
+    let(:programmes) { [create(:programme, :td_ipv)] }
+    let(:patient_session) { create(:patient_session, patient:, programmes:) }
 
     before do
       create(
@@ -385,9 +383,7 @@ describe AppActivityLogComponent do
   end
 
   describe "pre-screenings" do
-    let(:patient_session) do
-      create(:patient_session, patient:, programmes: [programme])
-    end
+    let(:patient_session) { create(:patient_session, patient:, programmes:) }
 
     before do
       create(

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -15,7 +15,9 @@ describe AppConsentConfirmationComponent do
   end
 
   context "consent for only MenACWY" do
-    let(:session) { create(:session, programme: create(:programme, :menacwy)) }
+    let(:session) do
+      create(:session, programmes: [create(:programme, :menacwy)])
+    end
     let(:consent_form) do
       create(
         :consent_form,

--- a/spec/components/app_consent_patient_summary_component_spec.rb
+++ b/spec/components/app_consent_patient_summary_component_spec.rb
@@ -13,7 +13,7 @@ describe AppConsentPatientSummaryComponent do
   end
   let(:school) { create(:school, name: "Waterloo Road", organisation:) }
   let(:session) do
-    create(:session, programme:, organisation:, location: school)
+    create(:session, programmes: [programme], organisation:, location: school)
   end
   let(:consent_form) { nil }
   let(:patient) { create(:patient) }

--- a/spec/components/app_imports_table_component_spec.rb
+++ b/spec/components/app_imports_table_component_spec.rb
@@ -5,10 +5,10 @@ describe AppImportsTableComponent do
 
   let(:component) { described_class.new(organisation:) }
 
-  let(:programme) { create(:programme) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme)] }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:school) { create(:school, organisation:, name: "Test School") }
-  let(:session) { create(:session, programme:, location: school) }
+  let(:session) { create(:session, programmes:, location: school) }
 
   before do
     cohort_imports =
@@ -42,7 +42,7 @@ describe AppImportsTableComponent do
       create(
         :vaccination_record,
         organisation:,
-        programme:,
+        programme: programmes.first,
         immunisation_imports: [immunisation_import]
       )
     end

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -33,7 +33,7 @@ describe AppPatientVaccinationTableComponent do
         address_postcode: "SE1 8TY"
       )
     end
-    let(:session) { create(:session, location:, programme:) }
+    let(:session) { create(:session, location:, programmes: [programme]) }
     let(:vaccination_record) do
       create(
         :vaccination_record,

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -7,8 +7,10 @@ describe AppProgrammeSessionTableComponent do
 
   let(:programme) { create(:programme) }
   let(:location) { create(:school, name: "Waterloo Road") }
-  let(:session) { create(:session, programme:, location:) }
-  let(:sessions) { [session] + create_list(:session, 2, programme:) }
+  let(:session) { create(:session, programmes: [programme], location:) }
+  let(:sessions) do
+    [session] + create_list(:session, 2, programmes: [programme])
+  end
   let(:patient) { create(:patient, session:) }
 
   before do

--- a/spec/components/app_session_summary_component_spec.rb
+++ b/spec/components/app_session_summary_component_spec.rb
@@ -5,15 +5,15 @@ describe AppSessionSummaryComponent do
 
   let(:component) { described_class.new(session) }
 
-  let(:programme) { create(:programme, :hpv) }
+  let(:programmes) { [create(:programme, :hpv)] }
   let(:location) { create(:school) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:session) do
     create(
       :session,
       location:,
       date: Date.new(2024, 1, 1),
-      programme:,
+      programmes:,
       organisation:
     )
   end
@@ -49,7 +49,7 @@ describe AppSessionSummaryComponent do
 
   context "when consent is open" do
     let(:session) do
-      create(:session, location:, date: 1.week.from_now.to_date, programme:)
+      create(:session, location:, date: 1.week.from_now.to_date, programmes:)
     end
 
     it { should have_content("Consent link") }

--- a/spec/components/app_session_table_component_spec.rb
+++ b/spec/components/app_session_table_component_spec.rb
@@ -5,7 +5,7 @@ describe AppSessionTableComponent do
 
   let(:component) { described_class.new(sessions) }
 
-  let(:programme) { create(:programme, :hpv) }
+  let(:programmes) { [create(:programme, :hpv)] }
   let(:sessions) do
     [
       create(
@@ -13,10 +13,10 @@ describe AppSessionTableComponent do
         academic_year: 2024,
         date: Date.new(2024, 10, 1),
         location: create(:school, name: "Waterloo Road"),
-        programme:
+        programmes:
       ),
-      create(:session, programme:)
-    ] + create_list(:session, 8, programme:)
+      create(:session, programmes:)
+    ] + create_list(:session, 8, programmes:)
   end
 
   before do

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -11,7 +11,9 @@ describe AppVaccinationRecordSummaryComponent do
   let(:location) { create(:school, name: "Hogwarts") }
   let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:session) { create(:session, programme:, location:, organisation:) }
+  let(:session) do
+    create(:session, programmes: [programme], location:, organisation:)
+  end
   let(:patient) { create(:patient) }
   let(:vaccine) { programme.vaccines.first }
   let(:batch) do

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -21,7 +21,8 @@ describe AppVaccinationRecordTableComponent do
             date_of_birth: Date.new(2000, 5, 28),
             address_postcode: "SW1A 2AA"
           ),
-        session: create(:session, programme:, date: Date.new(2020, 9, 1))
+        session:
+          create(:session, programmes: [programme], date: Date.new(2020, 9, 1))
       )
     ] + create_list(:vaccination_record, 4, programme:) +
       create_list(:vaccination_record, 5, :not_administered, programme:)

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -64,6 +64,6 @@ class AppConsentComponentPreview < ViewComponent::Preview
         :hpv,
         organisation: Organisation.first || create(:organisation)
       )
-    @session = create(:session, programme:)
+    @session = create(:session, programmes: [@programme])
   end
 end

--- a/spec/components/previews/app_health_questions_component_preview.rb
+++ b/spec/components/previews/app_health_questions_component_preview.rb
@@ -73,6 +73,6 @@ class AppHealthQuestionsComponentPreview < ViewComponent::Preview
         :hpv,
         organisation: Organisation.first || create(:organisation)
       )
-    @session = create(:session, programme:)
+    @session = create(:session, programmes: [@programme])
   end
 end

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -107,15 +107,15 @@ describe ConsentFormMailerConcern do
     end
 
     context "when there are no upcoming sessions" do
-      let(:programme) { create(:programme) }
-      let(:organisation) { create(:organisation, programmes: [programme]) }
+      let(:programmes) { [create(:programme)] }
+      let(:organisation) { create(:organisation, programmes:) }
       let(:consent_form) do
         create(
           :consent_form,
           organisation:,
           school_confirmed: false,
           school: create(:school, organisation:),
-          session: create(:session, organisation:, programme:)
+          session: create(:session, organisation:, programmes:)
         )
       end
 

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -25,7 +25,7 @@ describe VaccinationMailerConcern do
     end
 
     let(:programme) { create(:programme) }
-    let(:session) { create(:session, programme:) }
+    let(:session) { create(:session, programmes: [programme]) }
     let(:parent) { create(:parent) }
     let(:patient) { create(:patient, parents: [parent], session:) }
     let(:vaccination_record) do

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -29,14 +29,13 @@ FactoryBot.define do
     transient do
       date { Date.current }
       dates { [] }
-      programme { association :programme }
       team { association(:team, organisation:) }
     end
 
     sequence(:slug) { |n| "session-#{n}" }
 
     academic_year { (date || Date.current).academic_year }
-    programmes { [programme] }
+    programmes { [association(:programme)] }
     organisation { association(:organisation, programmes:) }
     location { association :school, team: }
 

--- a/spec/features/access_log_spec.rb
+++ b/spec/features/access_log_spec.rb
@@ -30,13 +30,12 @@ describe "Access log" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
 
     @user = organisation.users.first
 
-    @session = create(:session, organisation:, programme:)
+    @session = create(:session, organisation:, programmes:)
     @patient =
       create(
         :patient,

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -45,9 +45,10 @@ describe "End-to-end journey" do
   end
 
   def given_an_hpv_programme_is_underway
-    @programme = create(:programme, :hpv)
+    programme = create(:programme, :hpv)
+
     @organisation =
-      create(:organisation, :with_one_nurse, programmes: [@programme])
+      create(:organisation, :with_one_nurse, programmes: [programme])
     @school =
       create(
         :school,
@@ -60,14 +61,15 @@ describe "End-to-end journey" do
         :batch,
         expiry: Date.new(2024, 4, 1),
         organisation: @organisation,
-        vaccine: @programme.vaccines.first
+        vaccine: programme.vaccines.first
       )
+
     create(
       :session,
       :unscheduled,
       location: @school,
       organisation: @organisation,
-      programme: @programme
+      programmes: [programme]
     )
   end
 

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -266,7 +266,7 @@ describe "Edit vaccination record" do
         :session,
         :completed,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -78,7 +78,8 @@ describe "HPV vaccination" do
       build(:batch, :expired, organisation:, vaccine: @active_vaccine)
     @expired_batch.save!(validate: false)
 
-    @session = create(:session, organisation:, programme:, location:)
+    @session =
+      create(:session, organisation:, programmes: [programme], location:)
     @patient =
       create(
         :patient,

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -26,12 +26,12 @@ describe "HPV vaccination" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
     location = create(:school)
-    @batch = create(:batch, organisation:, vaccine: programme.vaccines.first)
-    @session = create(:session, organisation:, programme:, location:)
+    @batch =
+      create(:batch, organisation:, vaccine: programmes.first.vaccines.first)
+    @session = create(:session, organisation:, programmes:, location:)
     @patient =
       create(
         :patient,

--- a/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
@@ -10,11 +10,10 @@ describe "HPV vaccination" do
   end
 
   def given_i_am_signed_in_as_an_admin
-    programme = create(:programme, :hpv_all_vaccines)
-    organisation =
-      create(:organisation, :with_one_admin, programmes: [programme])
+    programmes = [create(:programme, :hpv_all_vaccines)]
+    organisation = create(:organisation, :with_one_admin, programmes:)
     location = create(:school)
-    @session = create(:session, organisation:, programme:, location:)
+    @session = create(:session, organisation:, programmes:, location:)
     @patient =
       create(:patient, :consent_given_triage_not_needed, session: @session)
 

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -43,7 +43,8 @@ describe "HPV vaccination" do
     active_vaccine = programme.vaccines.active.first
     @active_batch = create(:batch, organisation:, vaccine: active_vaccine)
 
-    @session = create(:session, organisation:, programme:, location:)
+    @session =
+      create(:session, organisation:, programmes: [programme], location:)
     @patient =
       create(
         :patient,

--- a/spec/features/hpv_vaccination_default_batch_spec.rb
+++ b/spec/features/hpv_vaccination_default_batch_spec.rb
@@ -32,7 +32,7 @@ describe "HPV vaccination" do
     @batch = batches.first
     @batch2 = batches.second
 
-    @session = create(:session, organisation:, programme:)
+    @session = create(:session, organisation:, programmes: [programme])
 
     @patient =
       create(

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -21,18 +21,19 @@ describe "HPV vaccination" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    @organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv)]
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
+
     location = create(:school)
     @batch =
       create(
         :batch,
         organisation: @organisation,
-        vaccine: programme.vaccines.first
+        vaccine: programmes.first.vaccines.first
       )
+
     @session =
-      create(:session, organisation: @organisation, programme:, location:)
+      create(:session, organisation: @organisation, programmes:, location:)
     @patient =
       create(
         :patient,

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -41,14 +41,10 @@ describe "HPV vaccination" do
   end
 
   def given_an_hpv_programme_is_underway(clinic: false)
-    programme = create(:programme, :hpv)
+    programmes = [create(:programme, :hpv)]
+
     @organisation =
-      create(
-        :organisation,
-        :with_one_nurse,
-        :with_generic_clinic,
-        programmes: [programme]
-      )
+      create(:organisation, :with_one_nurse, :with_generic_clinic, programmes:)
     school = create(:school)
     previous_date = 1.month.ago
 
@@ -65,7 +61,7 @@ describe "HPV vaccination" do
         )
     end
 
-    vaccine = programme.vaccines.active.first
+    vaccine = programmes.first.vaccines.active.first
     @batch = create(:batch, organisation: @organisation, vaccine:)
 
     create(:gp_practice, ods_code: "Y12345")
@@ -75,7 +71,7 @@ describe "HPV vaccination" do
         :session,
         :today,
         organisation: @organisation,
-        programme:,
+        programmes:,
         location: school
       )
 

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -13,16 +13,16 @@ describe "HPV vaccination" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv_all_vaccines)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv_all_vaccines)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
     location = create(:school)
 
-    programme.vaccines.discontinued.each do |vaccine|
-      create(:batch, organisation:, vaccine:)
-    end
+    Vaccine
+      .where(programme: programmes)
+      .discontinued
+      .each { |vaccine| create(:batch, organisation:, vaccine:) }
 
-    @session = create(:session, organisation:, programme:, location:)
+    @session = create(:session, organisation:, programmes:, location:)
     @patient =
       create(
         :patient,

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -56,19 +56,15 @@ describe "Child record imports duplicates" do
   end
 
   def and_an_hpv_programme_is_underway
-    @programme = create(:programme, :hpv)
-    create(
-      :organisation_programme,
-      organisation: @organisation,
-      programme: @programme
-    )
+    programme = create(:programme, :hpv, organisations: [@organisation])
+
     @school = create(:school, urn: "123456", organisation: @organisation)
     @session =
       create(
         :session,
         organisation: @organisation,
         location: @school,
-        programme: @programme
+        programmes: [programme]
       )
   end
 

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -31,7 +31,11 @@ describe "Import class lists - Moving patients" do
   end
 
   def given_an_hpv_programme_is_underway
-    @organisation = create(:organisation, :with_one_nurse)
+    programmes = [create(:programme, :hpv)]
+
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
+    @user = @organisation.users.first
+
     location =
       create(
         :school,
@@ -46,21 +50,20 @@ describe "Import class lists - Moving patients" do
         name: "Different Road",
         organisation: @organisation
       )
-    @user = @organisation.users.first
-    programme = create(:programme, :hpv, organisations: [@organisation])
+
     create(
       :session,
       :unscheduled,
       organisation: @organisation,
       location:,
-      programme:
+      programmes:
     )
     create(
       :session,
       :unscheduled,
       organisation: @organisation,
       location: other_location,
-      programme:
+      programmes:
     )
   end
 

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -41,7 +41,9 @@ describe "Import class lists" do
   end
 
   def given_an_hpv_programme_is_underway
-    @organisation = create(:organisation, :with_one_nurse)
+    programmes = [create(:programme, :hpv)]
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
+
     location =
       create(
         :school,
@@ -50,13 +52,13 @@ describe "Import class lists" do
         organisation: @organisation
       )
     @user = @organisation.users.first
-    programme = create(:programme, :hpv, organisations: [@organisation])
+
     create(
       :session,
       :unscheduled,
       organisation: @organisation,
       location:,
-      programme:
+      programmes:
     )
   end
 

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -49,12 +49,8 @@ describe "Class list imports duplicates" do
   end
 
   def and_an_hpv_programme_is_underway
-    @programme = create(:programme, :hpv)
-    create(
-      :organisation_programme,
-      organisation: @organisation,
-      programme: @programme
-    )
+    programmes = [create(:programme, :hpv, organisations: [@organisation])]
+
     @location =
       create(
         :school,
@@ -68,7 +64,7 @@ describe "Class list imports duplicates" do
         :unscheduled,
         organisation: @organisation,
         location: @location,
-        programme: @programme
+        programmes:
       )
   end
 

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -47,7 +47,12 @@ describe "Immunisation imports" do
       create(:programme, :hpv_all_vaccines, organisations: [@organisation])
     location = create(:school)
     @session =
-      create(:session, programme:, location:, organisation: @organisation)
+      create(
+        :session,
+        programmes: [programme],
+        location:,
+        organisation: @organisation
+      )
   end
 
   def and_school_locations_exist

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -52,7 +52,7 @@ describe "Immunisation imports duplicates" do
       create(
         :session,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location: @location,
         date: Date.new(2024, 5, 14)
       )

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -54,7 +54,7 @@ describe "Invalidate consent" do
     @programme = create(:programme, :hpv)
     organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    @session = create(:session, organisation:, programme: @programme)
+    @session = create(:session, organisation:, programmes: [@programme])
     @patient = create(:patient, session: @session)
 
     sign_in organisation.users.first

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -178,7 +178,7 @@ describe "Manage children" do
 
   def and_the_patient_belongs_to_a_session
     session =
-      create(:session, organisation: @organisation, programme: @programme)
+      create(:session, organisation: @organisation, programmes: [@programme])
     create(:patient_session, session:, patient: @patient)
   end
 

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -88,7 +88,7 @@ describe "Manage school sessions" do
         :unscheduled,
         location: @location,
         organisation: @organisation,
-        programme: @programme
+        programmes: [@programme]
       )
 
     @parent = create(:parent)

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -81,7 +81,8 @@ describe "MenACWY vaccination" do
       build(:batch, :expired, organisation:, vaccine: @active_vaccine)
     @expired_batch.save!(validate: false)
 
-    @session = create(:session, organisation:, programme:, location:)
+    @session =
+      create(:session, organisation:, programmes: [programme], location:)
     @patient =
       create(
         :patient,

--- a/spec/features/paper_consent_download_spec.rb
+++ b/spec/features/paper_consent_download_spec.rb
@@ -9,10 +9,9 @@ describe "Paper consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     sign_in organisation.users.first
   end

--- a/spec/features/parental_consent_authentication_spec.rb
+++ b/spec/features/parental_consent_authentication_spec.rb
@@ -24,7 +24,7 @@ describe "Parental consent" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
     location = create(:school, name: "Pilot School")
-    @session = create(:session, :scheduled, programme: @programme, location:)
+    @session = create(:session, :scheduled, programmes: [@programme], location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -81,9 +81,8 @@ RSpec.feature "Parental consent change answers" do
   end
 
   def given_a_flu_programme_is_underway
-    programme = create(:programme, :flu)
-    @organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :flu)]
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
     location =
       create(:school, name: "Pilot School", organisation: @organisation)
     @session =
@@ -91,7 +90,7 @@ RSpec.feature "Parental consent change answers" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme:,
+        programmes:,
         location:
       )
     @child = create(:patient, session: @session)

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -106,7 +106,7 @@ describe "Parental consent school" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
 
@@ -120,7 +120,7 @@ describe "Parental consent school" do
       :session,
       :scheduled,
       organisation: @organisation,
-      programme: @programme,
+      programmes: [@programme],
       location: @school
     )
   end

--- a/spec/features/parental_consent_closed_spec.rb
+++ b/spec/features/parental_consent_closed_spec.rb
@@ -17,7 +17,7 @@ describe "Parental consent closed" do
       create(
         :session,
         :completed,
-        programme: @programme,
+        programmes: [@programme],
         location:,
         date: Date.yesterday
       )

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -66,7 +66,7 @@ describe "Parental consent create patient" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
     @child = build(:patient, year_group: 8) # NB: Build, not create, so we don't persist to DB

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -26,7 +26,7 @@ describe "Parental consent" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
     location = create(:school, name: "Pilot School")
-    @session = create(:session, :scheduled, programme: @programme, location:)
+    @session = create(:session, :scheduled, programmes: [@programme], location:)
     @child = create(:patient, session: @session)
   end
 

--- a/spec/features/parental_consent_home_educated_spec.rb
+++ b/spec/features/parental_consent_home_educated_spec.rb
@@ -31,7 +31,7 @@ describe "Parental consent school" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
     @child = create(:patient, session: @session)

--- a/spec/features/parental_consent_inexact_auto_match_spec.rb
+++ b/spec/features/parental_consent_inexact_auto_match_spec.rb
@@ -22,7 +22,7 @@ describe "Parental consent given with an inexact automatic match" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
   end

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -39,9 +39,9 @@ describe "Parental consent manual matching" do
   end
 
   def given_the_app_is_setup
-    @programme = create(:programme, :hpv)
-    @organisation =
-      create(:organisation, :with_one_nurse, programmes: [@programme])
+    programmes = [create(:programme, :hpv)]
+
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
     @user = @organisation.users.first
     @school = create(:school, name: "Pilot School")
     @session =
@@ -49,7 +49,7 @@ describe "Parental consent manual matching" do
         :session,
         location: @school,
         organisation: @organisation,
-        programme: @programme
+        programmes:
       )
     @consent_form =
       create(

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -34,7 +34,7 @@ describe "Parental consent" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
     @child = create(:patient, session: @session)

--- a/spec/features/parental_consent_school_session_completed_spec.rb
+++ b/spec/features/parental_consent_school_session_completed_spec.rb
@@ -32,7 +32,7 @@ describe "Parental consent" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location: @scheduled_school
       )
 
@@ -41,7 +41,7 @@ describe "Parental consent" do
         :session,
         :completed,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location: @completed_school
       )
 

--- a/spec/features/parental_consent_school_spec.rb
+++ b/spec/features/parental_consent_school_spec.rb
@@ -27,7 +27,7 @@ describe "Parental consent school" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
     @child = create(:patient, session: @session)

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -20,9 +20,9 @@ describe "Parental consent" do
   end
 
   def given_a_patient_without_consent_exists
-    programme = create(:programme, :hpv)
-    @organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv)]
+
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
     @user = @organisation.users.first
 
     location = create(:generic_clinic, organisation: @organisation)
@@ -31,7 +31,7 @@ describe "Parental consent" do
       create(
         :session,
         organisation: @organisation,
-        programme:,
+        programmes:,
         location:,
         date: Date.current + 2.days
       )

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -37,7 +37,7 @@ describe "Parental consent" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
     @child = create(:patient, session: @session)

--- a/spec/features/patient_sorting_filtering_spec.rb
+++ b/spec/features/patient_sorting_filtering_spec.rb
@@ -76,7 +76,7 @@ describe "Patient sorting and filtering" do
       create(
         :session,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
 

--- a/spec/features/scheduled_consent_requests_spec.rb
+++ b/spec/features/scheduled_consent_requests_spec.rb
@@ -20,14 +20,9 @@ describe "Scheduled consent requests" do
   end
 
   def given_my_organisation_is_running_an_hpv_vaccination_programme
-    @programme = create(:programme, :hpv)
+    programmes = [create(:programme, :hpv)]
     @organisation =
-      create(
-        :organisation,
-        :with_one_nurse,
-        :with_generic_clinic,
-        programmes: [@programme]
-      )
+      create(:organisation, :with_one_nurse, :with_generic_clinic, programmes:)
     @location = create(:school, :secondary, organisation: @organisation)
     @session =
       create(
@@ -35,7 +30,7 @@ describe "Scheduled consent requests" do
         :unscheduled,
         location: @location,
         organisation: @organisation,
-        programme: @programme
+        programmes:
       )
     @user = @organisation.users.first
   end

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -35,7 +35,7 @@ describe "Self-consent" do
         :session,
         :today,
         organisation: @organisation,
-        programme:,
+        programmes: [programme],
         location: @school
       )
 

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -81,7 +81,8 @@ describe "Td/IPV vaccination" do
       build(:batch, :expired, organisation:, vaccine: @active_vaccine)
     @expired_batch.save!(validate: false)
 
-    @session = create(:session, organisation:, programme:, location:)
+    @session =
+      create(:session, organisation:, programmes: [programme], location:)
     @patient =
       create(
         :patient,

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -27,28 +27,23 @@ describe "Triage" do
   end
 
   def given_a_programme_with_a_running_session
-    @programme = create(:programme, :hpv)
-    @organisation =
-      create(:organisation, :with_one_nurse, programmes: [@programme])
+    programmes = [create(:programme, :hpv)]
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
+
     @batch =
       create(
         :batch,
         organisation: @organisation,
-        vaccine: @programme.vaccines.first
+        vaccine: programmes.first.vaccines.first
       )
     location = create(:school)
     @session =
-      create(
-        :session,
-        organisation: @organisation,
-        programme: @programme,
-        location:
-      )
+      create(:session, organisation: @organisation, programmes:, location:)
     @patient =
       create(
         :patient_session,
         :consent_given_triage_needed,
-        programmes: [@programme],
+        programmes:,
         session: @session
       ).patient
     create(
@@ -57,7 +52,7 @@ describe "Triage" do
       :health_question_notes,
       :from_granddad,
       patient: @patient,
-      programme: @programme
+      programme: programmes.first
     )
 
     @patient.reload # Make sure both consents are accessible

--- a/spec/features/triage_then_parental_consent_refused_spec.rb
+++ b/spec/features/triage_then_parental_consent_refused_spec.rb
@@ -29,7 +29,7 @@ describe "Triage" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme
+        programmes: [@programme]
       )
 
     @patient =

--- a/spec/features/user_authorisation_spec.rb
+++ b/spec/features/user_authorisation_spec.rb
@@ -35,7 +35,7 @@ describe "User authorisation" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
     @other_session =
@@ -43,7 +43,7 @@ describe "User authorisation" do
         :session,
         :scheduled,
         organisation: @other_organisation,
-        programme: @programme,
+        programmes: [@programme],
         location: other_location
       )
     @child = create(:patient, session: @session)

--- a/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
+++ b/spec/features/verbal_consent_but_no_triage_for_admin_spec.rb
@@ -11,10 +11,9 @@ describe "Verbal consent recorded by admin" do
   end
 
   def given_i_am_signed_in_as_an_admin
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_admin, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_admin, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -12,10 +12,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
     @patient = create(:patient, session: @session)
 
     sign_in organisation.users.first

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -11,10 +11,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -11,10 +11,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_safe_to_vaccinate_spec.rb
@@ -11,11 +11,10 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
 
-    @session = create(:session, organisation:, programme:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -12,10 +12,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -22,7 +22,7 @@ feature "Verbal consent" do
         :session,
         :scheduled,
         organisation: @organisation,
-        programme: @programme,
+        programmes: [@programme],
         location:
       )
   end

--- a/spec/features/verbal_consent_refused_personal_choice_spec.rb
+++ b/spec/features/verbal_consent_refused_personal_choice_spec.rb
@@ -13,10 +13,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -13,10 +13,9 @@ describe "Verbal consent" do
   end
 
   def given_i_am_signed_in
-    programme = create(:programme, :hpv)
-    organisation =
-      create(:organisation, :with_one_nurse, programmes: [programme])
-    @session = create(:session, organisation:, programme:)
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, :with_one_nurse, programmes:)
+    @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
     @patient = create(:patient, session: @session, parents: [@parent])

--- a/spec/features/withdraw_consent_spec.rb
+++ b/spec/features/withdraw_consent_spec.rb
@@ -57,7 +57,7 @@ describe "Withdraw consent" do
     organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
 
-    @session = create(:session, organisation:, programme: @programme)
+    @session = create(:session, organisation:, programmes: [@programme])
     @patient = create(:patient, session: @session)
 
     sign_in organisation.users.first

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 describe SessionsHelper do
-  let(:programme) { create(:programme, :flu) }
   let(:location) { create(:school, name: "Waterloo Road") }
   let(:date) { nil }
-  let(:session) do
-    create(:session, programme:, academic_year: 2024, date:, location:)
-  end
+  let(:session) { create(:session, academic_year: 2024, date:, location:) }
 
   describe "#session_academic_year" do
     subject(:session_academic_year) { helper.session_academic_year(session) }

--- a/spec/jobs/clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/clinic_session_invitations_job_spec.rb
@@ -3,8 +3,8 @@
 describe ClinicSessionInvitationsJob do
   subject(:perform_now) { described_class.perform_now }
 
-  let(:programme) { create(:programme, :hpv) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme, :hpv)] }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:parents) { create_list(:parent, 2) }
   let(:patient) { create(:patient, parents:, year_group: 8) }
   let(:location) { create(:generic_clinic, organisation:) }
@@ -12,7 +12,7 @@ describe ClinicSessionInvitationsJob do
   context "for a scheduled clinic session in 3 weeks" do
     let(:date) { 3.weeks.from_now.to_date }
     let(:session) do
-      create(:session, programme:, date:, location:, organisation:)
+      create(:session, programmes:, date:, location:, organisation:)
     end
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
@@ -67,7 +67,7 @@ describe ClinicSessionInvitationsJob do
           :vaccination_record,
           patient:,
           session:,
-          programme:,
+          programme: programmes.first,
           location_name: "A clinic."
         )
       end
@@ -80,7 +80,13 @@ describe ClinicSessionInvitationsJob do
 
     context "when refused consent has been received" do
       before do
-        create(:consent, :refused, patient:, programme:, parent: parents.first)
+        create(
+          :consent,
+          :refused,
+          patient:,
+          programme: programmes.first,
+          parent: parents.first
+        )
       end
 
       it "doesn't send any notifications" do
@@ -120,7 +126,7 @@ describe ClinicSessionInvitationsJob do
   context "for a scheduled clinic session in 2 weeks" do
     let(:date) { 2.weeks.from_now.to_date }
     let(:session) do
-      create(:session, programme:, date:, location:, organisation:)
+      create(:session, programmes:, date:, location:, organisation:)
     end
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
@@ -137,7 +143,7 @@ describe ClinicSessionInvitationsJob do
   context "for a scheduled clinic session in 4 weeks" do
     let(:date) { 4.weeks.from_now.to_date }
     let(:session) do
-      create(:session, programme:, date:, location:, organisation:)
+      create(:session, programmes:, date:, location:, organisation:)
     end
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
@@ -153,7 +159,7 @@ describe ClinicSessionInvitationsJob do
     before do
       create(
         :session,
-        programme:,
+        programmes:,
         date: 3.weeks.from_now.to_date,
         patients: [patient],
         organisation:,
@@ -171,7 +177,7 @@ describe ClinicSessionInvitationsJob do
     before do
       create(
         :session,
-        programme:,
+        programmes:,
         date: Date.yesterday,
         patients: [patient],
         location:,

--- a/spec/jobs/send_clinic_subsequent_invitations_job_spec.rb
+++ b/spec/jobs/send_clinic_subsequent_invitations_job_spec.rb
@@ -3,8 +3,8 @@
 describe SendClinicSubsequentInvitationsJob do
   subject(:perform_now) { described_class.perform_now(session) }
 
-  let(:programme) { create(:programme, :hpv) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme, :hpv)] }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:parents) { create_list(:parent, 2) }
   let(:patient) { create(:patient, parents:, year_group: 8) }
   let(:location) { create(:generic_clinic, organisation:) }
@@ -12,7 +12,7 @@ describe SendClinicSubsequentInvitationsJob do
   let(:session) do
     create(
       :session,
-      programme:,
+      programmes:,
       date: 1.week.ago.to_date,
       location:,
       organisation:
@@ -52,7 +52,7 @@ describe SendClinicSubsequentInvitationsJob do
           :vaccination_record,
           patient:,
           session:,
-          programme:,
+          programme: programmes.first,
           location_name: "A clinic."
         )
       end
@@ -65,7 +65,13 @@ describe SendClinicSubsequentInvitationsJob do
 
     context "when refused consent has been received" do
       before do
-        create(:consent, :refused, patient:, programme:, parent: parents.first)
+        create(
+          :consent,
+          :refused,
+          patient:,
+          programme: programmes.first,
+          parent: parents.first
+        )
       end
 
       it "doesn't send any notifications" do

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -42,7 +42,7 @@ describe SMSDeliveryJob do
 
     let(:template_name) { GOVUK_NOTIFY_SMS_TEMPLATES.keys.first }
     let(:programmes) { [create(:programme)] }
-    let(:session) { create(:session, programme: programmes.first) }
+    let(:session) { create(:session, programmes:) }
     let(:parent) { create(:parent, phone: "01234 567890") }
     let(:consent) { nil }
     let(:consent_form) { nil }

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -38,7 +38,7 @@ describe GovukNotifyPersonalisation do
       :session,
       location:,
       organisation:,
-      programme: programmes.first,
+      programmes:,
       date: Date.new(2026, 1, 1)
     )
   end
@@ -169,26 +169,13 @@ describe GovukNotifyPersonalisation do
           :consent_form,
           :given,
           :recorded,
-          session:
-            create(
-              :session,
-              location:,
-              programme: programmes.first,
-              organisation:
-            ),
+          session: create(:session, location:, programmes:, organisation:),
           school_confirmed: false,
           school:
         )
       end
 
-      before do
-        create(
-          :session,
-          location: school,
-          programme: programmes.first,
-          organisation:
-        )
-      end
+      before { create(:session, location: school, programmes:, organisation:) }
 
       it { should include(location_name: "Waterloo Road") }
     end

--- a/spec/lib/graph_records_spec.rb
+++ b/spec/lib/graph_records_spec.rb
@@ -3,9 +3,9 @@
 describe GraphRecords do
   subject(:graph) { described_class.new.graph(patients: [patient]) }
 
-  let!(:programme) { create(:programme, :hpv) }
-  let!(:organisation) { create(:organisation, programmes: [programme]) }
-  let!(:session) { create(:session, organisation:, programmes: [programme]) }
+  let!(:programmes) { [create(:programme, :hpv)] }
+  let!(:organisation) { create(:organisation, programmes:) }
+  let!(:session) { create(:session, organisation:, programmes:) }
   let!(:class_import) { create(:class_import, session:) }
   let!(:cohort_import) { create(:cohort_import, organisation:) }
   let!(:parent) do
@@ -21,13 +21,20 @@ describe GraphRecords do
       parents: [parent],
       session:,
       organisation:,
-      programme:,
+      programmes:,
       class_imports: [class_import],
       cohort_imports: [cohort_import]
     )
   end
   let!(:consent) do
-    create(:consent, :given, patient:, parent:, organisation:, programme:)
+    create(
+      :consent,
+      :given,
+      patient:,
+      parent:,
+      organisation:,
+      programme: programmes.first
+    )
   end
 
   it { should start_with "flowchart TB" }

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -24,7 +24,7 @@ describe PatientMerger do
     let(:user) { create(:user) }
 
     let(:programme) { create(:programme) }
-    let(:session) { create(:session, programme:) }
+    let(:session) { create(:session, programmes: [programme]) }
 
     let!(:patient_to_keep) { create(:patient) }
     let!(:patient_to_destroy) { create(:patient) }

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -4,15 +4,15 @@ describe Reports::CareplusExporter do
   subject(:csv) do
     described_class.call(
       organisation:,
-      programme:,
+      programme: programmes.first,
       start_date: 1.month.ago.to_date,
       end_date: Date.current
     )
   end
 
-  let(:programme) { create(:programme, :hpv) }
+  let(:programmes) { [create(:programme, :hpv)] }
   let(:organisation) do
-    create(:organisation, careplus_venue_code: "ABC", programmes: [programme])
+    create(:organisation, careplus_venue_code: "ABC", programmes:)
   end
   let(:location) do
     create(
@@ -21,9 +21,7 @@ describe Reports::CareplusExporter do
       gias_establishment_number: 456
     )
   end
-  let(:session) do
-    create(:session, organisation:, programmes: [programme], location:)
-  end
+  let(:session) { create(:session, organisation:, programmes:, location:) }
   let(:parsed_csv) { CSV.parse(csv) }
   let(:headers) { parsed_csv.first }
   let(:data_rows) { parsed_csv[1..] }
@@ -71,13 +69,13 @@ describe Reports::CareplusExporter do
       create(
         :patient_session,
         :consent_given_triage_not_needed,
-        programmes: [programme],
+        programmes:,
         session:
       )
     vaccination_record =
       create(
         :vaccination_record,
-        programme:,
+        programme: programmes.first,
         patient: patient_session.patient,
         session: patient_session.session,
         performed_at: 2.weeks.ago
@@ -114,13 +112,13 @@ describe Reports::CareplusExporter do
       create(
         :patient_session,
         :consent_given_triage_not_needed,
-        programmes: [programme],
+        programmes:,
         patient:,
         session:
       )
       create(
         :vaccination_record,
-        programme:,
+        programme: programmes.first,
         patient:,
         session:,
         location_name: "A clinic"
@@ -141,7 +139,7 @@ describe Reports::CareplusExporter do
 
     create(
       :vaccination_record,
-      programme:,
+      programme: programmes.first,
       patient:,
       session:,
       created_at: 2.months.ago,
@@ -158,7 +156,7 @@ describe Reports::CareplusExporter do
     create(
       :vaccination_record,
       :not_administered,
-      programme:,
+      programme: programmes.first,
       patient:,
       session:
     )
@@ -171,7 +169,7 @@ describe Reports::CareplusExporter do
 
     create(
       :vaccination_record,
-      programme:,
+      programme: programmes.first,
       patient:,
       session:,
       created_at: 2.months.ago,
@@ -183,10 +181,10 @@ describe Reports::CareplusExporter do
   end
 
   context "with a session in a different organisation" do
-    let(:session) { create(:session, programme:, location:) }
+    let(:session) { create(:session, programmes:, location:) }
 
     it "excludes the vaccination record" do
-      create(:vaccination_record, programme:, session:)
+      create(:vaccination_record, programme: programmes.first, session:)
 
       expect(data_rows.first).to be_nil
     end

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -33,7 +33,9 @@ describe Reports::OfflineSessionExporter do
   let(:organisation) { create(:organisation, programmes: [programme]) }
   let(:user) { create(:user, email: "nurse@example.com", organisation:) }
   let(:team) { create(:team, organisation:) }
-  let(:session) { create(:session, location:, organisation:, programme:) }
+  let(:session) do
+    create(:session, location:, organisation:, programmes: [programme])
+  end
 
   context "a school session" do
     subject(:workbook) { RubyXL::Parser.parse_buffer(call) }

--- a/spec/lib/unscheduled_sessions_factory_spec.rb
+++ b/spec/lib/unscheduled_sessions_factory_spec.rb
@@ -4,8 +4,8 @@ describe UnscheduledSessionsFactory do
   describe "#call" do
     subject(:call) { described_class.new.call }
 
-    let(:programme) { create(:programme, :hpv) }
-    let(:organisation) { create(:organisation, programmes: [programme]) }
+    let(:programmes) { [create(:programme, :hpv)] }
+    let(:organisation) { create(:organisation, programmes:) }
 
     context "with a school that's eligible for the programme" do
       let!(:location) { create(:school, :secondary, organisation:) }
@@ -15,7 +15,7 @@ describe UnscheduledSessionsFactory do
 
         session = organisation.sessions.includes(:location, :programmes).first
         expect(session.location).to eq(location)
-        expect(session.programmes).to eq([programme])
+        expect(session.programmes).to eq(programmes)
       end
     end
 
@@ -27,7 +27,7 @@ describe UnscheduledSessionsFactory do
 
         session = organisation.sessions.includes(:location, :programmes).first
         expect(session.location).to eq(location)
-        expect(session.programmes).to eq([programme])
+        expect(session.programmes).to eq(programmes)
       end
     end
 
@@ -50,7 +50,7 @@ describe UnscheduledSessionsFactory do
     context "when a session already exists" do
       before do
         location = create(:school, :secondary, organisation:)
-        create(:session, organisation:, location:, programme:)
+        create(:session, organisation:, location:, programmes:)
       end
 
       it "doesn't create any sessions" do
@@ -65,7 +65,7 @@ describe UnscheduledSessionsFactory do
           :session,
           organisation:,
           location:,
-          programme:,
+          programmes:,
           date: Date.new(2013, 1, 1)
         )
       end
@@ -78,7 +78,7 @@ describe UnscheduledSessionsFactory do
     context "with an unscheduled session for a location no longer managed by the organisation" do
       let(:location) { create(:school, :secondary) }
       let!(:session) do
-        create(:session, :unscheduled, organisation:, location:, programme:)
+        create(:session, :unscheduled, organisation:, location:, programmes:)
       end
 
       it "destroys the session" do
@@ -91,7 +91,7 @@ describe UnscheduledSessionsFactory do
       let(:location) { create(:school, :secondary) }
 
       before do
-        create(:session, :scheduled, organisation:, location:, programme:)
+        create(:session, :scheduled, organisation:, location:, programmes:)
       end
 
       it "doesn't destroy the session" do

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -7,11 +7,11 @@ describe ClassImportRow do
 
   let(:today) { Date.new(2024, 12, 1) }
 
-  let(:programme) { create(:programme) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme)] }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:school) { create(:school, organisation:) }
   let(:session) do
-    create(:session, organisation:, programme:, location: school)
+    create(:session, organisation:, programmes:, location: school)
   end
 
   let(:valid_data) do

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -39,10 +39,10 @@ describe ClassImport do
     create(:class_import, csv:, session:, organisation:)
   end
 
-  let(:programme) { create(:programme, :hpv) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme, :hpv)] }
+  let(:organisation) { create(:organisation, programmes:) }
   let(:location) { create(:school, organisation:) }
-  let(:session) { create(:session, location:, programme:, organisation:) }
+  let(:session) { create(:session, location:, programmes:, organisation:) }
 
   let(:file) { "valid.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/class_import/#{file}") }
@@ -366,7 +366,7 @@ describe ClassImport do
 
     context "with an unscheduled session" do
       let(:session) do
-        create(:session, :unscheduled, organisation:, programme:, location:)
+        create(:session, :unscheduled, organisation:, programmes:, location:)
       end
 
       it "adds the patients to the session" do
@@ -376,7 +376,7 @@ describe ClassImport do
 
     context "with a scheduled session" do
       let(:session) do
-        create(:session, :scheduled, organisation:, programme:, location:)
+        create(:session, :scheduled, organisation:, programmes:, location:)
       end
 
       it "adds the patients to the session" do

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -33,8 +33,8 @@
 describe CohortImport do
   subject(:cohort_import) { create(:cohort_import, csv:, organisation:) }
 
-  let(:programme) { create(:programme) }
-  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:programmes) { [create(:programme)] }
+  let(:organisation) { create(:organisation, programmes:) }
 
   let(:file) { "valid.csv" }
   let(:csv) { fixture_file_upload("spec/fixtures/cohort_import/#{file}") }
@@ -335,7 +335,7 @@ describe CohortImport do
 
     context "with an unscheduled session" do
       let(:session) do
-        create(:session, :unscheduled, organisation:, programme:, location:)
+        create(:session, :unscheduled, organisation:, programmes:, location:)
       end
 
       it "adds the patients to the session" do
@@ -345,7 +345,7 @@ describe CohortImport do
 
     context "with a scheduled session" do
       let(:session) do
-        create(:session, :scheduled, organisation:, programme:, location:)
+        create(:session, :scheduled, organisation:, programmes:, location:)
       end
 
       it "adds the patients to the session" do

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -539,7 +539,7 @@ describe ConsentForm do
       consent_form =
         create(
           :consent_form,
-          session: create(:session, programme: create(:programme, :flu))
+          session: create(:session, programmes: [create(:programme, :flu)])
         )
       consent_form.strict_loading!(false)
       expect(consent_form.gelatine_content_status_in_vaccines).to eq(:maybe)
@@ -550,7 +550,7 @@ describe ConsentForm do
         create(
           :consent_form,
           session:
-            create(:session, programme: create(:programme, :flu_nasal_only))
+            create(:session, programmes: [create(:programme, :flu_nasal_only)])
         )
       consent_form.strict_loading!(false)
       expect(consent_form.gelatine_content_status_in_vaccines).to be(true)
@@ -560,7 +560,7 @@ describe ConsentForm do
       consent_form =
         create(
           :consent_form,
-          session: create(:session, programme: create(:programme, :hpv))
+          session: create(:session, programmes: [create(:programme, :hpv)])
         )
       consent_form.strict_loading!(false)
       expect(consent_form.gelatine_content_status_in_vaccines).to be(false)
@@ -569,7 +569,7 @@ describe ConsentForm do
 
   describe "scope unmatched" do
     let(:programme) { create(:programme) }
-    let(:session) { create(:session, programme:) }
+    let(:session) { create(:session, programmes: [programme]) }
     let(:consent) { create(:consent, programme:) }
     let(:unmatched_consent_form) do
       create(:consent_form, consent: nil, session:)
@@ -584,7 +584,7 @@ describe ConsentForm do
 
   describe "scope recorded" do
     let(:programme) { create(:programme) }
-    let(:session) { create(:session, programme:) }
+    let(:session) { create(:session, programmes: [programme]) }
     let(:consent) { create(:consent, programme:) }
     let(:recorded_consent_form) do
       create(:consent_form, :recorded, consent:, session:)
@@ -601,7 +601,7 @@ describe ConsentForm do
     consent_form =
       create(
         :consent_form,
-        session: create(:session, programme: create(:programme, :hpv)),
+        session: create(:session, programmes: [create(:programme, :hpv)]),
         response: "refused"
       )
 
@@ -621,7 +621,7 @@ describe ConsentForm do
       create(
         :consent_form,
         :with_health_answers_no_branching,
-        session: create(:session, programme: create(:programme, :flu)),
+        session: create(:session, programmes: [create(:programme, :flu)]),
         response: nil
       )
 
@@ -690,7 +690,7 @@ describe ConsentForm do
       create(
         :consent_form,
         :with_health_answers_no_branching,
-        session: create(:session, programme: create(:programme, :hpv)),
+        session: create(:session, programmes: [create(:programme, :hpv)]),
         response: nil
       )
 
@@ -732,7 +732,9 @@ describe ConsentForm do
 
     let(:school) { create(:school) }
     let(:location) { school }
-    let(:session) { create(:session, organisation:, programme:, location:) }
+    let(:session) do
+      create(:session, organisation:, programmes: [programme], location:)
+    end
     let(:patient) { create(:patient, school:, session:) }
     let(:current_user) { create(:user) }
 
@@ -835,9 +837,9 @@ describe ConsentForm do
   end
 
   it "resets unused fields" do
-    programme = create(:programme)
+    programmes = [create(:programme)]
 
-    session = create(:session, programme:)
+    session = create(:session, programmes:)
 
     consent_form =
       build(

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -48,7 +48,7 @@ describe ConsentNotification do
       create(
         :session,
         location:,
-        programme: programmes.first,
+        programmes:,
         patients: [patient],
         organisation:
       )

--- a/spec/models/dps_export_row_spec.rb
+++ b/spec/models/dps_export_row_spec.rb
@@ -3,17 +3,17 @@
 describe DPSExportRow do
   subject(:row) { described_class.new(vaccination_record) }
 
-  let(:programme) { create(:programme, type: "hpv") }
+  let(:programme) { create(:programme, :hpv) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:vaccine) do
-    create(:vaccine, :gardasil_9, programme:, dose_volume_ml: 0.5)
-  end
+  let(:vaccine) { programme.vaccines.first }
   let(:location) { create(:school) }
   let(:school) { create(:school) }
   let(:patient) do
     create(:patient, date_of_birth: Date.new(2012, 12, 29), school:)
   end
-  let(:session) { create(:session, organisation:, programme:, location:) }
+  let(:session) do
+    create(:session, organisation:, programmes: [programme], location:)
+  end
   let(:performed_by) { create(:user, family_name: "Doe", given_name: "Jane") }
   let(:performed_by_given_name) { nil }
   let(:performed_by_family_name) { nil }

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -13,7 +13,7 @@ describe DraftVaccinationRecord do
   let(:current_user) { organisation.users.first }
 
   let(:programme) { create(:programme, :hpv) }
-  let(:session) { create(:session, programme:) }
+  let(:session) { create(:session, programmes: [programme]) }
   let(:patient) { create(:patient, session:) }
   let(:vaccine) { programme.vaccines.first }
   let(:batch) { create(:batch, vaccine:) }

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -5,10 +5,8 @@ describe ImmunisationImportRow do
     described_class.new(data:, organisation:)
   end
 
-  let(:programme) { create(:programme, :flu) }
-  let(:organisation) do
-    create(:organisation, ods_code: "abc", programmes: [programme])
-  end
+  let(:programmes) { [create(:programme, :flu)] }
+  let(:organisation) { create(:organisation, ods_code: "abc", programmes:) }
 
   let(:nhs_number) { "1234567890" }
   let(:given_name) { "Harry" }
@@ -211,7 +209,7 @@ describe ImmunisationImportRow do
           }
         end
 
-        let(:session) { create(:session, organisation:, programme:) }
+        let(:session) { create(:session, organisation:, programmes:) }
 
         it { should include(/current session/) }
       end
@@ -287,7 +285,7 @@ describe ImmunisationImportRow do
     end
 
     context "with an invalid dose sequence" do
-      let(:programme) { create(:programme, :hpv) }
+      let(:programmes) { [create(:programme, :hpv)] }
 
       let(:data) { { "PROGRAMME" => "HPV", "DOSE_SEQUENCE" => "4" } }
 
@@ -302,7 +300,7 @@ describe ImmunisationImportRow do
     context "vaccination in a session and no organisation provided" do
       let(:data) { { "SESSION_ID" => session.id.to_s } }
 
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -325,7 +323,7 @@ describe ImmunisationImportRow do
         )
       end
 
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -352,7 +350,7 @@ describe ImmunisationImportRow do
         )
       end
 
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -363,7 +361,7 @@ describe ImmunisationImportRow do
     end
 
     context "HPV vaccination in previous academic year, no vaccinator details provided" do
-      let(:programme) { create(:programme, :hpv) }
+      let(:programmes) { [create(:programme, :hpv)] }
 
       let(:data) do
         valid_hpv_data.except(
@@ -405,8 +403,8 @@ describe ImmunisationImportRow do
     end
 
     context "vaccination in a session, with a delivery site that is not appropriate for HPV" do
-      let(:programme) { create(:programme, :hpv) }
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:programmes) { [create(:programme, :hpv)] }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       let(:data) do
         valid_hpv_data.merge(
@@ -427,7 +425,7 @@ describe ImmunisationImportRow do
     end
 
     context "vaccination in a previous academic year, with a delivery site that's typically not appropriate for HPV" do
-      let(:programme) { create(:programme, :hpv) }
+      let(:programmes) { [create(:programme, :hpv)] }
 
       let(:data) do
         {
@@ -445,7 +443,8 @@ describe ImmunisationImportRow do
     end
 
     context "vaccination in a session, with a delivery site that is not appropriate for flu" do
-      let(:programme) { create(:programme, :flu) }
+      let(:programmes) { [create(:programme, :flu)] }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       let(:data) do
         {
@@ -458,8 +457,6 @@ describe ImmunisationImportRow do
         }
       end
 
-      let(:session) { create(:session, organisation:, programme:) }
-
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:delivery_site]).to eq(
@@ -469,7 +466,7 @@ describe ImmunisationImportRow do
     end
 
     context "vaccination in a session without a batch" do
-      let(:programme) { create(:programme, :flu) }
+      let(:programmes) { [create(:programme, :flu)] }
 
       let(:data) do
         {
@@ -480,7 +477,7 @@ describe ImmunisationImportRow do
         }
       end
 
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -494,7 +491,7 @@ describe ImmunisationImportRow do
     end
 
     context "vaccination in a session without a delivery site" do
-      let(:programme) { create(:programme, :flu) }
+      let(:programmes) { [create(:programme, :flu)] }
 
       let(:data) do
         {
@@ -505,7 +502,7 @@ describe ImmunisationImportRow do
         }
       end
 
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:session) { create(:session, organisation:, programmes:) }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
@@ -516,7 +513,7 @@ describe ImmunisationImportRow do
     end
 
     context "with valid fields for Flu" do
-      let(:programme) { create(:programme, :flu) }
+      let(:programmes) { [create(:programme, :flu)] }
 
       let(:data) do
         {
@@ -555,7 +552,7 @@ describe ImmunisationImportRow do
     end
 
     context "with valid fields for HPV" do
-      let(:programme) { create(:programme, :hpv) }
+      let(:programmes) { [create(:programme, :hpv)] }
 
       let(:data) do
         {
@@ -710,7 +707,7 @@ describe ImmunisationImportRow do
         )
       end
 
-      let(:session) { create(:session, organisation:, location:, programme:) }
+      let(:session) { create(:session, organisation:, location:, programmes:) }
 
       it { should be_nil }
     end
@@ -1094,7 +1091,7 @@ describe ImmunisationImportRow do
   describe "#dose_sequence" do
     subject(:dose_sequence) { immunisation_import_row.dose_sequence }
 
-    let(:programme) { create(:programme, :hpv) }
+    let(:programmes) { [create(:programme, :hpv)] }
 
     context "without a value" do
       let(:data) { { "PROGRAMME" => "HPV" } }
@@ -1116,7 +1113,7 @@ describe ImmunisationImportRow do
 
     %w[1P 2P 3P].each_with_index do |value, index|
       context "with an HPV special value of #{value}" do
-        let(:programme) { create(:programme, :hpv) }
+        let(:programmes) { [create(:programme, :hpv)] }
 
         let(:data) { { "PROGRAMME" => "HPV", "DOSE_SEQUENCE" => value } }
 
@@ -1126,7 +1123,7 @@ describe ImmunisationImportRow do
 
     %w[1P 1B 2B].each_with_index do |value, index|
       context "with a MenACWY special value of #{value}" do
-        let(:programme) { create(:programme, :menacwy) }
+        let(:programmes) { [create(:programme, :menacwy)] }
 
         let(:data) { { "PROGRAMME" => "MenACWY", "DOSE_SEQUENCE" => value } }
 
@@ -1136,7 +1133,7 @@ describe ImmunisationImportRow do
 
     %w[1P 2P 3P 1B 2B].each_with_index do |value, index|
       context "with a Td/IPV special value of #{value}" do
-        let(:programme) { create(:programme, :td_ipv) }
+        let(:programmes) { [create(:programme, :td_ipv)] }
 
         let(:data) { { "PROGRAMME" => "Td/IPV", "DOSE_SEQUENCE" => value } }
 
@@ -1473,8 +1470,8 @@ describe ImmunisationImportRow do
       let!(:existing_vaccination_record) do
         create(
           :vaccination_record,
-          programme:,
-          session: create(:session, organisation:, programme:)
+          programme: programmes.first,
+          session: create(:session, organisation:, programmes:)
         )
       end
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -42,14 +42,9 @@ describe ImmunisationImport do
     create(:school, urn: "144012")
   end
 
-  let(:programme) { create(:programme, :flu_all_vaccines) }
+  let(:programmes) { [create(:programme, :flu_all_vaccines)] }
   let(:organisation) do
-    create(
-      :organisation,
-      :with_generic_clinic,
-      ods_code: "R1L",
-      programmes: [programme]
-    )
+    create(:organisation, :with_generic_clinic, ods_code: "R1L", programmes:)
   end
 
   let(:file) { "valid_flu.csv" }
@@ -93,7 +88,7 @@ describe ImmunisationImport do
     before { immunisation_import.parse_rows! }
 
     context "with valid Flu rows" do
-      let(:programme) { create(:programme, :flu_all_vaccines) }
+      let(:programmes) { [create(:programme, :flu_all_vaccines)] }
       let(:file) { "valid_flu.csv" }
 
       it "populates the rows" do
@@ -103,7 +98,7 @@ describe ImmunisationImport do
     end
 
     context "with valid HPV rows" do
-      let(:programme) { create(:programme, :hpv_all_vaccines) }
+      let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
       let(:file) { "valid_hpv.csv" }
 
       it "populates the rows" do
@@ -127,7 +122,7 @@ describe ImmunisationImport do
     subject(:process!) { immunisation_import.process! }
 
     context "with valid Flu rows" do
-      let(:programme) { create(:programme, :flu_all_vaccines) }
+      let(:programmes) { [create(:programme, :flu_all_vaccines)] }
       let(:file) { "valid_flu.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -181,7 +176,7 @@ describe ImmunisationImport do
     end
 
     context "with valid HPV rows" do
-      let(:programme) { create(:programme, :hpv_all_vaccines) }
+      let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
       let(:file) { "valid_hpv.csv" }
 
       it "creates locations, patients, and vaccination records" do
@@ -235,7 +230,7 @@ describe ImmunisationImport do
     end
 
     context "with an existing patient matching the name" do
-      let(:programme) { create(:programme, :flu_all_vaccines) }
+      let(:programmes) { [create(:programme, :flu_all_vaccines)] }
       let(:file) { "valid_flu.csv" }
 
       let!(:patient) do
@@ -258,7 +253,7 @@ describe ImmunisationImport do
     end
 
     context "with an existing patient matching the name but with a different case" do
-      let(:programme) { create(:programme, :flu_all_vaccines) }
+      let(:programmes) { [create(:programme, :flu_all_vaccines)] }
       let(:file) { "valid_flu.csv" }
 
       before do
@@ -277,7 +272,7 @@ describe ImmunisationImport do
     end
 
     context "with a patient record that has different attributes" do
-      let(:programme) { create(:programme, :hpv_all_vaccines) }
+      let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
       let(:file) { "valid_hpv_with_changes.csv" }
       let!(:existing_patient) do
         create(

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -53,8 +53,8 @@ describe SchoolMove do
 
     let(:user) { create(:user) }
 
-    let(:programme) { create(:programme) }
-    let(:organisation) { create(:organisation, programmes: [programme]) }
+    let(:programmes) { [create(:programme)] }
+    let(:organisation) { create(:organisation, programmes:) }
     let(:generic_clinic_session) { organisation.generic_clinic_session }
 
     shared_examples "creates a log entry" do
@@ -184,7 +184,7 @@ describe SchoolMove do
             :scheduled,
             location: school,
             organisation:,
-            programme:
+            programmes:
           )
         end
 
@@ -207,7 +207,7 @@ describe SchoolMove do
             :completed,
             location: school,
             organisation:,
-            programme:
+            programmes:
           )
         end
 
@@ -232,7 +232,7 @@ describe SchoolMove do
     end
 
     context "with a patient in a school session" do
-      let(:session) { create(:session, organisation:, programme:) }
+      let(:session) { create(:session, organisation:, programmes:) }
       let(:patient) { create(:patient, session:) }
 
       context "and not already vaccinated" do
@@ -248,7 +248,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -272,7 +272,7 @@ describe SchoolMove do
               :completed,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -302,9 +302,7 @@ describe SchoolMove do
             create(:school_move, :to_school, patient:, school:)
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:school) { create(:school, organisation: new_organisation) }
           let(:new_session) do
             create(
@@ -312,7 +310,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation: new_organisation,
-              programme:
+              programmes:
             )
           end
 
@@ -334,9 +332,7 @@ describe SchoolMove do
             )
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:generic_clinic_session) do
             new_organisation.generic_clinic_session
           end
@@ -351,7 +347,14 @@ describe SchoolMove do
       end
 
       context "and already vaccinated" do
-        before { create(:vaccination_record, programme:, patient:, session:) }
+        before do
+          create(
+            :vaccination_record,
+            patient:,
+            session:,
+            programme: programmes.first
+          )
+        end
 
         context "to a school with a scheduled session" do
           let(:school_move) do
@@ -365,7 +368,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -388,7 +391,7 @@ describe SchoolMove do
               :completed,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -416,9 +419,7 @@ describe SchoolMove do
             create(:school_move, :to_school, patient:, school:)
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:school) { create(:school, organisation: new_organisation) }
           let(:new_session) do
             create(
@@ -426,7 +427,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation: new_organisation,
-              programme:
+              programmes:
             )
           end
 
@@ -447,9 +448,7 @@ describe SchoolMove do
             )
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:generic_clinic_session) do
             new_organisation.generic_clinic_session
           end
@@ -481,7 +480,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -505,7 +504,7 @@ describe SchoolMove do
               :completed,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -537,9 +536,7 @@ describe SchoolMove do
             create(:school_move, :to_school, patient:, school:)
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:school) { create(:school, organisation: new_organisation) }
           let(:new_session) do
             create(
@@ -547,7 +544,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation: new_organisation,
-              programme:
+              programmes:
             )
           end
 
@@ -575,9 +572,7 @@ describe SchoolMove do
               session: organisation.generic_clinic_session
             )
           end
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:generic_clinic_session) do
             new_organisation.generic_clinic_session
           end
@@ -597,9 +592,9 @@ describe SchoolMove do
         before do
           create(
             :vaccination_record,
-            programme:,
             patient:,
             session: generic_clinic_session,
+            programme: programmes.first,
             location_name: "A clinic"
           )
         end
@@ -616,7 +611,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -639,7 +634,7 @@ describe SchoolMove do
               :completed,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -669,9 +664,7 @@ describe SchoolMove do
             create(:school_move, :to_school, patient:, school:)
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:school) { create(:school, organisation: new_organisation) }
           let(:new_session) do
             create(
@@ -679,7 +672,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation: new_organisation,
-              programme:
+              programmes:
             )
           end
 
@@ -707,9 +700,7 @@ describe SchoolMove do
               session: organisation.generic_clinic_session
             )
           end
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
 
           it "keeps the patient as home-schooled" do
             expect { confirm! }.not_to(change { patient.reload.home_educated })
@@ -741,7 +732,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -764,7 +755,7 @@ describe SchoolMove do
               :completed,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -791,9 +782,7 @@ describe SchoolMove do
             create(:school_move, :to_school, patient:, school:)
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:school) { create(:school, organisation: new_organisation) }
           let(:new_session) do
             create(
@@ -801,7 +790,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation: new_organisation,
-              programme:
+              programmes:
             )
           end
 
@@ -829,9 +818,7 @@ describe SchoolMove do
               session: organisation.generic_clinic_session
             )
           end
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:generic_clinic_session) do
             new_organisation.generic_clinic_session
           end
@@ -848,9 +835,9 @@ describe SchoolMove do
         before do
           create(
             :vaccination_record,
-            programme:,
             patient:,
             session: generic_clinic_session,
+            programme: programmes.first,
             location_name: "A clinic"
           )
         end
@@ -867,7 +854,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -889,7 +876,7 @@ describe SchoolMove do
               :completed,
               location: school,
               organisation:,
-              programme:
+              programmes:
             )
           end
 
@@ -915,9 +902,7 @@ describe SchoolMove do
             create(:school_move, :to_school, patient:, school:)
           end
 
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
           let(:school) { create(:school, organisation: new_organisation) }
           let(:new_session) do
             create(
@@ -925,7 +910,7 @@ describe SchoolMove do
               :scheduled,
               location: school,
               organisation: new_organisation,
-              programme:
+              programmes:
             )
           end
 
@@ -953,9 +938,7 @@ describe SchoolMove do
               session: organisation.generic_clinic_session
             )
           end
-          let(:new_organisation) do
-            create(:organisation, programmes: [programme])
-          end
+          let(:new_organisation) { create(:organisation, programmes:) }
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -27,13 +27,13 @@
 
 describe Session do
   describe "scopes" do
-    let(:programme) { create(:programme) }
+    let(:programmes) { [create(:programme)] }
 
-    let(:closed_session) { create(:session, :closed, programme:) }
-    let(:completed_session) { create(:session, :completed, programme:) }
-    let(:scheduled_session) { create(:session, :scheduled, programme:) }
-    let(:today_session) { create(:session, :today, programme:) }
-    let(:unscheduled_session) { create(:session, :unscheduled, programme:) }
+    let(:closed_session) { create(:session, :closed, programmes:) }
+    let(:completed_session) { create(:session, :completed, programmes:) }
+    let(:scheduled_session) { create(:session, :scheduled, programmes:) }
+    let(:today_session) { create(:session, :today, programmes:) }
+    let(:unscheduled_session) { create(:session, :unscheduled, programmes:) }
 
     describe "#for_current_academic_year" do
       subject(:scope) { described_class.for_current_academic_year }
@@ -60,7 +60,7 @@ describe Session do
 
       context "for a different academic year" do
         let(:unscheduled_session) do
-          create(:session, :unscheduled, programme:, academic_year: 2023)
+          create(:session, :unscheduled, programmes:, academic_year: 2023)
         end
 
         it { should_not include(unscheduled_session) }
@@ -80,7 +80,7 @@ describe Session do
 
       context "for a different academic year" do
         let(:completed_session) do
-          create(:session, :completed, programme:, date: Date.new(2023, 9, 1))
+          create(:session, :completed, programmes:, date: Date.new(2023, 9, 1))
         end
 
         it { should_not include(completed_session) }
@@ -94,10 +94,8 @@ describe Session do
     let(:hpv_programme) { create(:programme, :hpv) }
     let(:menacwy_programme) { create(:programme, :menacwy) }
 
-    let(:session) { create(:session, programme: menacwy_programme) }
-
-    before do
-      session.update!(programme_ids: [menacwy_programme.id, hpv_programme.id])
+    let(:session) do
+      create(:session, programmes: [menacwy_programme, hpv_programme])
     end
 
     it "is ordered by name" do

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -59,7 +59,7 @@ describe VaccinationRecord do
       end
 
       let(:programme) { create(:programme) }
-      let(:session) { create(:session, programme: programme) }
+      let(:session) { create(:session, programmes: [programme]) }
 
       it { should validate_absence_of(:location_name) }
     end

--- a/spec/policies/session_attendance_policy_spec.rb
+++ b/spec/policies/session_attendance_policy_spec.rb
@@ -7,7 +7,7 @@ describe SessionAttendancePolicy do
 
   let(:programme) { create(:programme) }
   let(:organisation) { create(:organisation, programmes: [programme]) }
-  let(:session) { create(:session, organisation:, programme:) }
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
   let(:patient) { create(:patient) }
   let(:patient_session) { create(:patient_session, patient:, session:) }
 

--- a/spec/policies/session_policy_spec.rb
+++ b/spec/policies/session_policy_spec.rb
@@ -52,14 +52,14 @@ describe SessionPolicy do
   describe "Scope#resolve" do
     subject { SessionPolicy::Scope.new(user, Session).resolve }
 
-    let(:programme) { create(:programme) }
-    let(:organisation) { create(:organisation, programmes: [programme]) }
+    let(:programmes) { [create(:programme)] }
+    let(:organisation) { create(:organisation, programmes:) }
     let(:user) { create(:user, organisation:) }
 
     let(:users_organisations_session) do
-      create(:session, organisation:, programme:)
+      create(:session, organisation:, programmes:)
     end
-    let(:another_organisations_session) { create(:session, programme:) }
+    let(:another_organisations_session) { create(:session, programmes:) }
 
     it { should include(users_organisations_session) }
     it { should_not include(another_organisations_session) }

--- a/spec/policies/vaccination_record_policy_spec.rb
+++ b/spec/policies/vaccination_record_policy_spec.rb
@@ -17,7 +17,9 @@ describe VaccinationRecordPolicy do
       it { should be(false) }
 
       context "when vaccination record is managed by the organisation" do
-        let(:session) { create(:session, organisation:, programme:) }
+        let(:session) do
+          create(:session, organisation:, programmes: [programme])
+        end
         let(:vaccination_record) do
           create(:vaccination_record, organisation:, programme:, session:)
         end
@@ -32,7 +34,9 @@ describe VaccinationRecordPolicy do
       it { should be(false) }
 
       context "when vaccination record is managed by the organisation" do
-        let(:session) { create(:session, organisation:, programme:) }
+        let(:session) do
+          create(:session, organisation:, programmes: [programme])
+        end
         let(:vaccination_record) do
           create(:vaccination_record, organisation:, programme:, session:)
         end
@@ -81,7 +85,7 @@ describe VaccinationRecordPolicy do
     let(:organisation) { create(:organisation, programmes: [programme]) }
     let(:user) { create(:user, organisation:) }
 
-    let(:session) { create(:session, organisation:, programme:) }
+    let(:session) { create(:session, organisation:, programmes: [programme]) }
 
     let(:kept_vaccination_record) do
       create(:vaccination_record, session:, programme:)


### PR DESCRIPTION
This refactors the session factory to accept only a list of programmes rather than just a single one. There's no change to the functionality here, but as Mavis now supports multiple programmes I think it makes sense for the factories to follow this approach as well to encourage testing with multiple programmes by default.