### PR TITLE
Reduce N+1 queries on school move index

### DIFF
--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -9,7 +9,14 @@ class SchoolMovesController < ApplicationController
   layout "full"
 
   def index
-    @pagy, @school_moves = pagy(policy_scope(SchoolMove).order(:updated_at))
+    school_moves =
+      policy_scope(SchoolMove).includes(
+        :school,
+        :organisation,
+        patient: :school
+      ).order(:updated_at)
+
+    @pagy, @school_moves = pagy(school_moves)
   end
 
   def show


### PR DESCRIPTION
By preloading the patient's school, and the school move's school, we avoid needing a query to the database for each school move rendered on this page.