### PR TITLE
Updated status colours

### DIFF
--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -4,7 +4,7 @@ en:
       text: Not in a session
       banner_title: Not in session
     added_to_session:
-      colour: blue
+      colour: grey
       text: Get consent
       banner_title: No response
       banner_explanation: No-one responded to our requests for consent.
@@ -31,7 +31,7 @@ en:
       banner_title: Conflicting consent
       banner_explanation: You can only vaccinate if all respondents give consent.
     delay_vaccination:
-      colour: red
+      colour: dark-orange
       text: Delay vaccination to a later date
       banner_title: Could not vaccinate
       banner_explanation: "%{nurse} decided that %{full_name}’s vaccination should be delayed."
@@ -41,12 +41,12 @@ en:
       banner_title: Could not vaccinate
       banner_explanation: "%{nurse} decided that %{full_name} should not be vaccinated."
     triaged_ready_to_vaccinate:
-      colour: purple
+      colour: aqua-green
       text: Vaccinate
       banner_title: Ready for nurse
       banner_explanation: "%{nurse} decided that %{full_name} is ready for the nurse."
     unable_to_vaccinate:
-      colour: red
+      colour: dark-orange
       text: Could not vaccinate
       banner_title: Could not vaccinate
       banner_explanation:

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -50,10 +50,10 @@ en:
         absent_from_session: dark-orange
         administered: green
         already_had: green
-        contraindications: dark-orange
+        contraindications: red
         none: white
         not_well: dark-orange
-        refused: dark-orange
+        refused: red
     programme:
       label:
         could_not_vaccinate: Could not vaccinate

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -31,7 +31,7 @@ describe AppOutcomeBannerComponent do
       create(:patient_session, :unable_to_vaccinate, session:)
     end
 
-    it { should have_css(".app-card--red") }
+    it { should have_css(".app-card--dark-orange") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("MERTON, Alya was not well enough") }
     it { should have_text("Location\n#{location_name}") }
@@ -42,7 +42,7 @@ describe AppOutcomeBannerComponent do
       create(:patient_session, :unable_to_vaccinate, session:)
     end
 
-    it { should have_css(".app-card--red") }
+    it { should have_css(".app-card--dark-orange") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("Reason\nMERTON, Alya was not well enough") }
   end
@@ -52,7 +52,7 @@ describe AppOutcomeBannerComponent do
       create(:patient_session, :unable_to_vaccinate_and_had_no_triage, session:)
     end
 
-    it { should have_css(".app-card--red") }
+    it { should have_css(".app-card--dark-orange") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("Reason\nMERTON, Alya was not well enough") }
   end

--- a/spec/components/app_simple_status_banner_component_spec.rb
+++ b/spec/components/app_simple_status_banner_component_spec.rb
@@ -37,7 +37,7 @@ describe AppSimpleStatusBannerComponent do
       create(:patient_session, :added_to_session, programmes: [programme])
     end
 
-    it { should have_css(".app-card--blue") }
+    it { should have_css(".app-card--grey") }
   end
 
   context "state is consent_given_triage_not_needed" do
@@ -97,7 +97,7 @@ describe AppSimpleStatusBannerComponent do
       )
     end
 
-    it { should have_css(".app-card--purple") }
+    it { should have_css(".app-card--aqua-green") }
     it { should have_css(".nhsuk-card__heading", text: "Ready for nurse") }
 
     it do
@@ -135,7 +135,7 @@ describe AppSimpleStatusBannerComponent do
       create(:patient_session, :delay_vaccination, programmes: [programme])
     end
 
-    it { should have_css(".app-card--red") }
+    it { should have_css(".app-card--dark-orange") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
 
     it do


### PR DESCRIPTION
Update status colours used on patient session summary to more closely align with the status colours used on session lists.

Also update the 2 finite outcomes for a session (Refused, Contraindications) to use `red`, instead of `dark-orange` for their status colouring.