### PR TITLE
Show ticks according to programme outcome

### DIFF
--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -55,7 +55,7 @@
           href: session_patient_programme_path(@session, @patient, programme, return_to: params[:return_to]),
           text: programme.name,
           selected: @programme == programme,
-          ticked: @patient_session.session_outcome.vaccinated?(programme) || @patient_session.session_outcome.already_had?(programme),
+          ticked: @patient.programme_outcome.vaccinated?(programme),
         )
       end
     


### PR DESCRIPTION
If a patient was vaccinated in a clinic and they are being viewed in the context of a school session, the programme navigation item should be ticked to show that the patient is vaccinated, even if it wasn't in that session.