### PR TITLE
Restrict return_to parameter

### DIFF
--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -88,8 +88,13 @@ class PatientSessionsController < ApplicationController
 
   def set_back_link_path
     context = params[:return_to]
-    context_path = try(:"session_#{context}_path")
-    @back_link_path = context_path || session_outcome_path
+
+    @back_link_path =
+      if context.in?(%w[consent triage register record outcome])
+        send(:"session_#{context}_path")
+      else
+        session_outcome_path
+      end
   end
 
   def record_access_log_entry


### PR DESCRIPTION
This parameter is used to redirect the user and because we're using it to generate a path by executing a method name we should validate that it's an expected value to prevent a user providing a value that redirects the user elsewhere.