### PR TITLE
Make sure school name is stored on vaccination record

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -202,11 +202,8 @@ class ImmunisationImportRow
   def location_name
     return unless session.nil? || session.location.generic_clinic?
 
-    if school_urn == SCHOOL_URN_UNKNOWN &&
-         (
-           (care_setting.nil? && clinic_name.blank?) ||
-             care_setting == CARE_SETTING_SCHOOL
-         )
+    if care_setting == CARE_SETTING_SCHOOL ||
+         (care_setting.nil? && clinic_name.blank?)
       school_name.presence || "Unknown"
     else
       clinic_name.presence || "Unknown"

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -118,7 +118,8 @@ describe "Immunisation imports duplicates" do
         dose_sequence: 1,
         patient: @already_vaccinated_patient,
         vaccine: @vaccine,
-        performed_by_user: nil
+        performed_by_user: nil,
+        location_name: "Eton College"
       )
     @another_previous_vaccination_record =
       create(
@@ -133,7 +134,8 @@ describe "Immunisation imports duplicates" do
         dose_sequence: 1,
         patient: @third_patient,
         vaccine: @other_vaccine,
-        performed_by_user: nil
+        performed_by_user: nil,
+        location_name: "Eton College"
       )
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -734,6 +734,29 @@ describe ImmunisationImportRow do
       it { should be_nil }
     end
 
+    context "with a known school and unknown care setting" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "123456",
+          "SCHOOL_NAME" => "Waterloo Road"
+        )
+      end
+
+      it { should eq("Waterloo Road") }
+    end
+
+    context "with a known school and community care setting" do
+      let(:data) do
+        valid_data.merge(
+          "SCHOOL_URN" => "123456",
+          "SCHOOL_NAME" => "Waterloo Road",
+          "CARE_SETTING" => "2"
+        )
+      end
+
+      it { should eq("Unknown") }
+    end
+
     context "when home educated and community care setting" do
       let(:data) do
         valid_data.merge(


### PR DESCRIPTION
When recording a vaccination record not associated to a session in Mavis we need to ensure that the location on the vaccination record is stored as the name of the school.

This refactors the logic to make sure it was working in all cases.