### PR TITLE
Allow recording already had vaccination for a clinic session

### DIFF
--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -41,7 +41,8 @@ class PatientSessionsController < ApplicationController
       performed_ods_code: current_user.selected_organisation.ods_code
     )
 
-    redirect_to draft_vaccination_record_path("confirm")
+    next_step = @session.clinic? ? "location" : "confirm"
+    redirect_to draft_vaccination_record_path(next_step)
   end
 
   private

--- a/spec/features/td_ipv_already_had_spec.rb
+++ b/spec/features/td_ipv_already_had_spec.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
 describe "Td/IPV" do
-  scenario "record a patient as already vaccinated outside the session" do
-    given_a_menacwy_programme_with_a_session
-    and_i_am_signed_in_as_a_nurse
-
-    when_i_go_to_the_dashboard
-    and_i_go_to_the_session
-    and_i_upload_the_class_list
-    then_i_see_the_completed_upload
+  scenario "record a patient as already vaccinated outside the school session" do
+    given_a_td_ipv_programme_with_a_session(clinic: false)
+    and_a_patient_is_in_the_session
 
     when_i_go_the_session
     then_i_see_one_patient_needing_consent
@@ -17,18 +12,43 @@ describe "Td/IPV" do
     and_i_click_on_the_patient
     then_i_see_the_patient_needs_consent
 
-    when_i_record_the_patient_as_already_vaccinated
+    when_i_record_the_patient_as_already_vaccinated(clinic: false)
     and_the_consent_requests_are_sent
     then_the_parent_doesnt_receive_a_consent_request
   end
 
-  def given_a_menacwy_programme_with_a_session
-    programmes = [create(:programme, :menacwy)]
+  scenario "record a patient as already vaccinated outside the clinic session" do
+    given_a_td_ipv_programme_with_a_session(clinic: true)
+    and_a_patient_is_in_the_session
+
+    when_i_go_the_session
+    then_i_see_one_patient_needing_consent
+
+    when_i_click_on_consent
+    and_i_click_on_the_patient
+    then_i_see_the_patient_needs_consent
+
+    when_i_record_the_patient_as_already_vaccinated(clinic: true)
+    and_the_consent_requests_are_sent
+    then_the_parent_doesnt_receive_a_consent_request
+  end
+
+  def given_a_td_ipv_programme_with_a_session(clinic:)
+    programmes = [create(:programme, :td_ipv)]
 
     organisation = create(:organisation, programmes:)
-    @user = create(:nurse, organisations: [organisation])
+    @nurse = create(:nurse, organisations: [organisation])
 
-    location = create(:school, :secondary, urn: 123_456, organisation:)
+    location =
+      (
+        if clinic
+          organisation.generic_clinic
+        else
+          create(:school, :secondary, urn: 123_456, organisation:)
+        end
+      )
+
+    create(:community_clinic, name: "Waterloo Hospital", organisation:)
 
     @session =
       create(
@@ -40,34 +60,16 @@ describe "Td/IPV" do
       )
   end
 
-  def and_i_am_signed_in_as_a_nurse
-    sign_in @user
-  end
-
-  def when_i_go_to_the_dashboard
-    visit dashboard_path
+  def and_a_patient_is_in_the_session
+    @patient = create(:patient, session: @session)
   end
 
   def when_i_go_the_session
+    sign_in @nurse
+    visit dashboard_path
     click_on "Sessions", match: :first
     click_on "Scheduled"
     click_on @session.location.name
-  end
-
-  alias_method :and_i_go_to_the_session, :when_i_go_the_session
-
-  def and_i_upload_the_class_list
-    click_on "Import class lists"
-
-    check "Year 9"
-    click_on "Continue"
-
-    attach_file("class_import[csv]", file_fixture("menacwy/class_list.csv"))
-    click_on "Continue"
-  end
-
-  def then_i_see_the_completed_upload
-    expect(page).to have_content("Completed")
   end
 
   def then_i_see_one_patient_needing_consent
@@ -86,15 +88,21 @@ describe "Td/IPV" do
   end
 
   def and_i_click_on_the_patient
-    click_on "PICKLE, Chyna"
+    click_on @patient.full_name
   end
 
   def then_i_see_the_patient_needs_consent
     expect(page).to have_content("No response")
   end
 
-  def when_i_record_the_patient_as_already_vaccinated
+  def when_i_record_the_patient_as_already_vaccinated(clinic: false)
     click_on "Record as already vaccinated"
+
+    if clinic
+      choose "Waterloo Hospital"
+      click_on "Continue"
+    end
+
     click_on "Confirm"
   end
 


### PR DESCRIPTION
The "Record as already vaccinated" feature currently doesn't work on community clinic sessions as we need to ask the nurse which clinic they are recording this for. This is asked during the normal vaccination flow, but is missing in this scenario.

https://good-machine.sentry.io/issues/6334292237/