### PR TITLE
Validate individual pre-screening questions

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -121,9 +121,5 @@
 <% end %>
 
 <% if helpers.policy(VaccinationRecord).create? %>
-  <%= render AppVaccinateFormComponent.new(
-        patient_session:,
-        programme:,
-        vaccinate_form:,
-      ) %>
+  <%= render AppVaccinateFormComponent.new(vaccinate_form) %>
 <% end %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -65,6 +65,8 @@ class AppPatientPageComponent < ViewComponent::Base
         .first
 
     VaccinateForm.new(
+      patient_session:,
+      programme:,
       feeling_well: pre_screening&.feeling_well,
       not_pregnant: pre_screening&.not_pregnant
     )

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -12,20 +12,30 @@
       <%= patient.given_name %> has confirmed that they:
     </h2>
 
-    <%= f.govuk_check_boxes_fieldset :pre_screening, multiple: false, legend: nil do %>
+    <%= f.govuk_check_boxes_fieldset :knows_vaccination, multiple: false, legend: nil do %>
       <%= f.govuk_check_box :knows_vaccination, true, multiple: false, link_errors: true %>
+    <% end %>
 
+    <%= f.govuk_check_boxes_fieldset :not_already_had, multiple: false, legend: nil do %>
       <%= f.govuk_check_box :not_already_had, true, multiple: false, link_errors: true %>
+    <% end %>
 
+    <%= f.govuk_check_boxes_fieldset :feeling_well, multiple: false, legend: nil do %>
       <%= f.govuk_check_box :feeling_well, true, multiple: false, link_errors: true %>
+    <% end %>
 
+    <%= f.govuk_check_boxes_fieldset :no_allergies, multiple: false, legend: nil do %>
       <%= f.govuk_check_box :no_allergies, true, multiple: false, link_errors: true %>
+    <% end %>
 
-      <% if PreScreening.ask_not_taking_medication?(programme:) %>
+    <% if vaccinate_form.ask_not_taking_medication? %>
+      <%= f.govuk_check_boxes_fieldset :not_taking_medication, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :not_taking_medication, true, multiple: false, link_errors: true %>
       <% end %>
+    <% end %>
 
-      <% if PreScreening.ask_not_pregnant?(programme:) %>
+    <% if vaccinate_form.ask_not_pregnant? %>
+      <%= f.govuk_check_boxes_fieldset :not_pregnant, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :not_pregnant, true, multiple: false, link_errors: true %>
       <% end %>
     <% end %>
@@ -54,7 +64,6 @@
 
     <%= f.hidden_field :delivery_method, value: delivery_method %>
     <%= f.hidden_field :dose_sequence, value: dose_sequence %>
-    <%= f.hidden_field :programme_id, value: programme.id %>
     <%= f.hidden_field :vaccine_id, value: vaccine.id %>
 
     <%= f.govuk_submit "Continue" %>

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 class AppVaccinateFormComponent < ViewComponent::Base
-  def initialize(patient_session:, programme:, vaccinate_form:)
+  def initialize(vaccinate_form)
     super
 
-    @patient_session = patient_session
-    @programme = programme
     @vaccinate_form = vaccinate_form
   end
 
@@ -19,8 +17,9 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   private
 
-  attr_reader :patient_session, :programme, :vaccinate_form
+  attr_reader :vaccinate_form
 
+  delegate :patient_session, :programme, to: :vaccinate_form
   delegate :patient, :session, to: :patient_session
 
   def url

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -17,8 +17,9 @@ class VaccinationsController < ApplicationController
 
     @vaccinate_form =
       VaccinateForm.new(
-        patient_session: @patient_session,
         current_user:,
+        patient_session: @patient_session,
+        programme: @programme,
         todays_batch: @todays_batch,
         **vaccinate_form_params
       )
@@ -61,7 +62,6 @@ class VaccinationsController < ApplicationController
         not_pregnant
         not_taking_medication
         pre_screening_notes
-        programme_id
         vaccine_id
       ]
     )

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -4,7 +4,7 @@ class VaccinateForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :patient_session, :current_user, :todays_batch
+  attr_accessor :patient_session, :programme, :current_user, :todays_batch
 
   attribute :knows_vaccination, :boolean
   attribute :not_already_had, :boolean
@@ -18,18 +18,23 @@ class VaccinateForm
   attribute :delivery_method, :string
   attribute :delivery_site, :string
   attribute :dose_sequence, :integer
-  attribute :programme_id, :integer
   attribute :vaccine_id, :integer
 
-  validates :knows_vaccination, inclusion: { in: [true, nil] }
-  validates :not_already_had, inclusion: { in: [true, nil] }
-  validates :feeling_well, inclusion: { in: [true, nil] }
-  validates :no_allergies, inclusion: { in: [true, nil] }
-  validates :not_taking_medication, inclusion: { in: [true, nil] }
-  validates :not_pregnant, inclusion: { in: [true, nil] }
+  validates :administered, inclusion: [true, false]
 
-  validate :valid_administered_values
-  validates :programme_id, presence: true
+  with_options if: :administered do
+    validates :knows_vaccination, presence: true
+    validates :not_already_had, presence: true
+    validates :no_allergies, presence: true
+  end
+
+  with_options if: -> { administered && ask_not_taking_medication? } do
+    validates :not_taking_medication, presence: true
+  end
+
+  with_options if: -> { administered && ask_not_pregnant? } do
+    validates :not_pregnant, presence: true
+  end
 
   with_options if: :administered do
     validates :delivery_method, presence: true
@@ -59,11 +64,19 @@ class VaccinateForm
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user
     draft_vaccination_record.performed_ods_code = organisation.ods_code
