### PR TITLE
Remove margins on captions and submit buttons

### DIFF
--- a/app/views/batches/new.html.erb
+++ b/app/views/batches/new.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Add batch" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @batch.vaccine.brand %>
   </span>
   <%= page_title %>

--- a/app/views/consent_forms/archive.html.erb
+++ b/app/views/consent_forms/archive.html.erb
@@ -7,7 +7,7 @@
 
   <% page_title = "Archive response" %>
   <%= h1 page_title: do %>
-    <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <span class="nhsuk-caption-l">
       Consent response from <%= @consent_form.parent_full_name %>
     </span>
     <%= page_title %>

--- a/app/views/consent_forms/archive.html.erb
+++ b/app/views/consent_forms/archive.html.erb
@@ -17,7 +17,5 @@
 
   <%= f.govuk_text_area :notes, label: { text: "Notes", size: "m" } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Archive response", warning: true %>
-  </div>
+  <%= f.govuk_submit "Archive response", warning: true %>
 <% end %>

--- a/app/views/consent_forms/match.html.erb
+++ b/app/views/consent_forms/match.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Link consent response with child record?" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     Consent response from <%= @consent_form.parent_full_name %>
   </span>
   <%= page_title %>

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -4,7 +4,7 @@
 
 <% page_title = "Search for a child record" %>
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     Consent response from <%= @consent_form.parent_full_name %>
   </span>
   <%= page_title %>

--- a/app/views/consents/invalidate.html.erb
+++ b/app/views/consents/invalidate.html.erb
@@ -7,7 +7,7 @@
 
   <% page_title = "Mark response as invalid" %>
   <%= h1 page_title: do %>
-    <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <span class="nhsuk-caption-l">
       Consent response from <%= @consent.name %>
     </span>
     <%= page_title %>

--- a/app/views/consents/invalidate.html.erb
+++ b/app/views/consents/invalidate.html.erb
@@ -17,7 +17,5 @@
 
   <%= f.govuk_text_area :notes, label: { text: "Notes", size: "m" } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Mark as invalid", warning: true %>
-  </div>
+  <%= f.govuk_submit "Mark as invalid", warning: true %>
 <% end %>

--- a/app/views/consents/withdraw.html.erb
+++ b/app/views/consents/withdraw.html.erb
@@ -30,7 +30,5 @@
 
   <%= f.govuk_text_area :notes, label: { text: "Notes", size: "m" } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Withdraw consent" %>
-  </div>
+  <%= f.govuk_submit "Withdraw consent" %>
 <% end %>

--- a/app/views/consents/withdraw.html.erb
+++ b/app/views/consents/withdraw.html.erb
@@ -7,7 +7,7 @@
 
   <% page_title = "Withdraw consent" %>
   <%= h1 page_title: do %>
-    <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <span class="nhsuk-caption-l">
     Consent response from <%= @consent.name %>
   </span>
     <%= page_title %>

--- a/app/views/draft_consents/agree.html.erb
+++ b/app/views/draft_consents/agree.html.erb
@@ -24,7 +24,5 @@
     <% end %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Check and confirm answers" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @patient.full_name %>
   </span>
   <%= page_title %>

--- a/app/views/draft_consents/notes.html.erb
+++ b/app/views/draft_consents/notes.html.erb
@@ -9,7 +9,5 @@
 
   <%= f.govuk_text_area :notes, label: { text: "Give details" } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/parent_details.html.erb
+++ b/app/views/draft_consents/parent_details.html.erb
@@ -9,7 +9,7 @@
      end %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @parent.label %>
   </span>
   <%= page_title %>

