### PR TITLE
Sort patients when fuzzy searching

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -131,6 +131,11 @@ class Patient < ApplicationRecord
                 "similarity(given_name, :query) > 0.3 OR " \
                 "similarity(family_name, :query) > 0.3",
               query:
+            ).order(
+              Arel.sql(
+                "similarity(family_name, :query) DESC, similarity(given_name, :query) DESC",
+                query:
+              )
             )
           end
         end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -51,6 +51,32 @@
 
 describe Patient do
   describe "scopes" do
+    describe "#search_by_name" do
+      subject(:scope) { described_class.search_by_name(query) }
+
+      let(:query) { "Harry" }
+
+      let(:patient_a) do
+        # exact match comes first
+        create(:patient, given_name: "Harry", family_name: "Potter")
+      end
+      let(:patient_b) do
+        # similar match comes next
+        create(:patient, given_name: "Hari", family_name: "Potter")
+      end
+      let(:patient_c) do
+        # least similar match comes last
+        create(:patient, given_name: "Arry", family_name: "Potter")
+      end
+      let(:patient_d) do
+        # no match isn't returned
+        create(:patient, given_name: "James", family_name: "Potter")
+      end
+
+      it { should eq([patient_a, patient_b, patient_c]) }
+      it { should_not include(patient_d) }
+    end
+
     describe "#order_by_name" do
       subject(:scope) { described_class.order_by_name }
 


### PR DESCRIPTION
When searching for patients by name, we can return the results in order of similarity to the original query to help the nurses find the right patient when looking for patients.