### PR TITLE
Build new session outcome tab

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -54,7 +54,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   def vaccination_record
     @vaccination_record ||=
       begin
-        vaccination_records = @patient_session.vaccination_records(programme:)
+        vaccination_records = @patient_session.outcome.all(programme:)
         if @patient_session.vaccinated?(programme:)
           vaccination_records.select(&:administered?).last
         else

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -99,7 +99,7 @@
   <% end %>
 <% end %>
 
-<% patient_session.vaccination_records(programme:).each do |vaccination_record| %>
+<% patient_session.outcome.all(programme:).each do |vaccination_record| %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Vaccination details" } %>
     <%= render AppVaccinationRecordSummaryComponent.new(vaccination_record, current_user:) %>

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -40,7 +40,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
     @link_to = link_to
     @context = context
 
-    unless context.in?(%i[consent triage register record])
+    unless context.in?(%i[consent triage register record outcome])
       raise "Unknown context: #{context}"
     end
   end

--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -55,6 +55,15 @@ class AppSearchComponent < ViewComponent::Base
             <% end %>
           <% end %>
         <% end %>
+        
+        <% if outcome_statuses.any? %>
+          <%= f.govuk_radio_buttons_fieldset :outcome_status, legend: { text: "Programme outcome", size: "s" } do %>
+            <%= f.govuk_radio_button :outcome_status, "", label: { text: "Any" } %>
+            <% outcome_statuses.each do |status| %>
+              <%= f.govuk_radio_button :outcome_status, status, label: { text: t(status, scope: %i[patient_session status outcome label]) } %>
+            <% end %>
+          <% end %>
+        <% end %>
 
         <% if year_groups.any? %>
           <%= f.govuk_check_boxes_fieldset :year_groups, legend: { text: "Year group", size: "s" } do %>
@@ -93,6 +102,7 @@ class AppSearchComponent < ViewComponent::Base
     form:,
     url:,
     consent_statuses: [],
+    outcome_statuses: [],
     record_statuses: [],
     register_statuses: [],
     triage_statuses: [],
@@ -104,6 +114,7 @@ class AppSearchComponent < ViewComponent::Base
     @url = url
 
     @consent_statuses = consent_statuses
+    @outcome_statuses = outcome_statuses
     @register_statuses = register_statuses
     @triage_statuses = triage_statuses
     @record_statuses = record_statuses
@@ -115,6 +126,7 @@ class AppSearchComponent < ViewComponent::Base
   attr_reader :form,
               :url,
               :consent_statuses,
+              :outcome_statuses,
               :record_statuses,
               :register_statuses,
               :triage_statuses,
