### PR TITLE
Rename none outcome statuses

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -1,6 +1,6 @@
 <%= render AppConsentStatusComponent.new(patient_session:, programme:) %>
 
-<% if patient.consent_outcome.none?(programme) %>
+<% if patient.consent_outcome.no_response?(programme) %>
   <% if latest_consent_request %>
     <p class="nhsuk-body">
       No-one responded to our requests for consent.

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -28,8 +28,9 @@ class AppConsentComponent < ViewComponent::Base
   end
 
   def can_send_consent_request?
-    patient.consent_outcome.none?(programme) && patient.send_notifications? &&
-      session.open_for_consent? && patient.parents.any?
+    patient.consent_outcome.no_response?(programme) &&
+      patient.send_notifications? && session.open_for_consent? &&
+      patient.parents.any?
   end
 
   def status_colour(consent)

--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -30,11 +30,13 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   end
 
   def no_response_count(session:)
-    number_stat(session:) { it.patient.consent_outcome.none?(programme) }
+    number_stat(session:) { it.patient.consent_outcome.no_response?(programme) }
   end
 
   def no_response_percentage(session:)
-    percentage_stat(session:) { it.patient.consent_outcome.none?(programme) }
+    percentage_stat(session:) do
+      it.patient.consent_outcome.no_response?(programme)
+    end
   end
 
   def triage_needed_count(session:)

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -34,7 +34,7 @@ class AppSessionActionsComponent < ViewComponent::Base
   def no_consent_response_row
     consent_row(
       text: "No consent response",
-      status: Patient::ConsentOutcome::NONE
+      status: Patient::ConsentOutcome::NO_RESPONSE
     )
   end
 

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -26,7 +26,7 @@ class ConsentsController < ApplicationController
   end
 
   def send_request
-    return unless @patient.consent_outcome.none?(@programme)
+    return unless @patient.consent_outcome.no_response?(@programme)
 
     # For programmes that are administered together we should send the consent request together.
     programmes =

--- a/app/models/patient/consent_outcome.rb
+++ b/app/models/patient/consent_outcome.rb
@@ -6,19 +6,19 @@ class Patient::ConsentOutcome
   end
 
   STATUSES = [
-    NONE = :none,
+    NO_RESPONSE = :no_response,
     CONFLICTS = :conflicts,
     GIVEN = :given,
     REFUSED = :refused
   ].freeze
 
-  def given?(programme) = status[programme] == GIVEN
-
-  def refused?(programme) = status[programme] == REFUSED
+  def no_response?(programme) = status[programme] == NO_RESPONSE
 
   def conflicts?(programme) = status[programme] == CONFLICTS
 
-  def none?(programme) = status[programme] == NONE
+  def given?(programme) = status[programme] == GIVEN
+
+  def refused?(programme) = status[programme] == REFUSED
 
   def status
     @status ||=
@@ -57,7 +57,7 @@ class Patient::ConsentOutcome
     elsif consent_conflicts?(programme)
       CONFLICTS
     else
-      NONE
+      NO_RESPONSE
     end
   end
 

--- a/app/models/patient/next_activity.rb
+++ b/app/models/patient/next_activity.rb
@@ -37,7 +37,8 @@ class Patient::NextActivity
 
     return TRIAGE if triage_outcome.required?(programme)
 
-    if consent_outcome.none?(programme) || consent_outcome.conflicts?(programme)
+    if consent_outcome.no_response?(programme) ||
+         consent_outcome.conflicts?(programme)
       return CONSENT
     end
 

--- a/app/models/patient/programme_outcome.rb
+++ b/app/models/patient/programme_outcome.rb
@@ -8,14 +8,14 @@ class Patient::ProgrammeOutcome
   STATUSES = [
     VACCINATED = :vaccinated,
     COULD_NOT_VACCINATE = :could_not_vaccinate,
-    NONE = :none
+    NONE_YET = :none_yet
   ].freeze
 
   def vaccinated?(programme) = status[programme] == VACCINATED
 
   def could_not_vaccinate?(programme) = status[programme] == COULD_NOT_VACCINATE
 
-  def none?(programme) = status[programme] == NONE
+  def none_yet?(programme) = status[programme] == NONE_YET
 
   def status
     @status ||=
@@ -43,7 +43,7 @@ class Patient::ProgrammeOutcome
     elsif programme_could_not_vaccinate?(programme)
       COULD_NOT_VACCINATE
     else
-      NONE
+      NONE_YET
     end
   end
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -143,10 +143,10 @@ class PatientSession < ApplicationRecord
   def outstanding_programmes
     # If this patient hasn't been seen yet by a nurse for any of the programmes,
     # we don't want to show the banner.
-    return [] if programmes.all? { session_outcome.none?(it) }
+    return [] if programmes.all? { session_outcome.none_yet?(it) }
 
     programmes.select do
-      ready_for_vaccinator?(programme: it) && session_outcome.none?(it)
+      ready_for_vaccinator?(programme: it) && session_outcome.none_yet?(it)
     end
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -109,7 +109,7 @@ class PatientSession < ApplicationRecord
   end
 
   def can_record_as_already_vaccinated?(programme:)
-    !session.today? && patient.programme_outcome.none?(programme)
+    !session.today? && patient.programme_outcome.none_yet?(programme)
   end
 
   def programmes

--- a/app/models/patient_session/register_outcome.rb
+++ b/app/models/patient_session/register_outcome.rb
@@ -56,6 +56,6 @@ class PatientSession::RegisterOutcome
   end
 
   def all_programmes_have_outcome?
