### PR TITLE
Don't fetch school if no URN is provided

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -428,9 +428,12 @@ class ImmunisationImportRow
 
   def school
     @school ||=
-      if school_urn != SCHOOL_URN_HOME_EDUCATED &&
-           school_urn != SCHOOL_URN_UNKNOWN
-        Location.find_by(urn: school_urn)
+      if school_urn.present? &&
+           (
+             school_urn != SCHOOL_URN_HOME_EDUCATED &&
+               school_urn != SCHOOL_URN_UNKNOWN
+           )
+        Location.school.find_by(urn: school_urn)
       end
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -760,6 +760,20 @@ describe ImmunisationImportRow do
       it { should be_nil }
     end
 
+    context "without a school URN" do
+      let(:data) { valid_data.merge("SCHOOL_NAME" => "Waterloo Road") }
+
+      it { should eq("Waterloo Road") }
+    end
+
+    context "without a school URN and a clinic exists" do
+      let(:data) { valid_data.merge("SCHOOL_NAME" => "Waterloo Road") }
+
+      before { create(:community_clinic, urn: nil) }
+
+      it { should eq("Waterloo Road") }
+    end
+
     context "with a known school and unknown care setting" do
       let(:data) do
         valid_data.merge(


### PR DESCRIPTION
This fixes a bug where we would end up looking for a location with a `nil` `urn` when importing a vaccination record. We weren't properly filtering the locations meaning we would end up finding a community clinic (since they have no URNs) and assigning the location to the name of the community clinic.