### PR TITLE
Send vaccination administered per programme

### DIFF
--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -7,9 +7,11 @@ module VaccinationMailerConcern
     parents = parents_for_vaccination_mailer(vaccination_record)
     return if parents.empty?
 
+    programme_type = vaccination_record.programme.type
+
     template_name =
       if vaccination_record.administered?
-        :vaccination_administered
+        :"vaccination_administered_#{programme_type}"
       else
         :vaccination_not_administered
       end

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -9,9 +9,9 @@ module VaccinationMailerConcern
 
     template_name =
       if vaccination_record.administered?
-        :vaccination_confirmation_administered
+        :vaccination_administered
       else
-        :vaccination_confirmation_not_administered
+        :vaccination_not_administered
       end
 
     parents.each do |parent|

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -22,9 +22,8 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   triage_vaccination_at_clinic: "9faef718-bd76-4c30-93ea-fbe8584388a6",
   triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
   triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f",
-  vaccination_confirmation_administered: "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
-  vaccination_confirmation_not_administered:
-    "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
+  vaccination_administered: "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
+  vaccination_not_administered: "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
   vaccination_deleted: "1caf1459-abc9-4944-b8c0-deba906ea005"
 }.freeze
 
@@ -37,7 +36,6 @@ GOVUK_NOTIFY_SMS_TEMPLATES = {
   session_clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
   session_clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
   session_school_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
-  vaccination_confirmation_administered: "69612d3a-d6eb-4f04-8b99-ed14212e7245",
-  vaccination_confirmation_not_administered:
-    "aae061e0-b847-4d4c-a87a-12508f95a302"
+  vaccination_administered: "69612d3a-d6eb-4f04-8b99-ed14212e7245",
+  vaccination_not_administered: "aae061e0-b847-4d4c-a87a-12508f95a302"
 }.freeze

--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -22,9 +22,11 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
   triage_vaccination_at_clinic: "9faef718-bd76-4c30-93ea-fbe8584388a6",
   triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
   triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f",
