### PR TITLE
Improve test coverage for reports

### DIFF
--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -4,217 +4,229 @@ describe Reports::CareplusExporter do
   subject(:csv) do
     described_class.call(
       organisation:,
-      programme: programmes.first,
+      programme:,
       start_date: 1.month.ago.to_date,
       end_date: Date.current
     )
   end
 
-  let(:programmes) { [create(:programme, :hpv)] }
-  let(:organisation) do
-    create(:organisation, careplus_venue_code: "ABC", programmes:)
-  end
-  let(:location) do
-    create(
-      :school,
-      gias_local_authority_code: 123,
-      gias_establishment_number: 456
-    )
-  end
-  let(:session) { create(:session, organisation:, programmes:, location:) }
-  let(:parsed_csv) { CSV.parse(csv) }
-  let(:headers) { parsed_csv.first }
-  let(:data_rows) { parsed_csv[1..] }
+  shared_examples "generates a report" do |programme_type|
+    let(:programme) { create(:programme, programme_type) }
 
-  it "includes the expected headers" do
-    expect(headers).to include(
-      "NHS Number",
-      "Surname",
-      "Forename",
-      "Date of Birth",
-      "Address Line 1",
-      "Person Giving Consent",
-      "Ethnicity",
-      "Date Attended",
-      "Time Attended",
-      "Venue Type",
-      "Venue Code",
-      "Staff Type",
-      "Staff Code",
-      "Attended",
-      "Reason Not Attended",
-      "Suspension End Date"
-    )
+    context "#{programme_type} programme" do
+      let(:programmes) { [programme] }
 
-    (1..5).each do |i|
-      expect(headers).to include(
-        "Vaccine #{i}",
-        "Dose #{i}",
-        "Reason Not Given #{i}",
-        "Site #{i}",
-        "Manufacturer #{i}",
-        "Batch No #{i}"
-      )
-    end
-  end
-
-  it "does not include the patient if they have no vaccination details" do
-    create(:patient_session, session:)
-
-    expect(data_rows.first).to be_nil
-  end
-
-  it "includes the patient and vaccination details" do
-    patient_session =
-      create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        programmes:,
-        session:
-      )
-    vaccination_record =
-      create(
-        :vaccination_record,
-        programme: programmes.first,
-        patient: patient_session.patient,
-        session: patient_session.session,
-        performed_at: 2.weeks.ago
-      )
-
-    attended_index = headers.index("Attended")
-    vaccine_index = headers.index("Vaccine 1")
-    batch_index = headers.index("Batch No 1")
-    site_index = headers.index("Site 1")
-    staff_type_index = headers.index("Staff Type")
-    staff_code_index = headers.index("Staff Code")
-    venue_type_index = headers.index("Venue Type")
-    venue_code_index = headers.index("Venue Code")
-
-    row = data_rows.first
-
-    expect(row[attended_index]).to eq("Y")
-    expect(row[vaccine_index]).to eq(
-      vaccination_record.vaccine.snomed_product_code
-    )
-    expect(row[batch_index]).to eq(vaccination_record.batch.name)
-    expect(row[site_index]).to eq("ULA")
-    expect(row[staff_type_index]).to eq("IN")
-    expect(row[staff_code_index]).to eq("LW5PM")
-    expect(row[venue_type_index]).to eq("SC")
-    expect(row[venue_code_index]).to eq("123456")
-  end
-
-  context "in a community clinic" do
-    let(:location) { create(:generic_clinic, organisation:) }
-
-    it "includes clinic location details" do
-      patient = create(:patient, year_group: 8)
-      create(
-        :patient_session,
-        :consent_given_triage_not_needed,
-        programmes:,
-        patient:,
-        session:
-      )
-      create(
-        :vaccination_record,
-        programme: programmes.first,
-        patient:,
-        session:,
-        location_name: "A clinic"
-      )
-
-      venue_type_index = headers.index("Venue Type")
-      venue_code_index = headers.index("Venue Code")
-
-      row = data_rows.first
-
-      expect(row[venue_type_index]).to eq("CL")
-      expect(row[venue_code_index]).to eq("ABC")
-    end
-  end
-
-  it "excludes vaccination records outside the date range" do
-    patient = create(:patient_session, session:).patient
-
-    create(
-      :vaccination_record,
-      programme: programmes.first,
-      patient:,
-      session:,
-      created_at: 2.months.ago,
-      updated_at: 2.months.ago,
-      performed_at: 2.months.ago
-    )
-
-    expect(data_rows.first).to be_nil
-  end
-
-  it "excludes not administered vaccination records" do
-    patient = create(:patient_session, session:).patient
-
-    create(
-      :vaccination_record,
-      :not_administered,
-      programme: programmes.first,
-      patient:,
-      session:
-    )
-
-    expect(data_rows.first).to be_nil
-  end
-
-  it "includes vaccination records updated within the date range" do
-    patient = create(:patient_session, session:).patient
-
-    create(
-      :vaccination_record,
-      programme: programmes.first,
-      patient:,
-      session:,
-      created_at: 2.months.ago,
-      updated_at: 1.day.ago,
-      performed_at: 2.months.ago
-    )
-
-    expect(data_rows.first).not_to be_nil
-  end
-
-  context "with a session in a different organisation" do
-    let(:session) { create(:session, programmes:, location:) }
-
-    it "excludes the vaccination record" do
-      create(:vaccination_record, programme: programmes.first, session:)
-
-      expect(data_rows.first).to be_nil
-    end
-  end
-
-  context "with a restricted patient" do
-    it "doesn't include the address line 1" do
-      patient_session =
+      let(:organisation) do
+        create(:organisation, careplus_venue_code: "ABC", programmes:)
+      end
+      let(:location) do
         create(
-          :patient_session,
-          :consent_given_triage_not_needed,
-          programmes:,
+          :school,
+          gias_local_authority_code: 123,
+          gias_establishment_number: 456
+        )
+      end
+      let(:session) { create(:session, organisation:, programmes:, location:) }
+      let(:parsed_csv) { CSV.parse(csv) }
+      let(:headers) { parsed_csv.first }
+      let(:data_rows) { parsed_csv[1..] }
+
+      it "includes the expected headers" do
+        expect(headers).to include(
+          "NHS Number",
+          "Surname",
+          "Forename",
+          "Date of Birth",
+          "Address Line 1",
+          "Person Giving Consent",
+          "Ethnicity",
+          "Date Attended",
+          "Time Attended",
+          "Venue Type",
+          "Venue Code",
+          "Staff Type",
+          "Staff Code",
+          "Attended",
+          "Reason Not Attended",
+          "Suspension End Date"
+        )
+
+        (1..5).each do |i|
+          expect(headers).to include(
+            "Vaccine #{i}",
+            "Dose #{i}",
+            "Reason Not Given #{i}",
+            "Site #{i}",
+            "Manufacturer #{i}",
+            "Batch No #{i}"
+          )
+        end
+      end
+
+      it "does not include the patient if they have no vaccination details" do
+        create(:patient_session, session:)
+
+        expect(data_rows.first).to be_nil
+      end
+
+      it "includes the patient and vaccination details" do
+        patient_session =
+          create(
+            :patient_session,
+            :consent_given_triage_not_needed,
+            programmes:,
+            session:
+          )
+        vaccination_record =
+          create(
+            :vaccination_record,
+            programme:,
+            patient: patient_session.patient,
+            session: patient_session.session,
+            performed_at: 2.weeks.ago
+          )
+
+        attended_index = headers.index("Attended")
+        vaccine_index = headers.index("Vaccine 1")
+        batch_index = headers.index("Batch No 1")
+        site_index = headers.index("Site 1")
+        staff_type_index = headers.index("Staff Type")
+        staff_code_index = headers.index("Staff Code")
+        venue_type_index = headers.index("Venue Type")
+        venue_code_index = headers.index("Venue Code")
+
+        row = data_rows.first
+
+        expect(row[attended_index]).to eq("Y")
+        expect(row[vaccine_index]).to eq(
+          vaccination_record.vaccine.snomed_product_code
+        )
+        expect(row[batch_index]).to eq(vaccination_record.batch.name)
+        expect(row[site_index]).to eq("ULA")
+        expect(row[staff_type_index]).to eq("IN")
+        expect(row[staff_code_index]).to eq("LW5PM")
+        expect(row[venue_type_index]).to eq("SC")
+        expect(row[venue_code_index]).to eq("123456")
+      end
+
+      context "in a community clinic" do
+        let(:location) { create(:generic_clinic, organisation:) }
+
+        it "includes clinic location details" do
+          patient = create(:patient, year_group: programme.year_groups.first)
+
+          create(
+            :patient_session,
+            :consent_given_triage_not_needed,
+            programmes:,
+            patient:,
+            session:
+          )
+          create(
+            :vaccination_record,
+            programme:,
+            patient:,
+            session:,
+            location_name: "A clinic"
+          )
+
+          venue_type_index = headers.index("Venue Type")
+          venue_code_index = headers.index("Venue Code")
+
+          row = data_rows.first
+
+          expect(row[venue_type_index]).to eq("CL")
+          expect(row[venue_code_index]).to eq("ABC")
+        end
+      end
+
+      it "excludes vaccination records outside the date range" do
+        patient = create(:patient_session, session:).patient
+
+        create(
+          :vaccination_record,
+          programme:,
+          patient:,
+          session:,
+          created_at: 2.months.ago,
+          updated_at: 2.months.ago,
+          performed_at: 2.months.ago
+        )
+
+        expect(data_rows.first).to be_nil
+      end
+
+      it "excludes not administered vaccination records" do
+        patient = create(:patient_session, session:).patient
+
+        create(
+          :vaccination_record,
+          :not_administered,
+          programme:,
+          patient:,
           session:
         )
