### PR TITLE
Permit search_form parameter

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -33,8 +33,8 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
       
       <% if context == :register %>
         <div class="app-button-group">
-          <%= helpers.govuk_button_to "Attending", create_session_register_path(session, patient, "present", **params.permit(search_form: {})), class: "app-button--secondary app-button--small" %>
-          <%= helpers.govuk_button_to "Absent", create_session_register_path(session, patient, "absent", **params.permit(search_form: {})), class: "app-button--secondary-warning app-button--small" %>
+          <%= helpers.govuk_button_to "Attending", create_session_register_path(session, patient, "present", search_form: params[:search_form]&.permit!), class: "app-button--secondary app-button--small" %>
+          <%= helpers.govuk_button_to "Absent", create_session_register_path(session, patient, "absent", search_form: params[:search_form]&.permit!), class: "app-button--secondary-warning app-button--small" %>
         </div>
       <% end %>
     <% end %>


### PR DESCRIPTION
When passing it to the attendance buttons. This doesn't have any effect on the functionality, but avoids an error being logged related to the `session_slug` being unpermitted.