### PR TITLE
Remove "absent from school" outcome

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -241,8 +241,7 @@ class ImmunisationImportRow
     "unwell" => :not_well,
     "vaccination contraindicated" => :contraindications,
     "already had elsewhere" => :already_had,
-    "did not attend" => :absent_from_session,
-    "absent from school" => :absent_from_school
+    "did not attend" => :absent_from_session
   }.freeze
 
   def reason

--- a/app/models/patient_session/session_outcome.rb
+++ b/app/models/patient_session/session_outcome.rb
@@ -10,7 +10,6 @@ class PatientSession::SessionOutcome
     ALREADY_HAD = :already_had,
     HAD_CONTRAINDICATIONS = :contraindications,
     REFUSED = :refused,
-    ABSENT_FROM_SCHOOL = :absent_from_school,
     ABSENT_FROM_SESSION = :absent_from_session,
     UNWELL = :not_well,
     NONE_YET = :none_yet

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -126,7 +126,6 @@ class VaccinationRecord < ApplicationRecord
          not_well: 2,
          contraindications: 3,
          already_had: 4,
-         absent_from_school: 5,
          absent_from_session: 6
        },
        validate: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -412,7 +412,6 @@ en:
           right_arm_lower_position: Right arm (lower position)
           right_arm_upper_position: Right arm (upper position)
         outcomes:
-          absent_from_school: Absent from school
           absent_from_session: Absent from session
           administered: Vaccinated
           already_had: Already had the vaccine
@@ -785,7 +784,6 @@ en:
         will_be_vaccinated_elsewhere: they will be given the vaccine elsewhere
     vaccination_mailer:
       reasons_did_not_vaccinate:
-        absent_from_school: they were off school
         absent_from_session: they were not in the vaccination session
         already_had: they've already had the vaccine
         contraindications: they had contraindications

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -54,7 +54,6 @@ en:
         not_well: "%{full_name} was not well enough"
         contraindications: "%{full_name} had contraindications"
         already_had: "%{full_name} has already had the vaccine"
-        absent_from_school: "%{full_name} was absent from school"
         absent_from_session: "%{full_name} was absent from the session"
         gave_consent: "Their %{who_responded} gave consent"
         triaged_do_not_vaccinate: "Do not vaccinate in programme"

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -37,7 +37,6 @@ en:
         unknown: grey
     session:
       label:
-        absent_from_school: Absent from school
         absent_from_session: Absent from session
         administered: Vaccinated
         already_had: Already had vaccine
@@ -46,7 +45,6 @@ en:
         not_well: Unwell
         refused: Refused vaccine
       colour:
-        absent_from_school: dark-orange
         absent_from_session: dark-orange
         administered: green
         already_had: green

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1074,8 +1074,7 @@ describe ImmunisationImportRow do
       "unwell" => :not_well,
       "vaccination contraindicated" => :contraindications,
       "already had elsewhere" => :already_had,
-      "did not attend" => :absent_from_session,
-      "absent from school" => :absent_from_school
+      "did not attend" => :absent_from_session
     }.each do |input_reason, expected_enum|
       context "with reason '#{input_reason}'" do
         let(:data) do


### PR DESCRIPTION
We don't allow this outcome to be set by the nurses in the UI, only via uploading vaccination records. Typically, we would expect registration status to happen before the vaccination records are recorded, and either way we still have the "absent from session" outcome to support that.