### PR TITLE
MAV-818: Make listener rule idempotent

### DIFF
--- a/terraform/app/ecs.tf
+++ b/terraform/app/ecs.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_cluster" "cluster" {
 }
 
 resource "aws_ecs_service" "service" {
-  name                              = "mavis-${var.environment}"
+  name                              = local.ecs_service_name
   cluster                           = aws_ecs_cluster.cluster.id
   task_definition                   = aws_ecs_task_definition.task_definition.arn
   desired_count                     = var.minimum_replicas

--- a/terraform/app/main.tf
+++ b/terraform/app/main.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/time"
       version = "~> 0.12"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.3.4"
+    }
   }
 
   backend "s3" {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -154,6 +154,7 @@ variable "splunk_enabled" {
 locals {
   container_name = "${var.container_name}-${var.environment}"
   is_production  = var.environment == "production"
+  ecs_service_name = "mavis-${var.environment}"
 
   task_envs = [
     {


### PR DESCRIPTION
- Re-creation of listener rule will cause problems if blue-green deployment is on green cycle
  - Terraform will not know that ECS service is not wired to blue target group
  - Terraform will then switch listener to blue but ECS still connected to green
- To fix the state control-missmatch we need to ensure listener can get up to date information on ECS' target group
- Because this feature is not supported by AWS provider we need to use the AWS-CLI directly. Specifically there are 2 issues
  - The terraform aws_ecs_service "data" object does not have a "loadbalancer" field
  - We need to handle the data object not existing gracefullly
    - Default AWS behaviour is to throw error if data object cannot be fetched
      - A feature request for the providerto override this behaviour has been submitted:	issue 41788