### PR TITLE
Consider already had as vaccinated

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -54,15 +54,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def vaccination_record
-    @vaccination_record ||=
-      begin
-        vaccination_records = patient.programme_outcome.all[programme]
-        if patient.programme_outcome.vaccinated?(programme)
-          vaccination_records.select(&:administered?).last
-        else
-          vaccination_records.last
-        end
-      end
+    @vaccination_record ||= patient.programme_outcome.all[programme].last
   end
 
   def triage

--- a/app/models/patient/programme_outcome.rb
+++ b/app/models/patient/programme_outcome.rb
@@ -48,11 +48,12 @@ class Patient::ProgrammeOutcome
   end
 
   def programme_vaccinated?(programme)
-    VaccinatedCriteria.call(
-      programme,
-      patient:,
-      vaccination_records: all[programme]
-    )
+    all[programme].any?(&:already_had?) ||
+      VaccinatedCriteria.call(
+        programme,
+        patient:,
+        vaccination_records: all[programme]
+      )
   end
 
   def programme_could_not_vaccinate?(programme)

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -33,7 +33,7 @@ describe AppOutcomeBannerComponent do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
-    it { should have_text("MERTON, Alya has already had the vaccine") }
+    it { should have_text("MERTON, Alya was not well enough") }
     it { should have_text("Location\n#{location_name}") }
   end
 
@@ -44,7 +44,7 @@ describe AppOutcomeBannerComponent do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
-    it { should have_text("Reason\nMERTON, Alya has already had the vaccine") }
+    it { should have_text("Reason\nMERTON, Alya was not well enough") }
   end
 
   context "not triaged, not possible to vaccinate" do
@@ -54,6 +54,24 @@ describe AppOutcomeBannerComponent do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
+    it { should have_text("Reason\nMERTON, Alya was not well enough") }
+  end
+
+  context "already had vaccine" do
+    let(:patient_session) { create(:patient_session, session:) }
+
+    before do
+      create(
+        :vaccination_record,
+        :not_administered,
+        :already_had,
+        patient: patient_session.patient,
+        programme:
+      )
+    end
+
+    it { should have_css(".app-card--green") }
+    it { should have_css(".nhsuk-card__heading", text: "Vaccinated") }
     it { should have_text("Reason\nMERTON, Alya has already had the vaccine") }
   end
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -232,7 +232,7 @@ FactoryBot.define do
             programme:,
             performed_by: evaluator.user,
             location_name: evaluator.location_name,
-            outcome: :already_had
+            outcome: :not_well
           )
         end
       end
@@ -259,7 +259,7 @@ FactoryBot.define do
             session: patient_session.session,
             programme:,
             performed_by: evaluator.user,
-            outcome: :already_had
+            outcome: :not_well
           )
         end
       end

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -18,7 +18,7 @@ describe "HPV vaccination" do
     and_a_success_message
 
     when_i_go_to_the_patient
-    then_i_see_that_the_status_is_could_not_vaccinate
+    then_i_see_that_the_status_is_vaccinated
 
     when_vaccination_confirmations_are_sent
     then_an_email_is_sent_saying_the_vaccination_didnt_happen
@@ -105,8 +105,8 @@ describe "HPV vaccination" do
     click_link @patient.full_name, match: :first
   end
 
-  def then_i_see_that_the_status_is_could_not_vaccinate
-    expect(page).to have_content("Could not vaccinate")
+  def then_i_see_that_the_status_is_vaccinated
+    expect(page).to have_content("Vaccinated")
     expect(page).to have_content(
       "Reason#{@patient.full_name} has already had the vaccine"
     )

--- a/spec/models/patient/programme_outcome_spec.rb
+++ b/spec/models/patient/programme_outcome_spec.rb
@@ -21,6 +21,20 @@ describe Patient::ProgrammeOutcome do
       it { should be(described_class::VACCINATED) }
     end
 
+    context "with a vaccination already had" do
+      before do
+        create(
+          :vaccination_record,
+          :not_administered,
+          :already_had,
+          patient:,
+          programme:
+        )
+      end
+
+      it { should be(described_class::VACCINATED) }
+    end
+
     context "with a vaccination not administered" do
       before do
         create(:vaccination_record, :not_administered, patient:, programme:)


### PR DESCRIPTION
When recording a vaccination, if the reason is set to "already had", we should treat the patient as having a programme outcome of vaccinated.

## Screenshot

![Screenshot 2025-03-07 at 11 31 16](https://github.com/user-attachments/assets/214abca2-39cd-4214-b17d-e84c7b172a37)
