### PR TITLE
Update breadcrumbs to match designs

### DIFF
--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -5,7 +5,7 @@ class PatientSessionsController < ApplicationController
   before_action :set_programme, except: :log
   before_action :set_session
   before_action :set_patient
-  before_action :set_back_link_path
+  before_action :set_breadcrumb_item
 
   before_action :record_access_log_entry, except: :record_already_vaccinated
 
@@ -86,17 +86,17 @@ class PatientSessionsController < ApplicationController
     @patient = @patient_session.patient
   end
 
-  def set_back_link_path
-    context = params[:return_to]
+  def set_breadcrumb_item
+    return_to = params[:return_to]
+    return nil if return_to.blank?
 
-    @back_link_path =
-      if context == :session
-        session_outcome_path
-      elsif context.in?(%w[consent triage register record])
-        send(:"session_#{context}_path")
-      else
-        session_outcome_path
-      end
+    known_return_to = %w[consent triage register record outcome]
+    return unless return_to.in?(known_return_to)
+
+    @breadcrumb_item = {
+      text: t(return_to, scope: %i[sessions tabs]),
+      href: send(:"session_#{return_to}_path")
+    }
   end
 
   def record_access_log_entry

--- a/app/views/cohorts/index.html.erb
+++ b/app/views/cohorts/index.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_path(@programme) },
                                         ]) %>

--- a/app/views/cohorts/show.html.erb
+++ b/app/views/cohorts/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_path(@programme) },
                                           { text: t("cohorts.index.title"), href: programme_cohorts_path(@programme) },

--- a/app/views/imports/issues/show.html.erb
+++ b/app/views/imports/issues/show.html.erb
@@ -1,10 +1,9 @@
 <% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: t("programmes.index.title"), href: programmes_path },
-          { text: "Import issues", href: imports_issues_path },
-        ],
-      ) %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
+                                          { text: t("programmes.index.title"), href: programmes_path },
+                                          { text: "Import issues", href: imports_issues_path },
+                                        ]) %>
 <% end %>
 
 <% if @vaccination_record %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -1,9 +1,8 @@
 <% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: t("imports.index.title"), href: imports_path },
-        ],
-      ) %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
+                                          { text: t("imports.index.title"), href: imports_path },
+                                        ]) %>
 <% end %>
 
 <%= h1 "Import (#{import.created_at.to_fs(:long)})" %>

--- a/app/views/patient_sessions/_breadcrumbs.html.erb
+++ b/app/views/patient_sessions/_breadcrumbs.html.erb
@@ -1,0 +1,8 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: "Home", href: dashboard_path },
+                                          { text: t("sessions.index.title"), href: sessions_path },
+                                          { text: @session.location.name, href: session_path(@session) },
+                                          @breadcrumb_item,
+                                        ].compact) %>
+<% end %>

--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -1,6 +1,4 @@
-<% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(@back_link_path, name: "session") %>
-<% end %>
+<% render "patient_sessions/breadcrumbs" %>
 
 <%= h1 page_title: @patient.initials do %>
   <span class="nhsuk-caption-l"><%= patient_school(@patient) %></span>

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(@back_link_path, name: "session") %>
-<% end %>
+<% render "patient_sessions/breadcrumbs" %>
 
 <%= h1 page_title: @patient.initials do %>
   <span class="nhsuk-caption-l"><%= patient_school(@patient) %></span>

--- a/app/views/patients/log.html.erb
+++ b/app/views/patients/log.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: programmes_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("patients.index.title"), href: patients_path },
                                         ]) %>
 <% end %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: programmes_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("patients.index.title"), href: patients_path },
                                         ]) %>
 <% end %>

--- a/app/views/programmes/patients.html.erb
+++ b/app/views/programmes/patients.html.erb
@@ -1,12 +1,11 @@
 <%= content_for :page_title, "#{@programme.name} – #{t("patients.index.title")}" %>
 
 <% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: t("programmes.index.title"), href: programmes_path },
-          { text: @programme.name, href: programme_path(@programme) },
-        ],
-      ) %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
+                                          { text: t("programmes.index.title"), href: programmes_path },
+                                          { text: @programme.name, href: programme_path(@programme) },
+                                        ]) %>
 <% end %>
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>

--- a/app/views/programmes/sessions.html.erb
+++ b/app/views/programmes/sessions.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_path(@programme) },
                                         ]) %>

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                         ]) %>
 <% end %>

--- a/app/views/school_moves/show.html.erb
+++ b/app/views/school_moves/show.html.erb
@@ -1,10 +1,8 @@
 <% content_for :before_main do %>
-  <%= render AppBreadcrumbComponent.new(
-        items: [
-          { text: "Home", href: dashboard_path },
-          { text: t("school_moves.index.title"), href: school_moves_path },
-        ],
-      ) %>
+  <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
+                                          { text: t("school_moves.index.title"), href: school_moves_path },
+                                        ]) %>
 <% end %>
 
 <% page_title = "Review school move" %>

