### PR TITLE
Update vaccinated criteria for Td/IPV

### DIFF
--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -14,18 +14,19 @@ class VaccinatedCriteria
 
     return true if vaccination_records.any?(&:already_had?)
 
+    administered_records = vaccination_records.select(&:administered?)
+
     if programme.menacwy?
-      vaccination_records.any? do
-        it.administered? && patient.age(now: it.performed_at) >= 10
-      end
+      administered_records.any? { patient.age(now: it.performed_at) >= 10 }
     elsif programme.td_ipv?
-      vaccination_records.any? do
-        it.administered? &&
-          it.dose_sequence == programme.vaccinated_dose_sequence &&
-          patient.age(now: it.performed_at) >= 10
+      administered_records.any? do
+        (
+          it.dose_sequence == programme.vaccinated_dose_sequence ||
+            (it.dose_sequence.nil? && it.session.present?)
+        ) && patient.age(now: it.performed_at) >= 10
       end
     else
-      vaccination_records.any?(&:administered?)
+      administered_records.any?
     end
   end
 

--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -12,6 +12,8 @@ class VaccinatedCriteria
       raise "Vaccination records provided for different programme."
     end
 
+    return true if vaccination_records.any?(&:already_had?)
+
     if programme.menacwy?
       vaccination_records.any? do
         it.administered? && patient.age(now: it.performed_at) >= 10

--- a/app/models/patient/programme_outcome.rb
+++ b/app/models/patient/programme_outcome.rb
@@ -48,12 +48,11 @@ class Patient::ProgrammeOutcome
   end
 
   def programme_vaccinated?(programme)
-    all[programme].any?(&:already_had?) ||
-      VaccinatedCriteria.call(
-        programme,
-        patient:,
-        vaccination_records: all[programme]
-      )
+    VaccinatedCriteria.call(
+      programme,
+      patient:,
+      vaccination_records: all[programme]
+    )
   end
 
   def programme_could_not_vaccinate?(programme)

--- a/spec/lib/vaccinated_criteria_spec.rb
+++ b/spec/lib/vaccinated_criteria_spec.rb
@@ -29,6 +29,14 @@ describe VaccinatedCriteria do
 
         it { should be(true) }
       end
+
+      context "with an already had vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+        end
+
+        it { should be(true) }
+      end
     end
 
     context "with an HPV programme" do
@@ -47,6 +55,14 @@ describe VaccinatedCriteria do
       context "with an administered vaccination record" do
         let(:vaccination_records) do
           [create(:vaccination_record, :administered, patient:, programme:)]
+        end
+
+        it { should be(true) }
+      end
+
+      context "with an already had vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
         end
 
         it { should be(true) }
@@ -104,6 +120,14 @@ describe VaccinatedCriteria do
         end
 
         it { should be(false) }
+      end
+
+      context "with an already had vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+        end
+
+        it { should be(true) }
       end
     end
 
@@ -184,6 +208,14 @@ describe VaccinatedCriteria do
         end
 
         it { should be(false) }
+      end
+
+      context "with an already had vaccination record" do
+        let(:vaccination_records) do
+          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+        end
+
+        it { should be(true) }
       end
     end
   end

--- a/spec/lib/vaccinated_criteria_spec.rb
+++ b/spec/lib/vaccinated_criteria_spec.rb
@@ -32,7 +32,15 @@ describe VaccinatedCriteria do
 
       context "with an already had vaccination record" do
         let(:vaccination_records) do
-          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+          [
+            create(
+              :vaccination_record,
+              :not_administered,
+              :already_had,
+              patient:,
+              programme:
+            )
+          ]
         end
 
         it { should be(true) }
@@ -62,7 +70,15 @@ describe VaccinatedCriteria do
 
       context "with an already had vaccination record" do
         let(:vaccination_records) do
-          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+          [
+            create(
+              :vaccination_record,
+              :not_administered,
+              :already_had,
+              patient:,
+              programme:
+            )
+          ]
         end
 
         it { should be(true) }
@@ -124,7 +140,15 @@ describe VaccinatedCriteria do
 
       context "with an already had vaccination record" do
         let(:vaccination_records) do
-          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+          [
+            create(
+              :vaccination_record,
+              :not_administered,
+              :already_had,
+              patient:,
+              programme:
+            )
+          ]
         end
 
         it { should be(true) }
@@ -210,9 +234,50 @@ describe VaccinatedCriteria do
         it { should be(false) }
       end
 
+      context "with an unknown dose administered vaccination record" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: nil,
+              patient:,
+              programme:
+            )
+          ]
+        end
+
+        it { should be(false) }
+      end
+
+      context "with an unknown dose administered vaccination record recorded in a session" do
+        let(:vaccination_records) do
+          [
+            create(
+              :vaccination_record,
+              :administered,
+              dose_sequence: nil,
+              patient:,
+              programme:,
+              session: create(:session, programmes: [programme])
+            )
+          ]
+        end
+
+        it { should be(true) }
+      end
+
       context "with an already had vaccination record" do
         let(:vaccination_records) do
-          [create(:vaccination_record, :not_administered, :already_had, patient:, programme:)]
+          [
+            create(
+              :vaccination_record,
+              :not_administered,
+              :already_had,
+              patient:,
+              programme:
+            )
+          ]
         end
 
         it { should be(true) }


### PR DESCRIPTION
This updates the vaccinated criteria for Td/IPV to allow the patient to be considered vaccinated if they have an administered vaccination record that was recorded by a SAIS nurse in a school or community clinic session.

The criteria in the functional spec is written as:

> If a child has a Td/IPV vaccination record which is administered after the age of 10 and:
> a) recorded as a fifth dose / second booster, OR
> b) administered by a SAIS team
> then they will be considered already vaccinated for the Td/IPV programme in Mavis and will not be added to any future sessions.