### PR TITLE
Bootstrap cleanup

### DIFF
--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -168,13 +168,3 @@ resource "aws_dynamodb_table" "dynamodb_lock_table" {
     enabled = true
   }
 }
-
-resource "aws_ecr_repository" "ecr_repository" {
-  name = "mavis-${var.environment}"
-}
-
-
-variable "environment" {
-  type        = string
-  description = "String literal for the environment"
-}

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,0 +1,4 @@
+variable "environment" {
+  type        = string
+  description = "String literal for the environment"
+}


### PR DESCRIPTION
Remove code that is no longer needed as part of the terraform bootstrap setup.

* Remove ECR repository from terraform config. Every environment pulls images from mavis/webapp now
* Remove creation of docker build scripts from bootstrap script. The docker build is done by the build.yml Github workflow now and the images don't need to be pushed to container registries with different names anymore