### PR TITLE
Show a more meaningful error to users from organisations that aren't set up in Mavis

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -19,10 +19,12 @@ module AuthenticationConcern
           redirect_to start_path
         end
       elsif cis2_session?
-        if !selected_cis2_org_is_registered?
-          redirect_to users_organisation_not_found_path
+        if !selected_cis2_workgroup_is_valid?
+          redirect_to users_workgroup_not_found_path
         elsif !selected_cis2_role_is_valid?
           redirect_to users_role_not_found_path
+        elsif !selected_cis2_org_is_registered?
+          redirect_to users_organisation_not_found_path
         end
       end
     end
@@ -38,8 +40,8 @@ module AuthenticationConcern
     end
 
     def selected_cis2_workgroup_is_valid?
-      selected_cis2_nrbac_role.key?("workgroups") &&
-        CIS2_WORKGROUP.in?(selected_cis2_nrbac_role["workgroups"])
+      workgroups = session.dig("cis2_info", "selected_role", "workgroups")
+      workgroups.present? && CIS2_WORKGROUP.in?(workgroups)
     end
 
     def valid_cis2_roles

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -14,12 +14,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def cis2
     set_cis2_session_info
 
-    if !selected_cis2_role_is_valid?
+    if !selected_cis2_workgroup_is_valid?
+      redirect_to users_workgroup_not_found_path
+    elsif !selected_cis2_role_is_valid?
       redirect_to users_role_not_found_path
     elsif !selected_cis2_org_is_registered?
       redirect_to users_organisation_not_found_path
-    elsif !selected_cis2_workgroup_is_valid?
-      redirect_to users_workgroup_not_found_path
     else
       @user = User.find_or_create_from_cis2_oidc(user_cis2_info)
 

--- a/app/views/users/errors/organisation_not_found.html.erb
+++ b/app/views/users/errors/organisation_not_found.html.erb
@@ -9,6 +9,8 @@
   (<%= @cis2_info[:selected_org][:code] %>)
 <% end %>
 
+<p>You'll be able to use Mavis once your organisation has been onboarded.</p>
+
 <% if @cis2_info[:has_other_roles] %>
   <%= govuk_button_to "Change role", user_cis2_omniauth_authorize_path, params: { change_role: true } %>
 <% end %>

--- a/lib/omni_auth_strategies_openid_connect_patch.rb
+++ b/lib/omni_auth_strategies_openid_connect_patch.rb
@@ -6,9 +6,11 @@ module OmniAuthStrategiesOpenIDConnectPatch
 
     token_request_params = {
       scope: (options.scope if options.send_scope_to_token_endpoint),
-      client_auth_method: options.client_auth_method,
-      client_assertion: generate_client_assertion
+      client_auth_method: options.client_auth_method
     }
+    if client_options.key?(:private_key)
+      token_request_params[:client_assertion] = generate_client_assertion
+    end
 
     token_request_params[:code_verifier] = params["code_verifier"] ||
       session.delete("omniauth.pkce.verifier") if options.pkce

--- a/spec/features/user_cis2_authentication_with_empty_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_empty_role_spec.rb
@@ -6,21 +6,13 @@ describe "User CIS2 authentication", :cis2 do
     when_i_go_to_the_sessions_page
     then_i_am_on_the_start_page
     when_i_click_the_cis2_login_button
-    then_i_see_the_organisation_not_found_error
+    then_i_see_the_wrong_workgroup_error
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_an_empty_role
     @organisation = create :organisation, ods_code: "AB12"
 
-    mock_cis2_auth(
-      uid: "123",
-      given_name: "Nurse",
-      family_name: "Test",
-      org_code: @organisation.ods_code,
-      org_name: @organisation.name,
-      role_code: "S8002:G8003:R0001",
-      selected_roleid: nil
-    )
+    mock_cis2_auth(selected_roleid: "")
   end
 
   def when_i_click_the_cis2_login_button