-      create(
-        :vaccination_record,
-        programme: programmes.first,
-        patient: patient_session.patient,
-        session: patient_session.session,
-        performed_at: 2.weeks.ago
-      )
 
-      patient_session.patient.update!(restricted_at: Time.current)
+        expect(data_rows.first).to be_nil
+      end
 
-      address_index = headers.index("Address Line 1")
-      row = data_rows.first
+      it "includes vaccination records updated within the date range" do
+        patient = create(:patient_session, session:).patient
 
-      expect(row[0]).to eq(patient_session.patient.nhs_number)
-      expect(row).not_to be_nil
-      expect(row[address_index]).to be_blank
+        create(
+          :vaccination_record,
+          programme:,
+          patient:,
+          session:,
+          created_at: 2.months.ago,
+          updated_at: 1.day.ago,
+          performed_at: 2.months.ago
+        )
+
+        expect(data_rows.first).not_to be_nil
+      end
+
+      context "with a session in a different organisation" do
+        let(:session) { create(:session, programmes:, location:) }
+
+        it "excludes the vaccination record" do
+          create(:vaccination_record, programme:, session:)
+
+          expect(data_rows.first).to be_nil
+        end
+      end
+
+      context "with a restricted patient" do
+        it "doesn't include the address line 1" do
+          patient_session =
+            create(
+              :patient_session,
+              :consent_given_triage_not_needed,
+              programmes:,
+              session:
+            )
+          create(
+            :vaccination_record,
+            programme:,
+            patient: patient_session.patient,
+            session: patient_session.session,
+            performed_at: 2.weeks.ago
+          )
+
+          patient_session.patient.update!(restricted_at: Time.current)
+
+          address_index = headers.index("Address Line 1")
+          row = data_rows.first
+
+          expect(row[0]).to eq(patient_session.patient.nhs_number)
+          expect(row).not_to be_nil
+          expect(row[address_index]).to be_blank
+        end
+      end
     end
   end
