### PR TITLE
Include historical records in offline reporting

### DIFF
--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -252,6 +252,76 @@ describe Reports::OfflineSessionExporter do
         end
       end
 
+      context "with a vaccinated patient outside the session" do
+        before { create(:patient_session, patient:, session:) }
+
+        let!(:vaccination_record) do
+          create(
+            :vaccination_record,
+            performed_at:,
+            batch:,
+            patient:,
+            programme:,
+            performed_by: user,
+            notes: "Some notes.",
+            location_name: "Waterloo Road"
+          )
+        end
+
+        it "adds a row with the vaccination details" do
+          expect(rows.count).to eq(1)
+          expect(
+            rows.first.except(
+              "BATCH_EXPIRY_DATE",
+              "PERSON_DOB",
+              "DATE_OF_VACCINATION"
+            )
+          ).to eq(
+            {
+              "ANATOMICAL_SITE" => "left upper arm",
+              "BATCH_NUMBER" => batch.name,
+              "CARE_SETTING" => nil,
+              "CONSENT_DETAILS" => "",
+              "CONSENT_STATUS" => "",
+              "DOSE_SEQUENCE" => 1,
+              "GILLICK_ASSESSED_BY" => nil,
+              "GILLICK_ASSESSMENT_DATE" => nil,
+              "GILLICK_ASSESSMENT_NOTES" => nil,
+              "GILLICK_STATUS" => "",
+              "HEALTH_QUESTION_ANSWERS" => "",
+              "NHS_NUMBER" => patient.nhs_number,
+              "NOTES" => "Some notes.",
+              "ORGANISATION_CODE" => organisation.ods_code,
+              "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
+              "PERSON_FORENAME" => patient.given_name,
+              "PERSON_GENDER_CODE" => "Not known",
+              "PERSON_POSTCODE" => patient.address_postcode,
+              "PERSON_SURNAME" => patient.family_name,
+              "PROGRAMME" => "HPV",
+              "REASON_NOT_VACCINATED" => "",
+              "SCHOOL_NAME" => "Waterloo Road",
+              "SCHOOL_URN" => "888888",
+              "SESSION_ID" => nil,
+              "TIME_OF_VACCINATION" => "12:05:20",
+              "TRIAGED_BY" => nil,
+              "TRIAGE_DATE" => nil,
+              "TRIAGE_NOTES" => nil,
+              "TRIAGE_STATUS" => nil,
+              "VACCINATED" => "Y",
+              "VACCINE_GIVEN" => "Gardasil9",
+              "UUID" => vaccination_record.uuid,
+              "YEAR_GROUP" => patient.year_group
+            }
+          )
+          expect(rows.first["BATCH_EXPIRY_DATE"].to_date).to eq(batch.expiry)
+          expect(rows.first["PERSON_DOB"].to_date).to eq(patient.date_of_birth)
+          expect(rows.first["DATE_OF_VACCINATION"].to_date).to eq(
+            performed_at.to_date
+          )
+        end
+      end
+
       context "with a patient who couldn't be vaccinated" do
         before { create(:patient_session, patient:, session:) }
 


### PR DESCRIPTION
This is important to include as a record of previous vaccinations so that the nurses have all the information they need in a context where access to Mavis is unavailable due to a lack off Internet connection.

The `SESSION_ID` will not be provided for these, which allows them to be re-imported successfully, and there's no risk of the records being duplicated as we rely on the `UUID` column to uniquely reference the records.