### PR TITLE
Allow search on partial date of birth

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -73,8 +73,23 @@ class AppSearchComponent < ViewComponent::Base
           <% end %>
         <% end %>
 
-        <%= govuk_details(summary_text: "Advanced filters", open: @form.date_of_birth.present? || @form.missing_nhs_number) do %>
-          <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: "Date of birth", size: "s" } %>
+        <%= govuk_details(summary_text: "Advanced filters", open: open_details?) do %>
+          <div class="nhsuk-form-group">
+            <fieldset class="nhsuk-fieldset">
+              <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">Date of birth</legend>
+              <div class="nhsuk-date-input">
+                <div class="nhsuk-date-input__item">
+                  <%= f.govuk_number_field :date_of_birth_day, label: { text: "Day" }, width: 2 %>
+                </div>
+                <div class="nhsuk-date-input__item">
+                  <%= f.govuk_number_field :date_of_birth_month, label: { text: "Month" }, width: 2 %>
+                </div>
+                <div class="nhsuk-date-input__item">
+                  <%= f.govuk_number_field :date_of_birth_year, label: { text: "Year" }, width: 4 %>
+                </div>
+              </div>
+            </fieldset>
+          </div>
 
           <%= f.govuk_check_boxes_fieldset :missing_nhs_number, multiple: false, legend: { text: "Options", size: "s" } do %>
             <%= f.govuk_check_box :missing_nhs_number, 1, 0, multiple: false, link_errors: true, label: { text: "Missing NHS number" } %>
@@ -131,6 +146,11 @@ class AppSearchComponent < ViewComponent::Base
               :session_statuses,
               :triage_statuses,
               :year_groups
