### PR TITLE
Triage patients when recording vaccination already had

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -114,6 +114,8 @@ class DraftVaccinationRecordsController < ApplicationController
 
     send_vaccination_confirmation(@vaccination_record) if should_notify_parents
 
+    @vaccination_record.triage_patient_as_do_not_vaccinate!
+
     # In case the user navigates back to try and edit the newly created
     # vaccination record.
     @draft_vaccination_record.update!(editing_id: @vaccination_record.id)

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -32,7 +32,7 @@ class PatientSessionsController < ApplicationController
       outcome: :already_had,
       patient: @patient,
       performed_at: Time.current,
-      performed_by_user_id: nil,
+      performed_by_user_id: current_user.id,
       programme: @programme,
       # TODO: Ideally we wouldn't set these, but other parts of the service break if we don't.
       # These are set when recording an "already had" vaccination normally, and we probably


### PR DESCRIPTION
If an "already had" vaccination record is created, and the patient needs triage, we should record a "do not vaccinate" triage to make sure the patient isn't double vaccinated.