### PR TITLE
Build new pre-screening designs

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -174,7 +174,8 @@ class AppActivityLogComponent < ViewComponent::Base
         title: "Completed pre-screening checks",
         body: pre_screening.notes,
         at: pre_screening.created_at,
-        by: pre_screening.performed_by
+        by: pre_screening.performed_by,
+        programmes: programmes_for(pre_screening)
       }
     end
   end

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -44,6 +44,8 @@ class AppPatientPageComponent < ViewComponent::Base
       knows_vaccination: pre_screening&.knows_vaccination,
       no_allergies: pre_screening&.no_allergies,
       not_already_had: pre_screening&.not_already_had,
+      not_pregnant: pre_screening&.not_pregnant,
+      not_taking_medication: pre_screening&.not_taking_medication,
       pre_screening_notes: pre_screening&.notes || ""
     )
   end

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -18,7 +18,7 @@ class AppPatientPageComponent < ViewComponent::Base
     @programme = programme
     @current_user = current_user
     @triage = triage
-    @vaccinate_form = vaccinate_form || VaccinateForm.new
+    @vaccinate_form = vaccinate_form || default_vaccinate_form
   end
 
   delegate :patient, :session, to: :patient_session
@@ -34,5 +34,17 @@ class AppPatientPageComponent < ViewComponent::Base
 
   def gillick_assessment_can_be_recorded?
     patient_session.session.today? && helpers.policy(GillickAssessment).new?
+  end
+
+  def default_vaccinate_form
+    pre_screening = patient_session.pre_screenings.last
+
+    VaccinateForm.new(
+      feeling_well: pre_screening&.feeling_well,
+      knows_vaccination: pre_screening&.knows_vaccination,
+      no_allergies: pre_screening&.no_allergies,
+      not_already_had: pre_screening&.not_already_had,
+      pre_screening_notes: pre_screening&.notes || ""
+    )
   end
 end

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -9,38 +9,22 @@
 
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
-      Pre-screening questions
+      <%= patient.given_name %> has confirmed that they:
     </h2>
 
-    <% options = [OpenStruct.new(value: true, label: "Yes"), OpenStruct.new(value: false, label: "No")] %>
+    <%= f.govuk_check_boxes_fieldset :pre_screening, multiple: false, legend: nil do %>
+      <%= f.govuk_check_box :knows_vaccination, 1, 0, multiple: false, link_errors: true,
+                                                      label: { text: "know what the vaccination is for, and are happy to have it" } %>
 
-    <%= f.govuk_collection_radio_buttons :knows_vaccination,
-                                         options,
-                                         :value,
-                                         :label,
-                                         inline: true,
-                                         legend: { text: "Does the child know what the vaccination is for, and are they happy to have it?", size: nil } %>
+      <%= f.govuk_check_box :not_already_had, 1, 0, multiple: false, link_errors: true,
+                                                    label: { text: "have not already had the vaccination" } %>
 
-    <%= f.govuk_collection_radio_buttons :not_already_had,
-                                         options,
-                                         :value,
-                                         :label,
-                                         inline: true,
-                                         legend: { text: "Has the child confirmed they have not already had this vaccination?", size: nil } %>
+      <%= f.govuk_check_box :feeling_well, 1, 0, multiple: false, link_errors: true,
+                                                 label: { text: "are feeling well" } %>
 
-    <%= f.govuk_collection_radio_buttons :feeling_well,
-                                         options,
-                                         :value,
-                                         :label,
-                                         inline: true,
-                                         legend: { text: "Is the child is feeling well?", size: nil } %>
-
-    <%= f.govuk_collection_radio_buttons :no_allergies,
-                                         options,
-                                         :value,
-                                         :label,
-                                         inline: true,
-                                         legend: { text: "Has the child confirmed they have no allergies which would prevent vaccination?", size: nil } %>
+      <%= f.govuk_check_box :no_allergies, 1, 0, multiple: false, link_errors: true,
+                                                 label: { text: "have no allergies which would prevent vaccination" } %>
+    <% end %>
 
     <%= f.govuk_text_area :pre_screening_notes, label: { text: "Pre-screening notes (optional)" } %>
 

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -24,6 +24,16 @@
 
       <%= f.govuk_check_box :no_allergies, 1, 0, multiple: false, link_errors: true,
                                                  label: { text: "have no allergies which would prevent vaccination" } %>
