### PR TITLE
Ensure MenACWY is recorded with an unknown dose sequence

### DIFF
--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -37,7 +37,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def dose_sequence
-    programme.vaccinated_dose_sequence == 1 ? 1 : nil
+    programme.default_dose_sequence
   end
 
   def common_delivery_sites_options

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -313,7 +313,7 @@ class Reports::OfflineSessionExporter
     row[:anatomical_site] = Cell.new(
       allowed_values: ImmunisationImportRow::DELIVERY_SITES.keys
     )
-    row[:dose_sequence] = 1 if programme.vaccinated_dose_sequence == 1
+    row[:dose_sequence] = programme.default_dose_sequence
     row[:reason_not_vaccinated] = Cell.new(
       allowed_values: ImmunisationImportRow::REASONS.keys
     )

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -82,6 +82,10 @@ class Programme < ApplicationRecord
     DOSE_SEQUENCES.fetch(type)
   end
 
+  def default_dose_sequence
+    hpv? ? vaccinated_dose_sequence : nil
+  end
+
   def maximum_dose_sequence
     # HPV is given 3 times to patients with a weakened immune system.
     # MenACWY is sometimes given more frequently.

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -203,6 +203,7 @@ describe "MenACWY vaccination" do
 
   def and_i_see_the_vaccination_details
     expect(page).to have_content("Vaccination details").once
+    expect(page).to have_content("Dose numberUnknown")
   end
 
   def when_vaccination_confirmations_are_sent

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -82,6 +82,34 @@ describe Programme do
     end
   end
 
+  describe "#default_dose_sequence" do
+    subject(:default_dose_sequence) { programme.default_dose_sequence }
+
+    context "with a Flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should be_nil }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should eq(1) }
+    end
+
+    context "with a MenACWY programme" do
+      let(:programme) { build(:programme, :menacwy) }
+
+      it { should be_nil }
+    end
+
+    context "with an Td/IPV programme" do
+      let(:programme) { build(:programme, :td_ipv) }
+
+      it { should be_nil }
+    end
+  end
+
   describe "#maximum_dose_sequence" do
     subject(:maximum_dose_sequence) { programme.maximum_dose_sequence }
 


### PR DESCRIPTION
Like Td/IPV, we should be recording MenACWY with an unknown dose sequence, even those typically a patient would only ever receive one dose of this vaccine.