### PR TITLE
Ensure patients are shown in triage list

### DIFF
--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -22,13 +22,13 @@ class Sessions::TriageController < ApplicationController
 
     patient_sessions =
       @form.apply(scope) do |filtered_scope|
-        filtered_scope.select do
+        filtered_scope.reject do
           it
             .patient
             .triage_outcome
             .status
             .values_at(*it.programmes)
-            .none?(Patient::TriageOutcome::NOT_REQUIRED)
+            .all?(Patient::TriageOutcome::NOT_REQUIRED)
         end
       end
 


### PR DESCRIPTION
At the moment, patients are only shown in the triage list if all the programmes need triage, whereas the logic should be that if any programme needs triage the patient should appear in the list.