### PR TITLE
Only show future dates on consent confimrmation

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -54,8 +54,8 @@ class AppConsentConfirmationComponent < ViewComponent::Base
           your answers and get in touch again soon.
         END_OF_TEXT
       else
-        "#{full_name} is due to get the #{chosen_vaccinations} at school on" \
-          " #{session_dates}"
+        "#{full_name} is due to get the #{chosen_vaccinations} at school" +
+          (session_dates.present? ? " on #{session_dates}" : "")
       end
     when "refused"
       "You’ve told us that you do not want #{full_name} to get the" \
@@ -90,10 +90,8 @@ class AppConsentConfirmationComponent < ViewComponent::Base
 
   def session_dates
     @consent_form
-      .location
-      .sessions
-      .includes(:session_dates)
-      .flat_map(&:dates)
+      .actual_session
+      .today_or_future_dates
       .map { it.to_fs(:short_day_of_week) }
       .to_sentence(two_words_connector: " or ", last_word_connector: " or ")
   end

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -16,7 +16,11 @@ describe AppConsentConfirmationComponent do
 
   context "consent for only MenACWY" do
     let(:session) do
-      create(:session, programmes: [create(:programme, :menacwy)])
+      create(
+        :session,
+        dates: [Date.yesterday, Date.tomorrow],
+        programmes: [create(:programme, :menacwy)]
+      )
     end
     let(:consent_form) do
       create(
@@ -33,7 +37,7 @@ describe AppConsentConfirmationComponent do
       expect(rendered).to have_text(
         "#{consent_form.given_name} #{consent_form.family_name} is due to get " \
           "the MenACWY vaccination at school on " \
-          "#{session.dates.first.to_fs(:short_day_of_week)}"
+          "#{session.dates.second.to_fs(:short_day_of_week)}"
       )
     end
   end
@@ -42,6 +46,7 @@ describe AppConsentConfirmationComponent do
     let(:session) do
       create(
         :session,
+        dates: [Date.yesterday, Date.tomorrow],
         programmes: [create(:programme, :menacwy), create(:programme, :td_ipv)]
       )
     end
@@ -53,7 +58,7 @@ describe AppConsentConfirmationComponent do
       expect(rendered).to have_text(
         "#{consent_form.given_name} #{consent_form.family_name} is due to get " \
           "the MenACWY and Td/IPV vaccinations at school on " \
-          "#{session.dates.first.to_fs(:short_day_of_week)}"
+          "#{session.dates.second.to_fs(:short_day_of_week)}"
       )
     end
   end


### PR DESCRIPTION
When displaying the dates for a session after confirming consent we only want to show dates happening in the future as those are the only ones where the patient can be vaccinated.