### PR TITLE
Filter session triage and register tabs

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -38,10 +38,10 @@ class AppSearchComponent < ViewComponent::Base
           <% end %>
         <% end %>
         
-        <% if register_status %>
+        <% if register_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :register_status, legend: { text: "Registration status", size: "s" } do %>
             <%= f.govuk_radio_button :register_status, "", label: { text: "Any" } %>
-            <% PatientSession::Register::STATUSES.each do |status| %>
+            <% register_statuses.each do |status| %>
               <%= f.govuk_radio_button :register_status, status, label: { text: t(status, scope: %i[patient_session status register label]) } %>
             <% end %>
           <% end %>
@@ -84,7 +84,7 @@ class AppSearchComponent < ViewComponent::Base
     form:,
     url:,
     consent_statuses: [],
-    register_status: false,
+    register_statuses: [],
     triage_statuses: [],
     year_groups: []
   )
@@ -94,7 +94,7 @@ class AppSearchComponent < ViewComponent::Base
     @url = url
 
     @consent_statuses = consent_statuses
-    @register_status = register_status
+    @register_statuses = register_statuses
     @triage_statuses = triage_statuses
     @year_groups = year_groups
   end
@@ -104,13 +104,13 @@ class AppSearchComponent < ViewComponent::Base
   attr_reader :form,
               :url,
               :consent_statuses,
-              :register_status,
+              :register_statuses,
               :triage_statuses,
               :year_groups
 
   def show_buttons_in_details?
     !(
-      consent_statuses.any? || register_status || triage_statuses.any? ||
+      consent_statuses.any? || register_statuses || triage_statuses.any? ||
         year_groups.any?
     )
   end

--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -20,10 +20,10 @@ class AppSearchComponent < ViewComponent::Base
           </button>
         </div>
         
-        <% if consent_status %>
+        <% if consent_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :consent_status, legend: { text: "Consent status", size: "s" } do %>
             <%= f.govuk_radio_button :consent_status, "", label: { text: "Any" } %>
-            <% PatientSession::Consent::STATUSES.each do |status| %>
+            <% consent_statuses.each do |status| %>
               <%= f.govuk_radio_button :consent_status, status, label: { text: t(status, scope: %i[patient_session status consent label]) } %>
             <% end %>
           <% end %>
@@ -83,7 +83,7 @@ class AppSearchComponent < ViewComponent::Base
   def initialize(
     form:,
     url:,
-    consent_status: false,
+    consent_statuses: [],
     register_status: false,
     triage_status: false,
     year_groups: []
@@ -93,7 +93,7 @@ class AppSearchComponent < ViewComponent::Base
     @form = form
     @url = url
 
-    @consent_status = consent_status
+    @consent_statuses = consent_statuses
     @register_status = register_status
     @triage_status = triage_status
     @year_groups = year_groups
@@ -103,12 +103,15 @@ class AppSearchComponent < ViewComponent::Base
 
   attr_reader :form,
               :url,
-              :consent_status,
+              :consent_statuses,
               :register_status,
               :triage_status,
               :year_groups
 
   def show_buttons_in_details?
-    !(consent_status || register_status || triage_status || year_groups.any?)
+    !(
+      consent_statuses.any? || register_status || triage_status ||
+        year_groups.any?
+    )
   end
 end

--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -29,10 +29,10 @@ class AppSearchComponent < ViewComponent::Base
           <% end %>
         <% end %>
         
-        <% if triage_status %>
+        <% if triage_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :triage_status, legend: { text: "Triage outcome", size: "s" } do %>
             <%= f.govuk_radio_button :triage_status, "", label: { text: "Any" } %>
-            <% PatientSession::Triage::STATUSES.each do |status| %>
+            <% triage_statuses.each do |status| %>
               <%= f.govuk_radio_button :triage_status, status, label: { text: t(status, scope: %i[patient_session status triage label]) } %>
             <% end %>
           <% end %>
@@ -85,7 +85,7 @@ class AppSearchComponent < ViewComponent::Base
     url:,
     consent_statuses: [],
     register_status: false,
-    triage_status: false,
+    triage_statuses: [],
     year_groups: []
   )
     super
@@ -95,7 +95,7 @@ class AppSearchComponent < ViewComponent::Base
 
     @consent_statuses = consent_statuses
     @register_status = register_status
-    @triage_status = triage_status
+    @triage_statuses = triage_statuses
     @year_groups = year_groups
   end
 
@@ -105,12 +105,12 @@ class AppSearchComponent < ViewComponent::Base
               :url,
               :consent_statuses,
               :register_status,
-              :triage_status,
+              :triage_statuses,
               :year_groups
 
   def show_buttons_in_details?
     !(
-      consent_statuses.any? || register_status || triage_status ||
+      consent_statuses.any? || register_status || triage_statuses.any? ||
         year_groups.any?
     )
   end

