### PR TITLE
Make fuzzy search work on full name

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -127,14 +127,13 @@ class Patient < ApplicationRecord
             )
           else
             where(
-              "given_name % :query OR " \
-                "family_name % :query OR " \
-                "similarity(given_name, :query) > 0.3 OR " \
-                "similarity(family_name, :query) > 0.3",
+              "SIMILARITY(CONCAT(given_name, ' ', family_name), :query) > 0.3 OR " \
+                "SIMILARITY(CONCAT(family_name, ' ', given_name), :query) > 0.3",
               query:
             ).order(
               Arel.sql(
-                "similarity(family_name, :query) DESC, similarity(given_name, :query) DESC",
+                "GREATEST(SIMILARITY(CONCAT(given_name, ' ', family_name), :query), " \
+                  "SIMILARITY(CONCAT(family_name, ' ', given_name), :query)) DESC",
                 query:
               )
             )

--- a/spec/features/patient_search_spec.rb
+++ b/spec/features/patient_search_spec.rb
@@ -6,8 +6,8 @@ describe "Patient search" do
     when_i_visit_the_patients_page
     then_i_see_all_patients
 
-    when_i_search_for_cas
-    then_i_see_patients_matching_cas
+    when_i_search_by_name
+    then_i_see_patients_matching_the_name
     and_i_see_the_search_count
 
     when_i_open_advanced_filters
@@ -80,14 +80,14 @@ describe "Patient search" do
     expect(page).to have_content("SELDON, Hari")
   end
 
-  def when_i_search_for_cas
-    fill_in "Search", with: "cas"
+  def when_i_search_by_name
+    fill_in "Search", with: "Casy Brown" # intentional typo
     click_button "Search"
   end
 
-  def then_i_see_patients_matching_cas
+  def then_i_see_patients_matching_the_name
     expect(page).to have_content("BROWN, Casey")
-    expect(page).to have_content("WILSON, Cassidy")
+    expect(page).not_to have_content("WILSON, Cassidy")
     expect(page).not_to have_content("SMITH, Aaron")
     expect(page).not_to have_content("JONES, Aardvark")
     expect(page).not_to have_content("TAYLOR, Bob")
@@ -96,7 +96,7 @@ describe "Patient search" do
   end
 
   def and_i_see_the_search_count
-    expect(page).to have_content("2 children")
+    expect(page).to have_content("1 child")
   end
 
   def when_i_open_advanced_filters

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -54,7 +54,7 @@ describe Patient do
     describe "#search_by_name" do
       subject(:scope) { described_class.search_by_name(query) }
 
-      let(:query) { "Harry" }
+      let(:query) { "Harry Potter" }
 
       let(:patient_a) do
         # exact match comes first
@@ -66,11 +66,11 @@ describe Patient do
       end
       let(:patient_c) do
         # least similar match comes last
-        create(:patient, given_name: "Arry", family_name: "Potter")
+        create(:patient, given_name: "Arry", family_name: "Pott")
       end
       let(:patient_d) do
         # no match isn't returned
-        create(:patient, given_name: "James", family_name: "Potter")
+        create(:patient, given_name: "Ron", family_name: "Weasley")
       end
 
       it { should eq([patient_a, patient_b, patient_c]) }


### PR DESCRIPTION
This should improve the reliability and predictability of the search by comparing the similarity of the patient name as displayed to the user, rather than comparing only the first and last name separately. In most cases, nurses will search using the full name of the patient and the fuzzy search is designed to avoid typos or small errors from making it difficult to find a patient.

A few tests locally suggests this works better than our current approach.