### PR TITLE
Ensure invalid dates don't raise an error

### DIFF
--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -13,6 +13,18 @@ class SearchForm
   attribute :triage_status, :string
   attribute :year_groups, array: true
 
+  def initialize(options)
+    super(options)
+  rescue ActiveRecord::MultiparameterAssignmentErrors
+    super(
+      options.except(
+        :"date_of_birth(1i)",
+        :"date_of_birth(2i)",
+        :"date_of_birth(3i)"
+      )
+    )
+  end
+
   def year_groups=(values)
     super(values&.compact_blank&.map(&:to_i)&.compact || [])
   end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -21,6 +21,24 @@ describe SearchForm do
   let(:triage_status) { nil }
   let(:year_groups) { %w[8 9 10 11] }
 
+  context "with invalid date parameters" do
+    subject(:form) do
+      described_class.new(
+        "date_of_birth(1i)": "invalid",
+        "date_of_birth(2i)": "value",
+        "date_of_birth(3i)": "12345"
+      )
+    end
+
+    it "doesn't raise an error" do
+      expect { form }.not_to raise_error
+    end
+
+    it "doesn't filter by date" do
+      expect(form.date_of_birth).to be_nil
+    end
+  end
+
   context "for patients" do
     it "doesn't raise an error" do
       expect { form.apply(Patient.all) }.not_to raise_error


### PR DESCRIPTION
This ensures that when entering an invalid date in the search form the user won't see an unhandled exception page, instead the date will be left blank.

https://good-machine.sentry.io/issues/6359085868?project=4505625073876992