--- a/app/controllers/sessions/consent_controller.rb
+++ b/app/controllers/sessions/consent_controller.rb
@@ -17,6 +17,8 @@ class Sessions::ConsentController < ApplicationController
         @session.programmes
       )
 
+    @valid_statuses = PatientSession::Consent::STATUSES
+
     patient_sessions = @form.apply(scope)
 
     if patient_sessions.is_a?(Array)

--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -17,7 +17,15 @@ class Sessions::TriageController < ApplicationController
         @session.programmes
       )
 
-    patient_sessions = @form.apply(scope)
+    @valid_statuses =
+      PatientSession::Triage::STATUSES - [PatientSession::Triage::NOT_REQUIRED]
+
+    patient_sessions =
+      @form.apply(scope) do |filtered_scope|
+        filtered_scope.select do
+          it.triage.status.values.intersect?(@valid_statuses)
+        end
+      end
 
     if patient_sessions.is_a?(Array)
       @pagy, @patient_sessions = pagy_array(patient_sessions)

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -41,6 +41,8 @@ class SearchForm
 
     scope = scope.order_by_name
 
+    scope = yield(scope) if block_given?
+
     if (status = consent_status&.to_sym).present?
       scope = scope.select { it.consent.status.values.include?(status) }
     end

--- a/app/views/sessions/consent/show.html.erb
+++ b/app/views/sessions/consent/show.html.erb
@@ -12,7 +12,12 @@
 
 <div class="app-grid-row">
   <div class="app-grid-column-filters">
-    <%= render AppSearchComponent.new(form: @form, url: session_consent_path(@session), consent_status: true, year_groups: @session.year_groups) %>
+    <%= render AppSearchComponent.new(
+          form: @form,
+          url: session_consent_path(@session),
+          consent_statuses: @valid_statuses,
+          year_groups: @session.year_groups,
+        ) %>
   </div>
 
   <div class="app-grid-column-results">

--- a/app/views/sessions/register/show.html.erb
+++ b/app/views/sessions/register/show.html.erb
@@ -13,7 +13,12 @@
 <% if @session.today? %>
   <div class="app-grid-row">
     <div class="app-grid-column-filters">
-      <%= render AppSearchComponent.new(form: @form, url: session_register_path(@session), register_status: true, year_groups: @session.year_groups) %>
+      <%= render AppSearchComponent.new(
+            form: @form,
+            url: session_register_path(@session),
+            register_statuses: @valid_statuses,
+            year_groups: @session.year_groups,
+          ) %>
     </div>
 
     <div class="app-grid-column-results">

--- a/app/views/sessions/triage/show.html.erb
+++ b/app/views/sessions/triage/show.html.erb
@@ -12,7 +12,12 @@
 
 <div class="app-grid-row">
   <div class="app-grid-column-filters">
-    <%= render AppSearchComponent.new(form: @form, url: session_triage_path(@session), triage_status: true, year_groups: @session.year_groups) %>
+    <%= render AppSearchComponent.new(
+          form: @form,
+          url: session_triage_path(@session),
+          triage_statuses: @valid_statuses,
+          year_groups: @session.year_groups,
+        ) %>
   </div>
 
   <div class="app-grid-column-results">

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -92,9 +92,12 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -44,9 +44,12 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
+++ b/spec/features/hpv_vaccination_cannot_record_as_admin_spec.rb
@@ -25,9 +25,12 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -57,9 +57,12 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -46,9 +46,12 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -35,9 +35,12 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -92,9 +92,12 @@ describe "MenACWY vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -197,9 +197,11 @@ describe "Parental consent create patient" do
     end
     click_link "Pilot School"
 
-    click_on "Triage"
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    click_on "Consent"
   end
 
   def then_the_patient_should_be_ready_to_vaccinate

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -195,9 +195,11 @@ describe "Parental consent" do
   def when_they_check_triage
     click_link "Pilot School"
 
-    click_on "Triage"
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    click_on "Consent"
   end
 
   def then_the_patient_should_be_ready_to_vaccinate

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -92,9 +92,12 @@ describe "Td/IPV vaccination" do
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    visit session_triage_path(@session)
-    choose "No triage needed"
-    click_on "Update results"
+    # TODO: Check in "Record" tab
+    # visit session_triage_path(@session)
+    # choose "No triage needed"
+    # click_on "Update results"
+
+    visit session_consent_path(@session)
     click_link @patient.full_name
   end
 


### PR DESCRIPTION
This changes how the list of patients in the triage tab is filtered to only display patients that need triage, or have been triaged already. Patients that don't need triage are available immediately in the register tab.

This also changes how the list of patients in the register tab is filtered to only display patients that are ready to be vaccinated, specifically they've got consent and either don't need triage or have been triaged.

I will add some feature tests in a follow up PR that covers the entire flow, once the record and outcome tabs are in place.