+
+      <% if PreScreening.ask_not_taking_medication?(programme:) %>
+        <%= f.govuk_check_box :not_taking_medication, 1, 0, multiple: false, link_errors: true,
+                                                            label: { text: "are not taking any medication which prevents vaccination" } %>
+      <% end %>
+
+      <% if PreScreening.ask_not_pregnant?(programme:, patient:) %>
+        <%= f.govuk_check_box :not_pregnant, 1, 0, multiple: false, link_errors: true,
+                                                   label: { text: "are not pregnant" } %>
+      <% end %>
     <% end %>
 
     <%= f.govuk_text_area :pre_screening_notes, label: { text: "Pre-screening notes (optional)" } %>

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -12,27 +12,29 @@
       <%= patient.given_name %> has confirmed that they:
     </h2>
 
+    <% count = patient_session.programmes.count %>
+
     <%= f.govuk_check_boxes_fieldset :pre_screening, multiple: false, legend: nil do %>
       <%= f.govuk_check_box :knows_vaccination, 1, 0, multiple: false, link_errors: true,
-                                                      label: { text: "know what the vaccination is for, and are happy to have it" } %>
+                                                      label: { text: t("pre_screening.knows_vaccination", count:) } %>
 
       <%= f.govuk_check_box :not_already_had, 1, 0, multiple: false, link_errors: true,
-                                                    label: { text: "have not already had the vaccination" } %>
+                                                    label: { text: t("pre_screening.not_already_had", count:) } %>
 
       <%= f.govuk_check_box :feeling_well, 1, 0, multiple: false, link_errors: true,
-                                                 label: { text: "are feeling well" } %>
+                                                 label: { text: t("pre_screening.feeling_well", count:) } %>
 
       <%= f.govuk_check_box :no_allergies, 1, 0, multiple: false, link_errors: true,
-                                                 label: { text: "have no allergies which would prevent vaccination" } %>
+                                                 label: { text: t("pre_screening.no_allergies", count:) } %>
 
       <% if PreScreening.ask_not_taking_medication?(programme:) %>
         <%= f.govuk_check_box :not_taking_medication, 1, 0, multiple: false, link_errors: true,
-                                                            label: { text: "are not taking any medication which prevents vaccination" } %>
+                                                            label: { text: t("pre_screening.not_taking_medication", count:) } %>
       <% end %>
 
       <% if PreScreening.ask_not_pregnant?(programme:, patient:) %>
         <%= f.govuk_check_box :not_pregnant, 1, 0, multiple: false, link_errors: true,
-                                                   label: { text: "are not pregnant" } %>
+                                                   label: { text: t("pre_screening.not_pregnant", count:) } %>
       <% end %>
     <% end %>
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -61,6 +61,8 @@ class VaccinationsController < ApplicationController
         knows_vaccination
         no_allergies
         not_already_had
+        not_pregnant
+        not_taking_medication
         pre_screening_notes
         programme_id
         vaccine_id

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -69,13 +69,14 @@ class VaccinateForm
   def pre_screening
     @pre_screening ||=
       PreScreening.new(
+        feeling_well:,
+        knows_vaccination:,
+        no_allergies:,
+        not_already_had:,
+        notes: pre_screening_notes,
         patient_session:,
         performed_by: current_user,
-        knows_vaccination:,
-        not_already_had:,
-        feeling_well:,
-        no_allergies:,
-        notes: pre_screening_notes
+        programme_id:
       )
   end
 

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -10,6 +10,8 @@ class VaccinateForm
   attribute :not_already_had, :boolean
   attribute :feeling_well, :boolean
   attribute :no_allergies, :boolean
+  attribute :not_taking_medication, :boolean
+  attribute :not_pregnant, :boolean
   attribute :pre_screening_notes, :string
 
   attribute :administered, :boolean
@@ -23,6 +25,8 @@ class VaccinateForm
   validates :not_already_had, inclusion: { in: [true, false] }
   validates :feeling_well, inclusion: { in: [true, false] }
   validates :no_allergies, inclusion: { in: [true, false] }
