### PR TITLE
Fix intermittently failing specs

### DIFF
--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -127,26 +127,28 @@ describe "MenACWY and Td/IPV vaccination" do
   def then_an_email_is_sent_to_the_parent_confirming_the_vaccinations
     expect_email_to(
       @patient.consents.last.parent.email,
-      :vaccination_administered_menacwy
+      :vaccination_administered_menacwy,
+      :any
     )
 
     expect_email_to(
       @patient.consents.last.parent.email,
       :vaccination_administered_td_ipv,
-      :second
+      :any
     )
   end
 
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccinations
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_menacwy
+      :vaccination_administered_menacwy,
+      :any
     )
 
     expect_sms_to(
       @patient.consents.last.parent.phone,
       :vaccination_administered_td_ipv,
-      :second
+      :any
     )
   end
 end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -92,7 +92,9 @@ describe Reports::ProgrammeVaccinationsExporter do
       end
 
       describe "rows" do
-        subject(:rows) { freeze_time { CSV.parse(call, headers: true) } }
+        subject(:rows) { CSV.parse(call, headers: true) }
+
+        around { |example| freeze_time { example.run } }
 
         context "a school session" do
           let(:location) { create(:school, team:) }


### PR DESCRIPTION
- **spec/features/doubles_vaccination_administered_spec.rb** - The two "vaccination administered" emails for doubles can come in different order, as has been demonstrated with intermittent failures of specs in CI. I don't see why these need to be ordered, since sending emails can happen out-of-order.

- **spec/lib/reports/programme_vaccinations_exporter_spec.rb** - Timestamps are generated within the tests so we need to freeze time for the entire spec.