+
+  def open_details?
+    @form.date_of_birth_year.present? || @form.date_of_birth_month.present? ||
+      @form.date_of_birth_day.present? || @form.missing_nhs_number
+  end
 
   def show_buttons_in_details?
     !(

--- a/app/controllers/concerns/search_form_concern.rb
+++ b/app/controllers/concerns/search_form_concern.rb
@@ -7,15 +7,15 @@ module SearchFormConcern
     @form =
       SearchForm.new(
         params.fetch(:search_form, {}).permit(
-          :"date_of_birth(1i)",
-          :"date_of_birth(2i)",
-          :"date_of_birth(3i)",
           :consent_status,
+          :date_of_birth_day,
+          :date_of_birth_month,
+          :date_of_birth_year,
           :missing_nhs_number,
           :programme_status,
           :q,
-          :session_status,
           :register_status,
+          :session_status,
           :triage_status,
           year_groups: []
         )

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -6,26 +6,16 @@ class SearchForm
   include ActiveRecord::AttributeAssignment
 
   attribute :consent_status, :string
-  attribute :date_of_birth, :date
+  attribute :date_of_birth_day, :integer
+  attribute :date_of_birth_month, :integer
+  attribute :date_of_birth_year, :integer
   attribute :missing_nhs_number, :boolean
   attribute :programme_status, :string
   attribute :q, :string
-  attribute :session_status, :string
   attribute :register_status, :string
+  attribute :session_status, :string
   attribute :triage_status, :string
   attribute :year_groups, array: true
-
-  def initialize(options)
-    super(options)
-  rescue ActiveRecord::MultiparameterAssignmentErrors
-    super(
-      options.except(
-        :"date_of_birth(1i)",
-        :"date_of_birth(2i)",
-        :"date_of_birth(3i)"
-      )
-    )
-  end
 
   def year_groups=(values)
     super(values&.compact_blank&.map(&:to_i)&.compact || [])
@@ -36,8 +26,17 @@ class SearchForm
 
     scope = scope.search_by_year_groups(year_groups) if year_groups.present?
 
-    scope =
-      scope.search_by_date_of_birth(date_of_birth) if date_of_birth.present?
+    if date_of_birth_year.present?
+      scope = scope.search_by_date_of_birth_year(date_of_birth_year)
+    end
+
+    if date_of_birth_month.present?
+      scope = scope.search_by_date_of_birth_month(date_of_birth_month)
+    end
+
+    if date_of_birth_day.present?
+      scope = scope.search_by_date_of_birth_day(date_of_birth_day)
+    end
 
     scope = scope.search_by_nhs_number(nil) if missing_nhs_number.present?
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -145,7 +145,14 @@ class Patient < ApplicationRecord
           where(birth_academic_year: year_groups.map(&:to_birth_academic_year))
         end
 
-  scope :search_by_date_of_birth, ->(date_of_birth) { where(date_of_birth:) }
+  scope :search_by_date_of_birth_year,
+        ->(year) { where("extract(year from date_of_birth) = ?", year) }
+
+  scope :search_by_date_of_birth_month,
+        ->(month) { where("extract(month from date_of_birth) = ?", month) }
+
+  scope :search_by_date_of_birth_day,
+        ->(day) { where("extract(day from date_of_birth) = ?", day) }
 
   scope :search_by_nhs_number, ->(nhs_number) { where(nhs_number:) }
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -77,10 +77,18 @@ class PatientSession < ApplicationRecord
   scope :search_by_year_groups,
         ->(year_groups) { merge(Patient.search_by_year_groups(year_groups)) }
 
-  scope :search_by_date_of_birth,
-        ->(date_of_birth) do
-          merge(Patient.search_by_date_of_birth(date_of_birth))
+  scope :search_by_date_of_birth_year,
+        ->(year) do
+          where("extract(year from patients.date_of_birth) = ?", year)
         end
+
+  scope :search_by_date_of_birth_month,
+        ->(month) do
+          where("extract(month from patients.date_of_birth) = ?", month)
+        end
+
+  scope :search_by_date_of_birth_day,
+        ->(day) { where("extract(day from patients.date_of_birth) = ?", day) }
 
   scope :search_by_nhs_number,
         ->(nhs_number) { merge(Patient.search_by_nhs_number(nhs_number)) }

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -4,44 +4,30 @@ describe SearchForm do
   subject(:form) do
     described_class.new(
       consent_status:,
-      date_of_birth:,
+      date_of_birth_day:,
+      date_of_birth_month:,
+      date_of_birth_year:,
       missing_nhs_number:,
       programme_status:,
       q:,
-      session_status:,
       register_status:,
+      session_status:,
       triage_status:,
       year_groups:
     )
   end
 
   let(:consent_status) { nil }
-  let(:date_of_birth) { Date.current }
+  let(:date_of_birth_day) { Date.current.day }
+  let(:date_of_birth_month) { Date.current.month }
+  let(:date_of_birth_year) { Date.current.year }
   let(:missing_nhs_number) { true }
   let(:programme_status) { nil }
   let(:q) { "query" }
-  let(:session_status) { nil }
   let(:register_status) { nil }
+  let(:session_status) { nil }
   let(:triage_status) { nil }
   let(:year_groups) { %w[8 9 10 11] }
-
-  context "with invalid date parameters" do
-    subject(:form) do
-      described_class.new(
-        "date_of_birth(1i)": "invalid",
-        "date_of_birth(2i)": "value",
-        "date_of_birth(3i)": "12345"
-      )
-    end
-
-    it "doesn't raise an error" do
-      expect { form }.not_to raise_error
-    end
-
-    it "doesn't filter by date" do
-      expect(form.date_of_birth).to be_nil
-    end
-  end
 
   context "for patients" do
     let(:scope) { Patient.all }
@@ -50,14 +36,66 @@ describe SearchForm do
       expect { form.apply(scope) }.not_to raise_error
     end
 
+    context "filtering on date of birth" do
+      let(:consent_status) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
+      let(:missing_nhs_number) { nil }
+      let(:programme_status) { nil }
+      let(:q) { nil }
+      let(:register_status) { nil }
+      let(:session_status) { nil }
+      let(:triage_status) { nil }
+      let(:year_groups) { nil }
+
+      let(:patient) { create(:patient, date_of_birth: Date.new(2000, 1, 1)) }
+
+      context "with only a year specified" do
+        let(:date_of_birth_year) { 2000 }
+
+        it "includes the patient" do
+          expect(form.apply(scope)).to include(patient)
+        end
+      end
+
+      context "with only a month specified" do
+        let(:date_of_birth_month) { 1 }
+
+        it "includes the patient" do
+          expect(form.apply(scope)).to include(patient)
+        end
+      end
+
+      context "with only a day specified" do
+        let(:date_of_birth_day) { 1 }
+
+        it "includes the patient" do
+          expect(form.apply(scope)).to include(patient)
+        end
+      end
+
+      context "with all parts specified" do
+        let(:date_of_birth_year) { 2000 }
+        let(:date_of_birth_month) { 1 }
+        let(:date_of_birth_day) { 1 }
+
+        it "includes the patient" do
+          expect(form.apply(scope)).to include(patient)
+        end
+      end
+    end
+
     context "filtering on programme status" do
       let(:consent_status) { nil }
-      let(:date_of_birth) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { "vaccinated" }
       let(:q) { nil }
-      let(:session_status) { nil }
       let(:register_status) { nil }
+      let(:session_status) { nil }
       let(:triage_status) { nil }
       let(:year_groups) { nil }
 
@@ -79,7 +117,9 @@ describe SearchForm do
 
     context "filtering on consent status" do
       let(:consent_status) { "given" }
-      let(:date_of_birth) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
       let(:q) { nil }
@@ -96,12 +136,14 @@ describe SearchForm do
 
     context "filtering on session status" do
       let(:consent_status) { nil }
-      let(:date_of_birth) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
       let(:q) { nil }
-      let(:session_status) { "administered" }
       let(:register_status) { nil }
+      let(:session_status) { "administered" }
       let(:triage_status) { nil }
       let(:year_groups) { nil }
 
@@ -113,12 +155,14 @@ describe SearchForm do
 
     context "filtering on register status" do
       let(:consent_status) { nil }
-      let(:date_of_birth) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
       let(:q) { nil }
-      let(:session_status) { nil }
       let(:register_status) { "attending" }
+      let(:session_status) { nil }
       let(:triage_status) { nil }
       let(:year_groups) { nil }
 
@@ -130,12 +174,14 @@ describe SearchForm do
 
     context "filtering on triage status" do
       let(:consent_status) { nil }
-      let(:date_of_birth) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
       let(:q) { nil }
-      let(:session_status) { nil }
       let(:register_status) { nil }
+      let(:session_status) { nil }
       let(:triage_status) { "required" }
       let(:year_groups) { nil }
 


### PR DESCRIPTION
When searching for patients by date of birth, this allows the user to only specify part of the date of birth (year, month and day) and search across the patients only on that part of the date of birth.

## Screenshot

![Screenshot 2025-03-07 at 13 26 43](https://github.com/user-attachments/assets/4fc7dedc-1f6d-4120-a7b1-6e5b4152fe38)
