### PR TITLE
Change default TIME_OF_VACCINATION to midnight

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -420,7 +420,7 @@ class ImmunisationImportRow
       date_of_vaccination.year,
       date_of_vaccination.month,
       date_of_vaccination.day,
-      time_of_vaccination&.hour || 12,
+      time_of_vaccination&.hour || 0,
       time_of_vaccination&.min || 0,
       time_of_vaccination&.sec || 0
     )

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -109,7 +109,7 @@ describe "Immunisation imports duplicates" do
       create(
         :vaccination_record,
         programme: @programme,
-        performed_at: @session.dates.min.in_time_zone + 12.hours,
+        performed_at: @session.dates.min.in_time_zone,
         notes: "Foo",
         created_at: Time.zone.yesterday,
         batch: @batch,
@@ -125,7 +125,7 @@ describe "Immunisation imports duplicates" do
       create(
         :vaccination_record,
         programme: @programme,
-        performed_at: @session.dates.min.in_time_zone + 12.hours,
+        performed_at: @session.dates.min.in_time_zone,
         notes: "Bar",
         created_at: Time.zone.yesterday,
         batch: @other_batch,
@@ -211,7 +211,7 @@ describe "Immunisation imports duplicates" do
     expect(@existing_patient.vaccination_records.count).to eq(1)
     vaccs_record = @existing_patient.vaccination_records.first
     expect(vaccs_record.performed_at).to eq(
-      Time.new(2024, 5, 14, 12, 0, 0, "+01:00")
+      Time.new(2024, 5, 14, 0, 0, 0, "+01:00")
     )
     expect(vaccs_record.delivery_method).to eq("intramuscular")
     expect(vaccs_record.delivery_site).to eq("left_buttock")

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1490,7 +1490,7 @@ describe ImmunisationImportRow do
 
     it "sets the administered at time" do
       expect(vaccination_record.performed_at).to eq(
-        Time.new(2024, 1, 1, 12, 0, 0, "+00:00")
+        Time.new(2024, 1, 1, 0, 0, 0, "+00:00")
       )
     end
 
@@ -1499,7 +1499,7 @@ describe ImmunisationImportRow do
 
       it "sets the administered at time" do
         expect(vaccination_record.performed_at).to eq(
-          Time.new(2023, 9, 1, 12, 0, 0, "+01:00")
+          Time.new(2023, 9, 1, 0, 0, 0, "+01:00")
         )
       end
     end
@@ -1509,7 +1509,7 @@ describe ImmunisationImportRow do
 
       it "parses the date and sets the administered at time" do
         expect(vaccination_record.performed_at).to eq(
-          Time.new(2023, 9, 1, 12, 0, 0, "+01:00")
+          Time.new(2023, 9, 1, 0, 0, 0, "+01:00")
         )
       end
     end
@@ -1519,7 +1519,7 @@ describe ImmunisationImportRow do
 
       it "parses the date and sets the administered at time" do
         expect(vaccination_record.performed_at).to eq(
-          Time.new(2023, 9, 1, 12, 0, 0, "+01:00")
+          Time.new(2023, 9, 1, 0, 0, 0, "+01:00")
         )
       end
     end


### PR DESCRIPTION
If a `TIME_OF_VACCINATION` is not specified, the default is set to midday (`12:00`). This causes a problem if the file is uploaded in the morning for sessions that happened that day (which could occur for an offline recording), as the `performed_at` date/time ends up being in the future which fails the validation on the `VaccinationRecord`.

Setting the time to midnight ensures that this will always pass those validation checks.

Preferrably, I think we should treat the date and time separately, and allow for the scenario where the time of the vaccination is unknown and present that to the user rather than needing to pick a default. However, this would require changes to the data model.

Alternatively, my first implementation was to use the current time, which passes the validation checks, but introduces a new issue related to our duplicate checker. If the same file (without time of vaccinations) is uploaded twice, because the time has now changed, the records don't end up being flagged as duplicates, which runs the risk of duplicate vaccination records being imported. Again, I think if we treated the date separate to the time, we could improve this situation.

https://good-machine.sentry.io/issues/6339922906/