@@ -122,8 +134,8 @@ class AppSearchComponent < ViewComponent::Base
 
   def show_buttons_in_details?
     !(
-      consent_statuses.any? || record_statuses.any? || register_statuses.any? ||
-        triage_statuses.any? || year_groups.any?
+      consent_statuses.any? || outcome_statuses.any? || record_statuses.any? ||
+        register_statuses.any? || triage_statuses.any? || year_groups.any?
     )
   end
 end

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -52,13 +52,13 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
 
     if patient_session.consent_given_triage_needed?(programme:)
       reasons = [
-        if patient_session.consent.latest(programme:).any?(&:triage_needed?)
+        if patient_session.triage.consent_needs_triage?(programme:)
           I18n.t(
             "patient_session_statuses.#{status}.banner_explanation.consent_needs_triage",
             **options
           )
         end,
-        if patient_session.vaccination_partially_administered?(programme:)
+        if patient_session.triage.vaccination_history_needs_triage?(programme:)
           I18n.t(
             "patient_session_statuses.#{status}.banner_explanation.vaccination_partially_administered",
             **options
@@ -84,7 +84,7 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   def nurse
     (
       patient_session.triage.all(programme:) +
-        patient_session.vaccination_records(programme:)
+        patient_session.outcome.all(programme:)
     ).max_by(&:updated_at)&.performed_by&.full_name
   end
 

--- a/app/controllers/concerns/search_form_concern.rb
+++ b/app/controllers/concerns/search_form_concern.rb
@@ -12,6 +12,7 @@ module SearchFormConcern
           :"date_of_birth(3i)",
           :consent_status,
           :missing_nhs_number,
+          :outcome_status,
           :q,
           :record_status,
           :register_status,

--- a/app/controllers/sessions/outcome_controller.rb
+++ b/app/controllers/sessions/outcome_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "pagy/extras/array"
+
+class Sessions::OutcomeController < ApplicationController
+  include Pagy::Backend
+  include SearchFormConcern
+
+  before_action :set_session
+  before_action :set_search_form
+
+  layout "full"
+
+  def show
+    scope =
+      @session.patient_sessions.preload_for_status.in_programmes(
+        @session.programmes
+      )
+
+    @valid_statuses = PatientSession::Outcome::STATUSES
+
+    patient_sessions = @form.apply(scope)
+
+    if patient_sessions.is_a?(Array)
+      @pagy, @patient_sessions = pagy_array(patient_sessions)
+    else
+      @pagy, @patient_sessions = pagy(patient_sessions)
+    end
+  end
+
+  private
+
+  def set_session
+    @session =
+      policy_scope(Session).includes(:programmes).find_by!(
+        slug: params[:session_slug]
+      )
+  end
+end

--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -23,6 +23,10 @@ class Sessions::RegisterController < ApplicationController
     patient_sessions =
       @form.apply(scope) do |filtered_scope|
         filtered_scope.select do
+          if it.outcome.status.values.all?(PatientSession::Outcome::VACCINATED)
+            next false
+          end
+
           it.consent.status.values.include?(PatientSession::Consent::GIVEN) &&
             (
               it.triage.status.values.include?(

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -8,6 +8,7 @@ class SearchForm
   attribute :consent_status, :string
   attribute :date_of_birth, :date
   attribute :missing_nhs_number, :boolean
+  attribute :outcome_status, :string
   attribute :q, :string
   attribute :record_status, :string
   attribute :register_status, :string
@@ -46,6 +47,10 @@ class SearchForm
 
     if (status = consent_status&.to_sym).present?
       scope = scope.select { it.consent.status.values.include?(status) }
+    end
+
+    if (status = outcome_status&.to_sym).present?
+      scope = scope.select { it.outcome.status.values.include?(status) }
     end
 
     if (status = record_status&.to_sym).present?

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -159,7 +159,7 @@ class Reports::OfflineSessionExporter
         }
       }
 
-      vaccination_records = patient_session.vaccination_records(programme:)
+      vaccination_records = patient_session.outcome.all(programme:)
 
       if vaccination_records.any?
         vaccination_records.map do |vaccination_record|

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -98,20 +98,11 @@ module PatientSessionStatusConcern
     end
 
     def vaccination_administered?(programme:)
-      VaccinatedCriteria.call(
-        programme,
-        patient:,
-        vaccination_records: vaccination_records(programme:)
-      )
-    end
-
-    def vaccination_partially_administered?(programme:)
-      vaccination_records(programme:).any?(&:administered?) &&
-        !vaccination_administered?(programme:)
+      outcome.status[programme] == PatientSession::Outcome::VACCINATED
     end
 
     def vaccination_not_administered?(programme:)
-      vaccination_records(programme:).any?(&:not_administered?)
+      outcome.all(programme:).any?(&:not_administered?)
     end
 
     def vaccination_can_be_delayed?(programme:)

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -110,6 +110,10 @@ class PatientSession < ApplicationRecord
     session.programmes.select { it.year_groups.include?(patient.year_group) }
   end
 
+  def gillick_assessment(programme:)
+    gillick_assessments.select { it.programme_id == programme.id }.last
+  end
+
   def consent
     @consent ||= PatientSession::Consent.new(self)
   end
@@ -128,11 +132,5 @@ class PatientSession < ApplicationRecord
 
   def outcome
     @outcome ||= PatientSession::Outcome.new(self)
-  end
-
-  # TODO: Replace these two with objects like the above.
-
-  def gillick_assessment(programme:)
-    gillick_assessments.select { it.programme_id == programme.id }.last
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -126,13 +126,13 @@ class PatientSession < ApplicationRecord
     @record ||= PatientSession::Record.new(self)
   end
 
+  def outcome
+    @outcome ||= PatientSession::Outcome.new(self)
+  end
+
   # TODO: Replace these two with objects like the above.
 
   def gillick_assessment(programme:)
     gillick_assessments.select { it.programme_id == programme.id }.last
-  end
-
-  def vaccination_records(programme:)
-    patient.vaccination_records.select { it.programme_id == programme.id }
   end
 end

--- a/app/models/patient_session/outcome.rb
+++ b/app/models/patient_session/outcome.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class PatientSession::Outcome
+  def initialize(patient_session)
+    @patient_session = patient_session
+  end
+
+  STATUSES = [
+    VACCINATED = :vaccinated,
+    COULD_NOT_VACCINATE = :could_not_vaccinate,
+    NONE = :none
+  ].freeze
+
+  def status
+    @status ||= programmes.index_with { programme_status(it) }
+  end
+
+  def all(programme:)
+    patient
+      .vaccination_records
+      .reject(&:discarded?)
+      .select { it.programme_id == programme.id }
+  end
+
+  private
+
+  attr_reader :patient_session
+
+  delegate :consent, :triage, :patient, :programmes, to: :patient_session
+
+  def programme_status(programme)
+    if vaccinated?(programme:)
+      VACCINATED
+    elsif could_not_vaccinate?(programme:)
+      COULD_NOT_VACCINATE
+    else
+      NONE
+    end
+  end
+
+  def vaccinated?(programme:)
+    VaccinatedCriteria.call(
+      programme,
+      patient:,
+      vaccination_records: all(programme:)
+    )
+  end
+
+  def could_not_vaccinate?(programme:)
+    all(programme:).any?(&:not_administered?) ||
+      consent.status[programme] == PatientSession::Consent::REFUSED ||
+      triage.status[programme] == PatientSession::Triage::DO_NOT_VACCINATE
+  end
+end

--- a/app/models/patient_session/record.rb
+++ b/app/models/patient_session/record.rb
@@ -21,7 +21,7 @@ class PatientSession::Record
   end
 
   def all(programme:)
-    patient.vaccination_records.select do
+    vaccination_records.select do
       it.programme_id == programme.id && it.session_id == session.id
     end
   end
@@ -42,11 +42,13 @@ class PatientSession::Record
 
   def latest_by_programme
     @latest_by_programme ||=
-      patient
-        .vaccination_records
+      vaccination_records
         .select { it.session_id == session.id }
-        .reject(&:discarded?)
         .group_by(&:programme_id)
         .transform_values { it.max_by(&:created_at) }
+  end
+
+  def vaccination_records
+    patient.vaccination_records.reject(&:discarded?)
   end
 end

--- a/app/views/sessions/_secondary_navigation.html.erb
+++ b/app/views/sessions/_secondary_navigation.html.erb
@@ -28,4 +28,10 @@
        text: "Record",
        selected: request.path == session_record_path(@session),
      )
+   
+     nav.with_item(
+       href: session_outcome_path(@session),
+       text: "Outcome",
+       selected: request.path == session_outcome_path(@session),
+     )
    end %>

--- a/app/views/sessions/outcome/show.html.erb
+++ b/app/views/sessions/outcome/show.html.erb
@@ -1,0 +1,40 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: dashboard_path },
+                                          { text: t("sessions.index.title"), href: sessions_path },
+                                          { text: @session.location.name, href: session_path(@session) },
+                                        ]) %>
+<% end %>
+
+<%= h1 @session.location.name %>
+
+<%= render "sessions/secondary_navigation" %>
+
+<div class="app-grid-row">
+  <div class="app-grid-column-filters">
+    <%= render AppSearchComponent.new(
+          form: @form,
+          url: session_outcome_path(@session),
+          outcome_statuses: @valid_statuses,
+          year_groups: @session.year_groups,
+        ) %>
+  </div>
+
+  <div class="app-grid-column-results">
+    <%= render AppSearchResultsComponent.new(@pagy) do %>
+      <% @patient_sessions.each do |patient_session| %>
+        <% programme = patient_session.programmes.first %>
+
+        <% link_to = session_patient_programme_path(
+             patient_session.session,
+             patient_session.section(programme:),
+             patient_session.tab(programme:),
+             patient_session.patient,
+             programme
+           ) %>
+
+        <%= render AppPatientSessionSearchResultCardComponent.new(patient_session, link_to:, context: :outcome) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/patient_session.en.yml
+++ b/config/locales/patient_session.en.yml
@@ -53,3 +53,14 @@ en:
           none: grey
           not_well: red
           refused: red
