### PR TITLE
Remove SCHOOL_URN from offline export

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -86,7 +86,6 @@ class Reports::OfflineSessionExporter
         person_forename
         person_surname
         organisation_code
-        school_urn
         school_name
         care_setting
         person_dob
@@ -121,7 +120,7 @@ class Reports::OfflineSessionExporter
         session_id
         uuid
       ].tap do |values|
-        values.insert(6, :clinic_name) if location.generic_clinic?
+        values.insert(5, :clinic_name) if location.generic_clinic?
       end
   end
 
@@ -237,7 +236,6 @@ class Reports::OfflineSessionExporter
       vaccinated(vaccination_record:),
       allowed_values: %w[Y N]
     )
-    row[:school_urn] = location ? school_urn(location:, patient:) : "888888"
     row[:school_name] = (
       if location
         school_name(location:, patient:)
@@ -295,7 +293,6 @@ class Reports::OfflineSessionExporter
 
     row[:vaccinated] = Cell.new(allowed_values: %w[Y N])
     row[:date_of_vaccination] = Cell.new(type: :date)
-    row[:school_urn] = school_urn(location:, patient:)
     row[:school_name] = school_name(location:, patient:)
     row[:care_setting] = Cell.new(
       care_setting(location:),

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -43,7 +43,6 @@ class ImmunisationImport < ApplicationRecord
   def required_headers
     %w[
       ORGANISATION_CODE
-      SCHOOL_URN
       SCHOOL_NAME
       NHS_NUMBER
       PERSON_FORENAME

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -56,7 +56,6 @@ describe Reports::OfflineSessionExporter do
             PERSON_FORENAME
             PERSON_SURNAME
             ORGANISATION_CODE
-            SCHOOL_URN
             SCHOOL_NAME
             CARE_SETTING
             PERSON_DOB
@@ -137,7 +136,6 @@ describe Reports::OfflineSessionExporter do
               "PROGRAMME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => location.name,
-              "SCHOOL_URN" => location.urn,
               "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "",
               "TRIAGED_BY" => nil,
@@ -213,7 +211,6 @@ describe Reports::OfflineSessionExporter do
               "PROGRAMME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => location.name,
-              "SCHOOL_URN" => location.urn,
               "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,
@@ -301,7 +298,6 @@ describe Reports::OfflineSessionExporter do
               "PROGRAMME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "Waterloo Road",
-              "SCHOOL_URN" => "888888",
               "SESSION_ID" => nil,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,
@@ -366,7 +362,6 @@ describe Reports::OfflineSessionExporter do
               "PROGRAMME" => "HPV",
               "REASON_NOT_VACCINATED" => "unwell",
               "SCHOOL_NAME" => location.name,
-              "SCHOOL_URN" => location.urn,
               "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,
@@ -495,7 +490,6 @@ describe Reports::OfflineSessionExporter do
             PERSON_FORENAME
             PERSON_SURNAME
             ORGANISATION_CODE
-            SCHOOL_URN
             SCHOOL_NAME
             CARE_SETTING
             CLINIC_NAME
@@ -573,7 +567,6 @@ describe Reports::OfflineSessionExporter do
               "PROGRAMME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "",
-              "SCHOOL_URN" => "888888",
               "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "",
               "TRIAGED_BY" => nil,
@@ -650,7 +643,6 @@ describe Reports::OfflineSessionExporter do
               "PROGRAMME" => "HPV",
               "REASON_NOT_VACCINATED" => "",
               "SCHOOL_NAME" => "Waterloo Road",
-              "SCHOOL_URN" => "123456",
               "SESSION_ID" => session.id,
               "TIME_OF_VACCINATION" => "12:05:20",
               "TRIAGED_BY" => nil,


### PR DESCRIPTION
This isn't used when re-importing the file as the location is determined from the `SESSION_ID`, and having it present could cause confusion if the nurse tries to edit the value for a different school session.

This is proposed as a solution to: https://nhsd-jira.digital.nhs.uk/browse/MAV-755 (discussion: https://screening-discovery.slack.com/archives/C055LFS48RM/p1740754413297729)