### PR TITLE
Fix back link on parental consent confirm page

### DIFF
--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -36,6 +36,19 @@ module ParentInterface
     end
 
     def confirm
+      previous_step = t(@consent_form.wizard_steps.last, scope: :wicked)
+
+      @back_link_path =
+        if previous_step == "health-question"
+          question_number = @consent_form.each_health_answer.to_a.last&.id
+          parent_interface_consent_form_edit_path(
+            @consent_form,
+            previous_step,
+            question_number:
+          )
+        else
+          parent_interface_consent_form_edit_path(@consent_form, previous_step)
+        end
     end
 
     def record

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -1,8 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(
-        parent_interface_consent_form_edit_path(@consent_form, :consent),
-        name: "edit consent page",
-      ) %>
+  <%= render AppBacklinkComponent.new(@back_link_path, name: "edit consent page") %>
 <% end %>
 
 <% change_link = Proc.new do |attr, params = {}|

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -35,6 +35,10 @@ RSpec.feature "Parental consent change answers" do
     then_i_see_the_consent_form_confirmation_page
     and_i_see_the_answer_i_changed_is_yes
 
+    when_i_click_back
+    then_i_see_the_last_health_question
+    and_i_answer_no_to_the_last_health_question
+
     when_i_click_the_confirm_button
     then_i_see_the_needs_triage_confirmation_page
   end
@@ -205,6 +209,19 @@ RSpec.feature "Parental consent change answers" do
     expect(page).to have_content("Yes – He has had asthma since he was 2")
     expect(page).to have_content("Yes – Follow up details")
     expect(page).to have_content("Yes – Even more follow up details")
+  end
+
+  def when_i_click_back
+    click_link "Back"
+  end
+
+  def then_i_see_the_last_health_question
+    expect(page).to have_content("Does you child take regular aspirin?")
+  end
+
+  def and_i_answer_no_to_the_last_health_question
+    choose "No"
+    click_button "Continue"
   end
 
   def when_i_change_my_consent_to_refused


### PR DESCRIPTION
The back link wasn't working correctly, it was taking the user to the `consent` question rather than taking the user to the last step in the wizard flow.

There's also the potential for the previous question to have been a health question, in which case we need to take the user to the correct one.