+
+  include_examples "generates a report", :hpv
+  include_examples "generates a report", :menacwy
+  include_examples "generates a report", :td_ipv
 end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -2,509 +2,527 @@
 
 describe Reports::ProgrammeVaccinationsExporter do
   subject(:call) do
-    described_class.call(
-      organisation:,
-      programme: programmes.first,
-      start_date:,
-      end_date:
-    )
+    described_class.call(organisation:, programme:, start_date:, end_date:)
   end
 
-  let(:programmes) { [create(:programme, :hpv)] }
-  let(:organisation) { create(:organisation, programmes:) }
-  let(:user) do
-    create(
-      :user,
-      email: "nurse@example.com",
-      given_name: "Nurse",
-      family_name: "Test",
-      organisation:
-    )
+  shared_examples "generates a report" do |programme_type|
+    let(:programme) { create(:programme, programme_type) }
+
+    context "#{programme_type} programme" do
+      let(:programmes) { [programme] }
+      let(:organisation) { create(:organisation, programmes:) }
+      let(:user) do
+        create(
+          :user,
+          email: "nurse@example.com",
+          given_name: "Nurse",
+          family_name: "Test",
+          organisation:
+        )
+      end
+      let(:team) { create(:team, organisation:) }
+      let(:session) { create(:session, location:, organisation:, programmes:) }
+
+      let(:start_date) { nil }
+      let(:end_date) { nil }
+
+      describe "headers" do
+        subject(:headers) { CSV.parse(call).first }
+
+        it do
+          expect(headers).to eq(
+            %w[
+              ORGANISATION_CODE
+              SCHOOL_URN
+              SCHOOL_NAME
+              CARE_SETTING
+              CLINIC_NAME
+              PERSON_FORENAME
+              PERSON_SURNAME
+              PERSON_DATE_OF_BIRTH
+              PERSON_DATE_OF_DEATH
+              YEAR_GROUP
+              PERSON_GENDER_CODE
+              PERSON_ADDRESS_LINE_1
+              PERSON_POSTCODE
+              NHS_NUMBER
+              NHS_NUMBER_STATUS_CODE
+              GP_ORGANISATION_CODE
+              GP_NAME
+              CONSENT_STATUS
+              CONSENT_DETAILS
+              HEALTH_QUESTION_ANSWERS
+              TRIAGE_STATUS
+              TRIAGED_BY
+              TRIAGE_DATE
+              TRIAGE_NOTES
+              GILLICK_STATUS
+              GILLICK_ASSESSMENT_DATE
+              GILLICK_ASSESSED_BY
+              GILLICK_ASSESSMENT_NOTES
+              VACCINATED
+              DATE_OF_VACCINATION
+              TIME_OF_VACCINATION
+              PROGRAMME_NAME
+              VACCINE_GIVEN
+              PERFORMING_PROFESSIONAL_EMAIL
+              PERFORMING_PROFESSIONAL_FORENAME
+              PERFORMING_PROFESSIONAL_SURNAME
+              BATCH_NUMBER
+              BATCH_EXPIRY_DATE
+              ANATOMICAL_SITE
+              ROUTE_OF_VACCINATION
+              DOSE_SEQUENCE
+              REASON_NOT_VACCINATED
+              LOCAL_PATIENT_ID
+              SNOMED_PROCEDURE_CODE
+              REASON_FOR_INCLUSION
+              RECORD_CREATED
+              RECORD_UPDATED
+            ]
+          )
+        end
+
+        context "when Gillick notify parents is enabled" do
+          before { Flipper.enable(:report_gillick_notify_parents) }
+          after { Flipper.disable(:report_gillick_notify_parents) }
+
+          it { should include("GILLICK_NOTIFY_PARENTS") }
+        end
+      end
+
+      describe "rows" do
+        subject(:rows) { freeze_time { CSV.parse(call, headers: true) } }
+
+        context "a school session" do
+          let(:location) { create(:school, team:) }
+
+          it { should be_empty }
+
+          context "with a vaccinated patient" do
+            let(:patient) do
+              create(
+                :patient,
+                year_group: programme.year_groups.first,
+                session:
+              )
+            end
+            let(:batch) do
+              create(
+                :batch,
+                expiry: Date.new(2025, 12, 1),
+                vaccine: programme.vaccines.active.first
+              )
+            end
+            let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
+
+            let!(:vaccination_record) do
+              create(
+                :vaccination_record,
+                batch:,
+                patient:,
+                session:,
+                performed_at:,
+                created_at: performed_at,
+                updated_at: performed_at,
+                programme:,
+                performed_by: user
+              )
+            end
+
+            it "has a row" do
+              expect(rows.count).to eq(1)
+              expect(rows.first.to_hash).to eq(
+                {
+                  "ANATOMICAL_SITE" => "left upper arm",
+                  "BATCH_EXPIRY_DATE" => "2025-12-01",
+                  "BATCH_NUMBER" => batch.name,
+                  "CARE_SETTING" => "1",
+                  "CLINIC_NAME" => "",
+                  "CONSENT_DETAILS" => "",
+                  "CONSENT_STATUS" => "",
+                  "DATE_OF_VACCINATION" => "2024-01-01",
+                  "DOSE_SEQUENCE" => vaccination_record.dose_sequence.to_s,
+                  "GILLICK_ASSESSED_BY" => "",
+                  "GILLICK_ASSESSMENT_DATE" => "",
+                  "GILLICK_ASSESSMENT_NOTES" => "",
+                  "GILLICK_STATUS" => "",
+                  "GP_NAME" => "",
+                  "GP_ORGANISATION_CODE" => "",
+                  "HEALTH_QUESTION_ANSWERS" => "",
+                  "LOCAL_PATIENT_ID" => patient.id.to_s,
+                  "NHS_NUMBER" => patient.nhs_number,
+                  "NHS_NUMBER_STATUS_CODE" => "02",
+                  "ORGANISATION_CODE" => organisation.ods_code,
+                  "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+                  "PERFORMING_PROFESSIONAL_FORENAME" => "Nurse",
+                  "PERFORMING_PROFESSIONAL_SURNAME" => "Test",
+                  "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
+                  "PERSON_DATE_OF_BIRTH" =>
+                    patient.date_of_birth.strftime("%Y-%m-%d"),
+                  "PERSON_DATE_OF_DEATH" => "",
+                  "PERSON_FORENAME" => patient.given_name,
+                  "PERSON_GENDER_CODE" => "Not known",
+                  "PERSON_POSTCODE" => patient.address_postcode,
+                  "PERSON_SURNAME" => patient.family_name,
+                  "PROGRAMME_NAME" => programme.name,
+                  "REASON_NOT_VACCINATED" => "",
+                  "RECORD_CREATED" => "2024-01-01T12:05:20+00:00",
+                  "RECORD_UPDATED" => "",
+                  "REASON_FOR_INCLUSION" => "new",
+                  "ROUTE_OF_VACCINATION" => "intramuscular",
+                  "SCHOOL_NAME" => location.name,
+                  "SCHOOL_URN" => location.urn,
+                  "SNOMED_PROCEDURE_CODE" => programme.snomed_procedure_code,
+                  "TIME_OF_VACCINATION" => "12:05:20",
+                  "TRIAGED_BY" => "",
+                  "TRIAGE_DATE" => "",
+                  "TRIAGE_NOTES" => "",
+                  "TRIAGE_STATUS" => "",
+                  "VACCINATED" => "Y",
+                  "VACCINE_GIVEN" => vaccination_record.vaccine.nivs_name,
+                  "YEAR_GROUP" => programme.year_groups.first.to_s
+                }
+              )
+            end
+          end
+
+          context "with a vaccinated patient outside the date range" do
+            let(:patient) { create(:patient_session, session:).patient }
+            let(:start_date) { Date.current }
+
+            before do
+              create(
+                :vaccination_record,
+                patient:,
+                session:,
+                created_at: 1.day.ago,
+                updated_at: 1.day.ago,
+                programme: programmes.first,
+                performed_by: user
+              )
+            end
+
+            it { should be_empty }
+          end
+
+          context "with a vaccinated patient that was updated in the date range" do
+            let(:patient) { create(:patient_session, session:).patient }
+            let(:start_date) { 1.day.ago }
+
+            before do
+              create(
+                :vaccination_record,
+                patient:,
+                session:,
+                created_at: 10.days.ago,
+                updated_at: Time.current,
+                programme: programmes.first,
+                performed_by: user
+              )
+            end
+
+            it "includes the information" do
+              expect(rows.first.to_hash).to include(
+                "REASON_FOR_INCLUSION" => "updated"
+              )
+            end
+          end
+        end
+
+        context "a clinic session" do
+          let(:location) { create(:generic_clinic, team:) }
+
+          it { should be_empty }
+
+          context "with a vaccinated patient" do
+            let(:patient) do
+              create(
+                :patient,
+                year_group: programme.year_groups.first,
+                session:
+              )
+            end
+            let(:batch) do
+              create(
+                :batch,
+                expiry: Date.new(2025, 12, 1),
+                vaccine: programmes.first.vaccines.active.first
+              )
+            end
+            let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
+
+            let!(:vaccination_record) do
+              create(
+                :vaccination_record,
+                performed_at:,
+                batch:,
+                patient:,
+                session:,
+                programme:,
+                location_name: "A Clinic",
+                performed_by: user
+              )
+            end
+
+            it "has a row" do
+              expect(rows.count).to eq(1)
+              expect(rows.first.to_hash).to eq(
+                {
+                  "ANATOMICAL_SITE" => "left upper arm",
+                  "BATCH_EXPIRY_DATE" => "2025-12-01",
+                  "BATCH_NUMBER" => batch.name,
+                  "CARE_SETTING" => "2",
+                  "CLINIC_NAME" => "A Clinic",
+                  "CONSENT_DETAILS" => "",
+                  "CONSENT_STATUS" => "",
+                  "DATE_OF_VACCINATION" => "2024-01-01",
+                  "DOSE_SEQUENCE" => vaccination_record.dose_sequence.to_s,
+                  "GILLICK_ASSESSED_BY" => "",
+                  "GILLICK_ASSESSMENT_DATE" => "",
+                  "GILLICK_ASSESSMENT_NOTES" => "",
+                  "GILLICK_STATUS" => "",
+                  "GP_NAME" => "",
+                  "GP_ORGANISATION_CODE" => "",
+                  "HEALTH_QUESTION_ANSWERS" => "",
+                  "LOCAL_PATIENT_ID" => patient.id.to_s,
+                  "NHS_NUMBER" => patient.nhs_number,
+                  "NHS_NUMBER_STATUS_CODE" => "02",
+                  "ORGANISATION_CODE" => organisation.ods_code,
+                  "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
+                  "PERFORMING_PROFESSIONAL_FORENAME" => "Nurse",
+                  "PERFORMING_PROFESSIONAL_SURNAME" => "Test",
+                  "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
+                  "PERSON_DATE_OF_BIRTH" =>
+                    patient.date_of_birth.strftime("%Y-%m-%d"),
+                  "PERSON_DATE_OF_DEATH" => "",
+                  "PERSON_FORENAME" => patient.given_name,
+                  "PERSON_GENDER_CODE" => "Not known",
+                  "PERSON_POSTCODE" => patient.address_postcode,
+                  "PERSON_SURNAME" => patient.family_name,
+                  "PROGRAMME_NAME" => programme.name,
+                  "REASON_NOT_VACCINATED" => "",
+                  "RECORD_CREATED" => Time.current.iso8601,
+                  "RECORD_UPDATED" => "",
+                  "REASON_FOR_INCLUSION" => "new",
+                  "ROUTE_OF_VACCINATION" => "intramuscular",
+                  "SCHOOL_NAME" => "",
+                  "SCHOOL_URN" => "888888",
+                  "SNOMED_PROCEDURE_CODE" => programme.snomed_procedure_code,
+                  "TIME_OF_VACCINATION" => "12:05:20",
+                  "TRIAGED_BY" => "",
+                  "TRIAGE_DATE" => "",
+                  "TRIAGE_NOTES" => "",
+                  "TRIAGE_STATUS" => "",
+                  "VACCINATED" => "Y",
+                  "VACCINE_GIVEN" => vaccination_record.vaccine.nivs_name,
+                  "YEAR_GROUP" => programme.year_groups.first.to_s
+                }
+              )
+            end
+          end
+        end
+
+        context "with a deceased patient" do
+          let(:session) { create(:session, programmes:, organisation:) }
+
+          before do
+            create(
+              :patient,
+              :vaccinated,
+              :deceased,
+              date_of_death: Date.new(2010, 1, 1),
+              session:,
+              programmes:
+            )
+          end
+
+          it "includes the information" do
+            expect(rows.first.to_hash).to include(
+              "PERSON_DATE_OF_DEATH" => "2010-01-01"
+            )
+          end
+        end
+
+        context "with a restricted patient" do
+          let(:session) { create(:session, programmes:, organisation:) }
+          let(:patient) { create(:patient, :restricted, session:) }
+
+          before do
+            create(
+              :vaccination_record,
+              patient:,
+              session:,
+              programme:,
+              performed_by: user
+            )
+          end
+
+          it "doesn't include the address or postcode" do
+            expect(rows.count).to eq(1)
+            expect(rows.first["PERSON_ADDRESS_LINE_1"]).to be_blank
+            expect(rows.first["PERSON_POSTCODE"]).to be_blank
+          end
+        end
+
+        context "with a traced NHS number" do
+          let(:session) { create(:session, programmes:, organisation:) }
+
+          before do
+            create(
+              :patient,
+              :vaccinated,
+              updated_from_pds_at: Time.current,
+              session:,
+              programmes:
+            )
+          end
+
+          it "includes the information" do
+            expect(rows.first.to_hash).to include(
+              "NHS_NUMBER_STATUS_CODE" => "01"
+            )
+          end
+        end
+
+        context "with a GP practice" do
+          let(:gp_practice) do
+            create(:gp_practice, name: "Practice", ods_code: "GP")
+          end
+          let(:session) { create(:session, programmes:, organisation:) }
+
+          before do
+            create(:patient, :vaccinated, gp_practice:, session:, programmes:)
+          end
+
+          it "includes the information" do
+            expect(rows.first.to_hash).to include(
+              "GP_NAME" => "Practice",
+              "GP_ORGANISATION_CODE" => "GP"
+            )
+          end
+        end
+
+        context "with consent" do
+          let(:session) { create(:session, programmes:, organisation:) }
+          let(:patient) { create(:patient, :vaccinated, session:) }
+
+          let!(:consent) do
+            parent = create(:parent, full_name: "John Smith")
+            create(:parent_relationship, :father, parent:, patient:)
+            created_at = Time.zone.local(2024, 1, 1, 12, 5, 20)
+            create(:consent, :given, patient:, parent:, programme:, created_at:)
+          end
+
+          it "includes the information" do
+            expect(rows.first.to_hash).to include(
+              "CONSENT_DETAILS" =>
+                "Given by John Smith at 2024-01-01 12:05:20 +0000",
+              "CONSENT_STATUS" => "Consent given",
+              "HEALTH_QUESTION_ANSWERS" =>
+                consent
+                  .health_answers
+                  .map { "#{it.question} No from Dad" }
+                  .join("\r\n")
+            )
+          end
+        end
+
+        context "with a gillick assessment" do
+          let(:session) { create(:session, programmes:, organisation:) }
+          let(:patient_session) do
+            create(:patient_session, :vaccinated, session:)
+          end
+          let(:patient) { patient_session.patient }
+
+          before do
+            performed_by =
+              create(:user, given_name: "Test", family_name: "Nurse")
+            updated_at = Date.new(2024, 1, 1)
+            create(
+              :gillick_assessment,
+              :competent,
+              patient_session:,
+              performed_by:,
+              updated_at:
+            )
+
+            Flipper.enable(:report_gillick_notify_parents)
+          end
+
+          after { Flipper.disable(:report_gillick_notify_parents) }
+
+          it "includes the information" do
+            expect(rows.first.to_hash).to include(
+              "GILLICK_ASSESSED_BY" => "NURSE, Test",
+              "GILLICK_ASSESSMENT_DATE" => "2024-01-01",
+              "GILLICK_ASSESSMENT_NOTES" => "Assessed as Gillick competent",
+              "GILLICK_NOTIFY_PARENTS" => "",
+              "GILLICK_STATUS" => "Gillick competent"
+            )
+          end
+
+          context "when child doesn't want parents to be informed" do
+            before do
+              create(
+                :consent,
+                :self_consent,
+                patient:,
+                programme:,
+                notify_parents: false
+              )
+            end
+
+            it "includes the information" do
+              expect(rows.first.to_hash).to include(
+                "GILLICK_NOTIFY_PARENTS" => "N"
+              )
+            end
+          end
+
+          context "when child wants parents to be informed" do
+            before do
+              create(
+                :consent,
+                :self_consent,
+                patient:,
+                programme:,
+                notify_parents: true
+              )
+            end
+
+            it "includes the information" do
+              expect(rows.first.to_hash).to include(
+                "GILLICK_NOTIFY_PARENTS" => "Y"
+              )
+            end
+          end
+        end
+
+        context "with a triage assessment" do
+          let(:session) { create(:session, programmes:, organisation:) }
+          let(:performed_by) do
+            create(:user, given_name: "Test", family_name: "Nurse")
+          end
+
+          before do
+            create(:patient_session, :vaccinated, session:, user: performed_by)
+          end
+
+          it "includes the information" do
+            expect(rows.first.to_hash).to include(
+              "TRIAGED_BY" => "NURSE, Test",
+              "TRIAGE_DATE" => Date.current.strftime("%Y-%m-%d"),
+              "TRIAGE_NOTES" => "Okay to vaccinate",
+              "TRIAGE_STATUS" => "Ready to vaccinate"
+            )
+          end
+        end
+      end
+    end
   end