-    programmes.none? { session_outcome.none?(it) }
+    programmes.none? { session_outcome.none_yet?(it) }
   end
 end

--- a/app/models/patient_session/session_outcome.rb
+++ b/app/models/patient_session/session_outcome.rb
@@ -13,7 +13,7 @@ class PatientSession::SessionOutcome
     ABSENT_FROM_SCHOOL = :absent_from_school,
     ABSENT_FROM_SESSION = :absent_from_session,
     UNWELL = :not_well,
-    NONE = :none
+    NONE_YET = :none_yet
   ].freeze
 
   def vaccinated?(programme) = status[programme] == VACCINATED
@@ -21,9 +21,9 @@ class PatientSession::SessionOutcome
   def already_had?(programme) = status[programme] == ALREADY_HAD
 
   def not_vaccinated?(programme) =
-    status[programme] != VACCINATED && status[programme] != NONE
+    status[programme] != VACCINATED && status[programme] != NONE_YET
 
-  def none?(programme) = status[programme] == NONE
+  def none_yet?(programme) = status[programme] == NONE_YET
 
   def status
     @status ||= programmes.index_with { programme_status(it) }
@@ -58,7 +58,7 @@ class PatientSession::SessionOutcome
     elsif triage_outcome.do_not_vaccinate?(programme)
       HAD_CONTRAINDICATIONS
     else
-      NONE
+      NONE_YET
     end
   end
 

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -42,7 +42,7 @@ en:
         administered: Vaccinated
         already_had: Already had vaccine
         contraindications: Had contraindications
-        none: No outcome yet
+        none_yet: No outcome yet
         not_well: Unwell
         refused: Vaccine refused
       colour:
@@ -51,7 +51,7 @@ en:
         administered: green
         already_had: green
         contraindications: red
-        none: white
+        none_yet: white
         not_well: dark-orange
         refused: red
     programme:

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -57,11 +57,9 @@ en:
     programme:
       label:
         could_not_vaccinate: Could not vaccinate
-        none: No outcome yet
-        partially_vaccinated: Partially vaccinated
+        none_yet: No outcome yet
         vaccinated: Vaccinated
       colour:
         could_not_vaccinate: red
-        none: grey
-        partially_vaccinated: green
+        none_yet: grey
         vaccinated: green

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -4,12 +4,12 @@ en:
       label:
         conflicts: Conflicting consent
         given: Consent given
-        none: No response
+        no_response: No response
         refused: Consent refused
       colour:
         conflicts: dark-orange
         given: aqua-green
-        none: grey
+        no_response: grey
         refused: red
     triage:
       label:

--- a/spec/models/patient/consent_outcome_spec.rb
+++ b/spec/models/patient/consent_outcome_spec.rb
@@ -12,19 +12,19 @@ describe Patient::ConsentOutcome do
     subject(:status) { instance.status[programme] }
 
     context "with no consent" do
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NO_RESPONSE) }
     end
 
     context "with an invalidated consent" do
       before { create(:consent, :invalidated, patient:, programme:) }
 
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NO_RESPONSE) }
     end
 
     context "with a not provided consent" do
       before { create(:consent, :not_provided, patient:, programme:) }
 
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NO_RESPONSE) }
     end
 
     context "with both an invalidated and not provided consent" do
@@ -33,7 +33,7 @@ describe Patient::ConsentOutcome do
         create(:consent, :not_provided, patient:, programme:)
       end
 
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NO_RESPONSE) }
     end
 
     context "with a refused consent" do

--- a/spec/models/patient/programme_outcome_spec.rb
+++ b/spec/models/patient/programme_outcome_spec.rb
@@ -12,7 +12,7 @@ describe Patient::ProgrammeOutcome do
     subject(:status) { instance.status[programme] }
 
     context "with no vaccination record" do
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NONE_YET) }
     end
 
     context "with a vaccination administered" do
@@ -40,7 +40,7 @@ describe Patient::ProgrammeOutcome do
         create(:vaccination_record, :not_administered, patient:, programme:)
       end
 
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NONE_YET) }
     end
 
     context "with a consent refused" do
@@ -58,7 +58,7 @@ describe Patient::ProgrammeOutcome do
     context "with a discarded vaccination administered" do
       before { create(:vaccination_record, :discarded, patient:, programme:) }
 
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NONE_YET) }
     end
   end
 

--- a/spec/models/patient_session/session_outcome_spec.rb
+++ b/spec/models/patient_session/session_outcome_spec.rb
@@ -14,7 +14,7 @@ describe PatientSession::SessionOutcome do
     subject(:status) { instance.status[programme] }
 
     context "with no vaccination record" do
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NONE_YET) }
     end
 
     context "with a vaccination administered" do
@@ -42,7 +42,7 @@ describe PatientSession::SessionOutcome do
         create(:vaccination_record, :discarded, patient:, session:, programme:)
       end
 
-      it { should be(described_class::NONE) }
+      it { should be(described_class::NONE_YET) }
     end
 
     context "with a consent refused" do


### PR DESCRIPTION
This renames the consent "none" status to "no_response" and the programme/session status from "none" to "none_yet". This won't change how it looks to users on the frontend.

This avoids potential confusion with the built in Rails `none?` method and helps to clarify exactly what this status is for.

I've also removed the label and colour for the "partially vaccinated" status as this status doesn't exist in the service.