### PR TITLE
Add patient_sessions:add_to_clinic

### DIFF
--- a/lib/tasks/patient_sessions.rake
+++ b/lib/tasks/patient_sessions.rake
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+namespace :patient_sessions do
+  desc "Ensures all patients exist in both schools and clinics."
+  task add_to_clinic: :environment do |_task, _args|
+    count = PatientSession.count
+    puts "#{count} existing patient sessions."
+
+    to_import =
+      PatientSession
+        .includes(session: :organisation)
+        .map do
+          PatientSession.new(
+            patient_id: it.patient_id,
+            session: it.session.organisation.generic_clinic_session
+          )
+        end
+
+    PatientSession.import(to_import, on_duplicate_key_ignore: :all)
+
+    puts "#{PatientSession.count - count} new patient sessions created."
+  end
+end


### PR DESCRIPTION
This adds a Rake task that helps with the post-deploy tasks for version 2.0.0 where all patients are expected to be found in the community clinics session. Once this has been run in all environments we can delete this Rake task.