### PR TITLE
Avoid N+1 issue in vaccination criteria

### DIFF
--- a/app/jobs/vaccination_confirmations_job.rb
+++ b/app/jobs/vaccination_confirmations_job.rb
@@ -19,7 +19,7 @@ class VaccinationConfirmationsJob < ApplicationJob
       .kept
       .where("created_at >= ?", since)
       .where(confirmation_sent_at: nil)
-      .where.not(session_id: nil)
+      .recorded_in_service
       .select { _1.academic_year == academic_year }
       .each do |vaccation_record|
         send_vaccination_confirmation(vaccation_record)

--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -22,7 +22,7 @@ class VaccinatedCriteria
       administered_records.any? do
         (
           it.dose_sequence == programme.vaccinated_dose_sequence ||
-            (it.dose_sequence.nil? && it.session.present?)
+            (it.dose_sequence.nil? && it.recorded_in_service?)
         ) && patient.age(now: it.performed_at) >= 10
       end
     else

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -92,7 +92,7 @@ class VaccinationRecord < ApplicationRecord
   has_one :organisation, through: :session
   has_one :team, through: :session
 
-  scope :recorded_in_service, -> { where.not(session: nil) }
+  scope :recorded_in_service, -> { where.not(session_id: nil) }
   scope :unexported, -> { where.missing(:dps_exports) }
 
   scope :with_pending_changes,
@@ -161,6 +161,10 @@ class VaccinationRecord < ApplicationRecord
 
   def confirmation_sent?
     confirmation_sent_at != nil
+  end
+
+  def recorded_in_service?
+    session_id != nil
   end
 
   def dose_volume_ml


### PR DESCRIPTION
This avoids an N+1 issue when checking whether a patient is vaccinated by checking only if `session_id` is present rather than checking if `session` is present.

I've also tided up a few other places where we do this check in a scope for consistency.