### PR TITLE
Fix vaccinated criteria for MenACWY

### DIFF
--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -12,7 +12,11 @@ class VaccinatedCriteria
       raise "Vaccination records provided for different programme."
     end
 
-    if programme.doubles?
+    if programme.menacwy?
+      vaccination_records.any? do
+        it.administered? && patient.age(now: it.performed_at) >= 10
+      end
+    elsif programme.td_ipv?
       vaccination_records.any? do
         it.administered? &&
           it.dose_sequence == programme.vaccinated_dose_sequence &&

--- a/spec/lib/vaccinated_criteria_spec.rb
+++ b/spec/lib/vaccinated_criteria_spec.rb
@@ -74,6 +74,22 @@ describe VaccinatedCriteria do
         it { should be(true) }
       end
 
+      context "with a second dose administered vaccination record" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: 2,
+              patient:,
+              programme:
+            )
+          ]
+        end
+
+        it { should be(true) }
+      end
+
       context "with an administered vaccination record when the patient was younger than 10 years old" do
         let(:vaccination_records) do
           [


### PR DESCRIPTION
For MenACWY, the patient is considered vaccinated if there are any vaccination records regardless of dose sequence. Currently we were only considering the patient vaccinated if there was a vaccination record with a dose sequence of 1.