### PR TITLE
Update ordering of consent filters

### DIFF
--- a/app/models/patient/consent_outcome.rb
+++ b/app/models/patient/consent_outcome.rb
@@ -6,10 +6,10 @@ class Patient::ConsentOutcome
   end
 
   STATUSES = [
-    GIVEN = :given,
-    REFUSED = :refused,
+    NONE = :none,
     CONFLICTS = :conflicts,
-    NONE = :none
+    GIVEN = :given,
+    REFUSED = :refused
   ].freeze
 
   def given?(programme) = status[programme] == GIVEN


### PR DESCRIPTION
This updates the ordering of the consent filters to match the designs in the prototype.

## Before

<img width="337" alt="Screenshot 2025-03-10 at 11 27 25" src="https://github.com/user-attachments/assets/9c715639-a5ec-448a-a80c-cb6f58916c35" />

## After

<img width="336" alt="Screenshot 2025-03-10 at 11 27 12" src="https://github.com/user-attachments/assets/09740577-6079-42d6-8d94-5d0fa38de415" />
