### PR TITLE
Reinstate sticky secondary navigation on patient session page

### DIFF
--- a/app/assets/stylesheets/_secondary-navigation.scss
+++ b/app/assets/stylesheets/_secondary-navigation.scss
@@ -11,6 +11,13 @@
   }
 }
 
+.app-secondary-navigation--sticky {
+  background-color: $color_nhsuk-grey-5;
+  position: sticky;
+  top: 0;
+  z-index: 99;
+}
+
 .app-secondary-navigation__link {
   @include nhsuk-link-style-default;
   @include nhsuk-link-style-no-visited-state;


### PR DESCRIPTION
Reinstate the sticky navigation variant (used on the patient session page) to the secondary navigation component, that was removed in #3102.

(Note that for 2.1, the design of this will change further so that the sticky navigation appears across the full width of the page, and displays a shadow when stuck)  

<img width="875" alt="Screenshot of sticky navigation." src="https://github.com/user-attachments/assets/5b79bfef-e9fb-4059-bd07-f50466686cc6" />
