### PR TITLE
Always ask pregnancy pre-screening question

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -25,7 +25,7 @@
         <%= f.govuk_check_box :not_taking_medication, true, multiple: false, link_errors: true %>
       <% end %>
 
-      <% if PreScreening.ask_not_pregnant?(programme:, patient:) %>
+      <% if PreScreening.ask_not_pregnant?(programme:) %>
         <%= f.govuk_check_box :not_pregnant, true, multiple: false, link_errors: true %>
       <% end %>
     <% end %>

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -58,15 +58,14 @@ class PreScreening < ApplicationRecord
       (
         !PreScreening.ask_not_taking_medication?(programme:) ||
           not_taking_medication
-      ) &&
-      (!PreScreening.ask_not_pregnant?(programme:, patient:) || not_pregnant)
+      ) && (!PreScreening.ask_not_pregnant?(programme:) || not_pregnant)
   end
 
   def self.ask_not_taking_medication?(programme:)
     programme.doubles?
   end
 
-  def self.ask_not_pregnant?(programme:, patient:)
-    (programme.hpv? || programme.td_ipv?) && patient.gender_code != "male"
+  def self.ask_not_pregnant?(programme:)
+    programme.hpv? || programme.td_ipv?
   end
 end


### PR DESCRIPTION
If the programme is HPV or Td/IPV. Our concept of gender code isn't specific enough to rely on for this question.

From https://www.datadictionary.nhs.uk/attributes/person_gender_code.html:

> The classification is phenotypical rather than genotypical, i.e. it does not provide codes for medical or scientific purposes.