### PR TITLE
Ensure validation against SESSION_ID works

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -448,7 +448,7 @@ class ImmunisationImportRow
           .sessions
           .for_current_academic_year
           .includes(:location, :session_dates)
-          .find(session_id)
+          .find_by(id: session_id)
       end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
         reason: <code>REASON_NOT_VACCINATED</code>
         school_name: <code>SCHOOL_NAME</code>
         school_urn: <code>SCHOOL_URN</code>
+        session_id: <code>SESSION_ID</code>
         time_of_vaccination: <code>TIME_OF_VACCINATION</code>
         uuid: <code>UUID</code>
         vaccine_given: <code>VACCINE_GIVEN</code>
@@ -295,6 +296,8 @@ en:
               blank: Enter a school name.
             school_urn:
               inclusion: The school URN is not recognised. If you’ve checked the URN, and you believe it’s valid, contact our support organisation.
+            session_id:
+              inclusion: Enter a valid ID for this organisation and programme
             time_of_vaccination:
               blank: Enter a time in the correct format
               less_than_or_equal_to: Enter a time in the past

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -297,6 +297,28 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "with an invalid session ID" do
+      let(:data) { { "SESSION_ID" => "abc" } }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:session_id]).to include(
+          "Enter a valid ID for this organisation and programme"
+        )
+      end
+    end
+
+    context "with a session ID that doesn't exist" do
+      let(:data) { { "SESSION_ID" => "123" } }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:session_id]).to include(
+          "Enter a valid ID for this organisation and programme"
+        )
+      end
+    end
+
     context "vaccination in a session and no organisation provided" do
       let(:data) { { "SESSION_ID" => session.id.to_s } }
 


### PR DESCRIPTION
Currently this was failing as the `session` method was raising an exception if the `SESSION_ID` was present but didn't match one of the session IDs of the organisation. Instead we can refactor this method to return `nil` and then it can be used in other validations, specifically when checking that the date of vaccination matches one of the dates in the session.