+  validates :not_taking_medication, inclusion: { in: [true, false, nil] }
+  validates :not_pregnant, inclusion: { in: [true, false, nil] }
 
   validate :valid_administered_values
   validates :programme_id, presence: true
@@ -73,6 +77,8 @@ class VaccinateForm
         knows_vaccination:,
         no_allergies:,
         not_already_had:,
+        not_pregnant: not_pregnant || false,
+        not_taking_medication: not_taking_medication || false,
         notes: pre_screening_notes,
         patient_session:,
         performed_by: current_user,

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -4,17 +4,19 @@
 #
 # Table name: pre_screenings
 #
-#  id                   :bigint           not null, primary key
-#  feeling_well         :boolean          not null
-#  knows_vaccination    :boolean          not null
-#  no_allergies         :boolean          not null
-#  not_already_had      :boolean          not null
-#  notes                :text             default(""), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  patient_session_id   :bigint           not null
-#  performed_by_user_id :bigint           not null
-#  programme_id         :bigint           not null
+#  id                    :bigint           not null, primary key
+#  feeling_well          :boolean          not null
+#  knows_vaccination     :boolean          not null
+#  no_allergies          :boolean          not null
+#  not_already_had       :boolean          not null
+#  not_pregnant          :boolean          not null
+#  not_taking_medication :boolean          not null
+#  notes                 :text             default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  patient_session_id    :bigint           not null
+#  performed_by_user_id  :bigint           not null
+#  programme_id          :bigint           not null
 #
 # Indexes
 #
@@ -45,11 +47,26 @@ class PreScreening < ApplicationRecord
             :not_already_had,
             :feeling_well,
             :no_allergies,
+            :not_taking_medication,
+            :not_pregnant,
             inclusion: {
               in: [true, false]
             }
 
   def allows_vaccination?
-    knows_vaccination && not_already_had && no_allergies
+    knows_vaccination && not_already_had && no_allergies &&
+      (
+        !PreScreening.ask_not_taking_medication?(programme:) ||
+          not_taking_medication
+      ) &&
+      (!PreScreening.ask_not_pregnant?(programme:, patient:) || not_pregnant)
+  end
+
+  def self.ask_not_taking_medication?(programme:)
+    programme.doubles?
+  end
+
+  def self.ask_not_pregnant?(programme:, patient:)
+    (programme.hpv? || programme.td_ipv?) && patient.gender_code != "male"
   end
 end

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -14,21 +14,25 @@
 #  updated_at           :datetime         not null
 #  patient_session_id   :bigint           not null
 #  performed_by_user_id :bigint           not null
+#  programme_id         :bigint           not null
 #
 # Indexes
 #
 #  index_pre_screenings_on_patient_session_id    (patient_session_id)
 #  index_pre_screenings_on_performed_by_user_id  (performed_by_user_id)
+#  index_pre_screenings_on_programme_id          (programme_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
+#  fk_rails_...  (programme_id => programmes.id)
 #
 class PreScreening < ApplicationRecord
   audited associated_with: :patient_session
 
   belongs_to :patient_session
+  belongs_to :programme
   belongs_to :performed_by,
              class_name: "User",
              foreign_key: :performed_by_user_id

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -26,6 +26,7 @@ class Programme < ApplicationRecord
   has_many :gillick_assessments
   has_many :immunisation_imports
   has_many :organisation_programmes
+  has_many :pre_screenings
   has_many :session_programmes
   has_many :triages
   has_many :vaccination_records, -> { kept }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,14 +326,6 @@ en:
           attributes:
             delivery_site:
               blank: Choose where the injection will be given
-            knows_vaccination:
-              inclusion: Choose whether the child knows what the vaccination is for
-            not_already_had:
-              inclusion: Choose whether the child has confirmed they have not already had this vaccination
-            feeling_well:
-              inclusion: Choose whether the child is feeling well
-            no_allergies:
-              inclusion: Choose whether the child has confirmed they have no allergies which would prevent vaccination
         vaccination_report:
           attributes:
             file_format:

