### PR TITLE
Remove data migration

### DIFF
--- a/db/migrate/20250211092238_add_year_groups_to_class_imports.rb
+++ b/db/migrate/20250211092238_add_year_groups_to_class_imports.rb
@@ -8,16 +8,5 @@ class AddYearGroupsToClassImports < ActiveRecord::Migration[8.0]
                array: true,
                default: [],
                null: false
-
-    reversible do |dir|
-      dir.up do
-        ClassImport
-          .includes(session: :programmes)
-          .find_each do |class_import|
-            year_groups = class_import.session.year_groups
-            class_import.update!(year_groups:)
-          end
-      end
-    end
   end
 end

--- a/lib/tasks/class_imports.rake
+++ b/lib/tasks/class_imports.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :class_imports do
+  desc "Assign year groups to class imports without them."
+  task assign_year_groups: :environment do
+    ClassImport
+      .includes(session: :programmes)
+      .where(year_groups: [])
+      .find_each do |class_import|
+        year_groups = class_import.session.year_groups
+        class_import.update_column(:year_groups, year_groups)
+      end
+  end
+end


### PR DESCRIPTION
This part of the migration doesn't run successfully as part of the 2.0.0 release because the model has changed too much since then.

We can replace this with a Rake task that we can run post-deployment.