### PR TITLE
Change the CarePlus exporter to redact patient address_line_1 if patient is restricted

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -135,7 +135,7 @@ class Reports::CareplusExporter
       patient.family_name,
       patient.given_name,
       patient.date_of_birth.strftime("%d/%m/%Y"),
-      patient.address_line_1,
+      patient.restricted? ? "" : patient.address_line_1,
       patient_session.consent.latest(programme:).first&.name || "",
       99, # Ethnicity, 99 is "Not known"
       first_vaccination.performed_at.strftime("%d/%m/%Y"),

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -189,4 +189,32 @@ describe Reports::CareplusExporter do
       expect(data_rows.first).to be_nil
     end
   end
+
+  context "with a restricted patient" do
+    it "doesn't include the address line 1" do
+      patient_session =
+        create(
+          :patient_session,
+          :consent_given_triage_not_needed,
+          programmes:,
+          session:
+        )
+      create(
+        :vaccination_record,
+        programme: programmes.first,
+        patient: patient_session.patient,
+        session: patient_session.session,
+        performed_at: 2.weeks.ago
+      )
+
+      patient_session.patient.update!(restricted_at: Time.current)
+
+      address_index = headers.index("Address Line 1")
+      row = data_rows.first
+
+      expect(row[0]).to eq(patient_session.patient.nhs_number)
+      expect(row).not_to be_nil
+      expect(row[address_index]).to be_blank
+    end
+  end
 end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -333,6 +333,27 @@ describe Reports::ProgrammeVaccinationsExporter do
       end
     end
 
+    context "with a restricted patient" do
+      let(:session) { create(:session, programmes:, organisation:) }
+      let(:patient) { create(:patient, :restricted, session:) }
+
+      before do
+        create(
+          :vaccination_record,
+          patient:,
+          session:,
+          programme: programmes.first,
+          performed_by: user
+        )
+      end
+
+      it "doesn't include the address or postcode" do
+        expect(rows.count).to eq(1)
+        expect(rows.first["PERSON_ADDRESS_LINE_1"]).to be_blank
+        expect(rows.first["PERSON_POSTCODE"]).to be_blank
+      end
+    end
+
     context "with a traced NHS number" do
       let(:session) { create(:session, programmes:, organisation:) }
 


### PR DESCRIPTION
Extend spec coverage for both programme vaccinations exporter and careplus exporter.

Extends #3130.