### PR TITLE
Don't record a dose sequence for Td/IPV

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -272,9 +272,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
     [
       {
         name: "DOSE_SEQUENCE",
-        notes:
-          "Required if #{tag.code("VACCINATED")} is #{tag.i("Y")}, " \
-            "must be a number or #{special_values_sentence}"
+        notes: "Optional, must be a number or #{special_values_sentence}"
       }
     ]
   end

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -37,7 +37,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def dose_sequence
-    1
+    programme.vaccinated_dose_sequence == 1 ? 1 : nil
   end
 
   def common_delivery_sites_options

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -318,7 +318,9 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   end
 
   def dose_number
-    return nil if @vaccine&.seasonal? || @vaccination_record.dose_sequence.nil?
+    return nil if @vaccine&.seasonal?
+
+    return "Unknown" if @vaccination_record.dose_sequence.nil?
 
     numbers_to_words = {
       1 => "First",

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -83,10 +83,6 @@ class DraftVaccinationRecordsController < ApplicationController
   def handle_outcome
     # If not administered we can skip the remaining steps as they're not relevant.
     jump_to("confirm") unless @draft_vaccination_record.administered?
-
-    # TODO: Require the nurse to specify the dose sequence.
-    @draft_vaccination_record.dose_sequence ||=
-      1 if @draft_vaccination_record.administered?
   end
 
   def handle_batch

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -25,7 +25,6 @@ class VaccinateForm
   validates :no_allergies, inclusion: { in: [true, false] }
 
   validate :valid_administered_values
-  validates :dose_sequence, presence: true
   validates :programme_id, presence: true
 
   with_options if: :administered do

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -316,7 +316,7 @@ class Reports::OfflineSessionExporter
     row[:anatomical_site] = Cell.new(
       allowed_values: ImmunisationImportRow::DELIVERY_SITES.keys
     )
-    row[:dose_sequence] = programme.vaccinated_dose_sequence
+    row[:dose_sequence] = 1 if programme.vaccinated_dose_sequence == 1
     row[:reason_not_vaccinated] = Cell.new(
       allowed_values: ImmunisationImportRow::REASONS.keys
     )

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -93,7 +93,6 @@ class DraftVaccinationRecord
     validates :batch_id,
               :delivery_method,
               :delivery_site,
-              :dose_sequence,
               :performed_at,
               :vaccine_id,
               presence: true

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -205,6 +205,7 @@ describe "HPV vaccination" do
 
   def and_i_see_the_vaccination_details
     expect(page).to have_content("Vaccination details").once
+    expect(page).to have_content("Dose numberFirst")
   end
 
   def when_i_go_to_the_register_tab

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -200,8 +200,8 @@ describe "Td/IPV vaccination" do
   end
 
   def and_i_see_the_vaccination_details
-    # TODO: Check dose sequence is fifth.
     expect(page).to have_content("Vaccination details").once
+    expect(page).to have_content("Dose numberUnknown")
   end
 
   def when_vaccination_confirmations_are_sent


### PR DESCRIPTION
Td/IPV (or other multi-dose vaccines) shouldn't have a dose sequence number recorded on them by default as we can't be sure which dose sequence will be being administered on the day.