@@ -39,9 +31,9 @@ describe "User CIS2 authentication", :cis2 do
     expect(page).to have_current_path sessions_path
   end
 
-  def then_i_see_the_organisation_not_found_error
+  def then_i_see_the_wrong_workgroup_error
     expect(
       page
-    ).to have_heading "You do not have permission to use this service"
+    ).to have_heading "You’re not in the right workgroup to use this service"
   end
 end

--- a/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
@@ -16,7 +16,7 @@ describe "User CIS2 authentication" do
 
   context "user has no other orgs to select" do
     scenario "user has wrong organisation selected" do
-      given_i_am_setup_in_cis2_with_only_one_org
+      given_i_am_setup_in_cis2_with_only_one_role
       when_i_go_to_the_start_page
       then_i_should_see_the_cis2_login_button
 
@@ -31,13 +31,7 @@ describe "User CIS2 authentication" do
   end
 
   def given_i_am_setup_in_cis2_but_not_mavis
-    mock_cis2_auth(
-      uid: "123",
-      given_name: "Nurse",
-      family_name: "Test",
-      org_code: "A9A5A",
-      org_name: "SAIS Organisation"
-    )
+    mock_cis2_auth(org_code: "A9A5A", org_name: "SAIS Organisation")
   end
 
   def given_my_organisation_has_been_setup_in_mavis
@@ -68,14 +62,14 @@ describe "User CIS2 authentication" do
     expect(page).to have_current_path sessions_path
   end
 
-  def given_i_am_setup_in_cis2_with_only_one_org
+  def given_i_am_setup_in_cis2_with_only_one_role
     mock_cis2_auth(
       uid: "123",
       given_name: "Nurse",
       family_name: "Test",
       org_code: "A9A5A",
       org_name: "SAIS Organisation",
-      user_only_has_one_org: true
+      user_only_has_one_role: true
     )
   end
 

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -15,14 +15,7 @@ describe "User CIS2 authentication", :cis2 do
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
     @organisation = create :organisation, ods_code: "AB12"
 
-    mock_cis2_auth(
-      uid: "123",
-      given_name: "Nurse",
-      family_name: "Test",
-      org_code: @organisation.ods_code,
-      org_name: @organisation.name,
-      role_code: "S8002:G8003:R0001"
-    )
+    mock_cis2_auth(selected_roleid: "wrong-role")
   end
 
   def when_i_click_the_cis2_login_button
