### PR TITLE
Don't send vaccination confirmations outside of session

### DIFF
--- a/app/jobs/vaccination_confirmations_job.rb
+++ b/app/jobs/vaccination_confirmations_job.rb
@@ -19,6 +19,7 @@ class VaccinationConfirmationsJob < ApplicationJob
       .kept
       .where("created_at >= ?", since)
       .where(confirmation_sent_at: nil)
+      .where.not(session_id: nil)
       .select { _1.academic_year == academic_year }
       .each do |vaccation_record|
         send_vaccination_confirmation(vaccation_record)

--- a/spec/jobs/vaccination_confirmations_job_spec.rb
+++ b/spec/jobs/vaccination_confirmations_job_spec.rb
@@ -17,11 +17,19 @@ describe VaccinationConfirmationsJob do
       )
     end
 
+    let(:session) { create(:session, programmes: [programme]) }
+
     let(:old_vaccination_record) do
-      create(:vaccination_record, created_at: 2.days.ago, programme:)
+      create(:vaccination_record, created_at: 2.days.ago, programme:, session:)
     end
 
-    let(:new_vaccination_record) { create(:vaccination_record, programme:) }
+    let(:new_vaccination_record) do
+      create(:vaccination_record, programme:, session:)
+    end
+
+    let(:new_vaccination_record_outside_session) do
+      create(:vaccination_record, programme:)
+    end
 
     let(:discarded_vaccination_record) do
       create(:vaccination_record, :discarded, programme:)
@@ -37,7 +45,7 @@ describe VaccinationConfirmationsJob do
 
     before { allow(job).to receive(:send_vaccination_confirmation) }
 
-    it "sends vaccination confirmations for approriate records" do
+    it "sends vaccination confirmations for the appropriate records" do
       expect(job).not_to receive(:send_vaccination_confirmation).with(
         existing_vaccination_record_already_sent
       )
@@ -46,6 +54,9 @@ describe VaccinationConfirmationsJob do
       )
       expect(job).to receive(:send_vaccination_confirmation).with(
         new_vaccination_record
+      )
+      expect(job).not_to receive(:send_vaccination_confirmation).with(
+        new_vaccination_record_outside_session
       )
       expect(job).not_to receive(:send_vaccination_confirmation).with(
         discarded_vaccination_record


### PR DESCRIPTION
If a vaccination record exists that was recorded outside of a school or clinic session (i.e. it was imported) then we shouldn't be sending parental confirmation emails for these vaccination records.

We already have a check that prevents vaccination records outside of the current academic year from being sent, but in some cases, a patient may be vaccinated in the current academic year at a location outside of a school setting and this needs to be recorded in Mavis, for example if the patient receives a vaccination at a GP surgery.

Currently, although we try to send these emails, they're not actually succeeding as `GovukNotifyPersonalisation` requires there to be a `session` present, and for these vaccination records there won't be.

https://good-machine.sentry.io/issues/6382164907/?project=4505625073876992