### PR TITLE
Update session record and outcome tabs

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -16,9 +16,11 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
               row.with_value { helpers.patient_year_group(patient) }
             end
 
-            summary_list.with_row do |row|
-              row.with_key { "Status" }
-              row.with_value { status_tag }
+            if (value = status_tag)
+              summary_list.with_row do |row|
+                row.with_key { "Status" }
+                row.with_value { value }
+              end
             end
           end %>
       
@@ -59,6 +61,8 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
   end
 
   def status_tag
+    return if context == :record
+
     if context == :register
       status = patient_session.register_outcome.status
 
@@ -73,16 +77,17 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
           patient.consent_outcome
         when :triage
           patient.triage_outcome
-        when :record
-          patient_session.session_outcome
         when :outcome
-          patient.programme_outcome
+          patient_session.session_outcome
         end
 
       # ensure status is calculated for each programme
       patient_session.programmes.each { outcome.status[it] }
 
-      render AppProgrammeStatusTagsComponent.new(outcome.status, context:)
+      render AppProgrammeStatusTagsComponent.new(
+               outcome.status,
+               outcome: context == :outcome ? :session : context
+             )
     end
   end
 end

--- a/app/components/app_programme_status_tags_component.rb
+++ b/app/components/app_programme_status_tags_component.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class AppProgrammeStatusTagsComponent < ViewComponent::Base
-  def initialize(programme_statuses, context:)
+  def initialize(programme_statuses, outcome:)
     super
 
     @programme_statuses = programme_statuses
-    @context = context
+    @outcome = outcome
   end
 
   def call
@@ -18,7 +18,7 @@ class AppProgrammeStatusTagsComponent < ViewComponent::Base
 
   private
 
-  attr_reader :programme_statuses, :context
+  attr_reader :programme_statuses, :outcome
 
   def programme_status_tag(programme, status)
     programme_tag =
@@ -27,9 +27,8 @@ class AppProgrammeStatusTagsComponent < ViewComponent::Base
         class: "nhsuk-tag app-tag--attached nhsuk-tag--white"
       )
 
-    label = I18n.t(status, scope: [:status, context, :label])
-
-    colour = I18n.t(status, scope: [:status, context, :colour])
+    label = I18n.t(status, scope: [:status, outcome, :label])
+    colour = I18n.t(status, scope: [:status, outcome, :colour])
 
     status_tag = tag.strong(label, class: "nhsuk-tag nhsuk-tag--#{colour}")
 

--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -51,7 +51,7 @@ class AppSearchComponent < ViewComponent::Base
           <%= f.govuk_radio_buttons_fieldset :session_status, legend: { text: "Vaccination status", size: "s" } do %>
             <%= f.govuk_radio_button :session_status, "", label: { text: "Any" } %>
             <% session_statuses.each do |status| %>
-              <%= f.govuk_radio_button :session_status, status, label: { text: t(status, scope: %i[status record label]) } %>
+              <%= f.govuk_radio_button :session_status, status, label: { text: t(status, scope: %i[status session label]) } %>
             <% end %>
           <% end %>
         <% end %>
@@ -60,7 +60,7 @@ class AppSearchComponent < ViewComponent::Base
           <%= f.govuk_radio_buttons_fieldset :programme_status, legend: { text: "Programme outcome", size: "s" } do %>
             <%= f.govuk_radio_button :programme_status, "", label: { text: "Any" } %>
             <% programme_statuses.each do |status| %>
-              <%= f.govuk_radio_button :programme_status, status, label: { text: t(status, scope: %i[status outcome label]) } %>
+              <%= f.govuk_radio_button :programme_status, status, label: { text: t(status, scope: %i[status programme label]) } %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -90,7 +90,9 @@ class PatientSessionsController < ApplicationController
     context = params[:return_to]
 
     @back_link_path =
