### PR TITLE
Update change link for parents in consent journey

### DIFF
--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -78,10 +78,7 @@ class DraftConsent
               end
             }
 
-  with_options if: -> do
-                 parent_id.nil? &&
-                   required_for_step?(:parent_details, exact: true)
-               end do
+  with_options if: -> { required_for_step?(:parent_details, exact: true) } do
     validates :parent_full_name, presence: true
     validates :parent_relationship_type,
               inclusion: {
@@ -90,7 +87,7 @@ class DraftConsent
   end
 
   with_options if: -> do
-                 parent_id.nil? && parent_relationship_type == "other" &&
+                 parent_relationship_type == "other" &&
                    required_for_step?(:parent_details, exact: true)
                end do
     validates :parent_relationship_other_name,
@@ -199,6 +196,7 @@ class DraftConsent
     self.parent_phone_receive_updates = value&.phone_receive_updates
     self.parent_relationship_type = parent_relationship&.type
     self.parent_relationship_other_name = parent_relationship&.other_name
+    self.parent_responsibility = true # if consent was submitted this must've been true
   end
 
   def patient_session

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -26,8 +26,8 @@
 
 <% if (parent_relationship = @draft_consent.parent_relationship).present? %>
   <%= render AppParentCardComponent.new(parent_relationship:, change_links: {
-                                          name: wizard_path("who"),
-                                          relationship: wizard_path("who"),
+                                          name: wizard_path("parent-details"),
+                                          relationship: wizard_path("parent-details"),
                                           email: wizard_path("parent-details"),
                                           phone: wizard_path("parent-details"),
                                         }) %>

--- a/app/views/draft_consents/parent_details.html.erb
+++ b/app/views/draft_consents/parent_details.html.erb
@@ -18,33 +18,31 @@
 <%= form_with model: @draft_consent, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <% if @parent.new_record? %>
-    <%= f.govuk_text_field :parent_full_name, label: { text: "Full name" } %>
+  <%= f.govuk_text_field :parent_full_name, label: { text: "Full name" } %>
 
-    <%= f.govuk_radio_buttons_fieldset(:parent_relationship_type,
-                                       legend: { size: "s",
-                                                 text: "Relationship to the child" }) do %>
-      <%= f.govuk_radio_button :parent_relationship_type, "mother",
-                               label: { text: "Mum" }, link_errors: true %>
-      <%= f.govuk_radio_button :parent_relationship_type, "father",
-                               label: { text: "Dad" } %>
-      <%= f.govuk_radio_button :parent_relationship_type, "guardian",
-                               label: { text: "Guardian" } %>
-      <%= f.govuk_radio_button :parent_relationship_type, "other",
-                               label: { text: "Other" } do %>
-        <p>They need parental responsibility to give consent.</p>
-        <%= f.govuk_text_field :parent_relationship_other_name,
-                               label: { text: "Relationship to the child" },
-                               hint: { text: "For example, carer" } %>
-        <%= f.govuk_radio_buttons_fieldset(:parent_responsibility,
-                                           legend: { size: "s",
-                                                     text: "Do they have parental responsibility?" },
-                                           hint: { text: "They have the legal rights and duties relating to the child" }) do %>
-          <%= f.govuk_radio_button :parent_responsibility, "yes",
-                                   label: { text: "Yes" }, link_errors: true %>
-          <%= f.govuk_radio_button :parent_responsibility, "no",
-                                   label: { text: "No" } %>
-        <% end %>
+  <%= f.govuk_radio_buttons_fieldset(:parent_relationship_type,
+                                     legend: { size: "s",
+                                               text: "Relationship to the child" }) do %>
+    <%= f.govuk_radio_button :parent_relationship_type, "mother",
+                             label: { text: "Mum" }, link_errors: true %>
+    <%= f.govuk_radio_button :parent_relationship_type, "father",
+                             label: { text: "Dad" } %>
+    <%= f.govuk_radio_button :parent_relationship_type, "guardian",
+                             label: { text: "Guardian" } %>
+    <%= f.govuk_radio_button :parent_relationship_type, "other",
+                             label: { text: "Other" } do %>
+      <p>They need parental responsibility to give consent.</p>
+      <%= f.govuk_text_field :parent_relationship_other_name,
+                             label: { text: "Relationship to the child" },
+                             hint: { text: "For example, carer" } %>
+      <%= f.govuk_radio_buttons_fieldset(:parent_responsibility,
+                                         legend: { size: "s",
+                                                   text: "Do they have parental responsibility?" },
+                                         hint: { text: "They have the legal rights and duties relating to the child" }) do %>
+        <%= f.govuk_radio_button :parent_responsibility, "yes",
+                                 label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :parent_responsibility, "no",
+                                 label: { text: "No" } %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/features/verbal_consent_change_answers_spec.rb
+++ b/spec/features/verbal_consent_change_answers_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe "Verbal consent" do
+  scenario "Change answers" do
+    given_a_patient_is_in_an_hpv_programme
+
+    when_i_get_consent_for_the_patient
+    and_i_choose_the_parent
+    and_i_fill_out_the_consent_details(parent_name: @parent.full_name)
+    then_i_see_the_confirmation_page
+
+    when_i_click_on_change_name
+    and_i_fill_out_the_consent_details(parent_name: "New parent name")
+    then_i_see_the_confirmation_page
+  end
+
+  def given_a_patient_is_in_an_hpv_programme
+    programmes = [create(:programme, :hpv)]
+    organisation = create(:organisation, programmes:)
+
+    @nurse = create(:nurse, organisation:)
+
+    @session = create(:session, organisation:, programmes:)
+
+    @parent = create(:parent)
+    @patient = create(:patient, session: @session, parents: [@parent])
+  end
+
+  def when_i_get_consent_for_the_patient
+    sign_in @nurse
+    visit session_consent_path(@session)
+    click_link @patient.full_name
+    click_button "Get consent"
+  end
+
+  def and_i_choose_the_parent
+    click_button "Continue"
+    expect(page).to have_content(
+      "Choose who you are trying to get consent from"
+    )
+
+    choose "#{@parent.full_name} (#{@patient.parent_relationships.first.label})"
+    click_button "Continue"
+  end
+
+  def and_i_fill_out_the_consent_details(parent_name:)
+    expect(page).to have_content(
+      "Details for #{parent_name} (#{@patient.parent_relationships.first.label})"
+    )
+
+    fill_in "Full name", with: "New parent name"
+    click_button "Continue"
+
+    choose "By phone"
+    click_button "Continue"
+
+    choose "Yes, they agree"
+    click_button "Continue"
+
+    find_all(".nhsuk-fieldset")[0].choose "No"
+    find_all(".nhsuk-fieldset")[1].choose "No"
+    find_all(".nhsuk-fieldset")[2].choose "No"
+    find_all(".nhsuk-fieldset")[3].choose "No"
+    click_button "Continue"
+
+    choose "Yes, it’s safe to vaccinate"
+    click_button "Continue"
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content("Check and confirm answers")
+  end
+
+  def when_i_click_on_change_name
+    click_link "Change name"
+  end
+end


### PR DESCRIPTION
This fixes the change link for the parent when recording consent to the right place ensuring that the user isn't taken back to the beginning of the journey where they have start the process again.