-  let(:team) { create(:team, organisation:) }
-  let(:session) { create(:session, location:, organisation:, programmes:) }
 
-  let(:start_date) { nil }
-  let(:end_date) { nil }
-
-  describe "headers" do
-    subject(:headers) { CSV.parse(call).first }
-
-    it do
-      expect(headers).to eq(
-        %w[
-          ORGANISATION_CODE
-          SCHOOL_URN
-          SCHOOL_NAME
-          CARE_SETTING
-          CLINIC_NAME
-          PERSON_FORENAME
-          PERSON_SURNAME
-          PERSON_DATE_OF_BIRTH
-          PERSON_DATE_OF_DEATH
-          YEAR_GROUP
-          PERSON_GENDER_CODE
-          PERSON_ADDRESS_LINE_1
-          PERSON_POSTCODE
-          NHS_NUMBER
-          NHS_NUMBER_STATUS_CODE
-          GP_ORGANISATION_CODE
-          GP_NAME
-          CONSENT_STATUS
-          CONSENT_DETAILS
-          HEALTH_QUESTION_ANSWERS
-          TRIAGE_STATUS
-          TRIAGED_BY
-          TRIAGE_DATE
-          TRIAGE_NOTES
-          GILLICK_STATUS
-          GILLICK_ASSESSMENT_DATE
-          GILLICK_ASSESSED_BY
-          GILLICK_ASSESSMENT_NOTES
-          VACCINATED
-          DATE_OF_VACCINATION
-          TIME_OF_VACCINATION
-          PROGRAMME_NAME
-          VACCINE_GIVEN
-          PERFORMING_PROFESSIONAL_EMAIL
-          PERFORMING_PROFESSIONAL_FORENAME
-          PERFORMING_PROFESSIONAL_SURNAME
-          BATCH_NUMBER
-          BATCH_EXPIRY_DATE
-          ANATOMICAL_SITE
-          ROUTE_OF_VACCINATION
-          DOSE_SEQUENCE
-          REASON_NOT_VACCINATED
-          LOCAL_PATIENT_ID
-          SNOMED_PROCEDURE_CODE
-          REASON_FOR_INCLUSION
-          RECORD_CREATED
-          RECORD_UPDATED
-        ]
-      )
-    end
-
-    context "when Gillick notify parents is enabled" do
-      before { Flipper.enable(:report_gillick_notify_parents) }
-      after { Flipper.disable(:report_gillick_notify_parents) }
-
-      it { should include("GILLICK_NOTIFY_PARENTS") }
-    end
-  end
-
-  describe "rows" do
-    subject(:rows) { freeze_time { CSV.parse(call, headers: true) } }
-
-    context "a school session" do
-      let(:location) { create(:school, team:) }
-
-      it { should be_empty }
-
-      context "with a vaccinated patient" do
-        let(:patient) { create(:patient, year_group: 8, session:) }
-        let(:batch) do
-          create(
-            :batch,
-            expiry: Date.new(2025, 12, 1),
-            vaccine: programmes.first.vaccines.active.first
-          )
-        end
-        let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
-
-        before do
-          create(
-            :vaccination_record,
-            batch:,
-            patient:,
-            session:,
-            performed_at:,
-            created_at: performed_at,
-            updated_at: performed_at,
-            programme: programmes.first,
-            performed_by: user
-          )
-        end
-
-        it "has a row" do
-          expect(rows.count).to eq(1)
-          expect(rows.first.to_hash).to eq(
-            {
-              "ANATOMICAL_SITE" => "left upper arm",
-              "BATCH_EXPIRY_DATE" => "2025-12-01",
-              "BATCH_NUMBER" => batch.name,
-              "CARE_SETTING" => "1",
-              "CLINIC_NAME" => "",
-              "CONSENT_DETAILS" => "",
-              "CONSENT_STATUS" => "",
-              "DATE_OF_VACCINATION" => "2024-01-01",
-              "DOSE_SEQUENCE" => "1",
-              "GILLICK_ASSESSED_BY" => "",
-              "GILLICK_ASSESSMENT_DATE" => "",
-              "GILLICK_ASSESSMENT_NOTES" => "",
-              "GILLICK_STATUS" => "",
-              "GP_NAME" => "",
-              "GP_ORGANISATION_CODE" => "",
-              "HEALTH_QUESTION_ANSWERS" => "",
-              "LOCAL_PATIENT_ID" => patient.id.to_s,
-              "NHS_NUMBER" => patient.nhs_number,
-              "NHS_NUMBER_STATUS_CODE" => "02",
-              "ORGANISATION_CODE" => organisation.ods_code,
-              "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
-              "PERFORMING_PROFESSIONAL_FORENAME" => "Nurse",
-              "PERFORMING_PROFESSIONAL_SURNAME" => "Test",
-              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
-              "PERSON_DATE_OF_BIRTH" =>
-                patient.date_of_birth.strftime("%Y-%m-%d"),
-              "PERSON_DATE_OF_DEATH" => "",
-              "PERSON_FORENAME" => patient.given_name,
-              "PERSON_GENDER_CODE" => "Not known",
-              "PERSON_POSTCODE" => patient.address_postcode,
-              "PERSON_SURNAME" => patient.family_name,
-              "PROGRAMME_NAME" => "HPV",
-              "REASON_NOT_VACCINATED" => "",
-              "RECORD_CREATED" => "2024-01-01T12:05:20+00:00",
-              "RECORD_UPDATED" => "",
-              "REASON_FOR_INCLUSION" => "new",
-              "ROUTE_OF_VACCINATION" => "intramuscular",
-              "SCHOOL_NAME" => location.name,
-              "SCHOOL_URN" => location.urn,
-              "SNOMED_PROCEDURE_CODE" => "761841000",
-              "TIME_OF_VACCINATION" => "12:05:20",
-              "TRIAGED_BY" => "",
-              "TRIAGE_DATE" => "",
-              "TRIAGE_NOTES" => "",
-              "TRIAGE_STATUS" => "",
-              "VACCINATED" => "Y",
-              "VACCINE_GIVEN" => "Gardasil9",
-              "YEAR_GROUP" => "8"
-            }
-          )
-        end
-      end
-
-      context "with a vaccinated patient outside the date range" do
-        let(:patient) { create(:patient_session, session:).patient }
-        let(:start_date) { Date.current }
-
-        before do
-          create(
-            :vaccination_record,
-            patient:,
-            session:,
-            created_at: 1.day.ago,
-            updated_at: 1.day.ago,
-            programme: programmes.first,
-            performed_by: user
-          )
-        end
-
-        it { should be_empty }
-      end
-
-      context "with a vaccinated patient that was updated in the date range" do
-        let(:patient) { create(:patient_session, session:).patient }
-        let(:start_date) { 1.day.ago }
-
-        before do
-          create(
-            :vaccination_record,
-            patient:,
-            session:,
-            created_at: 10.days.ago,
-            updated_at: Time.current,
-            programme: programmes.first,
-            performed_by: user
-          )
-        end
-
-        it "includes the information" do
-          expect(rows.first.to_hash).to include(
-            "REASON_FOR_INCLUSION" => "updated"
-          )
-        end
-      end
-    end
-
-    context "a clinic session" do
-      let(:location) { create(:generic_clinic, team:) }
-
-      it { should be_empty }
-
-      context "with a vaccinated patient" do
-        let(:patient) { create(:patient, year_group: 8, session:) }
-        let(:batch) do
-          create(
-            :batch,
-            expiry: Date.new(2025, 12, 1),
-            vaccine: programmes.first.vaccines.active.first
-          )
-        end
-        let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
-
-        before do
-          create(
-            :vaccination_record,
-            performed_at:,
-            batch:,
-            patient:,
-            session:,
-            programme: programmes.first,
-            location_name: "A Clinic",
-            performed_by: user
-          )
-        end
-
-        it "has a row" do
-          expect(rows.count).to eq(1)
-          expect(rows.first.to_hash).to eq(
-            {
-              "ANATOMICAL_SITE" => "left upper arm",
-              "BATCH_EXPIRY_DATE" => "2025-12-01",
-              "BATCH_NUMBER" => batch.name,
-              "CARE_SETTING" => "2",
-              "CLINIC_NAME" => "A Clinic",
-              "CONSENT_DETAILS" => "",
-              "CONSENT_STATUS" => "",
-              "DATE_OF_VACCINATION" => "2024-01-01",
-              "DOSE_SEQUENCE" => "1",
-              "GILLICK_ASSESSED_BY" => "",
-              "GILLICK_ASSESSMENT_DATE" => "",
-              "GILLICK_ASSESSMENT_NOTES" => "",
-              "GILLICK_STATUS" => "",
-              "GP_NAME" => "",
-              "GP_ORGANISATION_CODE" => "",
-              "HEALTH_QUESTION_ANSWERS" => "",
-              "LOCAL_PATIENT_ID" => patient.id.to_s,
-              "NHS_NUMBER" => patient.nhs_number,
-              "NHS_NUMBER_STATUS_CODE" => "02",
-              "ORGANISATION_CODE" => organisation.ods_code,
-              "PERFORMING_PROFESSIONAL_EMAIL" => "nurse@example.com",
-              "PERFORMING_PROFESSIONAL_FORENAME" => "Nurse",
-              "PERFORMING_PROFESSIONAL_SURNAME" => "Test",
-              "PERSON_ADDRESS_LINE_1" => patient.address_line_1,
-              "PERSON_DATE_OF_BIRTH" =>
-                patient.date_of_birth.strftime("%Y-%m-%d"),
-              "PERSON_DATE_OF_DEATH" => "",
-              "PERSON_FORENAME" => patient.given_name,
-              "PERSON_GENDER_CODE" => "Not known",
-              "PERSON_POSTCODE" => patient.address_postcode,
-              "PERSON_SURNAME" => patient.family_name,
-              "PROGRAMME_NAME" => "HPV",
-              "REASON_NOT_VACCINATED" => "",
-              "RECORD_CREATED" => Time.current.iso8601,
-              "RECORD_UPDATED" => "",
-              "REASON_FOR_INCLUSION" => "new",
-              "ROUTE_OF_VACCINATION" => "intramuscular",
-              "SCHOOL_NAME" => "",
-              "SCHOOL_URN" => "888888",
-              "SNOMED_PROCEDURE_CODE" => "761841000",
-              "TIME_OF_VACCINATION" => "12:05:20",
-              "TRIAGED_BY" => "",
-              "TRIAGE_DATE" => "",
-              "TRIAGE_NOTES" => "",
-              "TRIAGE_STATUS" => "",
-              "VACCINATED" => "Y",
-              "VACCINE_GIVEN" => "Gardasil9",
-              "YEAR_GROUP" => "8"
-            }
-          )
-        end
-      end
-    end
-
-    context "with a deceased patient" do
-      let(:session) { create(:session, programmes:, organisation:) }
-
-      before do
-        create(
-          :patient,
-          :vaccinated,
-          :deceased,
-          date_of_death: Date.new(2010, 1, 1),
-          session:,
-          programmes:
-        )
-      end
-
-      it "includes the information" do
-        expect(rows.first.to_hash).to include(
-          "PERSON_DATE_OF_DEATH" => "2010-01-01"
-        )
-      end
-    end
-
-    context "with a restricted patient" do
-      let(:session) { create(:session, programmes:, organisation:) }
-      let(:patient) { create(:patient, :restricted, session:) }
-
-      before do
-        create(
-          :vaccination_record,
-          patient:,
-          session:,
-          programme: programmes.first,
-          performed_by: user
-        )
-      end
-
-      it "doesn't include the address or postcode" do
-        expect(rows.count).to eq(1)
-        expect(rows.first["PERSON_ADDRESS_LINE_1"]).to be_blank
-        expect(rows.first["PERSON_POSTCODE"]).to be_blank
-      end
-    end
-
-    context "with a traced NHS number" do
-      let(:session) { create(:session, programmes:, organisation:) }
-
-      before do
-        create(
-          :patient,
-          :vaccinated,
-          updated_from_pds_at: Time.current,
-          session:,
-          programmes:
-        )
-      end
-
-      it "includes the information" do
-        expect(rows.first.to_hash).to include("NHS_NUMBER_STATUS_CODE" => "01")
-      end
-    end
-
-    context "with a GP practice" do
-      let(:gp_practice) do
-        create(:gp_practice, name: "Practice", ods_code: "GP")
-      end
-      let(:session) { create(:session, programmes:, organisation:) }
-
-      before do
-        create(:patient, :vaccinated, gp_practice:, session:, programmes:)
-      end
-
-      it "includes the information" do
-        expect(rows.first.to_hash).to include(
-          "GP_NAME" => "Practice",
-          "GP_ORGANISATION_CODE" => "GP"
-        )
-      end
-    end
-
-    context "with consent" do
-      let(:session) { create(:session, programmes:, organisation:) }
-      let(:patient) { create(:patient, :vaccinated, session:) }
-
-      before do
-        parent = create(:parent, full_name: "John Smith")
-        create(:parent_relationship, :father, parent:, patient:)
-        created_at = Time.zone.local(2024, 1, 1, 12, 5, 20)
-        create(
-          :consent,
-          :given,
-          patient:,
-          parent:,
-          programme: programmes.first,
-          created_at:
-        )
-      end
-
-      it "includes the information" do
-        expect(rows.first.to_hash).to include(
-          "CONSENT_DETAILS" =>
-            "Given by John Smith at 2024-01-01 12:05:20 +0000",
-          "CONSENT_STATUS" => "Consent given",
-          "HEALTH_QUESTION_ANSWERS" => [
-            "Does your child have any severe allergies? No from Dad",
-            "Does your child have any medical conditions for which they receive treatment? No from Dad",
-            "Has your child ever had a severe reaction to any medicines, including vaccines? No from Dad",
-            "Does your child need extra support during vaccination sessions? No from Dad"
-          ].join("\r\n")
-        )
-      end
-    end
-
-    context "with a gillick assessment" do
-      let(:session) { create(:session, programmes:, organisation:) }
-      let(:patient_session) { create(:patient_session, :vaccinated, session:) }
-      let(:patient) { patient_session.patient }
-
-      before do
-        performed_by = create(:user, given_name: "Test", family_name: "Nurse")
-        updated_at = Date.new(2024, 1, 1)
-        create(
-          :gillick_assessment,
-          :competent,
-          patient_session:,
-          performed_by:,
-          updated_at:
-        )
-
-        Flipper.enable(:report_gillick_notify_parents)
-      end
-
-      after { Flipper.disable(:report_gillick_notify_parents) }
-
-      it "includes the information" do
-        expect(rows.first.to_hash).to include(
-          "GILLICK_ASSESSED_BY" => "NURSE, Test",
-          "GILLICK_ASSESSMENT_DATE" => "2024-01-01",
-          "GILLICK_ASSESSMENT_NOTES" => "Assessed as Gillick competent",
-          "GILLICK_NOTIFY_PARENTS" => "",
-          "GILLICK_STATUS" => "Gillick competent"
-        )
-      end
-
-      context "when child doesn't want parents to be informed" do
-        before do
-          create(
-            :consent,
-            :self_consent,
-            patient:,
-            programme: programmes.first,
-            notify_parents: false
-          )
-        end
-
-        it "includes the information" do
-          expect(rows.first.to_hash).to include("GILLICK_NOTIFY_PARENTS" => "N")
-        end
-      end
-
-      context "when child wants parents to be informed" do
-        before do
-          create(
-            :consent,
-            :self_consent,
-            patient:,
-            programme: programmes.first,
-            notify_parents: true
-          )
-        end
-
-        it "includes the information" do
-          expect(rows.first.to_hash).to include("GILLICK_NOTIFY_PARENTS" => "Y")
-        end
-      end
-    end
-
-    context "with a triage assessment" do
-      let(:session) { create(:session, programmes:, organisation:) }
-      let(:performed_by) do
-        create(:user, given_name: "Test", family_name: "Nurse")
-      end
-
-      before do
-        create(:patient_session, :vaccinated, session:, user: performed_by)
-      end
-
-      it "includes the information" do
-        expect(rows.first.to_hash).to include(
-          "TRIAGED_BY" => "NURSE, Test",
-          "TRIAGE_DATE" => Date.current.strftime("%Y-%m-%d"),
-          "TRIAGE_NOTES" => "Okay to vaccinate",
-          "TRIAGE_STATUS" => "Ready to vaccinate"
-        )
-      end
-    end
-  end
+  include_examples "generates a report", :hpv
+  include_examples "generates a report", :menacwy
+  include_examples "generates a report", :td_ipv
 end


### PR DESCRIPTION
This ensures that we're testing the reports in all 3 programmes that we currently support: HPV, MenACWY and Td/IPV.

Best reviewed hiding whitespace changes.