### PR TITLE
Ensure programmes are valid for session

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -444,7 +444,7 @@ class ImmunisationImportRow
         organisation
           .sessions
           .for_current_academic_year
-          .includes(:location, :session_dates)
+          .includes(:location, :programmes, :session_dates)
           .find_by(id: session_id)
       end
   end
@@ -472,7 +472,7 @@ class ImmunisationImportRow
 
   def programmes_by_name
     @programmes_by_name ||=
-      organisation
+      (session || organisation)
         .programmes
         .each_with_object({}) do |programme, hash|
           programme.import_names.each { |name| hash[name] = programme }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,6 +290,9 @@ en:
             performed_ods_code:
               blank: Enter an organisation code.
               equal_to: Enter an organisation code that matches the current organisation.
+            programme_name:
+              blank: Enter a programme
+              inclusion: Enter a programme administered by this organisation
             reason:
               blank: Enter a valid reason
             school_name:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -63,7 +63,7 @@ describe ImmunisationImportRow do
           /You need to record whether the child was vaccinated or not/
         )
         expect(immunisation_import_row.errors[:programme_name]).to include(
-          "is not included in the list"
+          "Enter a programme administered by this organisation"
         )
       end
     end
@@ -332,6 +332,26 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:performed_ods_code]).to eq(
           ["Enter an organisation code."]
+        )
+      end
+    end
+
+    context "vaccination in a session and invalid programme" do
+      let(:data) do
+        { "SESSION_ID" => session.id.to_s, "PROGRAMME" => "MenACWY" }
+      end
+
+      let(:programmes) do
+        [create(:programme, :hpv), create(:programme, :menacwy)]
+      end
+      let(:session) do
+        create(:session, organisation:, programmes: [programmes.first])
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:programme_name]).to eq(
+          ["Enter a programme administered by this organisation"]
         )
       end
     end


### PR DESCRIPTION
When importing vaccination records for a particular session we need to make sure that the programmes are valid for that session.