### PR TITLE
Improve offline recording detection

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -497,7 +497,7 @@ class ImmunisationImportRow
   delegate :maximum_dose_sequence, to: :programme, allow_nil: true
 
   def offline_recording?
-    session_id.present?
+    @data["SESSION_ID"].present?
   end
 
   def performed_by_details_present_where_required


### PR DESCRIPTION
This improves how we determine whether a file is being uploaded as part of offline recording by checking for the presence of a value in `SESSION_ID`, bypassing the `session_id` method which tries to parse the value in to an integer and returns `nil` if it's not an integer.

This ensures that if a non-integer value is in the `SESSION_ID` column, the file will be treated as offline recording and will be validated as a valid session ID.