### PR TITLE
Update session activity log entry

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -184,8 +184,9 @@ class AppActivityLogComponent < ViewComponent::Base
     patient_sessions.map do |patient_session|
       [
         {
-          title: "Added to session at #{patient_session.location.name}",
-          at: patient_session.created_at
+          title: "Invited to the session at #{patient_session.location.name}",
+          at: patient_session.created_at,
+          programmes: programmes_for(patient_session)
         }
       ]
     end
@@ -255,8 +256,13 @@ class AppActivityLogComponent < ViewComponent::Base
   end
 
   def programmes_for(object)
-    ids = object.try(:programme_ids) || [object.try(:programme_id)].compact
-    ids.map { programmes_by_id.fetch(it) }
+    if object.respond_to?(:programme_ids)
+      object.programme_ids.map { programmes_by_id.fetch(it) }
+    elsif object.respond_to?(:programme_id)
+      [programmes_by_id.fetch(object.programme_id)]
+    else
+      object.programmes
+    end
   end
 
   def programmes_by_id

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -183,7 +183,7 @@ describe AppActivityLogComponent do
                      programme: "HPV"
 
     include_examples "card",
-                     title: "Added to session at Hogwarts",
+                     title: "Invited to the session at Hogwarts",
                      date: "29 May 2024 at 12:00pm"
 
     include_examples "card",

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -225,7 +225,7 @@ describe "Manage children" do
   end
 
   def then_i_see_the_activity_log
-    expect(page).to have_content("Added to session")
+    expect(page).to have_content("Invited to the session")
     expect(page).to have_content("Vaccinated")
   end
 


### PR DESCRIPTION
This updates the design of the activity log entry where the patient is added to the session to match how it looks in the prototype.

## Screenshot

<img width="777" alt="Screenshot 2025-03-18 at 10 59 08" src="https://github.com/user-attachments/assets/76faa646-ca46-4954-9b13-656011be05a7" />
