### PR TITLE
Restrict "Record vaccination" tab patients

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -136,8 +136,11 @@ class PatientSession < ApplicationRecord
     programmes_to_check = programme ? [programme] : programmes
 
     programmes_to_check.any? do
-      session_outcome.latest[it].nil? ||
-        session_outcome.latest[it].retryable_reason?
+      patient.consent_given_and_safe_to_vaccinate?(programme: it) &&
+        (
+          session_outcome.latest[it].nil? ||
+            session_outcome.latest[it].retryable_reason?
+        )
     end
   end
 end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -68,4 +68,44 @@ describe PatientSession do
       end
     end
   end
+
+  describe "#ready_for_vaccinator?" do
+    subject(:ready_for_vaccinator?) { patient_session.ready_for_vaccinator? }
+
+    it { should be(false) }
+
+    context "when attending the session" do
+      let(:patient_session) do
+        create(:patient_session, :in_attendance, session:)
+      end
+
+      it { should be(false) }
+    end
+
+    context "when attending the session and consent given and triaged as safe to vaccinate" do
+      let(:patient_session) do
+        create(
+          :patient_session,
+          :in_attendance,
+          :consent_given_triage_not_needed,
+          session:
+        )
+      end
+
+      it { should be(true) }
+
+      context "when already vaccinated" do
+        before do
+          create(
+            :vaccination_record,
+            patient: patient_session.patient,
+            session:,
+            programme:
+          )
+        end
+
+        it { should be(false) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This ensures that only patients who can be vaccinated (i.e. have consent and triaged as safe to vaccinate) are shown in the "Record vaccination" list of patients.

Patients who have been registered, but are missing consent or need triage, won't appear in this list, but instead will be shown on the "Register" tab with an action next to them.