### PR TITLE
Show action required on record tab

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -16,17 +16,17 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
               row.with_value { helpers.patient_year_group(patient) }
             end
             
-            if context == :register
+            if action_required
               summary_list.with_row do |row|
                 row.with_key { "Action required" }
                 row.with_value { action_required }
               end
             end
 
-            if (value = status_tag)
+            if status_tag
               summary_list.with_row do |row|
                 row.with_key { "Status" }
-                row.with_value { value }
+                row.with_value { status_tag }
               end
             end
           end %>
@@ -68,7 +68,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
   end
 
   def action_required
-    return unless context == :register
+    return unless %i[register record].include?(context)
 
     tag.ul(class: "nhsuk-list nhsuk-list--bullet") do
       safe_join(

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -34,4 +34,10 @@ describe AppPatientSessionSearchResultCardComponent do
 
     it { should have_text("Action required\nGet consent for HPV") }
   end
+
+  context "when context is record" do
+    let(:context) { :record }
+
+    it { should have_text("Action required\nGet consent for HPV") }
+  end
 end


### PR DESCRIPTION
This is needed to match the designs in the prototype where the action required is shown on the search results.

## Screenshot

![Screenshot 2025-03-07 at 12 12 38](https://github.com/user-attachments/assets/13407f10-93c9-4c56-96ba-8e43faf82882)