--- a/app/views/sessions/_header.html.erb
+++ b/app/views/sessions/_header.html.erb
@@ -7,37 +7,37 @@
 <%= render AppSecondaryNavigationComponent.new do |nav|
       nav.with_item(
         href: session_path(@session),
-        text: "Overview",
+        text: t("sessions.tabs.overview"),
         selected: request.path == session_path(@session),
       )
     
       nav.with_item(
         href: session_consent_path(@session),
-        text: "Consent",
+        text: t("sessions.tabs.consent"),
         selected: request.path == session_consent_path(@session),
       )
     
       nav.with_item(
         href: session_triage_path(@session),
-        text: "Triage",
+        text: t("sessions.tabs.triage"),
         selected: request.path == session_triage_path(@session),
       )
     
       nav.with_item(
         href: session_register_path(@session),
-        text: "Register",
+        text: t("sessions.tabs.register"),
         selected: request.path == session_register_path(@session),
       )
     
       nav.with_item(
         href: session_record_path(@session),
-        text: "Record vaccinations",
+        text: t("sessions.tabs.record"),
         selected: request.path == session_record_path(@session),
       )
     
       nav.with_item(
         href: session_outcome_path(@session),
-        text: "Session outcomes",
+        text: t("sessions.tabs.outcome"),
         selected: request.path == session_outcome_path(@session),
       )
     end %>

--- a/app/views/sessions/consent/show.html.erb
+++ b/app/views/sessions/consent/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
                                           { text: @session.location.name, href: session_path(@session) },
                                         ]) %>

--- a/app/views/sessions/outcome/show.html.erb
+++ b/app/views/sessions/outcome/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
                                           { text: @session.location.name, href: session_path(@session) },
                                         ]) %>

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
                                           { text: @session.location.name, href: session_path(@session) },
                                         ]) %>

--- a/app/views/sessions/register/show.html.erb
+++ b/app/views/sessions/register/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
                                           { text: @session.location.name, href: session_path(@session) },
                                         ]) %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
                                         ]) %>
 <% end %>

--- a/app/views/sessions/triage/show.html.erb
+++ b/app/views/sessions/triage/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-                                          { text: "Home", href: dashboard_path },
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("sessions.index.title"), href: sessions_path },
                                           { text: @session.location.name, href: session_path(@session) },
                                         ]) %>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_path(@programme) },
                                         ]) %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
+                                          { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_vaccination_records_path(@programme) },
                                           { text: t("vaccination_records.index.title"), href: programme_vaccination_records_path(@programme) },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,6 +855,13 @@ en:
         zero: There are no locations with no sessions scheduled.
         one: 1 location with no sessions scheduled
         other: "%{count} locations with no sessions scheduled"
+    tabs:
+      overview: Overview
+      consent: Consent
+      triage: Triage
+      register: Register
+      record: Record vaccinations
+      outcome: Session outcomes
   table:
     no_filtered_results: We couldn’t find any children that matched your filters.
     no_results: No results

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -752,6 +752,7 @@ en:
       title: Give or refuse consent for vaccinations
   dashboard:
     index:
+      title: Home
       notices:
         header: Important notices
         description:

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -216,7 +216,6 @@ describe "End-to-end journey" do
   end
 
   def when_i_click_on_the_register_attendance_section
-    click_link "Back to session"
     click_link "Pilot School"
     click_link "Register"
   end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -208,8 +208,8 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_the_register_tab
-    click_on "Back to session"
-    click_on "Register"
+    click_link @session.location.name
+    click_link "Register"
   end
 
   def and_i_filter_by_completed_session

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -109,7 +109,7 @@ describe "HPV vaccination" do
   end
 
   def when_i_go_to_the_outcome_tab
-    click_on "Back to session"
+    click_on @session.location.name
     click_on "Session outcomes"
   end
 

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -255,7 +255,7 @@ describe "HPV vaccination" do
     )
     expect(page).to have_content("SiteLeft arm (upper position)")
 
-    click_link "Back to session"
+    click_link "Session outcomes"
 
     choose "Absent from session"
     click_on "Update results"
@@ -266,7 +266,7 @@ describe "HPV vaccination" do
     expect(page).to have_content("OutcomeAbsent from session")
     expect(page).to have_content("NotesSome notes.")
 
-    click_link "Back to session"
+    click_link "Session outcomes"
 
     choose "Vaccinated"
     click_on "Update results"

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -186,13 +186,10 @@ describe "Parental consent" do
     expect(page).not_to have_content(
       "Consent response manually matched with child record"
     )
-
-    click_link "Back to session"
   end
 
   def when_they_check_triage
-    click_link "Pilot School"
-
+    click_on @session.location.name
     click_on "Session outcomes"
     choose "No outcome yet"
     click_on "Update results"


### PR DESCRIPTION
This updates the various pages where breadcrumbs are shown to match the latest designs in the prototype:

- A "Home" entry is always shown, which takes the user to the dashboard page.
- When looking at a patient session, the tab that the user came from is shown as an item in the breadcrumbs.

## Screenshot

<img width="494" alt="Screenshot 2025-03-08 at 12 48 06" src="https://github.com/user-attachments/assets/23e87bdb-38a1-4e51-8ccf-b4ba7d334326" />
