### PR TITLE
Parse TIME_OF_VACCINATION with local time zone

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -541,7 +541,7 @@ class ImmunisationImportRow
 
     parsed_times =
       TIME_FORMATS.lazy.filter_map do |format|
-        Time.strptime(value, format)
+        Time.zone.strptime(value, format)
       rescue ArgumentError, TypeError
         nil
       end


### PR DESCRIPTION
This change has no effect on the functionality because we already use the local time zone when generating the value for `performed_at`, however this ensures that the tests pass when running the service in a time zone outside of `Europe/London`.