### PR TITLE
Set session outcome to absent from session

### DIFF
--- a/app/models/patient_session/register_outcome.rb
+++ b/app/models/patient_session/register_outcome.rb
@@ -56,6 +56,6 @@ class PatientSession::RegisterOutcome
   end
 
   def all_programmes_have_outcome?
-    programmes.none? { session_outcome.none_yet?(it) }
+    programmes.none? { session_outcome.latest[it].nil? }
   end
 end

--- a/app/models/patient_session/session_outcome.rb
+++ b/app/models/patient_session/session_outcome.rb
@@ -47,7 +47,11 @@ class PatientSession::SessionOutcome
 
   attr_reader :patient_session
 
-  delegate :patient, :session, :programmes, to: :patient_session
+  delegate :patient,
+           :programmes,
+           :register_outcome,
+           :session,
+           to: :patient_session
   delegate :consent_outcome, :triage_outcome, to: :patient
 
   def programme_status(programme)
@@ -57,6 +61,8 @@ class PatientSession::SessionOutcome
       REFUSED
     elsif triage_outcome.do_not_vaccinate?(programme)
       HAD_CONTRAINDICATIONS
+    elsif register_outcome.not_attending?
+      ABSENT_FROM_SESSION
     else
       NONE_YET
     end

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -17,6 +17,9 @@ describe "Manage attendance" do
     when_i_register_a_patient_as_absent
     then_i_see_the_absent_flash
 
+    when_i_go_to_the_session_outcomes
+    then_i_see_a_patient_is_absent
+
     when_i_go_to_a_patient
     then_the_patient_is_not_registered_yet
     and_i_am_not_able_to_vaccinate
@@ -87,7 +90,21 @@ describe "Manage attendance" do
     click_button "Absent", match: :first
   end
 
+  def when_i_go_to_the_session_outcomes
+    click_on "Session outcomes"
+  end
+
+  def then_i_see_a_patient_is_absent
+    choose "Absent from session"
+    click_on "Update results"
+
+    expect(page).to have_content("Showing 1 to 1 of 1 children")
+  end
+
   def when_i_go_to_a_patient
+    choose "Any"
+    click_on "Update results"
+
     click_link PatientSession
                  .where
                  .missing(:session_attendances)

--- a/spec/models/patient_session/session_outcome_spec.rb
+++ b/spec/models/patient_session/session_outcome_spec.rb
@@ -56,6 +56,12 @@ describe PatientSession::SessionOutcome do
 
       it { should be(described_class::HAD_CONTRAINDICATIONS) }
     end
+
+    context "when not attending the session" do
+      before { create(:session_attendance, :absent, patient_session:) }
+
+      it { should be(described_class::ABSENT_FROM_SESSION) }
+    end
   end
 
   describe "#all" do


### PR DESCRIPTION
If the patient's attendance has been marked as absent, the session outcome for that day should show as "absent from session".

Currently, the only way for a patient outcome to be "absent from session" would be if the vaccination was recorded as not administered for that reason, however we don't present "Absent from session" as one of the options available to the nurses. Instead, the expectation is that they would use the registration status.

In theory, you could import a vaccination record with this status, so we still need to support that, but it's not the usual way this would work.

Potentially we could remove "absent from school" and "absent from session" as vaccination record outcomes.