### PR TITLE
Small improvements to outstanding programmes banner

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -140,11 +140,13 @@ class PatientSession < ApplicationRecord
     end
   end
 
-  def programmes_ready_for_vaccinator
+  def outstanding_programmes
     # If this patient hasn't been seen yet by a nurse for any of the programmes,
     # we don't want to show the banner.
     return [] if programmes.all? { session_outcome.none?(it) }
 
-    programmes.select { ready_for_vaccinator?(programme: it) }
+    programmes.select do
+      ready_for_vaccinator?(programme: it) && session_outcome.none?(it)
+    end
   end
 end

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -9,7 +9,7 @@
                                         ].compact) %>
 <% end %>
 
-<% if (outstanding_programmes = @patient_session.outstanding_programmes).any? %>
+<% if policy(VaccinationRecord).new? && (outstanding_programmes = @patient_session.outstanding_programmes).any? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "You still need to record an outcome for #{outstanding_programmes.map(&:name).to_sentence}.") %>
   <% end %>

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -9,7 +9,7 @@
                                         ].compact) %>
 <% end %>
 
-<% if (outstanding_programmes = @patient_session.programmes_ready_for_vaccinator).any? %>
+<% if (outstanding_programmes = @patient_session.outstanding_programmes).any? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
     <% notification_banner.with_heading(text: "You still need to record an outcome for #{outstanding_programmes.map(&:name).to_sentence}.") %>
   <% end %>

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -95,6 +95,7 @@ describe "HPV vaccination" do
 
   def then_i_see_that_the_status_is_delayed
     expect(page).to have_content("Could not vaccinate")
+    expect(page).not_to have_content("You still need to record an outcome")
   end
 
   def and_i_can_record_a_second_vaccination


### PR DESCRIPTION
This makes a number of small improvements to the banner listing outstanding programmes to ensure that only programmes without an outcome are shown and only to nurse users.