-      if context.in?(%w[consent triage register record outcome])
+      if context == :session
+        session_outcome_path
+      elsif context.in?(%w[consent triage register record])
         send(:"session_#{context}_path")
       else
         session_outcome_path

--- a/app/controllers/sessions/outcome_controller.rb
+++ b/app/controllers/sessions/outcome_controller.rb
@@ -12,7 +12,7 @@ class Sessions::OutcomeController < ApplicationController
   layout "full"
 
   def show
-    @statuses = Patient::ProgrammeOutcome::STATUSES
+    @statuses = PatientSession::SessionOutcome::STATUSES
 
     scope =
       @session.patient_sessions.preload_for_status.in_programmes(

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -15,20 +15,26 @@ class Sessions::RecordController < ApplicationController
   before_action :set_batches, except: :show
 
   def show
-    @statuses = PatientSession::SessionOutcome::STATUSES
-
     scope =
       @session.patient_sessions.preload_for_status.in_programmes(
         @session.programmes
       )
 
+    vaccinated_statuses = [
+      PatientSession::SessionOutcome::VACCINATED,
+      PatientSession::SessionOutcome::ALREADY_HAD
+    ]
+
     patient_sessions =
       @form.apply(scope) do |filtered_scope|
         filtered_scope.select do
-          it.register_outcome.attending? ||
-            it.session_outcome.status.values.none?(
-              PatientSession::SessionOutcome::NONE
-            )
+          vaccinated =
+            it.session_outcome.status.values.all? do
+              it.in?(vaccinated_statuses)
+            end
+
+          !vaccinated &&
+            (it.register_outcome.attending? || it.register_outcome.completed?)
         end
       end
 

--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -28,7 +28,7 @@ class Sessions::TriageController < ApplicationController
             .triage_outcome
             .status
             .values_at(*it.programmes)
-            .intersect?(@statuses)
+            .none?(Patient::TriageOutcome::NOT_REQUIRED)
         end
       end
 

--- a/app/views/sessions/_header.html.erb
+++ b/app/views/sessions/_header.html.erb
@@ -31,13 +31,13 @@
     
       nav.with_item(
         href: session_record_path(@session),
-        text: "Record",
+        text: "Record vaccinations",
         selected: request.path == session_record_path(@session),
       )
     
       nav.with_item(
         href: session_outcome_path(@session),
-        text: "Outcome",
+        text: "Session outcomes",
         selected: request.path == session_outcome_path(@session),
       )
     end %>

--- a/app/views/sessions/outcome/show.html.erb
+++ b/app/views/sessions/outcome/show.html.erb
@@ -13,7 +13,7 @@
     <%= render AppSearchComponent.new(
           form: @form,
           url: session_outcome_path(@session),
-          programme_statuses: @statuses,
+          session_statuses: @statuses,
           year_groups: @session.year_groups,
         ) %>
   </div>

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -31,7 +31,6 @@
       <%= render AppSearchComponent.new(
             form: @form,
             url: session_record_path(@session),
-            session_statuses: @statuses,
             year_groups: @session.year_groups,
           ) %>
     </div>

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -35,7 +35,7 @@ en:
         completed: green
         not_attending: red
         unknown: blue
-    record:
+    session:
       label:
         absent_from_school: Absent from school
         absent_from_session: Absent from session
@@ -46,15 +46,15 @@ en:
         not_well: Unwell
         refused: Vaccine refused
       colour:
-        absent_from_school: red
-        absent_from_session: red
+        absent_from_school: dark-orange
+        absent_from_session: dark-orange
         administered: green
         already_had: green
-        contraindications: red
-        none: grey
-        not_well: red
-        refused: red
-    outcome:
+        contraindications: dark-orange
+        none: white
+        not_well: dark-orange
+        refused: dark-orange
+    programme:
       label:
         could_not_vaccinate: Could not vaccinate
         none: No outcome yet

--- a/spec/components/app_programme_status_tags_component_spec.rb
+++ b/spec/components/app_programme_status_tags_component_spec.rb
@@ -3,7 +3,7 @@
 describe AppProgrammeStatusTagsComponent do
   subject { render_inline(component) }
 
-  let(:component) { described_class.new(programme_statuses, context: :consent) }
+  let(:component) { described_class.new(programme_statuses, outcome: :consent) }
 
   let(:menacwy_programme) { create(:programme, :menacwy) }
   let(:td_ipv_programme) { create(:programme, :td_ipv) }

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -227,9 +227,7 @@ describe "End-to-end journey" do
 
   def when_i_click_on_the_vaccination_section
     click_link "Back"
-    click_link "Record"
-
-    choose "No outcome yet"
+    click_link "Record vaccinations"
     click_on "Update results"
   end
 
@@ -256,6 +254,7 @@ describe "End-to-end journey" do
   end
 
   def then_i_see_that_the_child_is_vaccinated
+    click_on "Session outcomes"
     choose "Vaccinated"
     click_on "Update results"
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -43,7 +43,7 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_see_the_record_vaccinations_page
+    then_i_no_longer_see_the_patient_in_the_record_tab
     and_a_success_message
 
     when_i_go_back
@@ -97,8 +97,6 @@ describe "HPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 
@@ -179,8 +177,8 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_see_the_record_vaccinations_page
-    expect(page).to have_content("Vaccination status")
+  def then_i_no_longer_see_the_patient_in_the_record_tab
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def and_a_success_message

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -14,7 +14,7 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_see_the_record_vaccinations_page
+    then_i_no_longer_see_the_patient_in_the_record_tab
     and_a_success_message
 
     when_i_go_to_the_patient
@@ -45,8 +45,6 @@ describe "HPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 
@@ -95,8 +93,8 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_see_the_record_vaccinations_page
-    expect(page).to have_content("Vaccination status")
+  def then_i_no_longer_see_the_patient_in_the_record_tab
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def and_a_success_message

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -17,7 +17,7 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_see_the_record_vaccinations_page
+    then_i_no_longer_see_the_patient_in_the_record_tab
     and_a_success_message
 
     when_i_go_to_the_patient
@@ -58,8 +58,6 @@ describe "HPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 
@@ -103,8 +101,8 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_see_the_record_vaccinations_page
-    expect(page).to have_content("Vaccination status")
+  def then_i_no_longer_see_the_patient_in_the_record_tab
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def and_a_success_message

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -9,7 +9,7 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_see_the_record_vaccinations_page
+    then_i_still_see_the_patient_in_the_record_tab
     and_a_success_message
 
     when_i_go_to_the_patient
@@ -50,8 +50,6 @@ describe "HPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 
@@ -93,8 +91,9 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_see_the_record_vaccinations_page
-    expect(page).to have_content("Vaccination status")
+  def then_i_still_see_the_patient_in_the_record_tab
+    expect(page).to have_content("Showing 1 to 1 of 1 children")
+    expect(page).to have_content(@patient.full_name)
   end
 
   def and_a_success_message
@@ -111,11 +110,11 @@ describe "HPV vaccination" do
 
   def when_i_go_to_the_outcome_tab
     click_on "Back to session"
-    click_on "Outcome"
+    click_on "Session outcomes"
   end
 
   def then_i_see_the_patient_has_no_outcome_yet
-    expect(page).to have_content("Status\nHPVNo outcome yet")
+    expect(page).to have_content("Status\nHPVUnwell")
   end
 
   def when_vaccination_confirmations_are_sent

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -239,7 +239,7 @@ describe "HPV vaccination" do
   end
 
   def then_i_see_the_uploaded_vaccination_outcomes_reflected_in_the_session
-    click_on "Outcome"
+    click_on "Session outcomes"
 
     choose "Vaccinated"
     click_on "Update results"
@@ -257,7 +257,7 @@ describe "HPV vaccination" do
 
     click_link "Back to session"
 
-    choose "No outcome yet"
+    choose "Absent from session"
     click_on "Update results"
 
     click_on @unvaccinated_patient.full_name

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -36,8 +36,6 @@ describe "HPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -43,7 +43,7 @@ describe "MenACWY vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_see_the_record_vaccinations_page
+    then_i_no_longer_see_the_patient_in_the_record_tab
     and_a_success_message
 
     when_i_go_back
@@ -93,8 +93,6 @@ describe "MenACWY vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 
@@ -175,8 +173,8 @@ describe "MenACWY vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_see_the_record_vaccinations_page
-    expect(page).to have_content("Vaccination status")
+  def then_i_no_longer_see_the_patient_in_the_record_tab
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def and_a_success_message

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -274,7 +274,7 @@ describe "Parental consent school" do
       click_on "Community clinics"
     end
 
-    click_on "Outcome"
+    click_on "Session outcome"
     click_on @child.full_name
   end
 

--- a/spec/features/parental_consent_create_patient_spec.rb
+++ b/spec/features/parental_consent_create_patient_spec.rb
@@ -197,7 +197,7 @@ describe "Parental consent create patient" do
     end
     click_link "Pilot School"
 
-    click_on "Outcome"
+    click_on "Session outcomes"
   end
 
   def then_the_patient_should_be_ready_to_vaccinate

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -152,12 +152,13 @@ describe "Parental consent" do
     end
     click_on "Pilot School"
 
-    click_on "Outcome"
-
-    expect(page).to have_content("Could not vaccinate")
-    choose "Could not vaccinate"
-    click_on "Update results"
-
-    expect(page).to have_content(@child.full_name)
+    # TODO: Check in programme children tab
+    # click_on "Session outcomes"
+    #
+    # expect(page).to have_content("Could not vaccinate")
+    # choose "Could not vaccinate"
+    # click_on "Update results"
+    #
+    # expect(page).to have_content(@child.full_name)
   end
 end

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -193,7 +193,7 @@ describe "Parental consent" do
   def when_they_check_triage
     click_link "Pilot School"
 
-    click_on "Outcome"
+    click_on "Session outcomes"
     choose "No outcome yet"
     click_on "Update results"
   end

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -43,7 +43,7 @@ describe "Td/IPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_see_the_record_vaccinations_page
+    then_i_no_longer_see_the_patient_in_the_record_tab
     and_a_success_message
 
     when_i_go_back
@@ -93,8 +93,6 @@ describe "Td/IPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
-    choose "No outcome yet"
-    click_on "Update results"
     click_link @patient.full_name
   end
 
@@ -175,8 +173,8 @@ describe "Td/IPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_see_the_record_vaccinations_page
-    expect(page).to have_content("Vaccination status")
+  def then_i_no_longer_see_the_patient_in_the_record_tab
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def and_a_success_message

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -88,8 +88,7 @@ describe "Triage" do
 
   def when_i_access_the_vaccinate_later_page
     click_on @school.name, match: :first
-    click_on "Record"
-
+    click_on "Session outcomes"
     choose "No outcome yet"
     click_on "Update results"
   end


### PR DESCRIPTION
This updates the tabs on the session page to match the latest designs in the prototype. The record tab has been renamed to "Record vaccinations" and now shows only patients that have been registered as attending, and don't have a vaccinated session outcome. The outcome tab has been renamed to "Session outcomes" and shows the outcome of the patients in the session, the overall programme outcome will be displayed in the programme children tab.

## Screenshots

![Screenshot 2025-03-07 at 09 26 04](https://github.com/user-attachments/assets/e051aadf-a7c4-4bb9-a050-b2c3bc84bf9a)
![Screenshot 2025-03-07 at 09 26 08](https://github.com/user-attachments/assets/175f2125-bf05-4b67-b2d3-a8f3bd9c4813)
![Screenshot 2025-03-07 at 09 26 14](https://github.com/user-attachments/assets/0915d973-03a7-4674-8fda-1ecf03439dd6)
