### PR TITLE
Create and destroy infrastructure pipelines

### DIFF
--- a/.github/workflows/destroy_infrastructure.yml
+++ b/.github/workflows/destroy_infrastructure.yml
@@ -1,0 +1,81 @@
+name: Destroy Infrastructure
+run-name: Destroy Infrastructure for ${{ inputs.environment }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to be Destroyed"
+        required: true
+        type: choice
+        options:
+          - qa
+          - poc
+          - copilotmigration
+          - test
+          - preview
+          - training
+
+env:
+  aws_role: 'arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure'
+  tf_dir: terraform/app
+        
+jobs:
+  DestroyTerraformResources:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+      - name: Ensure DB cluster can be deleted
+        working-directory: ${{ env.tf_dir }}
+        run: |
+          set -e
+          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
+          if terraform state list | grep -q 'aws_rds_cluster.aurora_cluster'; then
+            echo "DB cluster exsits: removing delete protection"
+            terraform apply -var-file="env/${{ inputs.environment }}.tfvars" \
+            -var="db_delete_protection=false" -var="image_digest=notneededfortargetedapply" \
+            -target=aws_rds_cluster.aurora_cluster -auto-approve
+            echo "DB cluster delete protection removed: proceeding to delete stage"
+          else 
+            echo "DB cluster not in state: proceeding to delete stage"
+          fi
+
+      - name: Delete cluster
+        working-directory: ${{ env.tf_dir }}
+        run: | 
+          terraform destroy -var-file="env/${{ inputs.environment }}.tfvars" \
+          -var="image_digest=notneededfordestroy" -auto-approve
+  DestroyTerraformBackend:
+    runs-on: ubuntu-latest
+    needs: DestroyTerraformResources
+    permissions:
+      id-token: write
+    environment: ${{ inputs.environment }}
+    steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.aws_role }}
+        aws-region: eu-west-2
+    - name: Install AWS CLI
+      run: |
+        sudo snap install --classic aws-cli
+    - name: Delete terraform backend elements
+      run: |
+        TF_STATE_FILE=nhse-mavis-terraform-state/terraform-${{ inputs.environment }}.tfstate
+        aws s3 rm s3://$TF_STATE_FILE
+        aws dynamodb delete-item --table-name mavis-terraform-state-lock \
+        --key "{\"LockID\": {\"S\": \"$TF_STATE_FILE-md5\"}}"