-  vaccination_administered: "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
-  vaccination_not_administered: "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
-  vaccination_deleted: "1caf1459-abc9-4944-b8c0-deba906ea005"
+  vaccination_administered_hpv: "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
+  vaccination_administered_menacwy: "38727494-9a81-42b3-9c1f-5c31e55333e7",
+  vaccination_administered_td_ipv: "3abe7ca8-a889-484b-ab9f-07523302eb6a",
+  vaccination_deleted: "1caf1459-abc9-4944-b8c0-deba906ea005",
+  vaccination_not_administered: "130fe52a-014a-45dd-9f53-8e65c1b8bb79"
 }.freeze
 
 GOVUK_NOTIFY_SMS_TEMPLATES = {
@@ -36,6 +38,8 @@ GOVUK_NOTIFY_SMS_TEMPLATES = {
   session_clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
   session_clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
   session_school_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
-  vaccination_administered: "69612d3a-d6eb-4f04-8b99-ed14212e7245",
+  vaccination_administered_hpv: "69612d3a-d6eb-4f04-8b99-ed14212e7245",
+  vaccination_administered_menacwy: "16ae7602-c2b1-4731-bb74-fd4f1357feca",
+  vaccination_administered_td_ipv: "4c616b22-eee8-423f-84d6-bd5710f744fd",
   vaccination_not_administered: "aae061e0-b847-4d4c-a87a-12508f95a302"
 }.freeze

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -24,7 +24,7 @@ describe VaccinationMailerConcern do
       sample.send_vaccination_confirmation(vaccination_record)
     end
 
-    let(:programme) { create(:programme) }
+    let(:programme) { create(:programme, :hpv) }
     let(:session) { create(:session, programmes: [programme]) }
     let(:parent) { create(:parent) }
     let(:patient) { create(:patient, parents: [parent], session:) }
@@ -37,13 +37,13 @@ describe VaccinationMailerConcern do
 
       it "sends an email" do
         expect { send_vaccination_confirmation }.to have_delivered_email(
-          :vaccination_administered
+          :vaccination_administered_hpv
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
 
       it "sends a text message" do
         expect { send_vaccination_confirmation }.to have_delivered_sms(
-          :vaccination_administered
+          :vaccination_administered_hpv
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
     end
@@ -93,13 +93,13 @@ describe VaccinationMailerConcern do
 
         it "sends an email" do
           expect { send_vaccination_confirmation }.to have_delivered_email(
-            :vaccination_administered
+            :vaccination_administered_hpv
           ).with(parent:, vaccination_record:, sent_by: current_user)
         end
 
         it "sends a text message" do
           expect { send_vaccination_confirmation }.to have_delivered_sms(
-            :vaccination_administered
+            :vaccination_administered_hpv
           ).with(parent:, vaccination_record:, sent_by: current_user)
         end
       end

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -37,13 +37,13 @@ describe VaccinationMailerConcern do
 
       it "sends an email" do
         expect { send_vaccination_confirmation }.to have_delivered_email(
-          :vaccination_confirmation_administered
+          :vaccination_administered
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
 
       it "sends a text message" do
         expect { send_vaccination_confirmation }.to have_delivered_sms(
-          :vaccination_confirmation_administered
+          :vaccination_administered
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
     end
@@ -63,13 +63,13 @@ describe VaccinationMailerConcern do
 
       it "sends an email" do
         expect { send_vaccination_confirmation }.to have_delivered_email(
-          :vaccination_confirmation_not_administered
+          :vaccination_not_administered
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
 
       it "sends a text message" do
         expect { send_vaccination_confirmation }.to have_delivered_sms(
-          :vaccination_confirmation_not_administered
+          :vaccination_not_administered
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
     end
@@ -93,13 +93,13 @@ describe VaccinationMailerConcern do
 
         it "sends an email" do
           expect { send_vaccination_confirmation }.to have_delivered_email(
-            :vaccination_confirmation_administered
+            :vaccination_administered
           ).with(parent:, vaccination_record:, sent_by: current_user)
         end
 
         it "sends a text message" do
           expect { send_vaccination_confirmation }.to have_delivered_sms(
-            :vaccination_confirmation_administered
+            :vaccination_administered
           ).with(parent:, vaccination_record:, sent_by: current_user)
         end
       end

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -123,14 +123,14 @@ describe "MenACWY and Td/IPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -20,8 +20,8 @@ describe "MenACWY and Td/IPV vaccination" do
     then_i_see_the_patient_is_vaccinated_for_td_ipv
 
     when_vaccination_confirmations_are_sent
-    then_an_email_is_sent_to_the_parent_confirming_the_vaccination
-    and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+    then_an_email_is_sent_to_the_parent_confirming_the_vaccinations
+    and_a_text_is_sent_to_the_parent_confirming_the_vaccinations
   end
 
   def given_a_doubles_session_exists
@@ -120,17 +120,29 @@ describe "MenACWY and Td/IPV vaccination" do
     VaccinationConfirmationsJob.perform_now
   end
 
-  def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
+  def then_an_email_is_sent_to_the_parent_confirming_the_vaccinations
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_administered
+      :vaccination_administered_menacwy
+    )
+
+    expect_email_to(
+      @patient.consents.last.parent.email,
+      :vaccination_administered_td_ipv,
+      :second
     )
   end
 
-  def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
+  def and_a_text_is_sent_to_the_parent_confirming_the_vaccinations
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered
+      :vaccination_administered_menacwy
+    )
+
+    expect_sms_to(
+      @patient.consents.last.parent.phone,
+      :vaccination_administered_td_ipv,
+      :second
     )
   end
 end

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -517,7 +517,7 @@ describe "Edit vaccination record" do
   end
 
   def then_the_parent_receives_an_administered_email
-    expect_email_to(@patient.parents.first.email, :vaccination_administered)
+    expect_email_to(@patient.parents.first.email, :vaccination_administered_hpv)
   end
 
   alias_method :and_the_parent_receives_an_administered_email,

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -513,17 +513,11 @@ describe "Edit vaccination record" do
                :then_the_parent_doesnt_receive_an_email
 
   def and_the_parent_receives_a_not_administered_email
-    expect_email_to(
-      @patient.parents.first.email,
-      :vaccination_confirmation_not_administered
-    )
+    expect_email_to(@patient.parents.first.email, :vaccination_not_administered)
   end
 
   def then_the_parent_receives_an_administered_email
-    expect_email_to(
-      @patient.parents.first.email,
-      :vaccination_confirmation_administered
-    )
+    expect_email_to(@patient.parents.first.email, :vaccination_administered)
   end
 
   alias_method :and_the_parent_receives_an_administered_email,

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -236,14 +236,14 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_administered
+      :vaccination_administered_hpv
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered
+      :vaccination_administered_hpv
     )
   end
 end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -236,14 +236,14 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -106,14 +106,14 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_saying_the_vaccination_didnt_happen
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_not_administered
+      :vaccination_not_administered
     )
   end
 
   def and_a_text_is_sent_saying_the_vaccination_didnt_happen
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_not_administered
+      :vaccination_not_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -129,14 +129,14 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -129,14 +129,14 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_administered
+      :vaccination_administered_hpv
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered
+      :vaccination_administered_hpv
     )
   end
 end

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -117,14 +117,14 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_delay
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_not_administered
+      :vaccination_not_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_delay
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_not_administered
+      :vaccination_not_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -288,7 +288,7 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @vaccinated_patient.consents.last.parent.email,
-      :vaccination_administered,
+      :vaccination_administered_hpv,
       :any
     )
 
@@ -302,7 +302,7 @@ describe "HPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @vaccinated_patient.consents.last.parent.phone,
-      :vaccination_administered,
+      :vaccination_administered_hpv,
       :any
     )
 

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -288,13 +288,13 @@ describe "HPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @vaccinated_patient.consents.last.parent.email,
-      :vaccination_confirmation_administered,
+      :vaccination_administered,
       :any
     )
 
     expect_email_to(
       @unvaccinated_patient.consents.last.parent.email,
-      :vaccination_confirmation_not_administered,
+      :vaccination_not_administered,
       :any
     )
   end
@@ -302,13 +302,13 @@ describe "HPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @vaccinated_patient.consents.last.parent.phone,
-      :vaccination_confirmation_administered,
+      :vaccination_administered,
       :any
     )
 
     expect_sms_to(
       @unvaccinated_patient.consents.last.parent.phone,
-      :vaccination_confirmation_not_administered,
+      :vaccination_not_administered,
       :any
     )
   end

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -213,14 +213,14 @@ describe "MenACWY vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -213,14 +213,14 @@ describe "MenACWY vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_administered
+      :vaccination_administered_menacwy
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered
+      :vaccination_administered_menacwy
     )
   end
 end

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -214,14 +214,14 @@ describe "Td/IPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_confirmation_administered
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -214,14 +214,14 @@ describe "Td/IPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_administered
+      :vaccination_administered_td_ipv
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered
+      :vaccination_administered_td_ipv
     )
   end
 end


### PR DESCRIPTION
This updates the vaccination administered emails and texts to send one appropriate for the programme that was vaccinated. We need this as the content will be different for each programme.

I've also added the Td/IPV and MenACWY templates in to the service so we can start to test these, although the content is not quite finalised.