### PR TITLE
Fix spelling of programme

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -317,7 +317,7 @@ en:
           attributes:
             programme_ids:
               blank: Choose which programmes this session is part of
-              inclusion: You cannot remove a program from the session once it has been added
+              inclusion: You cannot remove a programme from the session once it has been added
         vaccinate_form:
           attributes:
             delivery_site:

--- a/spec/forms/session_programmes_form_spec.rb
+++ b/spec/forms/session_programmes_form_spec.rb
@@ -20,7 +20,7 @@ describe SessionProgrammesForm do
     it "is invalid" do
       expect(form).to be_invalid
       expect(form.errors[:programme_ids]).to include(
-        "You cannot remove a program from the session once it has been added"
+        "You cannot remove a programme from the session once it has been added"
       )
     end
   end


### PR DESCRIPTION
This was a typo in the content.