### PR TITLE
Fix could not vaccinate outcome

### DIFF
--- a/app/models/patient_session/outcome.rb
+++ b/app/models/patient_session/outcome.rb
@@ -47,7 +47,7 @@ class PatientSession::Outcome
   end
 
   def could_not_vaccinate?(programme:)
-    all(programme:).any?(&:not_administered?) ||
+    all(programme:).any? { it.not_administered? && !it.retryable_reason? } ||
       consent.status[programme] == PatientSession::Consent::REFUSED ||
       triage.status[programme] == PatientSession::Triage::DO_NOT_VACCINATE
   end

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -257,7 +257,7 @@ describe "HPV vaccination" do
 
     click_link "Back to session"
 
-    choose "Could not vaccinate"
+    choose "No outcome yet"
     click_on "Update results"
 
     click_on @unvaccinated_patient.full_name

--- a/spec/models/patient_session/outcome_spec.rb
+++ b/spec/models/patient_session/outcome_spec.rb
@@ -29,6 +29,18 @@ describe PatientSession::Outcome do
         create(:vaccination_record, :not_administered, patient:, programme:)
       end
 
+      it { should be(described_class::NONE) }
+    end
+
+    context "with a consent refused" do
+      before { create(:consent, :refused, patient:, programme:) }
+
+      it { should be(described_class::COULD_NOT_VACCINATE) }
+    end
+
+    context "with a triage as unsafe to vaccination" do
+      before { create(:triage, :do_not_vaccinate, patient:, programme:) }
+
       it { should be(described_class::COULD_NOT_VACCINATE) }
     end
 


### PR DESCRIPTION
This outcome status should only be used when it's not possible to continue attempting to vaccinate the patient. This is only the case where the parents have refused consent, or a nurse has triaged the patient as unsafe to vaccinate, or a vaccination record exists with a reason that's not retryable.

The outcome rules are specified here: https://docs.google.com/document/d/1RkyibohJEV7V4ywv-52GKgfyfuDiFqfjvRYWwwYGO7U/edit?usp=sharing
