### PR TITLE
Update header on patient session page

### DIFF
--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, @patient.initials %>
+
+<h1 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">
+  <%= @patient.full_name %>
+</h1>
+
+<p class="nhsuk-caption-l nhsuk-u-margin-bottom-4">
+  <%= patient_year_group(@patient) %>
+</p>

--- a/app/views/patient_sessions/log.html.erb
+++ b/app/views/patient_sessions/log.html.erb
@@ -1,9 +1,6 @@
 <% render "patient_sessions/breadcrumbs" %>
 
-<%= h1 page_title: @patient.initials do %>
-  <span class="nhsuk-caption-l"><%= patient_school(@patient) %></span>
-  <%= @patient.full_name %>
-<% end %>
+<%= render "patient_sessions/header" %>
 
 <%= render "patient_sessions/secondary_navigation" %>
 

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -1,9 +1,6 @@
 <% render "patient_sessions/breadcrumbs" %>
 
-<%= h1 page_title: @patient.initials do %>
-  <span class="nhsuk-caption-l"><%= patient_school(@patient) %></span>
-  <%= @patient.full_name %>
-<% end %>
+<%= render "patient_sessions/header" %>
 
 <ul class="app-action-list">
   <% if (session_attendance = @patient_session.register_outcome.latest) %>


### PR DESCRIPTION
This updates the header on the patient session page to match the latest designs in the prototype where the name of the patient is shown above the year group.

## Screenshot

<img width="445" alt="Screenshot 2025-03-08 at 13 13 49" src="https://github.com/user-attachments/assets/f0d438da-a8a5-4718-b983-b3766046c1b5" />