### PR TITLE
Allow attempting vaccination again if retryable

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -79,7 +79,7 @@
   <% end %>
 <% end %>
 
-<% if helpers.policy(Triage).create? && patient_session.next_step(programme:) == :triage %>
+<% if helpers.policy(Triage).create? && patient.triage_outcome.required?(programme) %>
   <%= render AppCardComponent.new do %>
     <%= render AppTriageFormComponent.new(
           patient_session:,

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -10,7 +10,8 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def render?
-    patient_session.next_step(programme:) == :vaccinate
+    patient.consent_given_and_safe_to_vaccinate?(programme:) &&
+      patient_session.register_outcome.attending?
   end
 
   private

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -11,7 +11,10 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   def render?
     patient.consent_given_and_safe_to_vaccinate?(programme:) &&
-      patient_session.register_outcome.attending?
+      (
+        patient_session.register_outcome.attending? ||
+          patient_session.register_outcome.completed?
+      )
   end
 
   private

--- a/app/models/concerns/patient_session_status_concern.rb
+++ b/app/models/concerns/patient_session_status_concern.rb
@@ -49,14 +49,5 @@ module PatientSessionStatusConcern
         "added_to_session"
       end
     end
-
-    def next_step(programme:)
-      if patient.triage_outcome.required?(programme)
-        :triage
-      elsif patient.consent_given_and_safe_to_vaccinate?(programme:) &&
-            register_outcome.attending?
-        :vaccinate
-      end
-    end
   end
 end

--- a/app/models/patient/programme_outcome.rb
+++ b/app/models/patient/programme_outcome.rb
@@ -56,8 +56,7 @@ class Patient::ProgrammeOutcome
   end
 
   def programme_could_not_vaccinate?(programme)
-    all[programme].any? { it.not_administered? && !it.retryable_reason? } ||
-      consent_outcome.refused?(programme) ||
+    consent_outcome.refused?(programme) ||
       triage_outcome.do_not_vaccinate?(programme)
   end
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -136,11 +136,7 @@ class PatientSession < ApplicationRecord
     programmes_to_check = programme ? [programme] : programmes
 
     programmes_to_check.any? do
-      patient.consent_given_and_safe_to_vaccinate?(programme: it) &&
-        (
-          session_outcome.latest[it].nil? ||
-            session_outcome.latest[it].retryable_reason?
-        )
+      patient.consent_given_and_safe_to_vaccinate?(programme: it)
     end
   end
 end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -162,11 +162,6 @@ class VaccinationRecord < ApplicationRecord
     confirmation_sent_at != nil
   end
 
-  def retryable_reason?
-    not_well? || contraindications? || absent_from_session? ||
-      absent_from_school? || refused?
-  end
-
   def dose_volume_ml
     # TODO: this will need to be revisited once it's possible to record half-doses
     # e.g. for the flu programme where a child refuses the second half of the dose

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -39,20 +39,20 @@ describe AppVaccinateFormComponent do
   describe "#render?" do
     subject(:render) { component.render? }
 
+    it { should be(true) }
+
     context "patient is not ready for vaccination" do
-      before do
-        allow(patient_session).to receive(:next_step).and_return(:triage)
-      end
+      let(:patient) { create(:patient, programmes:, given_name: "Hari") }
 
       it { should be(false) }
     end
 
-    context "patient is ready for vaccination" do
-      before do
-        allow(patient_session).to receive(:next_step).and_return(:vaccinate)
+    context "patient is not attending the session" do
+      let(:patient_session) do
+        create(:patient_session, programmes:, patient:, session:)
       end
 
-      it { should be(true) }
+      it { should be(false) }
     end
   end
 end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -44,6 +44,7 @@ describe "HPV vaccination" do
 
     when_i_confirm_the_details
     then_i_see_a_success_message
+    and_i_can_no_longer_vaccinate_the_patient
     and_i_no_longer_see_the_patient_in_the_record_tab
 
     when_i_go_back
@@ -182,6 +183,10 @@ describe "HPV vaccination" do
     expect(page).to have_content(
       "Vaccination recorded for #{@patient.full_name}"
     )
+  end
+
+  def and_i_can_no_longer_vaccinate_the_patient
+    expect(page).not_to have_content("ready for their HPV vaccination?")
   end
 
   def and_i_no_longer_see_the_patient_in_the_record_tab

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -14,6 +14,7 @@ describe "HPV vaccination" do
 
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_delayed
+    and_i_can_record_a_second_vaccination
 
     when_i_go_to_the_outcome_tab
     then_i_see_the_patient_has_no_outcome_yet
@@ -94,6 +95,10 @@ describe "HPV vaccination" do
 
   def then_i_see_that_the_status_is_delayed
     expect(page).to have_content("Could not vaccinate")
+  end
+
+  def and_i_can_record_a_second_vaccination
+    expect(page).to have_content("ready for their HPV vaccination?")
   end
 
   def when_i_go_to_the_outcome_tab


### PR DESCRIPTION
In most cases, a vaccination record can be retried. The only time it can't be is if the outcome was "already had", in which case the programme outcome will be vaccinated and therefore the patient is unsafe to vaccinate.

Worth reviewing commit by commit as I've done some refactoring or unnecessary methods in the first two commits to this PR.