### PR TITLE
Don't allow dose sequence to be provided

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,6 +264,7 @@ en:
               inclusion: Enter a anatomical site that is appropriate for the vaccine.
             dose_sequence:
               blank: The dose sequence number cannot be greater than 3. Enter a dose sequence number, for example, 1, 2 or 3.
+              present: Do not provide a dose sequence for this programme (leave blank)
             existing_patients:
               too_long: Two or more possible patients match the patient first name, last name, date of birth or postcode.
             patient_date_of_birth:

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -408,6 +408,46 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "vaccination in a MenACWY session and a dose sequence is provided" do
+      let(:data) do
+        {
+          "SESSION_ID" => session.id.to_s,
+          "PROGRAMME" => "MenACWY",
+          "DOSE_SEQUENCE" => "1"
+        }
+      end
+
+      let(:programmes) { [create(:programme, :menacwy)] }
+      let(:session) { create(:session, organisation:, programmes:) }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:dose_sequence]).to eq(
+          ["Do not provide a dose sequence for this programme (leave blank)"]
+        )
+      end
+    end
+
+    context "vaccination in a Td/IPV session and a dose sequence is provided" do
+      let(:data) do
+        {
+          "SESSION_ID" => session.id.to_s,
+          "PROGRAMME" => "3-in-1",
+          "DOSE_SEQUENCE" => "1"
+        }
+      end
+
+      let(:programmes) { [create(:programme, :td_ipv)] }
+      let(:session) { create(:session, organisation:, programmes:) }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:dose_sequence]).to eq(
+          ["Do not provide a dose sequence for this programme (leave blank)"]
+        )
+      end
+    end
+
     context "HPV vaccination in previous academic year, no vaccinator details provided" do
       let(:programmes) { [create(:programme, :hpv)] }
 
@@ -1170,8 +1210,20 @@ describe ImmunisationImportRow do
 
     let(:programmes) { [create(:programme, :hpv)] }
 
-    context "without a value" do
+    context "without a value and for HPV" do
       let(:data) { { "PROGRAMME" => "HPV" } }
+
+      it { should eq(1) }
+    end
+
+    context "without a value and for Td/IPV" do
+      let(:data) { { "PROGRAMME" => "3-in-1" } }
+
+      it { should be_nil }
+    end
+
+    context "without a value and for MenACWY" do
+      let(:data) { { "PROGRAMME" => "MenACWY" } }
 
       it { should be_nil }
     end


### PR DESCRIPTION
For Td/IPV and MenACWY, the dose sequence should not be provided when a nurse is uploading a file containing vaccination records for a session (i.e. for offline recording).

This is because we don't currently allow the nurses to set the dose sequence while using the service normally, and it can lead to a confusing situation where the nurse uploads a vaccination record that's not the fifth dose, leading to the patient not being marked as vaccinated in the service.