### PR TITLE
Change the Careplus exporter to redact patient address_line_1 if patient is restricted.

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -138,7 +138,7 @@ class Reports::CareplusExporter
       patient.family_name,
       patient.given_name,
       patient.date_of_birth.strftime("%d/%m/%Y"),
-      patient.address_line_1,
+      patient.restricted? ? "" : patient.address_line_1,
       patient_session.latest_consents(programme:).first&.name || "",
       99, # Ethnicity, 99 is "Not known"
       first_vaccination.performed_at.strftime("%d/%m/%Y"),


### PR DESCRIPTION
This now matches `programme_vaccinations_exporter.rb`