-    draft_vaccination_record.programme_id = programme_id
+    draft_vaccination_record.programme = programme
     draft_vaccination_record.session_id = patient_session.session_id
     draft_vaccination_record.vaccine_id = vaccine_id
 
     draft_vaccination_record.save # rubocop:disable Rails/SaveBang
+  end
+
+  def ask_not_taking_medication?
+    programme.doubles?
+  end
+
+  def ask_not_pregnant?
+    programme.hpv? || programme.td_ipv?
   end
 
   private
@@ -81,25 +94,12 @@ class VaccinateForm
         not_taking_medication: not_taking_medication || false,
         notes: pre_screening_notes,
         performed_by: current_user,
-        programme_id:,
+        programme:,
         session_date_id:
       )
   end
 
   def session_date_id
     patient_session.session.session_dates.today.first&.id
-  end
-
-  def valid_administered_values
-    if administered.nil?
-      errors.add(:administered, "Choose if they are ready to vaccinate")
-    end
-
-    vaccination_allowed =
-      pre_screening.invalid? || pre_screening.allows_vaccination?
-
-    if administered && !vaccination_allowed
-      errors.add(:administered, "Patient should not be vaccinated")
-    end
   end
 end

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -46,30 +46,4 @@ class PreScreening < ApplicationRecord
   has_one :patient, through: :patient_session
 
   encrypts :notes
-
-  validates :knows_vaccination,
-            :not_already_had,
-            :feeling_well,
-            :no_allergies,
-            :not_taking_medication,
-            :not_pregnant,
-            inclusion: {
-              in: [true, false]
-            }
-
-  def allows_vaccination?
-    knows_vaccination && not_already_had && no_allergies &&
-      (
-        !PreScreening.ask_not_taking_medication?(programme:) ||
-          not_taking_medication
-      ) && (!PreScreening.ask_not_pregnant?(programme:) || not_pregnant)
-  end
-
-  def self.ask_not_taking_medication?(programme:)
-    programme.doubles?
-  end
-
-  def self.ask_not_pregnant?(programme:)
-    programme.hpv? || programme.td_ipv?
-  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,8 +108,22 @@ en:
               inclusion: You cannot remove a programme from the session once it has been added
         vaccinate_form:
           attributes:
+            administered:
+              inclusion: Choose if they are ready to vaccinate
             delivery_site:
               blank: Choose where the injection will be given
+            feeling_well:
+              blank: Confirm that they are feeling well
+            knows_vaccination:
+              blank: Confirm that they know what the vaccination is for, and are happy to have it
+            no_allergies:
+              blank: Confirm that they have no allergies which would prevent vaccination
+            not_already_had:
+              blank: Confirm that they have not already had the vaccination
+            not_pregnant:
+              blank: Confirm that they are not pregnant
+            not_taking_medication:
+              blank: Confirm that they are not taking any medication which prevents vaccination
         vaccination_report:
           attributes:
             file_format:

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -19,13 +19,11 @@ describe AppVaccinateFormComponent do
     create(:patient_session, :in_attendance, programmes:, patient:, session:)
   end
 
-  let(:component) do
-    described_class.new(
-      patient_session:,
-      programme: programmes.first,
-      vaccinate_form: VaccinateForm.new
-    )
+  let(:vaccinate_form) do
+    VaccinateForm.new(patient_session:, programme: programmes.first)
   end
+
+  let(:component) { described_class.new(vaccinate_form) }
 
   before { patient_session.strict_loading!(false) }
 

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -53,6 +53,8 @@ describe "HPV vaccination" do
   end
 
   def then_i_see_an_error_message
-    expect(page).to have_content("Patient should not be vaccinated")
+    expect(page).to have_content(
+      "Confirm that they have not already had the vaccination"
+    )
   end
 end

--- a/spec/models/pre_screening_spec.rb
+++ b/spec/models/pre_screening_spec.rb
@@ -37,34 +37,12 @@ describe PreScreening do
   subject(:pre_screening) { build(:pre_screening) }
 
   describe "validations" do
-    it { should allow_values(true, false).for(:knows_vaccination) }
-    it { should allow_values(true, false).for(:not_already_had) }
     it { should allow_values(true, false).for(:feeling_well) }
+    it { should allow_values(true, false).for(:knows_vaccination) }
     it { should allow_values(true, false).for(:no_allergies) }
+    it { should allow_values(true, false).for(:not_already_had) }
+    it { should allow_values(true, false).for(:not_pregnant) }
+    it { should allow_values(true, false).for(:not_taking_medication) }
     it { should_not validate_presence_of(:notes) }
-  end
-
-  describe "#allows_vaccination?" do
-    subject(:allows_vaccination?) { pre_screening.allows_vaccination? }
-
-    context "when allows vaccination" do
-      let(:pre_screening) { create(:pre_screening, :allows_vaccination) }
-
-      it { should be(true) }
-
-      context "and the patient is feeling unwell" do
-        let(:pre_screening) do
-          create(:pre_screening, :allows_vaccination, feeling_well: false)
-        end
-
-        it { should be(true) }
-      end
-    end
-
-    context "when prevents vaccination" do
-      let(:pre_screening) { create(:pre_screening, :prevents_vaccination) }
-
-      it { should be(false) }
-    end
   end
 end


### PR DESCRIPTION
When recording a vaccination, this ensures that each answer to the pre-screening questions is validated individually so the user understands why a child cannot be vaccinated if the pre-screening requirements are not valid.

## Screenshot

<img width="758" alt="Screenshot 2025-03-18 at 13 16 31" src="https://github.com/user-attachments/assets/82547b16-9a49-41eb-b9b3-753a912f5a5a" />
