### PR TITLE
Change given to confirmed on confirmation pages

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -23,7 +23,7 @@ class AppConsentConfirmationComponent < ViewComponent::Base
     else
       case response
       when "given"
-        "Consent given"
+        "Consent confirmed"
       when "given_one"
         chosen_programme = chosen_programmes.first.name
         "Consent for the #{chosen_programme} vaccination confirmed"

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -6,7 +6,7 @@ describe AppConsentConfirmationComponent do
   let(:consent_form) { create(:consent_form) }
   let(:component) { described_class.new(consent_form) }
 
-  it { should have_text("Consent given") }
+  it { should have_text("Consent confirmed") }
 
   it "informs the user a confirmation email will be sent" do
     expect(rendered).to have_text(
@@ -52,7 +52,7 @@ describe AppConsentConfirmationComponent do
     end
     let(:consent_form) { create(:consent_form, response: "given", session:) }
 
-    it { should have_text("Consent given") }
+    it { should have_text("Consent confirmed") }
 
     it "informs the user that their child is due a vaccination" do
       expect(rendered).to have_text(

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -245,7 +245,7 @@ RSpec.feature "Parental consent change answers" do
   end
 
   def then_i_see_the_needs_triage_confirmation_page
-    expect(page).to have_content("Consent given")
+    expect(page).to have_content("Consent confirmed")
     expect(page).to have_content(
       "As you answered ‘yes’ to some of the health questions, " \
         "we need to check the nasal flu vaccination is suitable for Joe Test."

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -128,7 +128,7 @@ describe "Parental consent" do
   end
 
   def then_i_get_a_confirmation_email_and_scheduled_survey_email
-    expect(page).to have_content("Consent given")
+    expect(page).to have_content("Consent confirmed")
 
     expect_email_to("jane@example.com", :consent_confirmation_given)
   end


### PR DESCRIPTION
Updates consent confirmation panels to say "Consent confirmed" not "Consent given".