--- a/config/locales/pre_screening.en.yml
+++ b/config/locales/pre_screening.en.yml
@@ -1,0 +1,20 @@
+en:
+  pre_screening:
+    knows_vaccination:
+      one: know what the vaccination is for, and are happy to have it
+      other: know what these vaccinations are for, and are happy to have them
+    not_already_had:
+      one: have not already had the vaccination
+      other: have not already had these vaccinations
+    feeling_well:
+      one: are feeling well
+      other: are feeling well
+    no_allergies:
+      one: have no allergies which would prevent vaccination
+      other: have no allergies which would prevent vaccination
+    not_taking_medication:
+      one: are not taking any medication which prevents vaccination
+      other: are not taking any medication which prevents vaccination
+    not_pregnant:
+      one: are not pregnant
+      other: are not pregnant

--- a/db/migrate/20250307161252_add_programme_to_pre_screenings.rb
+++ b/db/migrate/20250307161252_add_programme_to_pre_screenings.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddProgrammeToPreScreenings < ActiveRecord::Migration[8.0]
+  def up
+    add_reference :pre_screenings, :programme, foreign_key: true
+
+    PreScreening
+      .includes(patient_session: { session: :programmes })
+      .find_each do |pre_screening|
+        pre_screening.update_column(
+          :programme_id,
+          pre_screening.patient_session.programmes.first.id
+        )
+      end
+
+    change_column_null :pre_screenings, :programme_id, false
+  end
+
+  def down
+    remove_reference :pre_screenings, :programme
+  end
+end

--- a/db/migrate/20250307163053_add_questions_to_pre_screening.rb
+++ b/db/migrate/20250307163053_add_questions_to_pre_screening.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddQuestionsToPreScreening < ActiveRecord::Migration[8.0]
+  def change
+    change_table :pre_screenings, bulk: true do |t|
+      t.boolean :not_taking_medication, null: false, default: false
+      t.boolean :not_pregnant, null: false, default: false
+    end
+
+    change_table :pre_screenings, bulk: true do |t|
+      t.change_default :not_taking_medication, from: false, to: nil
+      t.change_default :not_pregnant, from: false, to: nil
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_07_161252) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_07_163053) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -604,6 +604,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_07_161252) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "programme_id", null: false
+    t.boolean "not_taking_medication", null: false
+    t.boolean "not_pregnant", null: false
     t.index ["patient_session_id"], name: "index_pre_screenings_on_patient_session_id"
     t.index ["performed_by_user_id"], name: "index_pre_screenings_on_performed_by_user_id"
     t.index ["programme_id"], name: "index_pre_screenings_on_programme_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_25_161342) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_07_161252) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -603,8 +603,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_25_161342) do
     t.text "notes", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "programme_id", null: false
     t.index ["patient_session_id"], name: "index_pre_screenings_on_patient_session_id"
     t.index ["performed_by_user_id"], name: "index_pre_screenings_on_performed_by_user_id"
+    t.index ["programme_id"], name: "index_pre_screenings_on_programme_id"
   end
 
   create_table "programmes", force: :cascade do |t|
@@ -866,6 +868,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_25_161342) do
   add_foreign_key "patients", "locations", column: "school_id"
   add_foreign_key "patients", "organisations"
   add_foreign_key "pre_screenings", "patient_sessions"
+  add_foreign_key "pre_screenings", "programmes"
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
   add_foreign_key "school_move_log_entries", "locations", column: "school_id"
   add_foreign_key "school_move_log_entries", "patients"

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -21,7 +21,13 @@ describe AppActivityLogComponent do
   let(:location) { create(:school, name: "Hogwarts") }
   let(:session) { create(:session, programmes:, location:) }
   let(:patient) do
-    create(:patient, school: location, given_name: "Sarah", family_name: "Doe")
+    create(
+      :patient,
+      school: location,
+      given_name: "Sarah",
+      family_name: "Doe",
+      year_group: 8
+    )
   end
 
   let(:mum) { create(:parent, full_name: "Jane Doe") }
@@ -400,6 +406,7 @@ describe AppActivityLogComponent do
                      title: "Completed pre-screening checks",
                      notes: "Some notes",
                      date: "1 June 2024 at 12:00pm",
-                     by: "JOY, Nurse"
+                     by: "JOY, Nurse",
+                     programme: "HPV"
   end
 end

--- a/spec/factories/pre_screenings.rb
+++ b/spec/factories/pre_screenings.rb
@@ -14,20 +14,24 @@
 #  updated_at           :datetime         not null
 #  patient_session_id   :bigint           not null
 #  performed_by_user_id :bigint           not null
