### PR TITLE
MAV-745: Deploy infrastructure on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,18 +2,13 @@ name: Build Mavis image
 on:
   workflow_dispatch:
   workflow_call:
-    inputs:
-      github_sha:
-        required: true
-        type: string
+
 jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.github_sha || github.sha }}
       - name: Build Docker image
         run: |
           docker build -t "mavis:latest" .

--- a/.github/workflows/continuous_deployment.yml
+++ b/.github/workflows/continuous_deployment.yml
@@ -6,16 +6,17 @@ on:
 jobs:
   Test:
     uses: ./.github/workflows/test.yml
-    with:
-      github_sha: ${{ github.sha }}
   Build:
-    uses: ./.github/workflows/build.yml
-    with:
-      github_sha: ${{ github.sha }}
     needs: Test
-  Deploy:
+    uses: ./.github/workflows/build.yml
+  DeployInfrastructure:
+    needs: Test
+    uses: ./.github/workflows/deploy_infrastructure.yml
+    with:
+      environment: "copilotmigration"
+  DeployApplication:
+    needs: DeployInfrastructure
     uses: ./.github/workflows/deploy_mavis.yml
     with:
       environment: "copilotmigration"
       image_tag: ${{ github.sha }}
-    needs: Build

--- a/.github/workflows/deploy_infrastructure.yml
+++ b/.github/workflows/deploy_infrastructure.yml
@@ -16,6 +16,12 @@ on:
           - preview
           - training
 #          - production
+  workflow_call:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: string
 
 env:
   aws_role: ${{ inputs.environment == 'production'

--- a/.github/workflows/deploy_infrastructure.yml
+++ b/.github/workflows/deploy_infrastructure.yml
@@ -15,7 +15,7 @@ on:
           - test
           - preview
           - training
-#          - production
+  #          - production
   workflow_call:
     inputs:
       environment:

--- a/.github/workflows/deploy_mavis.yml
+++ b/.github/workflows/deploy_mavis.yml
@@ -22,9 +22,6 @@ on:
         type: string
   workflow_call:
     inputs:
-      image_tag:
-        required: true
-        type: string
       environment:
         required: true
         type: string

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.github_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions
@@ -75,8 +73,6 @@ jobs:
       MAVIS__CIS2__ENABLED: false
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.github_sha || github.sha }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: .tool-versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,6 @@ name: Test
 on:
   pull_request:
   workflow_call:
-    inputs:
-      github_sha:
-        required: true
-        type: string
 
 jobs:
   rails:
@@ -29,8 +25,6 @@ jobs:
       RAILS_ENV: test
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.github_sha || github.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version-file: .tool-versions


### PR DESCRIPTION
- Call infrastructure deploy workflow
- Also remove explicit github.sha inputs
-- From documentation: `When a reusable workflow is triggered by a caller workflow, the github context is always associated with the caller workflow.`