### PR TITLE
Add missing test for could not vaccinate

### DIFF
--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -21,7 +21,7 @@ describe "Parental consent" do
 
     when_the_nurse_checks_the_consent_responses
     then_they_see_that_the_child_has_consent_refused
-    and_the_action_in_the_vaccination_session_is_to_check_refusal
+    and_the_programme_outcome_is_could_not_vaccinate
   end
 
   def given_an_hpv_programme_is_underway
@@ -144,21 +144,17 @@ describe "Parental consent" do
     expect(page).to have_content(@child.full_name)
   end
 
-  def and_the_action_in_the_vaccination_session_is_to_check_refusal
+  def and_the_programme_outcome_is_could_not_vaccinate
     click_on "Programmes", match: :first
     click_on "HPV"
-    within ".app-secondary-navigation" do
-      click_on "Sessions"
-    end
-    click_on "Pilot School"
 
-    # TODO: Check in programme children tab
-    # click_on "Session outcomes"
-    #
-    # expect(page).to have_content("Could not vaccinate")
-    # choose "Could not vaccinate"
-    # click_on "Update results"
-    #
-    # expect(page).to have_content(@child.full_name)
+    within ".app-secondary-navigation" do
+      click_on "Children"
+    end
+
+    choose "Could not vaccinate"
+    click_on "Update results"
+
+    expect(page).to have_content(@child.full_name)
   end
 end


### PR DESCRIPTION
When a parent refuses consent, the programme outcome should be marked as "Could not vaccinate".