### PR TITLE
Update vaccination journey content

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -47,7 +47,7 @@
     <hr class="nhsuk-section-break nhsuk-section-break--visible nhsuk-section-break--l">
 
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
-      Is <%= patient.given_name %> ready to vaccinate in this session?
+      Is <%= patient.given_name %> ready for their <%= programme.name %> vaccination?
     </h2>
 
     <%= f.govuk_radio_buttons_fieldset :administered, legend: nil do %>

--- a/app/views/draft_vaccination_records/batch.html.erb
+++ b/app/views/draft_vaccination_records/batch.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% content_for :page_title, "Which batch did you use?" %>
+<% content_for :page_title, "Which batch did you use for the #{@programme.name} vaccination?" %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/draft_vaccination_records/date_and_time.html.erb
+++ b/app/views/draft_vaccination_records/date_and_time.html.erb
@@ -6,7 +6,7 @@
   <%= f.govuk_error_summary %>
 
   <span class="nhsuk-caption-l"><%= @patient.full_name %></span>
-  <%= h1 "When was the vaccination given?" %>
+  <%= h1 "When was the #{@programme.name} vaccination given?" %>
 
   <%= f.govuk_date_field :performed_at,
                          legend: { text: "Date" },

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% page_title = "Tell us how the vaccination was given" %>
+<% page_title = "How was the #{@programme.name} vaccination given?" %>
 
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l">
@@ -18,17 +18,13 @@
                                        vaccination_delivery_methods_for(@draft_vaccination_record.vaccine),
                                        :first,
                                        :second,
-                                       legend: {
-                                         text: "How was the vaccination given?",
-                                       } %>
+                                       legend: { text: "Method" } %>
 
   <%= f.govuk_collection_radio_buttons :delivery_site,
                                        vaccination_delivery_sites_for(@draft_vaccination_record.vaccine),
                                        :first,
                                        :second,
-                                       legend: {
-                                         text: "Site",
-                                       } %>
+                                       legend: { text: "Site" } %>
 
   <%= f.govuk_submit "Continue" %>
 <% end %>

--- a/app/views/draft_vaccination_records/location.html.erb
+++ b/app/views/draft_vaccination_records/location.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% title = "Where was the vaccination given?" %>
+<% title = "Where was the #{@programme.name} vaccination given?" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>

--- a/app/views/draft_vaccination_records/outcome.html.erb
+++ b/app/views/draft_vaccination_records/outcome.html.erb
@@ -4,7 +4,7 @@
 
 <% editing = @draft_vaccination_record.editing? || @draft_vaccination_record.outcome.present? %>
 
-<% title = editing ? "Vaccination outcome" : "Why was the vaccine not given?" %>
+<% title = editing ? "Vaccination outcome" : "Why was the #{@programme.name} vaccination not given?" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>

--- a/app/views/draft_vaccination_records/vaccine.html.erb
+++ b/app/views/draft_vaccination_records/vaccine.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% page_title = "Vaccine" %>
+<% page_title = "Which vaccine did you use for the #{@programme.name} vaccination?" %>
 <% content_for :page_title, page_title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -43,7 +43,7 @@ describe AppPatientPageComponent do
 
     it { should have_content("Is it safe to vaccinate") }
 
-    it { should_not have_content("ready to vaccinate in this session?") }
+    it { should_not have_content("ready for their HPV vaccination?") }
 
     it { should have_css("a", text: "Assess Gillick competence") }
 
@@ -71,12 +71,12 @@ describe AppPatientPageComponent do
 
     it { should_not have_content("Is it safe to vaccinate") }
 
-    it { should have_content("ready to vaccinate in this session?") }
+    it { should have_content("ready for their HPV vaccination?") }
 
     context "user is not allowed to triage or vaccinate" do
       before { stub_authorization(allowed: false) }
 
-      it { should_not have_content("ready to vaccinate in this session?") }
+      it { should_not have_content("ready for their HPV vaccination?") }
     end
   end
 

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -37,7 +37,7 @@ describe AppVaccinateFormComponent do
   it "has the correct heading" do
     expect(rendered).to have_css(
       ".nhsuk-card__heading",
-      text: "Is Hari ready to vaccinate in this session?"
+      text: "Is Hari ready for their HPV vaccination?"
     )
   end
 

--- a/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
@@ -32,6 +32,6 @@ describe "HPV vaccination" do
   end
 
   def then_i_cannot_record_that_the_patient_has_been_vaccinated
-    expect(page).not_to have_content("ready to vaccinate in this session?")
+    expect(page).not_to have_content("ready for their HPV vaccination?")
   end
 end

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -124,6 +124,6 @@ describe "Invalidate consent" do
 
   def and_i_am_not_able_to_record_a_vaccination
     expect(page).to have_content("No response")
-    expect(page).not_to have_content("ready to vaccinate in this session?")
+    expect(page).not_to have_content("ready for their HPV vaccination?")
   end
 end

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -101,7 +101,7 @@ describe "Manage attendance" do
   end
 
   def and_i_am_not_able_to_vaccinate
-    expect(page).not_to have_content("ready to vaccinate in this session?")
+    expect(page).not_to have_content("ready for their HPV vaccination?")
   end
 
   def when_i_choose_the_patient_has_not_been_registered_yet
@@ -145,7 +145,7 @@ describe "Manage attendance" do
   alias_method :then_i_see_the_attending_flash, :and_i_see_the_attending_flash
 
   def and_i_can_vaccinate
-    expect(page).to have_content("ready to vaccinate in this session?")
+    expect(page).to have_content("ready for their HPV vaccination?")
   end
 
   def when_i_go_to_the_activity_log

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -101,6 +101,6 @@ describe "Triage" do
   end
 
   def and_i_am_able_to_record_a_vaccination
-    expect(page).to have_content("ready to vaccinate in this session?")
+    expect(page).to have_content("ready for their HPV vaccination?")
   end
 end

--- a/spec/features/withdraw_consent_spec.rb
+++ b/spec/features/withdraw_consent_spec.rb
@@ -128,6 +128,6 @@ describe "Withdraw consent" do
 
   def and_i_am_not_able_to_record_a_vaccination
     expect(page).to have_content("Consent refused")
-    expect(page).not_to have_content("ready to vaccinate in this session?")
+    expect(page).not_to have_content("ready for their HPV vaccination?")
   end
 end


### PR DESCRIPTION
This updates various pages of the vaccination journey to include the name of the programme in the heading to make it clear to the nurses which programme they're recording a vaccination for.