--- a/app/views/draft_consents/parent_details.html.erb
+++ b/app/views/draft_consents/parent_details.html.erb
@@ -57,7 +57,5 @@
     <%= f.govuk_check_box :parent_phone_receive_updates, 1, 0, multiple: false, link_errors: true, label: { text: "Get updates by text message" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/questions.html.erb
+++ b/app/views/draft_consents/questions.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Health questions" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @patient.full_name %>
   </span>
   <%= page_title %>

--- a/app/views/draft_consents/questions.html.erb
+++ b/app/views/draft_consents/questions.html.erb
@@ -31,7 +31,5 @@
     <% end %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/reason.html.erb
+++ b/app/views/draft_consents/reason.html.erb
@@ -26,7 +26,5 @@
                              label: { text: "Other" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/route.html.erb
+++ b/app/views/draft_consents/route.html.erb
@@ -18,7 +18,5 @@
                                                  tag: "h1",
                                                  text: title } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/triage.html.erb
+++ b/app/views/draft_consents/triage.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Is it safe to vaccinate?" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @patient.full_name %>
   </span>
   <%= page_title %>

--- a/app/views/draft_consents/who.html.erb
+++ b/app/views/draft_consents/who.html.erb
@@ -40,7 +40,5 @@
                              link_errors: !gillick_competent && @parent_options.empty? %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_consents/who.html.erb
+++ b/app/views/draft_consents/who.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Who are you trying to get consent from?" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @patient.full_name %>
   </span>
   <%= page_title %>

--- a/app/views/draft_vaccination_records/date_and_time.html.erb
+++ b/app/views/draft_vaccination_records/date_and_time.html.erb
@@ -29,7 +29,5 @@
     <% end %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit %>
-  </div>
+  <%= f.govuk_submit %>
 <% end %>

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -5,7 +5,7 @@
 <% page_title = "Tell us how the vaccination was given" %>
 
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @patient.full_name %>
   </span>
   <%= page_title %>

--- a/app/views/draft_vaccination_records/notes.html.erb
+++ b/app/views/draft_vaccination_records/notes.html.erb
@@ -12,7 +12,5 @@
                         label: { text: "Notes", tag: "h1", size: "l" },
                         hint: { text: "For example, if the child had a reaction to the vaccine" } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/address.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/address.html.erb
@@ -29,7 +29,5 @@
                          autocomplete: "postal-code",
                          class: "nhsuk-input--width-10" %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/confirm_school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/confirm_school.html.erb
@@ -25,7 +25,5 @@
                              label: { text: "No, they go to a different school" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/consent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/consent.html.erb
@@ -33,7 +33,5 @@
     <%= f.govuk_radio_button :response, "refused", label: { text: "No" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/contact_method.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/contact_method.html.erb
@@ -26,7 +26,5 @@
                              label: { text: "I do not have specific needs" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/date_of_birth.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/date_of_birth.html.erb
@@ -17,7 +17,5 @@
                          hint: { text: "For example, 27 3 2012" },
                          link_errors: true %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/education_setting.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/education_setting.html.erb
@@ -19,7 +19,5 @@
                              label: { text: "No, they are not in education" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/health_question.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/health_question.html.erb
@@ -25,7 +25,5 @@
                              label: { text: "No" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/injection.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/injection.html.erb
@@ -22,7 +22,5 @@
                              label: { text: "No" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -30,7 +30,5 @@
     <%= f.govuk_radio_button :use_preferred_name, false, label: { text: "No" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/parent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/parent.html.erb
@@ -52,7 +52,5 @@
     <%= f.govuk_check_box :parent_phone_receive_updates, 1, 0, multiple: false, link_errors: true, label: { text: "Tick this box if you’d like to get updates by text message" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -30,7 +30,5 @@
                              label: { text: "Other" } %>
   <% end %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
@@ -10,7 +10,5 @@
   <%= f.govuk_text_area :reason_notes,
                         label: { text: "Give details" + (@consent_form.reason_notes_must_be_provided? ? "" : " (optional)") } %>
 
-  <div class="nhsuk-u-margin-top-6">
-    <%= f.govuk_submit "Continue" %>
-  </div>
+  <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/school_moves/show.html.erb
+++ b/app/views/school_moves/show.html.erb
@@ -9,7 +9,7 @@
 
 <% page_title = "Review school move" %>
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+  <span class="nhsuk-caption-l">
     <%= @patient.full_name %>
   </span>
   <%= page_title %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -8,7 +8,7 @@
 <%= h1 @session.location.name %>
 
 <% if (school = @session.location)&.school? %>
-  <p class="nhsuk-caption-l nhsuk-u-margin-bottom-4">
+  <p class="nhsuk-caption-l">
     URN: <span class="app-u-monospace"><%= school.urn %></span>
   </p>
 <% end %>


### PR DESCRIPTION
These margins don't exist in the prototype so we don't need them in the live service. If we do need a margin on the captions and submit buttons then we should apply it across the service rather than on an individual basis to ensure consistency.