### PR TITLE
Get location name from school if available

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -204,7 +204,7 @@ class ImmunisationImportRow
 
     if care_setting == CARE_SETTING_SCHOOL ||
          (care_setting.nil? && clinic_name.blank?)
-      school_name.presence || "Unknown"
+      school&.name || school_name.presence || "Unknown"
     else
       clinic_name.presence || "Unknown"
     end

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -47,7 +47,7 @@ describe "Immunisation imports duplicates" do
       organisation: @organisation,
       programme: @programme
     )
-    @location = create(:school, urn: "110158")
+    @location = create(:school, urn: "110158", name: "Eton College")
     @session =
       create(
         :session,

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -51,7 +51,7 @@ describe ImmunisationImportRow do
   end
   let(:valid_data) { valid_flu_data }
 
-  let!(:location) { create(:school, urn: "123456") }
+  let!(:location) { create(:school, urn: "123456", name: "Waterloo Road") }
 
   describe "validations" do
     context "with an empty row" do
@@ -745,6 +745,12 @@ describe ImmunisationImportRow do
           "SCHOOL_NAME" => "Waterloo Road"
         )
       end
+
+      it { should eq("Waterloo Road") }
+    end
+
+    context "with a known school and no school name" do
+      let(:data) { valid_data.merge("SCHOOL_URN" => "123456") }
 
       it { should eq("Waterloo Road") }
     end


### PR DESCRIPTION
When importing vaccination records, if we have a school URN and no school name, we can try and get the school name from the school by looking up the URN.