### PR TITLE
Add audit associations

### DIFF
--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -27,7 +27,7 @@
 class Batch < ApplicationRecord
   include Archivable
 
-  audited
+  audited associated_with: :vaccine
 
   belongs_to :organisation
   belongs_to :vaccine

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -42,7 +42,7 @@ class Consent < ApplicationRecord
   include Invalidatable
   include HasHealthAnswers
 
-  audited
+  audited associated_with: :patient
 
   belongs_to :patient
   belongs_to :programme

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -73,7 +73,8 @@ class ConsentForm < ApplicationRecord
 
   attr_accessor :health_question_number, :parental_responsibility
 
-  audited
+  audited associated_with: :consent
+  has_associated_audits
 
   belongs_to :consent, optional: true
   belongs_to :location

--- a/app/models/consent_form_programme.rb
+++ b/app/models/consent_form_programme.rb
@@ -20,8 +20,6 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class ConsentFormProgramme < ApplicationRecord
-  audited
-
   belongs_to :consent_form
   belongs_to :programme
 end

--- a/app/models/consent_notification_programme.rb
+++ b/app/models/consent_notification_programme.rb
@@ -20,8 +20,6 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class ConsentNotificationProgramme < ApplicationRecord
-  audited
-
   belongs_to :consent_notification
   belongs_to :programme
 end

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -30,7 +30,7 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class GillickAssessment < ApplicationRecord
-  audited
+  audited associated_with: :patient_session
 
   belongs_to :patient_session
   belongs_to :programme

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -37,7 +37,8 @@ class Location < ApplicationRecord
 
   self.inheritance_column = :nil
 
-  audited
+  audited associated_with: :team
+  has_associated_audits
 
   belongs_to :team, optional: true
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -27,6 +27,7 @@
 class Organisation < ApplicationRecord
   include ODSCodeConcern
 
+  audited
   has_associated_audits
 
   has_many :batches

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -27,6 +27,8 @@
 class Organisation < ApplicationRecord
   include ODSCodeConcern
 
+  has_associated_audits
+
   has_many :batches
   has_many :cohort_imports
   has_many :consent_forms

--- a/app/models/organisation_programme.rb
+++ b/app/models/organisation_programme.rb
@@ -20,8 +20,6 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class OrganisationProgramme < ApplicationRecord
-  audited
-
   belongs_to :programme
   belongs_to :organisation
 end

--- a/app/models/parent_relationship.rb
+++ b/app/models/parent_relationship.rb
@@ -24,7 +24,7 @@
 #  fk_rails_...  (patient_id => patients.id)
 #
 class ParentRelationship < ApplicationRecord
-  audited
+  audited associated_with: :patient
 
   self.inheritance_column = nil
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -56,7 +56,8 @@ class Patient < ApplicationRecord
   include PendingChangesConcern
   include Schoolable
 
-  audited
+  audited associated_with: :organisation
+  has_associated_audits
 
   belongs_to :gp_practice, class_name: "Location", optional: true
   belongs_to :organisation, optional: true

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -23,7 +23,8 @@
 #
 
 class PatientSession < ApplicationRecord
-  audited
+  audited associated_with: :patient
+  has_associated_audits
 
   include PatientSessionStatusConcern
 

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -26,7 +26,7 @@
 #  fk_rails_...  (performed_by_user_id => users.id)
 #
 class PreScreening < ApplicationRecord
-  audited
+  audited associated_with: :patient_session
 
   belongs_to :patient_session
   belongs_to :performed_by,

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -17,6 +17,7 @@ class Programme < ApplicationRecord
   self.inheritance_column = nil
 
   audited
+  has_associated_audits
 
   has_many :consent_forms
   has_many :consent_notification_programmes

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -25,7 +25,8 @@
 #  fk_rails_...  (organisation_id => organisations.id)
 #
 class Session < ApplicationRecord
-  audited
+  audited associated_with: :location
+  has_associated_audits
 
   belongs_to :organisation
   belongs_to :location

--- a/app/models/session_attendance.rb
+++ b/app/models/session_attendance.rb
@@ -23,6 +23,8 @@
 #  fk_rails_...  (session_date_id => session_dates.id)
 #
 class SessionAttendance < ApplicationRecord
+  audited associated_with: :patient_session
+
   belongs_to :patient_session
   belongs_to :session_date
 

--- a/app/models/session_date.rb
+++ b/app/models/session_date.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (session_id => sessions.id)
 #
 class SessionDate < ApplicationRecord
-  audited
+  audited associated_with: :session
 
   belongs_to :session
 

--- a/app/models/session_programme.rb
+++ b/app/models/session_programme.rb
@@ -20,7 +20,7 @@
 #  fk_rails_...  (session_id => sessions.id)
 #
 class SessionProgramme < ApplicationRecord
-  audited
+  audited associated_with: :session
 
   belongs_to :session
   belongs_to :programme

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -23,6 +23,9 @@
 #  fk_rails_...  (organisation_id => organisations.id)
 #
 class Team < ApplicationRecord
+  audited associated_with: :organisation
+  has_associated_audits
+
   belongs_to :organisation
 
   has_many :locations

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -34,7 +34,7 @@ class Triage < ApplicationRecord
 
   self.table_name = "triage"
 
-  audited
+  audited associated_with: :patient
 
   belongs_to :patient
   belongs_to :programme

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -32,7 +32,8 @@
 class Vaccine < ApplicationRecord
   self.inheritance_column = nil
 
-  audited
+  audited associated_with: :programme
+  has_associated_audits
 
   belongs_to :programme
 


### PR DESCRIPTION
This updates the auditing setup on our models. By associating models for audits, it makes it easier for us to get a more complete picture of the changes done to a record with the `own_and_associated_audits`. Here's a minor example of a patient that has been removed from a cohort:

![image](https://github.com/user-attachments/assets/59913bec-ddce-46ac-8ab7-b356dc0a0cdc)

The general approach used to decide how and what auditing to add:

- Typically auditing is for tracking updates to records or, in rarer cases, deletion of records.
  - Only enable auditing for those records where we want to track those activities.
  - Join tables don't typically need auditing.
- Models can be associated with one of their `belongs_to` relationships, with a view on usefulness in operational settings, where it's most useful to see associated changes easily.