+      outcome:
+        label:
+          could_not_vaccinate: Could not vaccinate
+          none: No outcome yet
+          partially_vaccinated: Partially vaccinated
+          vaccinated: Vaccinated
+        colour:
+          could_not_vaccinate: red
+          none: grey
+          partially_vaccinated: green
+          vaccinated: green

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,6 +201,7 @@ Rails.application.routes.draw do
       get "batch/:programme_type", action: :edit_batch, as: :batch
       post "batch/:programme_type", action: :update_batch
     end
+    resource :outcome, only: :show, controller: "sessions/outcome"
 
     resource :invite_to_clinic,
              path: "invite-to-clinic",

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -59,9 +59,7 @@ describe AppOutcomeBannerComponent do
 
   context "state is vaccinated" do
     let(:patient_session) { create(:patient_session, :vaccinated, session:) }
-    let(:vaccination_record) do
-      patient_session.vaccination_records(programme:).first
-    end
+    let(:vaccination_record) { patient_session.outcome.all(programme:).first }
     let(:vaccine) { programme.vaccines.first }
     let(:location) { patient_session.session.location }
     let(:batch) { vaccine.batches.first }
@@ -81,7 +79,7 @@ describe AppOutcomeBannerComponent do
       let(:patient_session) do
         create(:patient_session, :vaccinated, session:).tap do |ps|
           ps.strict_loading!(false)
