### PR TITLE
Avoid N+1 issue when rendering session table

### DIFF
--- a/app/components/app_session_table_component.html.erb
+++ b/app/components/app_session_table_component.html.erb
@@ -63,7 +63,7 @@
 
           <% row.with_cell(numeric: true) do %>
             <span class="nhsuk-table-responsive__heading">Cohort</span>
-            <%= (count = session.patients.count).zero? ? "None" : count %>
+            <%= (count = patient_count(session)).zero? ? "None" : count %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/app_session_table_component.rb
+++ b/app/components/app_session_table_component.rb
@@ -24,4 +24,13 @@ class AppSessionTableComponent < ViewComponent::Base
               :show_dates,
               :show_programmes,
               :show_consent_period
+
+  def patient_count(session)
+    patient_count_by_session_id.fetch(session.id, 0)
+  end
+
+  def patient_count_by_session_id
+    @patient_count_by_session_id ||=
+      PatientSession.where(session: sessions).group(:session_id).count
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -74,11 +74,6 @@ class SessionsController < ApplicationController
   end
 
   def sessions_scope
-    policy_scope(Session).includes(
-      :programmes,
-      :session_dates,
-      location: :organisation,
-      organisation: :programmes
-    )
+    policy_scope(Session).includes(:location, :programmes, :session_dates)
   end
 end


### PR DESCRIPTION
This avoids needing a query for each row in the table by calculating the counts of all the patients in a single query and caching the value.

I've also removed some unnecessary preloading that as far as I can tell isn't being used anywhere.