### PR TITLE
Filter reports by programme

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -91,15 +91,13 @@ class Reports::ProgrammeVaccinationsExporter
 
   def vaccination_records
     scope =
-      programme
+      organisation
         .vaccination_records
-        .joins(:organisation)
-        .where(organisations: { id: organisation.id })
+        .where(programme:)
         .includes(
           :batch,
           :location,
           :performed_by_user,
-          :programme,
           :vaccine,
           patient: [:gp_practice, :school, :triages, { consents: :parent }]
         )
@@ -146,7 +144,6 @@ class Reports::ProgrammeVaccinationsExporter
   def row(vaccination_record:)
     location = vaccination_record.location
     patient = vaccination_record.patient
-    programme = vaccination_record.programme
     session = vaccination_record.session
 
     consents = patient.consent_outcome.latest[programme]

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -78,12 +78,11 @@ class Reports::SystmOneExporter
 
   def vaccination_records
     scope =
-      programme
+      organisation
         .vaccination_records
-        .joins(:organisation)
-        .where(organisations: { id: organisation.id })
-        .merge(VaccinationRecord.administered)
-        .includes(:batch, :location, :programme, :vaccine, :patient)
+        .administered
+        .where(programme:)
+        .includes(:batch, :location, :vaccine, :patient)
 
     if start_date.present?
       scope =

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -48,6 +48,7 @@ class Organisation < ApplicationRecord
   has_many :programmes, through: :organisation_programmes
   has_many :schools, through: :teams
   has_many :vaccines, through: :programmes
+  has_many :vaccination_records, through: :sessions
 
   has_and_belongs_to_many :users
 

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -186,6 +186,25 @@ describe Reports::CareplusExporter do
         expect(data_rows.first).not_to be_nil
       end
 
+      it "excludes vaccination records for a different programme outside the date range" do
+        patient = create(:patient_session, session:).patient
+
+        other_programme =
+          create(
+            :programme,
+            type: (Programme.types.values - [programme.type]).sample
+          )
+
+        create(
+          :vaccination_record,
+          programme: other_programme,
+          patient:,
+          session:
+        )
+
+        expect(data_rows.first).to be_nil
+      end
+
       context "with a session in a different organisation" do
         let(:session) { create(:session, programmes:, location:) }
 

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -208,6 +208,28 @@ describe Reports::ProgrammeVaccinationsExporter do
             it { should be_empty }
           end
 
+          context "with a vaccination for a different programme" do
+            let(:patient) { create(:patient_session, session:).patient }
+
+            let(:other_programme) do
+              create(
+                :programme,
+                type: (Programme.types.values - programmes.map(&:type)).sample
+              )
+            end
+
+            let(:vaccination_record) do
+              create(
+                :vaccination_record,
+                programme: other_programme,
+                patient:,
+                session:
+              )
+            end
+
+            it { should be_blank }
+          end
+
           context "with a vaccinated patient that was updated in the date range" do
             let(:patient) { create(:patient_session, session:).patient }
             let(:start_date) { 1.day.ago }

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -113,6 +113,26 @@ describe Reports::SystmOneExporter do
     it { should_not be_blank }
   end
 
+  context "with vaccination records for a different programme" do
+    let(:other_programme) do
+      create(
+        :programme,
+        type: (Programme.types.values - [programme.type]).sample
+      )
+    end
+
+    let(:vaccination_record) do
+      create(
+        :vaccination_record,
+        programme: other_programme,
+        patient:,
+        session:
+      )
+    end
+
+    it { should be_blank }
+  end
+
   context "with a session in a different organisation" do
     let(:programme) do
       create(:programme, :hpv, organisations: [other_organisation])


### PR DESCRIPTION
When requesting a report, we should only be returning vaccination records for the programme the user requested the report for. At the moment, the programme is being ignored in the CarePlus report and we're instead returning all the vaccination records for the organisation.

I've also refactored the code to make it clearer where the vaccination records are coming from.