### PR TITLE
Return to patient session page

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -139,7 +139,12 @@ class DraftVaccinationRecordsController < ApplicationController
 
   def finish_wizard_path
     if @session.today?
-      session_record_path(@session)
+      session_patient_programme_path(
+        @session,
+        @patient,
+        @programme,
+        return_to: "record"
+      )
     else
       programme_vaccination_record_path(@programme, @vaccination_record)
     end

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -83,11 +83,11 @@ describe "MenACWY and Td/IPV vaccination" do
   def then_i_see_the_patient_is_vaccinated_for_menacwy
     expect(page).to have_content("Vaccination recorded")
 
-    # actions required
+    click_on "Record vaccinations"
     expect(page).to have_content("Report for MenACWY")
     expect(page).to have_content("Record vaccination for Td/IPV")
 
-    click_link @patient.full_name, match: :first
+    click_link @patient.full_name
     expect(page).to have_content("Vaccinated")
   end
 
@@ -108,10 +108,11 @@ describe "MenACWY and Td/IPV vaccination" do
   def then_i_see_the_patient_is_vaccinated_for_td_ipv
     expect(page).to have_content("Vaccination recorded")
 
-    # patient should no longer be in record tab
+    click_on "Record vaccinations"
     expect(page).to have_content("No children matching search criteria found")
 
-    click_link @patient.full_name
+    click_on "Session outcomes"
+    click_on @patient.full_name
     expect(page).to have_content("Vaccinated")
   end
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -254,6 +254,7 @@ describe "End-to-end journey" do
   end
 
   def then_i_see_that_the_child_is_vaccinated
+    click_on "Pilot School"
     click_on "Session outcomes"
     choose "Vaccinated"
     click_on "Update results"

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -43,8 +43,8 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_no_longer_see_the_patient_in_the_record_tab
-    and_a_success_message
+    then_i_see_a_success_message
+    and_i_no_longer_see_the_patient_in_the_record_tab
 
     when_i_go_back
     and_i_save_changes
@@ -178,14 +178,15 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_no_longer_see_the_patient_in_the_record_tab
-    expect(page).to have_content("No children matching search criteria found")
-  end
-
-  def and_a_success_message
+  def then_i_see_a_success_message
     expect(page).to have_content(
       "Vaccination recorded for #{@patient.full_name}"
     )
+  end
+
+  def and_i_no_longer_see_the_patient_in_the_record_tab
+    click_on "Record vaccinations"
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def when_i_go_back

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -14,8 +14,8 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_no_longer_see_the_patient_in_the_record_tab
-    and_a_success_message
+    then_i_see_a_success_message
+    and_i_no_longer_see_the_patient_in_the_record_tab
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_vaccinated
@@ -78,16 +78,18 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_no_longer_see_the_patient_in_the_record_tab
-    expect(page).to have_content("No children matching search criteria found")
-  end
-
-  def and_a_success_message
+  def then_i_see_a_success_message
     expect(page).to have_content("Record updated for #{@patient.full_name}")
   end
 
+  def and_i_no_longer_see_the_patient_in_the_record_tab
+    click_on "Record vaccinations"
+    expect(page).to have_content("No children matching search criteria found")
+  end
+
   def when_i_go_to_the_patient
-    click_link @patient.full_name, match: :first
+    click_on "Session outcomes"
+    click_on @patient.full_name
   end
 
   def then_i_see_that_the_status_is_vaccinated

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -17,8 +17,8 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_no_longer_see_the_patient_in_the_record_tab
-    and_a_success_message
+    then_i_see_a_success_message
+    and_i_no_longer_see_the_patient_in_the_record_tab
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_vaccinated
@@ -102,18 +102,20 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_no_longer_see_the_patient_in_the_record_tab
-    expect(page).to have_content("No children matching search criteria found")
-  end
-
-  def and_a_success_message
+  def then_i_see_a_success_message
     expect(page).to have_content(
       "Vaccination recorded for #{@patient.full_name}"
     )
   end
 
+  def and_i_no_longer_see_the_patient_in_the_record_tab
+    click_on "Record vaccinations"
+    expect(page).to have_content("No children matching search criteria found")
+  end
+
   def when_i_go_to_the_patient
-    click_link @patient.full_name, match: :first
+    click_on "Session outcomes"
+    click_on @patient.full_name, match: :first
   end
 
   def then_i_see_that_the_status_is_vaccinated

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -9,8 +9,8 @@ describe "HPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_still_see_the_patient_in_the_record_tab
-    and_a_success_message
+    then_i_see_a_success_message
+    and_i_still_see_the_patient_in_the_record_tab
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_delayed
@@ -78,13 +78,14 @@ describe "HPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_still_see_the_patient_in_the_record_tab
-    expect(page).to have_content("Showing 1 to 1 of 1 children")
-    expect(page).to have_content(@patient.full_name)
+  def then_i_see_a_success_message
+    expect(page).to have_content("Record updated for #{@patient.full_name}")
   end
 
-  def and_a_success_message
-    expect(page).to have_content("Record updated for #{@patient.full_name}")
+  def and_i_still_see_the_patient_in_the_record_tab
+    click_on "Record vaccinations"
+    expect(page).to have_content("Showing 1 to 1 of 1 children")
+    expect(page).to have_content(@patient.full_name)
   end
 
   def when_i_go_to_the_patient

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -43,8 +43,8 @@ describe "MenACWY vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_no_longer_see_the_patient_in_the_record_tab
-    and_a_success_message
+    then_i_see_a_success_message
+    and_i_no_longer_see_the_patient_in_the_record_tab
 
     when_i_go_back
     and_i_save_changes
@@ -174,14 +174,15 @@ describe "MenACWY vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_no_longer_see_the_patient_in_the_record_tab
-    expect(page).to have_content("No children matching search criteria found")
-  end
-
-  def and_a_success_message
+  def then_i_see_a_success_message
     expect(page).to have_content(
       "Vaccination recorded for #{@patient.full_name}"
     )
+  end
+
+  def and_i_no_longer_see_the_patient_in_the_record_tab
+    click_on "Record vaccinations"
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def when_i_go_back

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -43,8 +43,8 @@ describe "Td/IPV vaccination" do
     then_i_see_the_confirmation_page
 
     when_i_confirm_the_details
-    then_i_no_longer_see_the_patient_in_the_record_tab
-    and_a_success_message
+    then_i_see_a_success_message
+    and_i_no_longer_see_the_patient_in_the_record_tab
 
     when_i_go_back
     and_i_save_changes
@@ -175,14 +175,15 @@ describe "Td/IPV vaccination" do
     click_button "Confirm"
   end
 
-  def then_i_no_longer_see_the_patient_in_the_record_tab
-    expect(page).to have_content("No children matching search criteria found")
-  end
-
-  def and_a_success_message
+  def then_i_see_a_success_message
     expect(page).to have_content(
       "Vaccination recorded for #{@patient.full_name}"
     )
+  end
+
+  def and_i_no_longer_see_the_patient_in_the_record_tab
+    click_on "Record vaccinations"
+    expect(page).to have_content("No children matching search criteria found")
   end
 
   def when_i_go_back

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -93,6 +93,9 @@ describe "Vaccination" do
     click_button "Continue"
 
     click_button "Confirm"
+
+    # back to session
+    click_on "Record vaccinations"
   end
 
   def when_i_vaccinate_a_second_patient_with_hpv


### PR DESCRIPTION
After vaccinating a patient, the user should be taken back to the patient page in the session, so they can record another vaccination if necessary (for example with doubles).