-          ps.vaccination_records(programme:).first.update!(performed_at: date)
+          ps.outcome.all(programme:).first.update!(performed_at: date)
         end
       end
 

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -25,7 +25,7 @@ describe AppSimpleStatusBannerComponent do
     patient_session.triage.all(programme:).last.performed_by.full_name
   end
   let(:vaccination_nurse_name) do
-    patient_session.vaccination_records(programme:).last.performed_by.full_name
+    patient_session.outcome.all(programme:).last.performed_by.full_name
   end
   let(:patient_name) { patient_session.patient.full_name }
 

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -152,12 +152,9 @@ describe "Delete vaccination record" do
   end
 
   def and_i_go_to_a_patient_that_is_vaccinated_in_the_session
-    # TODO: Check "Outcome" tab
-    # visit session_record_path(@session)
-    # choose "Vaccinated"
-    # click_on "Update results"
-
-    visit session_consent_path(@session)
+    visit session_outcome_path(@session)
+    choose "Vaccinated"
+    click_on "Update results"
     click_link @patient.full_name
   end
 

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -245,12 +245,10 @@ describe "HPV vaccination" do
   def then_i_see_the_uploaded_vaccination_outcomes_reflected_in_the_session(
     clinic:
   )
-    # TODO: Check "Outcome" tab
-    # click_on "Record"
-    # choose "Vaccinated"
-    # click_on "Update results"
+    click_on "Outcome"
+    choose "Vaccinated"
+    click_on "Update results"
 