--- a/terraform/app/codedeploy.tf
+++ b/terraform/app/codedeploy.tf
@@ -59,14 +59,14 @@ resource "aws_s3_bucket" "code_deploy_bucket" {
 
 
 data "aws_s3_bucket" "logs" {
-  bucket = "nhse-mavis-logs-${var.environment}"
+  bucket = var.access_logs_bucket
 }
 
 resource "aws_s3_bucket_logging" "example" {
   bucket = aws_s3_bucket.code_deploy_bucket.id
 
   target_bucket = data.aws_s3_bucket.logs.id
-  target_prefix = "codedeploy-log/"
+  target_prefix = "codedeploy-log-${var.environment}/"
 }
 
 resource "aws_s3_bucket_versioning" "code_deploy_bucket_versioning" {

--- a/terraform/app/env/copilotmigration-backend.hcl
+++ b/terraform/app/env/copilotmigration-backend.hcl
@@ -1,4 +1,4 @@
-bucket         = "nhse-mavis-terraform-state-copilotmigration"
+bucket         = "nhse-mavis-terraform-state"
 key            = "terraform-copilotmigration.tfstate"
 region         = "eu-west-2"
-dynamodb_table = "mavis-state-lock-copilotmigration"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/app/env/copilotmigration.tfvars
+++ b/terraform/app/env/copilotmigration.tfvars
@@ -1,7 +1,7 @@
-environment = "copilotmigration"
+environment           = "copilotmigration"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-db_secret_arn       = "arn:aws:secretsmanager:eu-west-2:393416225559:secret:dbAuroraSecret-zdVWVjrfgplI-7RGaPm"
-dns_certificate_arn = ["arn:aws:acm:eu-west-2:393416225559:certificate/2936cd40-34df-40b9-a902-f77be4edb05e"]
+db_secret_arn         = "arn:aws:secretsmanager:eu-west-2:393416225559:secret:dbAuroraSecret-zdVWVjrfgplI-7RGaPm"
+dns_certificate_arn   = ["arn:aws:acm:eu-west-2:393416225559:certificate/2936cd40-34df-40b9-a902-f77be4edb05e"]
 resource_name = {
   dbsubnet_group           = "mavis-copilotmigration-addonsstack-an4d9pidj1qd-dbdbsubnetgroup-il53a9jq9xg1"
   db_cluster               = "mavis-copilotmigration-addonsstack-an4-dbdbcluster-jrv5mrfo45rl"
@@ -15,7 +15,8 @@ http_hosts = {
   MAVIS__HOST                        = "copilotmigration.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "copilotmigration.mavistesting.com"
 }
-splunk_enabled = "false"
-cis2_enabled   = "false"
-pds_enabled    = "false"
-minimum_replicas = 3
+splunk_enabled       = "false"
+cis2_enabled         = "false"
+pds_enabled          = "false"
+minimum_replicas     = 3
+db_delete_protection = true

--- a/terraform/app/env/poc-backend.hcl
+++ b/terraform/app/env/poc-backend.hcl
@@ -1,4 +1,4 @@
-bucket         = "nhse-mavis-terraform-state-poc"
+bucket         = "nhse-mavis-terraform-state"
 key            = "terraform-poc.tfstate"
 region         = "eu-west-2"
-dynamodb_table = "mavis-state-lock-poc"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/app/env/poc.tfvars
+++ b/terraform/app/env/poc.tfvars
@@ -1,7 +1,7 @@
-environment         = "poc"
+environment           = "poc"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-db_secret_arn       = null
-dns_certificate_arn = null
+db_secret_arn         = null
+dns_certificate_arn   = null
 resource_name = {
   dbsubnet_group           = "mavis-poc-rds-subnet"
   db_cluster               = "mavis-poc-rds-cluster"
@@ -15,3 +15,4 @@ http_hosts = {
   MAVIS__HOST                        = "poc.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "poc.mavistesting.com"
 }
+db_delete_protection = true

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -22,4 +22,5 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "preview.mavistesting.com"
 }
 
-minimum_replicas = 3
+minimum_replicas     = 3
+db_delete_protection = true

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -28,3 +28,4 @@ vpc_log_retention_days  = 14
 ecs_log_retention_days  = 30
 backup_retention_period = 7
 ssl_policy              = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+db_delete_protection    = true

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -21,4 +21,5 @@ http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "qa.mavistesting.com"
 }
-minimum_replicas = 3
+minimum_replicas     = 3
+db_delete_protection = true

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -21,4 +21,5 @@ http_hosts = {
   MAVIS__HOST                        = "test.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "test.mavistesting.com"
 }
-minimum_replicas = 3
+minimum_replicas     = 3
+db_delete_protection = true

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -24,4 +24,5 @@ http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "training.manage-vaccinations-in-schools.nhs.uk"
 }
-minimum_replicas = 3
+minimum_replicas     = 3
+db_delete_protection = true

--- a/terraform/app/loadbalancer.tf
+++ b/terraform/app/loadbalancer.tf
@@ -62,8 +62,8 @@ resource "aws_lb" "app_lb" {
   internal           = false
   load_balancer_type = "application"
   access_logs {
-    bucket  = "nhse-mavis-logs-${var.environment}"
-    prefix  = "lb-access-logs"
+    bucket  = var.access_logs_bucket
+    prefix  = "lb-access-logs-${var.environment}"
     enabled = true
   }
   security_groups = [aws_security_group.lb_service_sg.id]
@@ -139,8 +139,8 @@ resource "aws_lb_listener" "app_listener_https" {
 }
 
 resource "aws_lb_listener_certificate" "https_sni_certificates" {
-  count = length(local.additional_sni_certificates)
-  listener_arn = aws_lb_listener.app_listener_https.arn
+  count           = length(local.additional_sni_certificates)
+  listener_arn    = aws_lb_listener.app_listener_https.arn
   certificate_arn = local.additional_sni_certificates[count.index]
 }
 

--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -57,7 +57,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   skip_final_snapshot         = !local.is_production
   db_subnet_group_name        = aws_db_subnet_group.aurora_subnet_group.name
   vpc_security_group_ids      = [aws_security_group.rds_security_group.id]
-  deletion_protection         = true
+  deletion_protection         = var.db_delete_protection
 
   serverlessv2_scaling_configuration {
     max_capacity = 8.0

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -17,6 +17,12 @@ variable "environment" {
   }
 }
 
+variable "access_logs_bucket" {
+  type        = string
+  default     = "nhse-mavis-access-logs"
+  description = "Name of the S3 bucket which stores access logs for various resources"
+}
+
 variable "account_id" {
   type        = string
   default     = "393416225559"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -49,7 +49,7 @@ variable "ssl_policy" {
 
 locals {
   unique_host_headers = toset(values(var.http_hosts))
-  host_headers = concat(tolist(local.unique_host_headers), [for v in local.unique_host_headers : "www.${v}"])
+  host_headers        = concat(tolist(local.unique_host_headers), [for v in local.unique_host_headers : "www.${v}"])
 }
 
 variable "dns_certificate_arn" {
@@ -58,7 +58,7 @@ variable "dns_certificate_arn" {
 }
 
 locals {
-  default_certificate_arn = var.dns_certificate_arn == null ? module.dns_route53[0].certificate_arn : var.dns_certificate_arn[0]
+  default_certificate_arn     = var.dns_certificate_arn == null ? module.dns_route53[0].certificate_arn : var.dns_certificate_arn[0]
   additional_sni_certificates = var.dns_certificate_arn == null ? [] : slice(var.dns_certificate_arn, 1, length(var.dns_certificate_arn))
 }
 
@@ -216,6 +216,12 @@ variable "backup_retention_period" {
   type        = number
   default     = 7
   description = "The number of days to retain backups for the RDS cluster."
+}
+
+variable "db_delete_protection" {
+  type        = bool
+  default     = true
+  description = "Boolean of whether the aurora cluster should have delete protection enabled"
 }
 
 ########## ESC/Scaling Configuration ##########

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -18,7 +18,7 @@ provider "aws" {
 
 #### S3 bucket to store the terraform state
 resource "aws_s3_bucket" "s3_bucket_backend" {
-  bucket = "nhse-mavis-terraform-state-${var.environment}"
+  bucket = "nhse-mavis-terraform-state"
 }
 
 resource "aws_s3_bucket_ownership_controls" "s3_bucket_acl_ownership" {

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -90,7 +90,7 @@ resource "aws_s3_bucket_logging" "backend_bucket_logging" {
 
 ##### Set up a logging bucket
 resource "aws_s3_bucket" "logs" {
-  bucket = "nhse-mavis-logs-${var.environment}"
+  bucket = "nhse-mavis-access-logs"
 }
 
 resource "aws_s3_bucket_versioning" "log_bucket_version" {
@@ -144,8 +144,9 @@ resource "aws_s3_bucket_policy" "logs" {
   })
 }
 
+#### Dynamo DB table for terraform state locking
 resource "aws_dynamodb_table" "dynamodb_lock_table" {
-  name         = "mavis-state-lock-${var.environment}"
+  name         = "mavis-terraform-state-lock"
   hash_key     = "LockID"
   billing_mode = "PAY_PER_REQUEST"
 

--- a/terraform/scripts/bootstrap.sh
+++ b/terraform/scripts/bootstrap.sh
@@ -92,14 +92,14 @@ EOF
 environment           = "$ENV"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 db_secret_arn         = null
-db_secret_arn         = null
+dns_certificate_arn   = null
 resource_name = {
-  dbsubnet_group     = "mavis-$ENV-rds-subnet"
-  db_cluster         = "mavis-$ENV-rds-cluster"
-  db_instance        = "mavis-$ENV-rds-instance"
-  rds_security_group = "mavis-$ENV-rds-sg"
-  loadbalancer       = "mavis-$ENV-alb"
-  lb_security_group  = "mavis-$ENV-alb-sg"
+  dbsubnet_group           = "mavis-$ENV-rds-subnet"
+  db_cluster               = "mavis-$ENV-rds-cluster"
+  db_instance              = "mavis-$ENV-rds-instance"
+  rds_security_group       = "mavis-$ENV-rds-sg"
+  loadbalancer             = "mavis-$ENV-alb"
+  lb_security_group        = "mavis-$ENV-alb-sg"
   cloudwatch_vpc_log_group = "mavis-$ENV-FlowLogs"
 }
 http_hosts = {


### PR DESCRIPTION
 - With changes to bootstrap no unique create pipeline is needed
      - Will be included in normal deploy infrastructure
- Destroy pipeline deletes both
    - TF managed resources
    - Backend configuration for environment
       - Note S3 Bucket/DynamoDB table are not deleted as they are shared
         among environments in an account