### PR TITLE
Add AppRegisterStatusTagComponent

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -84,12 +84,9 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
     return if context == :record
 
     if context == :register
-      status = patient_session.register_outcome.status
-
-      text = I18n.t(status, scope: %i[status register label])
-      colour = I18n.t(status, scope: %i[status register colour])
-
-      govuk_tag(text:, colour:)
+      render AppRegisterStatusTagComponent.new(
+               patient_session.register_outcome.status
+             )
     else
       outcome =
         case context

--- a/app/components/app_register_status_tag_component.rb
+++ b/app/components/app_register_status_tag_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AppRegisterStatusTagComponent < ViewComponent::Base
+  def initialize(status)
+    super
+
+    @status = status
+  end
+
+  def call = govuk_tag(text:, colour:)
+
+  private
+
+  def text
+    I18n.t(@status, scope: %i[status register label])
+  end
+
+  def colour
+    I18n.t(@status, scope: %i[status register colour])
+  end
+end

--- a/app/views/patient_sessions/show.html.erb
+++ b/app/views/patient_sessions/show.html.erb
@@ -5,14 +5,9 @@
 <ul class="app-action-list">
   <% if (session_attendance = @patient_session.register_outcome.latest) %>
     <li class="app-action-list__item">
-      <% if session_attendance.attending %>
-        <%= govuk_tag(text: "Attending today’s session") %>
-      <% elsif session_attendance.attending == false %>
-        <%= govuk_tag(text: "Absent from today’s session", colour: "red") %>
-      <% else %>
-        <%= govuk_tag(text: "Not registered yet", colour: "blue") %>
-      <% end %>
+      <%= render AppRegisterStatusTagComponent.new(@patient_session.register_outcome.status) %>
     </li>
+
     <% if policy(session_attendance).edit? %>
       <li class="app-action-list__item">
         <%= link_to(

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -31,10 +31,10 @@ en:
         not_attending: Absent from session
         unknown: Not registered yet
       colour:
-        attending: green
+        attending: blue
         completed: green
         not_attending: red
-        unknown: blue
+        unknown: grey
     session:
       label:
         absent_from_school: Absent from school

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -121,7 +121,7 @@ describe "Manage attendance" do
   end
 
   def then_the_patient_is_absent
-    expect(page).to have_content("Absent from today")
+    expect(page).to have_content("Absent from session")
   end
 
   def and_i_see_the_absent_flash
@@ -136,7 +136,7 @@ describe "Manage attendance" do
   end
 
   def then_the_patient_is_attending
-    expect(page).to have_content("Attending today")
+    expect(page).to have_content("Attending session")
   end
 
   def and_i_see_the_attending_flash


### PR DESCRIPTION
This adds a component that renders a patient registration status and updates the two places where this is shown to use the same component.

At the same time, I've also fixed the colours to match the latest ones in the prototype where "Not registered yet" is grey and "Attending session is blue".