### PR TITLE
Show next activity on register tab

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -15,6 +15,13 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
               row.with_key { "Year group" }
               row.with_value { helpers.patient_year_group(patient) }
             end
+            
+            if context == :register
+              summary_list.with_row do |row|
+                row.with_key { "Action required" }
+                row.with_value { action_required }
+              end
+            end
 
             if (value = status_tag)
               summary_list.with_row do |row|
@@ -58,6 +65,19 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
       programme,
       return_to: context
     )
+  end
+
+  def action_required
+    return unless context == :register
+
+    tag.ul(class: "nhsuk-list nhsuk-list--bullet") do
+      safe_join(
+        patient_session.programmes.map do |programme|
+          status = patient_session.patient.next_activity.status[programme]
+          tag.li("#{I18n.t(status, scope: :activity)} for #{programme.name}")
+        end
+      )
+    end
   end
 
   def status_tag

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -267,6 +267,10 @@ class Patient < ApplicationRecord
     @programme_outcome ||= Patient::ProgrammeOutcome.new(self)
   end
 
+  def next_activity
+    @next_activity ||= Patient::NextActivity.new(self)
+  end
+
   def consent_given_and_safe_to_vaccinate?(programme:)
     return false if programme_outcome.vaccinated?(programme)
 

--- a/app/models/patient/next_activity.rb
+++ b/app/models/patient/next_activity.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class Patient::NextActivity
+  def initialize(patient)
+    @patient = patient
+  end
+
+  STATUSES = [
+    DO_NOT_RECORD = :do_not_record,
+    CONSENT = :consent,
+    TRIAGE = :triage,
+    REPORT = :report,
+    RECORD = :record
+  ].freeze
+
+  def status
+    @status ||=
+      Hash.new do |hash, programme|
+        hash[programme] = status_for_programme(programme)
+      end
+  end
+
+  private
+
+  attr_reader :patient
+
+  delegate :consent_given_and_safe_to_vaccinate?,
+           :consent_outcome,
+           :triage_outcome,
+           :programme_outcome,
+           to: :patient
+
+  def status_for_programme(programme)
+    return REPORT if programme_outcome.vaccinated?(programme)
+
+    return RECORD if consent_given_and_safe_to_vaccinate?(programme:)
+
+    return TRIAGE if triage_outcome.required?(programme)
+
+    if consent_outcome.none?(programme) || consent_outcome.conflicts?(programme)
+      return CONSENT
+    end
+
+    DO_NOT_RECORD
+  end
+end

--- a/config/locales/activity.en.yml
+++ b/config/locales/activity.en.yml
@@ -1,0 +1,7 @@
+en:
+  activity:
+    do_not_record: Do not vaccinate
+    consent: Get consent
+    triage: Triage
+    report: Report
+    record: Record vaccination

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -28,4 +28,10 @@ describe AppPatientSessionSearchResultCardComponent do
   it { should have_link("SELDON, Hari", href:) }
   it { should have_text("Year 8") }
   it { should have_text("Status") }
+
+  context "when context is register" do
+    let(:context) { :register }
+
+    it { should have_text("Action required\nGet consent for HPV") }
+  end
 end

--- a/spec/models/patient/next_activity_spec.rb
+++ b/spec/models/patient/next_activity_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+describe Patient::NextActivity do
+  subject(:instance) { described_class.new(patient) }
+
+  let(:programme) { create(:programme, :hpv) }
+  let(:patient) { create(:patient, year_group: 8) }
+
+  before { patient.strict_loading!(false) }
+
+  describe "#status" do
+    subject(:status) { instance.status[programme] }
+
+    context "with no consent" do
+      it { should be(described_class::CONSENT) }
+    end
+
+    context "with consent refused" do
+      before { create(:consent, :refused, patient:, programme:) }
+
+      it { should be(described_class::DO_NOT_RECORD) }
+    end
+
+    context "with triaged as do not vaccinate" do
+      before do
+        create(:consent, patient:, programme:)
+        create(:triage, :do_not_vaccinate, patient:, programme:)
+      end
+
+      it { should be(described_class::DO_NOT_RECORD) }
+    end
+
+    context "with consent needing triage" do
+      before { create(:consent, :needing_triage, patient:, programme:) }
+
+      it { should be(described_class::TRIAGE) }
+    end
+
+    context "with triaged as safe to vaccinate" do
+      before do
+        create(:consent, :needing_triage, patient:, programme:)
+        create(:triage, :ready_to_vaccinate, patient:, programme:)
+      end
+
+      it { should be(described_class::RECORD) }
+    end
+
+    context "with consent no triage needed" do
+      before { create(:consent, patient:, programme:) }
+
+      it { should be(described_class::RECORD) }
+    end
+
+    context "with an administered vaccination record" do
+      before do
+        create(:consent, patient:, programme:)
+        create(:vaccination_record, patient:, programme:)
+      end
+
+      it { should be(described_class::REPORT) }
+    end
+
+    context "with an already had administered vaccination record" do
+      before do
+        create(:consent, patient:, programme:)
+        create(
+          :vaccination_record,
+          :not_administered,
+          :already_had,
+          patient:,
+          programme:
+        )
+      end
+
+      it { should be(described_class::REPORT) }
+    end
+
+    context "with an un-administered vaccination record" do
+      before do
+        create(:consent, patient:, programme:)
+        create(:vaccination_record, :not_administered, patient:, programme:)
+      end
+
+      it { should be(described_class::RECORD) }
+    end
+  end
+end


### PR DESCRIPTION
When displaying the patient sessions on the register tab, we want to show the next action required to be taken to help the nurses with registering the patients.

## Screenshots

![Screenshot 2025-03-07 at 11 20 49](https://github.com/user-attachments/assets/def0fbac-663e-4ba6-859e-585e1c364dd7)

![Screenshot 2025-03-07 at 11 20 54](https://github.com/user-attachments/assets/62e342ea-ec09-4f91-9ff7-b3c88c7eaf72)

![Screenshot 2025-03-07 at 11 21 22](https://github.com/user-attachments/assets/48f2de51-dd44-4266-b9fa-c4cbde54b1a8)

![Screenshot 2025-03-07 at 11 21 24](https://github.com/user-attachments/assets/2c120e82-9950-4716-8645-e6ece338bd57)