+#  programme_id         :bigint           not null
 #
 # Indexes
 #
 #  index_pre_screenings_on_patient_session_id    (patient_session_id)
 #  index_pre_screenings_on_performed_by_user_id  (performed_by_user_id)
+#  index_pre_screenings_on_programme_id          (programme_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
+#  fk_rails_...  (programme_id => programmes.id)
 #
 FactoryBot.define do
   factory :pre_screening do
     patient_session
+    programme { patient_session.programmes.first }
     performed_by
 
     trait :allows_vaccination do

--- a/spec/factories/pre_screenings.rb
+++ b/spec/factories/pre_screenings.rb
@@ -4,17 +4,19 @@
 #
 # Table name: pre_screenings
 #
-#  id                   :bigint           not null, primary key
-#  feeling_well         :boolean          not null
-#  knows_vaccination    :boolean          not null
-#  no_allergies         :boolean          not null
-#  not_already_had      :boolean          not null
-#  notes                :text             default(""), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  patient_session_id   :bigint           not null
-#  performed_by_user_id :bigint           not null
-#  programme_id         :bigint           not null
+#  id                    :bigint           not null, primary key
+#  feeling_well          :boolean          not null
+#  knows_vaccination     :boolean          not null
+#  no_allergies          :boolean          not null
+#  not_already_had       :boolean          not null
+#  not_pregnant          :boolean          not null
+#  not_taking_medication :boolean          not null
+#  notes                 :text             default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  patient_session_id    :bigint           not null
+#  performed_by_user_id  :bigint           not null
+#  programme_id          :bigint           not null
 #
 # Indexes
 #
@@ -39,6 +41,8 @@ FactoryBot.define do
       not_already_had { true }
       feeling_well { true }
       no_allergies { true }
+      not_taking_medication { true }
+      not_pregnant { true }
       notes { "Fine to vaccinate" }
     end
 
@@ -47,6 +51,8 @@ FactoryBot.define do
       not_already_had { false }
       feeling_well { false }
       no_allergies { false }
+      not_taking_medication { false }
+      not_pregnant { false }
       notes { "Not safe to vaccinate" }
     end
   end

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -61,8 +61,8 @@ describe "MenACWY and Td/IPV vaccination" do
   end
 
   def and_i_fill_out_pre_screening_questions
