### PR TITLE
Mention both vaccines when doubles refused

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -59,13 +59,21 @@ class AppConsentConfirmationComponent < ViewComponent::Base
       end
     when "refused"
       "You’ve told us that you do not want #{full_name} to get the" \
-        " #{not_chosen_programmes.first.name} vaccination at school"
+        " #{not_chosen_vaccinations} at school"
     else
       raise "unrecognised consent response: #{response}"
     end
   end
 
-  def chosen_vaccinations(programmes: chosen_programmes)
+  def chosen_vaccinations
+    vaccinations_text(chosen_programmes)
+  end
+
+  def not_chosen_vaccinations
+    vaccinations_text(not_chosen_programmes)
+  end
+
+  def vaccinations_text(programmes)
     programme_names =
       programmes.map do |programme|
         programme.type == "flu" ? "nasal flu" : programme.name

--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -95,6 +95,6 @@ class AppConsentConfirmationComponent < ViewComponent::Base
       .includes(:session_dates)
       .flat_map(&:dates)
       .map { it.to_fs(:short_day_of_week) }
-      .to_sentence
+      .to_sentence(two_words_connector: " or ", last_word_connector: " or ")
   end
 end

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -71,4 +71,24 @@ describe AppConsentConfirmationComponent do
       )
     end
   end
+
+  context "consent refused for MenACWY and Td/IPV" do
+    let(:session) do
+      create(
+        :session,
+        programmes: [create(:programme, :menacwy), create(:programme, :td_ipv)]
+      )
+    end
+    let(:consent_form) { create(:consent_form, response: "refused", session:) }
+
+    it { should have_text("Consent refused") }
+
+    it "informs the user that they have refused consent" do
+      expect(rendered).to have_text(
+        "You’ve told us that you do not want #{consent_form.given_name} " \
+          "#{consent_form.family_name} to get the MenACWY and Td/IPV " \
+          "vaccinations at school"
+      )
+    end
+  end
 end

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -91,4 +91,23 @@ describe AppConsentConfirmationComponent do
       )
     end
   end
+
+  context "multiple session dates" do
+    let(:session) do
+      create(
+        :session,
+        programmes: [create(:programme, :hpv)],
+        dates: [10.days.from_now, 11.days.from_now, 13.days.from_now]
+      )
+    end
+    let(:consent_form) { create(:consent_form, response: "given", session:) }
+
+    it "lists the session dates" do
+      expect(rendered).to have_text(
+        "at school on #{10.days.from_now.to_date.to_fs(:short_day_of_week)}, " \
+          "#{11.days.from_now.to_date.to_fs(:short_day_of_week)} or " \
+          "#{13.days.from_now.to_date.to_fs(:short_day_of_week)}"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Bug in initial implementation, only one of the vaccines was mentioned on confirmation of refusal.

New version:

![image](https://github.com/user-attachments/assets/63f946df-5632-4292-be88-0b3c99d3dd51)

This change also fixes the dates so the last two are separated with " or " instead of ", and ".

![image](https://github.com/user-attachments/assets/38271b5b-1cbb-4ff1-b08d-da27ccec20d0)


