### PR TITLE
Ensure vaccination records without vaccines are handled correctly

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -208,7 +208,11 @@ class AppActivityLogComponent < ViewComponent::Base
     vaccination_records.flat_map do |vaccination_record|
       title =
         if vaccination_record.administered?
-          "Vaccinated with #{vaccination_record.vaccine.brand}"
+          if (vaccine = vaccination_record.vaccine)
+            "Vaccinated with #{vaccine.brand}"
+          else
+            "Vaccinated"
+          end
         else
           "Vaccination not given: #{vaccination_record.human_enum_name(:outcome)}"
         end

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -74,9 +74,19 @@ class AppOutcomeBannerComponent < ViewComponent::Base
 
   def vaccine_summary
     type = vaccination_record.programme.name
-    brand = vaccination_record.vaccine.brand
-    batch = vaccination_record.batch.name
-    "#{type} (#{brand}, #{batch})"
+    batch = vaccination_record.batch&.name
+    brand =
+      (vaccination_record.vaccine || vaccination_record.batch&.vaccine)&.brand
+
+    if brand.present? && batch.present?
+      "#{type} (#{brand}, #{batch})"
+    elsif brand.present?
+      "#{type} (#{brand})"
+    elsif batch.present?
+      "#{type} (#{batch})"
+    else
+      type
+    end
   end
 
   def reason_do_not_vaccinate

--- a/app/components/app_patient_vaccination_table_component.html.erb
+++ b/app/components/app_patient_vaccination_table_component.html.erb
@@ -15,7 +15,12 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccine</span>
-            <% label = "#{vaccination_record.vaccine.brand} (#{vaccination_record.programme.name})" %>
+            <% label = if (vaccine = vaccination_record.vaccine)
+                   "#{vaccine.brand} (#{vaccination_record.programme.name})"
+                 else
+                   vaccination_record.programme.name
+                 end %>
+
             <%= link_to label, programme_vaccination_record_path(vaccination_record.programme, vaccination_record) %>
           <% end %>
           <% row.with_cell do %>

--- a/app/jobs/mesh_dps_export_job.rb
+++ b/app/jobs/mesh_dps_export_job.rb
@@ -7,7 +7,12 @@ class MESHDPSExportJob < ApplicationJob
     return unless Flipper.enabled? :mesh_jobs
 
     Programme.find_each do |programme|
-      if programme.vaccination_records.administered.unexported.any?
+      if programme
+           .vaccination_records
+           .administered
+           .unexported
+           .recorded_in_service
+           .any?
         dps_export = DPSExport.create!(programme:)
         response =
           MESH.send_file(data: dps_export.csv, to: Settings.mesh.dps_mailbox)

--- a/app/models/dps_export.rb
+++ b/app/models/dps_export.rb
@@ -59,6 +59,6 @@ class DPSExport < ApplicationRecord
 
   def set_vaccination_records
     self.vaccination_records =
-      programme.vaccination_records.administered.unexported
+      programme.vaccination_records.administered.unexported.recorded_in_service
   end
 end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -92,6 +92,7 @@ class VaccinationRecord < ApplicationRecord
   has_one :organisation, through: :session
   has_one :team, through: :session
 
+  scope :recorded_in_service, -> { where.not(session: nil) }
   scope :unexported, -> { where.missing(:dps_exports) }
 
   scope :with_pending_changes,

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -402,4 +402,23 @@ describe AppActivityLogComponent do
                      date: "1 June 2024 at 12:00pm",
                      by: "Nurse Joy"
   end
+
+  describe "vaccination records" do
+    context "without a vaccine" do
+      before do
+        create(
+          :vaccination_record,
+          patient:,
+          programme: programmes.first,
+          vaccine: nil,
+          performed_at: Time.zone.parse("2024-05-31 13:00")
+        )
+      end
+
+      include_examples "card",
+                       title: "Vaccinated",
+                       date: "31 May 2024 at 1:00pm",
+                       programme: "HPV"
+    end
+  end
 end

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -93,6 +93,14 @@ describe AppOutcomeBannerComponent do
 
       it { should have_text("Vaccinator\nUnknown") }
     end
+
+    context "when the vaccination is historical" do
+      before do
+        vaccination_record.update!(session: nil, location_name: "Unknown")
+      end
+
+      it { should have_text("Vaccinated") }
+    end
   end
 
   context "state is triaged_do_not_vaccinate" do

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -34,20 +34,38 @@ describe AppPatientVaccinationTableComponent do
       )
     end
     let(:session) { create(:session, location:, programmes: [programme]) }
-    let(:vaccination_record) do
-      create(
-        :vaccination_record,
-        patient:,
-        programme:,
-        session:,
-        performed_at: Time.zone.local(2024, 1, 1)
-      )
+
+    context "with a vaccine" do
+      before do
+        create(
+          :vaccination_record,
+          patient:,
+          programme:,
+          session:,
+          performed_at: Time.zone.local(2024, 1, 1)
+        )
+      end
+
+      it { should have_link("Gardasil 9 (HPV)") }
+      it { should have_content("Test School, Waterloo Road, London, SE1 8TY") }
+      it { should have_content("1 January 2024") }
     end
 
-    before { vaccination_record }
+    context "without a vaccine" do
+      before do
+        create(
+          :vaccination_record,
+          patient:,
+          programme:,
+          session:,
+          performed_at: Time.zone.local(2024, 1, 1),
+          vaccine: nil
+        )
+      end
 
-    it { should have_link("Gardasil 9 (HPV)") }
-    it { should have_content("Test School, Waterloo Road, London, SE1 8TY") }
-    it { should have_content("1 January 2024") }
+      it { should have_link("HPV") }
+      it { should have_content("Test School, Waterloo Road, London, SE1 8TY") }
+      it { should have_content("1 January 2024") }
+    end
   end
 end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -70,11 +70,13 @@ FactoryBot.define do
     delivery_method { "intramuscular" }
 
     vaccine do
-      programme.vaccines.active.first || association(:vaccine, programme:)
+      if session
+        programme.vaccines.active.first || association(:vaccine, programme:)
+      end
     end
 
     batch do
-      association :batch, organisation:, vaccine:, strategy: :create if vaccine
+      association(:batch, organisation:, vaccine:, strategy: :create) if vaccine
     end
 
     performed_by

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -309,7 +309,7 @@ describe Reports::OfflineSessionExporter do
               "TRIAGE_NOTES" => nil,
               "TRIAGE_STATUS" => nil,
               "VACCINATED" => "Y",
-              "VACCINE_GIVEN" => "Gardasil9",
+              "VACCINE_GIVEN" => nil,
               "UUID" => vaccination_record.uuid,
               "YEAR_GROUP" => patient.year_group
             }

--- a/spec/models/dps_export_spec.rb
+++ b/spec/models/dps_export_spec.rb
@@ -28,10 +28,11 @@ describe DPSExport do
   end
 
   let(:programme) { create(:programme) }
+  let(:session) { create(:session, programmes: [programme]) }
 
   before do
-    create_list(:vaccination_record, 2, programme:)
-    create(:vaccination_record, :discarded, programme:)
+    create_list(:vaccination_record, 2, programme:, session:)
+    create(:vaccination_record, :discarded, programme:, session:)
   end
 
   describe "#csv" do


### PR DESCRIPTION
A number of components currently break when they try to render a vaccination record that doesn't have a vaccine. This is a valid state for a historical vaccination record that was imported and performed outside of the service, so it needs to be handled correctly.