-    click_on "Consent"
     click_on @vaccinated_patient.full_name
 
     expect(page).to have_content("Vaccinated")
@@ -266,9 +264,9 @@ describe "HPV vaccination" do
 
     # TODO: Update this once back links work
     # click_link "Back to record tab"
-    visit session_consent_path(session)
+    visit session_outcome_path(session)
 
-    # choose "Absent from session"
+    choose "Could not vaccinate"
     click_on "Update results"
 
     click_on @unvaccinated_patient.full_name
@@ -279,9 +277,9 @@ describe "HPV vaccination" do
 
     # TODO: Update this once back links work
     # click_link "Back to record tab"
-    visit session_consent_path(session)
+    visit session_outcome_path(session)
 
-    # choose "Vaccinated"
+    choose "Vaccinated"
     click_on "Update results"
 
     click_on @restricted_vaccinated_patient.full_name

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -274,9 +274,7 @@ describe "Parental consent school" do
       click_on "Community clinics"
     end
 
-    # TODO: Check in "Outcome" tab
-    click_on "Consent"
-
+    click_on "Outcome"
     click_on @child.full_name
   end
 

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -197,8 +197,7 @@ describe "Parental consent create patient" do
     end
     click_link "Pilot School"
 
-    # TODO: Check "Outcome" tab
-    click_on "Consent"
+    click_on "Outcome"
   end
 
   def then_the_patient_should_be_ready_to_vaccinate

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -152,10 +152,10 @@ describe "Parental consent" do
     end
     click_on "Pilot School"
 
-    click_on "Consent" # TODO: Outcome
+    click_on "Outcome"
 
-    expect(page).to have_content("Consent refused")
-    choose "Consent refused"
+    expect(page).to have_content("Could not vaccinate")
+    choose "Could not vaccinate"
     click_on "Update results"
 
     expect(page).to have_content(@child.full_name)

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -195,11 +195,9 @@ describe "Parental consent" do
   def when_they_check_triage
     click_link "Pilot School"
 
-    # TODO: Check in "Outcome" tab
-    # choose "No triage needed"
-    # click_on "Update results"
-
-    click_on "Consent"
+    click_on "Outcome"
+    choose "No outcome yet"
+    click_on "Update results"
   end
 
   def then_the_patient_should_be_ready_to_vaccinate

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -6,6 +6,7 @@ describe SearchForm do
       consent_status:,
       date_of_birth:,
       missing_nhs_number:,
+      outcome_status:,
       q:,
       record_status:,
       register_status:,
@@ -17,6 +18,7 @@ describe SearchForm do
   let(:consent_status) { nil }
   let(:date_of_birth) { Date.current }
   let(:missing_nhs_number) { true }
+  let(:outcome_status) { nil }
   let(:q) { "query" }
   let(:record_status) { nil }
   let(:register_status) { nil }
@@ -58,6 +60,7 @@ describe SearchForm do
       let(:consent_status) { "given" }
       let(:date_of_birth) { nil }
       let(:missing_nhs_number) { nil }
+      let(:outcome_status) { nil }
       let(:q) { nil }
       let(:register_status) { nil }
       let(:triage_status) { nil }
@@ -70,10 +73,28 @@ describe SearchForm do
       end
     end
 
+    context "filtering on outcome status" do
+      let(:consent_status) { nil }
+      let(:date_of_birth) { nil }
+      let(:missing_nhs_number) { nil }
+      let(:outcome_status) { "vaccinated" }
+      let(:q) { nil }
+      let(:record_status) { nil }
+      let(:register_status) { nil }
+      let(:triage_status) { nil }
+      let(:year_groups) { nil }
+
+      it "filters on outcome status" do
+        patient_session = create(:patient_session, :vaccinated)
+        expect(form.apply(scope)).to include(patient_session)
+      end
+    end
+
     context "filtering on record status" do
       let(:consent_status) { nil }
       let(:date_of_birth) { nil }
       let(:missing_nhs_number) { nil }