@@ -51,9 +44,6 @@ describe "User CIS2 authentication", :cis2 do
     # With don't actually get to select the right role directly in our test
     # setup so we change the cis2 response to simulate it.
     mock_cis2_auth(
-      uid: "123",
-      given_name: "Nurse",
-      family_name: "Test",
       org_code: @organisation.ods_code,
       org_name: @organisation.name,
       role: :nurse

--- a/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
@@ -15,12 +15,7 @@ describe "User CIS2 authentication", :cis2 do
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
     @organisation = create :organisation, ods_code: "A9A5A"
 
-    mock_cis2_auth(
-      uid: "123",
-      given_name: "Nurse",
-      family_name: "Test",
-      no_workgroup: true
-    )
+    mock_cis2_auth(selected_roleid: "wrong-workgroup")
   end
 
   def when_i_click_the_cis2_login_button
@@ -49,13 +44,8 @@ describe "User CIS2 authentication", :cis2 do
     # With don't actually get to select the right role directly in our test
     # setup so we change the cis2 response to simulate it.
     mock_cis2_auth(
-      uid: "123",
-      given_name: "Nurse",
-      family_name: "Test",
       org_code: @organisation.ods_code,
-      org_name: @organisation.name,
-      role: :nurse,
-      workgroups: %w[schoolagedimmunisations]
+      org_name: @organisation.name
     )
     click_button "Change role"
   end

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -34,30 +34,46 @@ module CIS2AuthHelper
               "role_name" =>
                 '"Clinical":"Clinical Provision":"Nurse Access Role"',
               "role_code" => "S8000:G8000:R8001",
-              "activities" => [
-                "Receive Self Claimed LR Alerts",
-                "Receive Legal Override and Emergency View Alerts",
-                "Receive Sealing Alerts"
-              ],
-              "activity_codes" => %w[B0016 B0015 B0018],
+              "activities" => [],
+              "activity_codes" => [],
               "workgroups" => ["schoolagedimmunisations"],
               "workgroups_codes" => ["15025792819"]
             },
             {
+              "person_orgid" => "1111222233334444",
+              "person_roleid" => "wrong-role",
+              "org_code" => "A9A5A",
+              "role_name" =>
+                '"Clinical":"Clinical Provision":"Health Professional Access Role"',
+              "role_code" => "S8000:G8000:R8003",
+              "activities" => [],
+              "activity_codes" => [],
+              "workgroups" => ["schoolagedimmunisations"],
+              "workgroups_codes" => ["15025792819"]
+            },
+            {
+              "person_orgid" => "1111222233334444",
+              "person_roleid" => "wrong-workgroup",
+              "org_code" => "A9A5A",
+              "role_name" =>
+                '"Clinical":"Clinical Provision":"Nurse Access Role"',
+              "role_code" => "S8000:G8000:R8001",
+              "activities" => [],
+              "activity_codes" => [],
+              "workgroups" => [],
+              "workgroups_codes" => []
+            },
+            {
               "person_orgid" => "1234123412341234",
-              "person_roleid" => "5678567856785678",
+              "person_roleid" => "wrong-organisation",
               "org_code" => "AB12",
               "role_name" =>
                 '"Clinical":"Clinical Provision":"Nurse Access Role"',
               "role_code" => "S8000:G8000:R8001",
-              "activities" => [
-                "Personal Medication Administration",
-                "Perform Detailed Health Record",
-                "Amend Patient Demographics",
-                "Perform Patient Administration",
-                "Verify Health Records"
-              ],
-              "activity_codes" => %w[B0428 B0380 B0825 B0560 B8028]
+              "activities" => [],
+              "activity_codes" => [],
+              "workgroups" => ["schoolagedimmunisations"],
+              "workgroups_codes" => ["15025792819"]
             }
           ],
           "given_name" => "Nurse",
@@ -106,15 +122,15 @@ module CIS2AuthHelper
   end
 
   def mock_cis2_auth(
-    uid:,
-    given_name:,
-    family_name:,
+    uid: "123",
+    given_name: "Nurse",
+    family_name: "Test",
     email: nil,
     role: :nurse,
     role_code: nil,
     org_code: nil,
     org_name: "Test SAIS Org",
-    user_only_has_one_org: false,
+    user_only_has_one_role: false,
     workgroups: nil,
     no_workgroup: false,
     sid: nil,
@@ -128,8 +144,10 @@ module CIS2AuthHelper
       raw_info["nhsid_user_orgs"][0].merge!(org_code:, org_name:)
     end
 
-    if user_only_has_one_org
-      raw_info["nhsid_nrbac_roles"].select! { _1["org_code"] == org_code }
+    if user_only_has_one_role
+      raw_info["nhsid_nrbac_roles"].select! do
+        _1["person_roleid"] == selected_roleid
+      end
     end
 
     role_code ||= {


### PR DESCRIPTION
This allows us to return a more meaningful error when someone from an organisation that hasn't been setup in Mavis but that is otherwise setup correctly tries to login. This will be useful for pre-launch checks by orgs.

The organisation-not-found page has been updated to the following:

![image](https://github.com/user-attachments/assets/06ae8bde-4cd3-4709-bbf7-10a9d635040d)

[MAV-364](https://nhsd-jira.digital.nhs.uk/browse/MAV-364)