### PR TITLE
Enable Splunk logging in qa

### DIFF
--- a/app/components/app_hosting_environment_component.rb
+++ b/app/components/app_hosting_environment_component.rb
@@ -43,6 +43,6 @@ class AppHostingEnvironmentComponent < ViewComponent::Base
   end
 
   def environment
-    pull_request ? "review" : ENV.fetch("SENTRY_ENVIRONMENT", "development")
+    pull_request ? "review" : Rails.configuration.deploy_env
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ Bundler.require(*Rails.groups)
 
 module ManageVaccinations
   class Application < Rails::Application
+    config.deploy_env = ENV.fetch("DEPLOY_ENV", ENV["RAILS_ENV"])
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -59,7 +59,7 @@ environments:
       rolling: recreate # Disables blue-green deployment for speed
     variables:
       RAILS_ENV: staging
-      SENTRY_ENVIRONMENT: preview
+      DEPLOY_ENV: preview
       MAVIS__HOST: "preview.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "preview.mavistesting.com"
       MAVIS__CIS2__ENABLED: false
@@ -73,7 +73,7 @@ environments:
       rolling: recreate # Disables blue-green deployment for speed
     variables:
       RAILS_ENV: staging
-      SENTRY_ENVIRONMENT: qa
+      DEPLOY_ENV: qa
       MAVIS__HOST: "qa.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "qa.mavistesting.com"
       MAVIS__CIS2__ENABLED: false
@@ -86,7 +86,7 @@ environments:
       rolling: recreate # Disables blue-green deployment for speed
     variables:
       RAILS_ENV: staging
-      SENTRY_ENVIRONMENT: test
+      DEPLOY_ENV: test
       MAVIS__HOST: "test.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "test.mavistesting.com"
   training:
@@ -98,7 +98,7 @@ environments:
       rolling: recreate # Disables blue-green deployment for speed
     variables:
       RAILS_ENV: staging
-      SENTRY_ENVIRONMENT: training
+      DEPLOY_ENV: training
       MAVIS__HOST: "training.manage-vaccinations-in-schools.nhs.uk"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "training.manage-vaccinations-in-schools.nhs.uk"
       MAVIS__CIS2__ENABLED: false
@@ -117,7 +117,6 @@ environments:
         - "give-or-refuse-consent-for-vaccinations.nhs.uk"
     variables:
       RAILS_ENV: production
-      SENTRY_ENVIRONMENT: production
       MAVIS__HOST: "www.manage-vaccinations-in-schools.nhs.uk"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "www.give-or-refuse-consent-for-vaccinations.nhs.uk"
   copilotmigration:
@@ -128,7 +127,7 @@ environments:
       rolling: recreate # Disables blue-green deployment for speed
     variables:
       RAILS_ENV: staging
-      SENTRY_ENVIRONMENT: copilotmigration
+      DEPLOY_ENV: copilotmigration
       MAVIS__HOST: "copilotmigration.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "copilotmigration.mavistesting.com"
       MAVIS__CIS2__ENABLED: false

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -78,7 +78,6 @@ environments:
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "qa.mavistesting.com"
       MAVIS__CIS2__ENABLED: false
       MAVIS__PDS__PERFORM_JOBS: false
-      MAVIS__SPLUNK__ENABLED: false
   test:
     http:
       alias:


### PR DESCRIPTION
This is particularly useful to investigate performance-related issues.