### PR TITLE
Only show attendance buttons if allowed

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -31,7 +31,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
             end
           end %>
       
-      <% if context == :register %>
+      <% if context == :register && helpers.policy(patient_session.register_outcome.latest).new? %>
         <div class="app-button-group">
           <%= helpers.govuk_button_to "Attending", create_session_register_path(session, patient, "present", **params.permit(search_form: {})), class: "app-button--secondary app-button--small" %>
           <%= helpers.govuk_button_to "Absent", create_session_register_path(session, patient, "absent", **params.permit(search_form: {})), class: "app-button--secondary-warning app-button--small" %>

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -64,7 +64,7 @@ class PatientSession < ApplicationRecord
   scope :preload_for_status,
         -> do
           eager_load(:patient).preload(
-            :session_attendances,
+            session_attendances: :session_date,
             patient: [:triages, { consents: :parent }, :vaccination_records],
             session: :programmes
           )

--- a/app/policies/session_attendance_policy.rb
+++ b/app/policies/session_attendance_policy.rb
@@ -11,12 +11,12 @@ class SessionAttendancePolicy < ApplicationPolicy
 
   private
 
-  delegate :patient, :session_date, to: :record
+  delegate :patient_session, :session_date, to: :record
+  delegate :patient, to: :patient_session
 
   def was_seen_by_nurse?
-    patient
-      .vaccination_records
-      .where(performed_at: session_date.value.all_day)
-      .exists?
+    patient.vaccination_records.any? do
+      it.performed_at.to_date == session_date.value
+    end
   end
 end

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -32,7 +32,21 @@ describe AppPatientSessionSearchResultCardComponent do
   context "when context is register" do
     let(:context) { :register }
 
-    it { should have_text("Action required\nGet consent for HPV") }
+    context "when allowed to record attendance" do
+      before { stub_authorization(allowed: true) }
+
+      it { should have_text("Action required\nGet consent for HPV") }
+      it { should have_button("Attending") }
+      it { should have_button("Absent") }
+    end
+
+    context "when not allowed to record attendance" do
+      before { stub_authorization(allowed: false) }
+
+      it { should have_text("Action required\nGet consent for HPV") }
+      it { should_not have_button("Attending") }
+      it { should_not have_button("Absent") }
+    end
   end
 
   context "when context is record" do


### PR DESCRIPTION
This ensures that we're not showing the buttons when the attendance cannot be changed, for example if a vaccination record has been created against that patient and session for the particular date.