-    check "know what the vaccination is for, and are happy to have it"
-    check "have not already had the vaccination"
+    check "know what these vaccinations are for, and are happy to have them"
+    check "have not already had these vaccinations"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
     check "are not taking any medication which prevents vaccination"

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+describe "MenACWY and Td/IPV vaccination" do
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
+
+  scenario "Administered" do
+    given_a_doubles_session_exists
+    and_a_patient_is_ready_to_be_vaccinated
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    then_i_see_the_menacwy_vaccination_form
+    and_i_fill_out_pre_screening_questions
+    and_i_record_the_vaccination(@menacwy_batch)
+    then_i_see_the_patient_is_vaccinated_for_menacwy
+
+    when_i_switch_to_td_ipv
+    then_i_see_the_td_ipv_vaccination_form
+    # pre-screening questions already pre-populated
+    and_i_record_the_vaccination(@td_ipv_batch)
+    then_i_see_the_patient_is_vaccinated_for_td_ipv
+
+    when_vaccination_confirmations_are_sent
+    then_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+  end
+
+  def given_a_doubles_session_exists
+    programmes = [create(:programme, :menacwy), create(:programme, :td_ipv)]
+
+    organisation = create(:organisation, programmes:)
+    location = create(:school)
+
+    @menacwy_batch =
+      create(:batch, organisation:, vaccine: programmes.first.vaccines.first)
+    @td_ipv_batch =
+      create(:batch, organisation:, vaccine: programmes.second.vaccines.first)
+
+    @session = create(:session, organisation:, programmes:, location:)
+
+    @nurse = create(:nurse, organisation:)
+  end
+
+  def and_a_patient_is_ready_to_be_vaccinated
+    @patient =
+      create(
+        :patient,
+        :consent_given_triage_not_needed,
+        :in_attendance,
+        session: @session
+      )
+  end
+
+  def when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    sign_in @nurse
+    visit session_record_path(@session)
+    click_link @patient.full_name
+  end
+
+  def then_i_see_the_menacwy_vaccination_form
+    expect(page).to have_content("ready for their MenACWY vaccination?")
+  end
+
+  def and_i_fill_out_pre_screening_questions
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
+  end
+
+  def and_i_record_the_vaccination(batch)
+    choose "Yes"
+    choose "Left arm (upper position)"
+    click_on "Continue"
+
+    choose batch.name
+    click_on "Continue"
+
+    expect(page).to have_content("Check and confirm")
+    click_on "Confirm"
+  end
+
+  def then_i_see_the_patient_is_vaccinated_for_menacwy
+    expect(page).to have_content("Vaccination recorded")
+
+    # actions required
+    expect(page).to have_content("Report for MenACWY")
+    expect(page).to have_content("Record vaccination for Td/IPV")
+
+    click_link @patient.full_name, match: :first
+    expect(page).to have_content("Vaccinated")
+  end
+
+  def when_i_switch_to_td_ipv
+    click_on "Td/IPV"
+  end
+
+  def then_i_see_the_td_ipv_vaccination_form
+    expect(page).to have_content("ready for their Td/IPV vaccination?")
+  end
+
+  def then_i_see_the_patient_is_vaccinated_for_td_ipv
+    expect(page).to have_content("Vaccination recorded")
+
+    # patient should no longer be in record tab
+    expect(page).to have_content("No children matching search criteria found")
+
+    click_link @patient.full_name
+    expect(page).to have_content("Vaccinated")
+  end
+
+  def when_vaccination_confirmations_are_sent
+    VaccinationConfirmationsJob.perform_now
+  end
+
+  def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    expect_email_to(
+      @patient.consents.last.parent.email,
+      :vaccination_confirmation_administered
+    )
+  end
+
+  def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+    expect_sms_to(
+      @patient.consents.last.parent.phone,
+      :vaccination_confirmation_administered
+    )
+  end
+end

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -15,7 +15,7 @@ describe "MenACWY and Td/IPV vaccination" do
 
     when_i_switch_to_td_ipv
     then_i_see_the_td_ipv_vaccination_form
-    # pre-screening questions already pre-populated
+    and_i_check_the_patient_is_not_pregnant
     and_i_record_the_vaccination(@td_ipv_batch)
     then_i_see_the_patient_is_vaccinated_for_td_ipv
 
@@ -65,6 +65,7 @@ describe "MenACWY and Td/IPV vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not taking any medication which prevents vaccination"
   end
 
   def and_i_record_the_vaccination(batch)
@@ -96,6 +97,12 @@ describe "MenACWY and Td/IPV vaccination" do
 
   def then_i_see_the_td_ipv_vaccination_form
     expect(page).to have_content("ready for their Td/IPV vaccination?")
+  end
+
+  def and_i_check_the_patient_is_not_pregnant
+    # The other pre-screening questions should be pre-checked
+    # from the MenACWY vaccination.
+    check "are not pregnant"
   end
 
   def then_i_see_the_patient_is_vaccinated_for_td_ipv

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -240,6 +240,7 @@ describe "End-to-end journey" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -236,13 +236,13 @@ describe "End-to-end journey" do
     expect(page).to have_content("Update attendance")
 
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -102,13 +102,13 @@ describe "HPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -106,6 +106,7 @@ describe "HPV vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -49,27 +49,11 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_wasnt_vaccinated
-    within(
-      "fieldset",
-      text:
-        "Does the child know what the vaccination is for, and are they happy to have it?"
-    ) { choose "Yes" }
+    check "know what the vaccination is for, and are happy to have it"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
-    within(
-      "fieldset",
-      text:
-        "Has the child confirmed they have not already had this vaccination?"
-    ) { choose "No" }
-
-    within("fieldset", text: "Is the child is feeling well?") { choose "Yes" }
-
-    within(
-      "fieldset",
-      text:
-        "Has the child confirmed they have no allergies which would prevent vaccination?"
-    ) { choose "Yes" }
-
-    find_all(".nhsuk-fieldset")[4].choose "No"
+    choose "No"
     click_button "Continue"
   end
 

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -52,6 +52,7 @@ describe "HPV vaccination" do
     check "know what the vaccination is for, and are happy to have it"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     choose "No"
     click_button "Continue"

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -67,6 +67,7 @@ describe "HPV vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -63,13 +63,13 @@ describe "HPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -54,27 +54,13 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_was_unwell
-    within(
-      "fieldset",
-      text:
-        "Does the child know what the vaccination is for, and are they happy to have it?"
-    ) { choose "Yes" }
+    # pre-screening
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "have no allergies which would prevent vaccination"
 
