### PR TITLE
Improve vaccine and programme error messages

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,7 +292,7 @@ en:
               equal_to: Enter an organisation code that matches the current organisation.
             programme_name:
               blank: Enter a programme
-              inclusion: Enter a programme administered by this organisation
+              inclusion: This programme is not available in this session
             reason:
               blank: Enter a valid reason
             school_name:
@@ -307,7 +307,8 @@ en:
             uuid:
               inclusion: Enter an existing record
             vaccine_given:
-              inclusion: Enter a valid vaccine, eg Gardasil9.
+              blank: Enter a vaccine
+              inclusion: This vaccine is not available in this session
         import_duplicate_form:
           attributes:
             apply_changes:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -63,7 +63,7 @@ describe ImmunisationImportRow do
           /You need to record whether the child was vaccinated or not/
         )
         expect(immunisation_import_row.errors[:programme_name]).to include(
-          "Enter a programme administered by this organisation"
+          "This programme is not available in this session"
         )
       end
     end
@@ -100,7 +100,7 @@ describe ImmunisationImportRow do
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:vaccine_given]).to eq(
-          ["Enter a valid vaccine, eg Gardasil9."]
+          ["This vaccine is not available in this session"]
         )
       end
     end
@@ -351,7 +351,7 @@ describe ImmunisationImportRow do
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:programme_name]).to eq(
-          ["Enter a programme administered by this organisation"]
+          ["This programme is not available in this session"]
         )
       end
     end


### PR DESCRIPTION
When importing vaccination records, the current error messages weren't clear enough and we've been given some improved content.