### PR TITLE
Update design of patient session table

### DIFF
--- a/app/components/app_patient_session_table_component.rb
+++ b/app/components/app_patient_session_table_component.rb
@@ -7,8 +7,8 @@ class AppPatientSessionTableComponent < ViewComponent::Base
         <% table.with_head do |head| %>
           <% head.with_row do |row| %>
             <% row.with_cell(text: "Location") %>
+            <% row.with_cell(text: "Session dates") %>
             <% row.with_cell(text: "Programme") %>
-            <% row.with_cell(text: "Academic year") %>
           <% end %>
         <% end %>
     
@@ -23,13 +23,17 @@ class AppPatientSessionTableComponent < ViewComponent::Base
                 <% end %>
       
                 <% row.with_cell do %>
-                  <span class="nhsuk-table-responsive__heading">Programme</span>
-                  <%= render AppProgrammeTagsComponent.new([programme]) %>
+                  <span class="nhsuk-table-responsive__heading">Session dates</span>
+                  <ul class="nhsuk-list app-list--spaced">
+                    <% patient_session.session.dates.each do |date| %>
+                      <li><%= date.to_fs(:long) %></li>
+                    <% end %>
+                  </ul>
                 <% end %>
       
                 <% row.with_cell do %>
-                  <span class="nhsuk-table-responsive__heading">Academic year</span>
-                  <%= helpers.session_academic_year(patient_session.session) %>
+                  <span class="nhsuk-table-responsive__heading">Programme</span>
+                  <%= render AppProgrammeTagsComponent.new([programme]) %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 module SessionsHelper
-  def session_academic_year(session)
-    academic_year = session.academic_year
-
-    year_1 = academic_year.to_s
-    year_2 = (academic_year + 1).to_s
-    "#{year_1}/#{year_2[2..3]}"
-  end
-
   def session_consent_period(session, in_sentence:)
     if session.close_consent_at.nil?
       in_sentence ? "not provided" : "Not provided"

--- a/spec/components/app_patient_session_table_component_spec.rb
+++ b/spec/components/app_patient_session_table_component_spec.rb
@@ -15,17 +15,23 @@ describe AppPatientSessionTableComponent do
     let(:location) { create(:school, name: "Waterloo Road") }
     let(:programme) { create(:programme, :hpv) }
     let(:session) do
-      create(:session, academic_year: 2024, location:, programmes: [programme])
+      create(
+        :session,
+        location:,
+        programmes: [programme],
+        academic_year: 2024,
+        date: Date.new(2025, 1, 1)
+      )
     end
 
     let(:patient_sessions) { create_list(:patient_session, 1, session:) }
 
     it { should have_content("Location") }
+    it { should have_content("Session dates") }
     it { should have_content("Programme") }
-    it { should have_content("Academic year") }
 
     it { should have_link("Waterloo Road") }
+    it { should have_content("1 January 2025") }
     it { should have_content("HPV") }
-    it { should have_content("2024/25") }
   end
 end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -5,12 +5,6 @@ describe SessionsHelper do
   let(:date) { nil }
   let(:session) { create(:session, academic_year: 2024, date:, location:) }
 
-  describe "#session_academic_year" do
-    subject(:session_academic_year) { helper.session_academic_year(session) }
-
-    it { should eq("2024/25") }
-  end
-
   describe "#session_consent_period" do
     subject(:session_consent_period) do
       helper.session_consent_period(session, in_sentence:)


### PR DESCRIPTION
This updates the design of the table of sessions shown on the patient page to match the latest designs in the prototype.

## Screenshot

<img width="775" alt="Screenshot 2025-03-18 at 10 41 42" src="https://github.com/user-attachments/assets/0a514622-b21e-410e-85b8-1340cc634257" />
