### PR TITLE
Don't try to create a batch if not provided

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -318,7 +318,7 @@ class ImmunisationImportRow
   end
 
   def vaccine_given
-    @data["VACCINE_GIVEN"]&.strip
+    @data["VACCINE_GIVEN"]&.strip&.presence
   end
 
   def patient_first_name
@@ -461,7 +461,10 @@ class ImmunisationImportRow
   end
 
   def batch
-    return unless valid? && administered && vaccine
+    unless valid? && administered && vaccine && batch_expiry_date &&
+             batch_number.present?
+      return
+    end
 
     @batch ||=
       Batch.create_with(archived_at: Time.current).find_or_create_by!(

--- a/spec/fixtures/immunisation_import/valid_hpv.csv
+++ b/spec/fixtures/immunisation_import/valid_hpv.csv
@@ -8,6 +8,6 @@ R1L,110158,Eton College,8160442742,Oliver,Bowers,20100917,Male,LE5 2RP,20240514,
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20240514,HPV,Cervarix,123013326,20220730,Right Thigh,2,LocalPatient7,www.LocalPatient7,1
 R1L,888888,Eton College,3314278071,Rosalind,Penn,20100918,Female,LE10 2DA,20230410,HPV,Cervarix,123013325,20250730,,1,LocalPatient7,www.LocalPatient7,1
 ,110158,,9999148581,Harold,Andrew,20101002,Not known,SW11 1AA,20230113,HPV,Gardasil,OU1731,20241015,left upper arm,1,LocalPatient7,www.LocalPatient7,1
-R1L,110158,,9999525156,Martial,Dare,20101002,Not known,SW11 1AA,20230126,HPV,Gardasil,OZ2022,20241010,left upper arm,1,LocalPatient7,www.LocalPatient7,1
+R1L,110158,,9999525156,Martial,Dare,20101002,Not known,SW11 1AA,20230126,HPV,Gardasil,,,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 R1L,110158,,9999525157,Harold,Dare,20101002,Not known,SW11 1AA,20220126,HPV,Gardasil,SA6880,20241012,left upper arm,1,LocalPatient7,www.LocalPatient7,1
 ,,,,,,,,,,,,,,,,,

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1628,5 +1628,19 @@ describe ImmunisationImportRow do
     let(:data) { valid_data }
 
     it { should be_archived }
+
+    context "without a vaccine" do
+      let(:data) { valid_data.merge("VACCINE_GIVEN" => "") }
+
+      it { should be_nil }
+    end
+
+    context "without a batch number or expiry date" do
+      let(:data) do
+        valid_data.merge("BATCH_NUMBER" => "", "BATCH_EXPIRY_DATE" => "")
+      end
+
+      it { should be_nil }
+    end
   end
 end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -185,7 +185,7 @@ describe ImmunisationImport do
           .to change(immunisation_import, :processed_at).from(nil)
           .and change(immunisation_import.vaccination_records, :count).by(11)
           .and change(immunisation_import.patients, :count).by(10)
-          .and change(immunisation_import.batches, :count).by(9)
+          .and change(immunisation_import.batches, :count).by(8)
           .and not_change(immunisation_import.patient_sessions, :count)
 
         # Second import should not duplicate the vaccination records if they're


### PR DESCRIPTION
When importing immunisation records, if the batch details are not provided we shouldn't try to create a batch instance because that fails validation errors on the batch.

It's valid to try and upload a vaccination record with a vaccine, but without batch details.

https://good-machine.sentry.io/issues/6390859317/