### PR TITLE
Update "could not vaccinate" session outcome

### DIFF
--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -28,21 +28,21 @@ module PatientSessionStatusConcern
         "vaccinated"
       elsif patient.triage_outcome.delay_vaccination?(programme)
         "delay_vaccination"
+      elsif patient.consent_outcome.refused?(programme)
+        "consent_refused"
+      elsif patient.triage_outcome.do_not_vaccinate?(programme)
+        "triaged_do_not_vaccinate"
       elsif session_outcome.not_vaccinated?(programme)
         "unable_to_vaccinate"
       elsif patient.consent_outcome.given?(programme) &&
             patient.triage_outcome.safe_to_vaccinate?(programme)
         "triaged_ready_to_vaccinate"
-      elsif patient.triage_outcome.do_not_vaccinate?(programme)
-        "triaged_do_not_vaccinate"
       elsif patient.consent_outcome.given?(programme) &&
             patient.triage_outcome.required?(programme)
         "consent_given_triage_needed"
       elsif patient.consent_outcome.given?(programme) &&
             patient.triage_outcome.not_required?(programme)
         "consent_given_triage_not_needed"
-      elsif patient.consent_outcome.refused?(programme)
-        "consent_refused"
       elsif patient.consent_outcome.conflicts?(programme)
         "consent_conflicts"
       else

--- a/app/models/patient_session/session_outcome.rb
+++ b/app/models/patient_session/session_outcome.rb
@@ -46,9 +46,18 @@ class PatientSession::SessionOutcome
   attr_reader :patient_session
 
   delegate :patient, :session, :programmes, to: :patient_session
+  delegate :consent_outcome, :triage_outcome, to: :patient
 
   def programme_status(programme)
-    latest[programme]&.outcome&.to_sym || NONE
+    if (vaccination_record = latest[programme])
+      vaccination_record.outcome.to_sym
+    elsif consent_outcome.refused?(programme)
+      REFUSED
+    elsif triage_outcome.do_not_vaccinate?(programme)
+      HAD_CONTRAINDICATIONS
+    else
+      NONE
+    end
   end
 
   def all_by_programme_id

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -21,6 +21,7 @@ describe "Parental consent" do
 
     when_the_nurse_checks_the_consent_responses
     then_they_see_that_the_child_has_consent_refused
+    and_the_session_outcome_is_could_not_vaccinate
     and_the_programme_outcome_is_could_not_vaccinate
   end
 
@@ -140,6 +141,13 @@ describe "Parental consent" do
   def then_they_see_that_the_child_has_consent_refused
     expect(page).to have_content("Consent refused")
     choose "Consent refused"
+    click_on "Update results"
+    expect(page).to have_content(@child.full_name)
+  end
+
+  def and_the_session_outcome_is_could_not_vaccinate
+    click_on "Session outcomes"
+    choose "Vaccine refused"
     click_on "Update results"
     expect(page).to have_content(@child.full_name)
   end

--- a/spec/models/patient_session/session_outcome_spec.rb
+++ b/spec/models/patient_session/session_outcome_spec.rb
@@ -44,6 +44,18 @@ describe PatientSession::SessionOutcome do
 
       it { should be(described_class::NONE) }
     end
+
+    context "with a consent refused" do
+      before { create(:consent, :refused, patient:, programme:) }
+
+      it { should be(described_class::REFUSED) }
+    end
+
+    context "when triaged as do not vaccinate" do
+      before { create(:triage, :do_not_vaccinate, patient:, programme:) }
+
+      it { should be(described_class::HAD_CONTRAINDICATIONS) }
+    end
   end
 
   describe "#all" do


### PR DESCRIPTION
If the patient has consent refused, or they've been triaged as "do not vaccinate", then they should have a session outcome of "refused" or "had contraindications" respectively. Currently they would show as "No outcome yet" which is confusing and not correct.