### PR TITLE
Add pagination to register attendances page

### DIFF
--- a/app/controllers/register_attendances_controller.rb
+++ b/app/controllers/register_attendances_controller.rb
@@ -1,19 +1,37 @@
 # frozen_string_literal: true
 
+require "pagy/extras/array"
+
 class RegisterAttendancesController < ApplicationController
+  include Pagy::Backend
   include PatientSortingConcern
 
   before_action :set_session
   before_action :set_session_date
   before_action :set_programme, only: :index
-  before_action :set_patient_sessions, only: :index
   before_action :set_patient, only: :create
   before_action :set_patient_session, only: :create
 
   layout "full"
 
   def index
-    sort_and_filter_patients!(@patient_sessions, programme: @programme)
+    ps =
+      @session
+        .patient_sessions
+        .eager_load(:patient)
+        .preload_for_status
+        .includes(session: :session_dates, session_attendances: :session_date)
+        .merge(Patient.in_programme(@programme))
+
+    patient_sessions =
+      ps
+        .where
+        .missing(:session_attendances)
+        .or(ps.where.not(session_attendances: { session_date: @session_date }))
+        .to_a
+
+    sort_and_filter_patients!(patient_sessions, programme: @programme)
+    @pagy, @patient_sessions = pagy_array(patient_sessions, limit: 500)
   end
 
   def create
@@ -49,23 +67,6 @@ class RegisterAttendancesController < ApplicationController
     @programme =
       @session.programmes.find_by(type: params[:programme_type]) ||
         @session.programmes.first
-  end
-
-  def set_patient_sessions
-    ps =
-      @session
-        .patient_sessions
-        .eager_load(:patient)
-        .preload_for_status
-        .includes(session: :session_dates, session_attendances: :session_date)
-        .merge(Patient.in_programme(@programme))
-
-    @patient_sessions =
-      ps
-        .where
-        .missing(:session_attendances)
-        .or(ps.where.not(session_attendances: { session_date: @session_date }))
-        .to_a
   end
 
   def set_patient

--- a/app/views/register_attendances/index.html.erb
+++ b/app/views/register_attendances/index.html.erb
@@ -12,7 +12,7 @@
 
 <%= render AppSessionPatientTableComponent.new(
       caption: t("patients_table.register_attendance.caption",
-                 children: t("children", count: @patient_sessions.count)),
+                 children: t("children", count: @pagy.count)),
       columns: %i[name year_group attendance],
       params:,
       patient_sessions: @patient_sessions,
@@ -20,3 +20,7 @@
       section: :attendance,
       session: @session,
     ) %>
+
+<div class="nhsuk-u-margin-top-6">
+  <%= govuk_pagination(pagy: @pagy) %>
+</div>


### PR DESCRIPTION
This is the only page left in the sessions view where we don't paginate the list of patients. In most cases the list won't be too long, but for the community clinic it could be very long and therefore might require pagination.

## Screenshot

![Screenshot 2025-02-26 at 15 04 27](https://github.com/user-attachments/assets/bc8d966d-1583-408d-80ef-2378b5b3a13a)