-    within(
-      "fieldset",
-      text:
-        "Has the child confirmed they have not already had this vaccination?"
-    ) { choose "Yes" }
-
-    within("fieldset", text: "Is the child is feeling well?") { choose "No" }
-
-    within(
-      "fieldset",
-      text:
-        "Has the child confirmed they have no allergies which would prevent vaccination?"
-    ) { choose "Yes" }
-
-    find_all(".nhsuk-fieldset")[4].choose "No"
+    # vaccination
+    choose "No"
     click_button "Continue"
 
     choose "They were not well enough"

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -58,6 +58,7 @@ describe "HPV vaccination" do
     check "know what the vaccination is for, and are happy to have it"
     check "have not already had the vaccination"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "No"

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -43,6 +43,7 @@ describe "HPV vaccination" do
     check "know what the vaccination is for, and are happy to have it"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
   end
 
   def and_i_choose_that_the_patient_is_ready_to_vaccinate

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -40,29 +40,13 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_has_already_received_the_vaccination
-    within(
-      "fieldset",
-      text:
-        "Does the child know what the vaccination is for, and are they happy to have it?"
-    ) { choose "Yes" }
-
-    within(
-      "fieldset",
-      text:
-        "Has the child confirmed they have not already had this vaccination?"
-    ) { choose "No" }
-
-    within("fieldset", text: "Is the child is feeling well?") { choose "Yes" }
-
-    within(
-      "fieldset",
-      text:
-        "Has the child confirmed they have no allergies which would prevent vaccination?"
-    ) { choose "Yes" }
+    check "know what the vaccination is for, and are happy to have it"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
   end
 
   def and_i_choose_that_the_patient_is_ready_to_vaccinate
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -98,13 +98,13 @@ describe "MenACWY vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -102,6 +102,7 @@ describe "MenACWY vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not taking any medication which prevents vaccination"
 
     # vaccination
     choose "Yes"

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -102,6 +102,8 @@ describe "Td/IPV vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not taking any medication which prevents vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -98,13 +98,13 @@ describe "Td/IPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -67,8 +67,8 @@ describe "Vaccination" do
     click_link @patient.full_name
 
     # pre-screening
-    check "know what the vaccination is for, and are happy to have it"
-    check "have not already had the vaccination"
+    check "know what these vaccinations are for, and are happy to have them"
+    check "have not already had these vaccinations"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
     check "are not pregnant"
@@ -157,8 +157,8 @@ describe "Vaccination" do
     click_on "MenACWY"
 
     # pre-screening
-    check "know what the vaccination is for, and are happy to have it"
-    check "have not already had the vaccination"
+    check "know what these vaccinations are for, and are happy to have them"
+    check "have not already had these vaccinations"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
     check "are not taking any medication which prevents vaccination"

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -67,13 +67,13 @@ describe "Vaccination" do
     click_link @patient.full_name
 
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
 
@@ -100,13 +100,13 @@ describe "Vaccination" do
     click_link @patient2.full_name
 
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end
@@ -155,13 +155,13 @@ describe "Vaccination" do
     click_on "MenACWY"
 
     # pre-screening
-    find_all(".nhsuk-fieldset")[0].choose "Yes"
-    find_all(".nhsuk-fieldset")[1].choose "Yes"
-    find_all(".nhsuk-fieldset")[2].choose "Yes"
-    find_all(".nhsuk-fieldset")[3].choose "Yes"
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "are feeling well"
+    check "have no allergies which would prevent vaccination"
 
     # vaccination
-    find_all(".nhsuk-fieldset")[4].choose "Yes"
+    choose "Yes"
     choose "Left arm (upper position)"
     click_button "Continue"
   end

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -71,6 +71,7 @@ describe "Vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "Yes"
@@ -104,6 +105,7 @@ describe "Vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not pregnant"
 
     # vaccination
     choose "Yes"
