### PR TITLE
Reset chosen_vaccine if changing response

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -532,6 +532,8 @@ class ConsentForm < ApplicationRecord
 
     self.parent_relationship_other_name = nil unless parent_relationship_other?
 
+    self.chosen_vaccine = nil unless consent_given_one?
+
     if consent_given?
       self.reason = nil
       self.reason_notes = nil

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -672,7 +672,8 @@ describe ConsentForm do
       )
 
     consent_form.update!(
-      response: "given",
+      response: "given_one",
+      reason: "personal_choice",
       chosen_vaccine: programme2.type,
       address_line_1: "123 Fake St",
       address_town: "London",


### PR DESCRIPTION
If the parent originally decided to consent to only one vaccine and then went back to refuse or give consent, we need to make sure that the `chosen_vaccine` value is `nil` to accurately represent this state.