### PR TITLE
Fix "Refused vaccine" label

### DIFF
--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -44,7 +44,7 @@ en:
         contraindications: Had contraindications
         none_yet: No outcome yet
         not_well: Unwell
-        refused: Vaccine refused
+        refused: Refused vaccine
       colour:
         absent_from_school: dark-orange
         absent_from_session: dark-orange

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -147,7 +147,7 @@ describe "Parental consent" do
 
   def and_the_session_outcome_is_could_not_vaccinate
     click_on "Session outcomes"
-    choose "Vaccine refused"
+    choose "Refused vaccine"
     click_on "Update results"
     expect(page).to have_content(@child.full_name)
   end


### PR DESCRIPTION
This updates the label to match the wording in the designs.