@@ -159,6 +161,7 @@ describe "Vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+    check "are not taking any medication which prevents vaccination"
 
     # vaccination
     choose "Yes"

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -23,11 +23,11 @@ describe PatientMerger do
 
     let(:user) { create(:user) }
 
-    let(:programme) { create(:programme) }
+    let(:programme) { create(:programme, :hpv) }
     let(:session) { create(:session, programmes: [programme]) }
 
-    let!(:patient_to_keep) { create(:patient) }
-    let!(:patient_to_destroy) { create(:patient) }
+    let!(:patient_to_keep) { create(:patient, year_group: 8) }
+    let!(:patient_to_destroy) { create(:patient, year_group: 8) }
 
     let(:access_log_entry) do
       create(:access_log_entry, patient: patient_to_destroy)

--- a/spec/models/pre_screening_spec.rb
+++ b/spec/models/pre_screening_spec.rb
@@ -4,17 +4,19 @@
 #
 # Table name: pre_screenings
 #
-#  id                   :bigint           not null, primary key
-#  feeling_well         :boolean          not null
-#  knows_vaccination    :boolean          not null
-#  no_allergies         :boolean          not null
-#  not_already_had      :boolean          not null
-#  notes                :text             default(""), not null
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
-#  patient_session_id   :bigint           not null
-#  performed_by_user_id :bigint           not null
-#  programme_id         :bigint           not null
+#  id                    :bigint           not null, primary key
+#  feeling_well          :boolean          not null
+#  knows_vaccination     :boolean          not null
+#  no_allergies          :boolean          not null
+#  not_already_had       :boolean          not null
+#  not_pregnant          :boolean          not null
+#  not_taking_medication :boolean          not null
+#  notes                 :text             default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  patient_session_id    :bigint           not null
+#  performed_by_user_id  :bigint           not null
+#  programme_id          :bigint           not null
 #
 # Indexes
 #
@@ -43,13 +45,13 @@ describe PreScreening do
     subject(:allows_vaccination?) { pre_screening.allows_vaccination? }
 
     context "when allows vaccination" do
-      let(:pre_screening) { build(:pre_screening, :allows_vaccination) }
+      let(:pre_screening) { create(:pre_screening, :allows_vaccination) }
 
       it { should be(true) }
 
       context "and the patient is feeling unwell" do
         let(:pre_screening) do
-          build(:pre_screening, :allows_vaccination, feeling_well: false)
+          create(:pre_screening, :allows_vaccination, feeling_well: false)
         end
 
         it { should be(true) }
@@ -57,7 +59,7 @@ describe PreScreening do
     end
 
     context "when prevents vaccination" do
-      let(:pre_screening) { build(:pre_screening, :prevents_vaccination) }
+      let(:pre_screening) { create(:pre_screening, :prevents_vaccination) }
 
       it { should be(false) }
     end

--- a/spec/models/pre_screening_spec.rb
+++ b/spec/models/pre_screening_spec.rb
@@ -14,16 +14,19 @@
 #  updated_at           :datetime         not null
 #  patient_session_id   :bigint           not null
 #  performed_by_user_id :bigint           not null
+#  programme_id         :bigint           not null
 #
 # Indexes
 #
 #  index_pre_screenings_on_patient_session_id    (patient_session_id)
 #  index_pre_screenings_on_performed_by_user_id  (performed_by_user_id)
+#  index_pre_screenings_on_programme_id          (programme_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
+#  fk_rails_...  (programme_id => programmes.id)
 #
 describe PreScreening do
   subject(:pre_screening) { build(:pre_screening) }


### PR DESCRIPTION
This makes a number of changes to the pre-screening form to match the latest designs in the prototype. Specifically this changes the radio buttons to checkboxes, adds two new questions asking about medication and pregnancy, and pre-populates the answers when vaccinating a patient for multiple vaccines in the same session.

## Screenshot

![Screenshot 2025-03-07 at 16 43 25](https://github.com/user-attachments/assets/c4d2a564-d4c7-4657-85d1-1be88ef1c6b3)


![Screenshot 2025-03-07 at 16 56 38](https://github.com/user-attachments/assets/19757150-f23b-4a00-822e-070f32dec820)