+      let(:outcome_status) { nil }
       let(:q) { nil }
       let(:record_status) { "administered" }
       let(:register_status) { nil }
@@ -90,6 +111,7 @@ describe SearchForm do
       let(:consent_status) { nil }
       let(:date_of_birth) { nil }
       let(:missing_nhs_number) { nil }
+      let(:outcome_status) { nil }
       let(:q) { nil }
       let(:record_status) { nil }
       let(:register_status) { "present" }
@@ -106,6 +128,7 @@ describe SearchForm do
       let(:consent_status) { nil }
       let(:date_of_birth) { nil }
       let(:missing_nhs_number) { nil }
+      let(:outcome_status) { nil }
       let(:q) { nil }
       let(:record_status) { nil }
       let(:register_status) { nil }

--- a/spec/models/patient_session/outcome_spec.rb
+++ b/spec/models/patient_session/outcome_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+describe PatientSession::Outcome do
+  subject(:instance) { described_class.new(patient_session) }
+
+  let(:programme) { create(:programme, :hpv) }
+  let(:patient) { create(:patient, year_group: 8) }
+  let(:patient_session) do
+    create(:patient_session, patient:, programmes: [programme])
+  end
+
+  before { patient.strict_loading!(false) }
+
+  describe "#status" do
+    subject(:status) { instance.status.fetch(programme) }
+
+    context "with no vaccination record" do
+      it { should be(described_class::NONE) }
+    end
+
+    context "with a vaccination administered" do
+      before { create(:vaccination_record, patient:, programme:) }
+
+      it { should be(described_class::VACCINATED) }
+    end
+
+    context "with a vaccination not administered" do
+      before do
+        create(:vaccination_record, :not_administered, patient:, programme:)
+      end
+
+      it { should be(described_class::COULD_NOT_VACCINATE) }
+    end
+
+    context "with a discarded vaccination administered" do
+      before { create(:vaccination_record, :discarded, patient:, programme:) }
+
+      it { should be(described_class::NONE) }
+    end
+  end
+
+  describe "#all" do
+    subject(:all) { instance.all(programme:) }
+
+    let(:later_vaccination_record) do
+      create(:vaccination_record, patient:, programme:)
+    end
+    let(:earlier_vaccination_record) do
+      create(:vaccination_record, patient:, programme:, created_at: 1.day.ago)
+    end
+
+    it { should eq([earlier_vaccination_record, later_vaccination_record]) }
+  end
+end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -30,20 +30,6 @@ describe PatientSession do
 
   it { should have_many(:gillick_assessments).order(:created_at) }
 
-  describe "#vaccination_records" do
-    subject(:vaccination_records) do
-      patient_session.vaccination_records(programme:)
-    end
-
-    let(:patient) { patient_session.patient }
-    let(:later_record) { create(:vaccination_record, programme:, patient:) }
-    let(:earlier_record) do
-      create(:vaccination_record, programme:, patient:, performed_at: 1.day.ago)
-    end
-
-    it { should eq([earlier_record, later_record]) }
-  end
-
   describe "#safe_to_destroy?" do
     subject(:safe_to_destroy?) { patient_session.safe_to_destroy? }
 


### PR DESCRIPTION
This updates the design of the session outcome page to match the latest designs in the prototype, where a single tab for vaccinations are shown and the nurses are able to filter the patients by vaccination status and see the value per programme.

## Screenshots

<img width="1159" alt="Screenshot 2025-03-05 at 07 25 49" src="https://github.com/user-attachments/assets/3f45ce80-62cd-49ff-90e4-04279575dd85" />
<img width="1153" alt="Screenshot 2025-03-05 at 07 26 01" src="https://github.com/user-attachments/assets/838593bf-b0dd-418c-9bf9-64c0fe400396" />
