### PR TITLE
Set default working directory where possible

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -30,7 +30,7 @@ env:
   aws-role: ${{ inputs.environment == 'production'
     && 'arn:aws:iam::820242920762:role/GitHubActionsRole'
     || 'arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure' }}
-  tf-dir: terraform/app
+  terraform-working-directory: terraform/app
 
 jobs:
   plan-changes:
@@ -65,7 +65,7 @@ jobs:
           terraform_version: 1.10.5
       - name: Update the task definition
         id: plan
-        working-directory: ${{ env.tf-dir }}
+        working-directory: ${{ env.terraform-working-directory }}
         run: |
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
           terraform plan -var="image_digest=$DIGEST" -target=aws_ecs_task_definition.task_definition \
@@ -105,7 +105,7 @@ jobs:
         with:
           terraform_version: 1.10.5
       - name: Apply the changes
-        working-directory: ${{ env.tf-dir }}
+        working-directory: ${{ env.terraform-working-directory }}
         run: |
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
           terraform apply ${{ runner.temp }}/tfplan

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -27,7 +27,10 @@ env:
   aws_role: ${{ inputs.environment == 'production'
     && 'arn:aws:iam::820242920762:role/GitHubActionsRole'
     || 'arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure' }}
-  tf_dir: terraform/app
+
+defaults:
+  run:
+    working-directory: terraform/app
 
 jobs:
   plan:
@@ -50,7 +53,6 @@ jobs:
       - name: Install AWS Cli
         run: sudo snap install --classic aws-cli
       - name: Check if any deployments are running
-        working-directory: ${{ env.tf_dir }}
         run: |
           set -e
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
@@ -67,7 +69,6 @@ jobs:
             exit 1
           fi
       - name: Get saved image digest
-        working-directory: ${{ env.tf_dir }}
         run: |
           DIGEST=$(terraform state show aws_ecs_task_definition.task_definition | grep -oP '(?<=mavis/webapp@)sha256:[0-9a-z]{64}')
           if [ -z "$DIGEST" ]; then
@@ -79,7 +80,6 @@ jobs:
           echo "Image digest in terraform state: $DIGEST"
       - name: Terraform Plan
         id: plan
-        working-directory: ${{ env.tf_dir }}
         run: |
           set -e
           terraform plan -var="image_digest=$DIGEST" -var-file="env/${{ inputs.environment }}.tfvars" \
@@ -87,7 +87,7 @@ jobs:
       - name: Validate the changes
         run: |
           set -e
-          ./terraform/scripts/validate_plan.sh ${{ runner.temp }}/tf_stdout
+          ../scripts/validate_plan.sh ${{ runner.temp }}/tf_stdout
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -119,7 +119,6 @@ jobs:
         with:
           terraform_version: 1.10.5
       - name: Apply the changes
-        working-directory: ${{ env.tf_dir }}
         run: |
           set -e
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade

--- a/.github/workflows/destroy-infrastructure.yml
+++ b/.github/workflows/destroy-infrastructure.yml
@@ -1,5 +1,5 @@
-name: Destroy Infrastructure
-run-name: Destroy Infrastructure for ${{ inputs.environment }}
+name: Destroy infrastructure
+run-name: Destroy infrastructure for ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
@@ -18,14 +18,17 @@ on:
 
 env:
   aws_role: arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure
-  tf_dir: terraform/app
 
 jobs:
   destroy-resources:
+    name: Destroy resources
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     environment: ${{ inputs.environment }}
+    defaults:
+      run:
+        working-directory: terraform/app
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,7 +42,6 @@ jobs:
         with:
           terraform_version: 1.10.5
       - name: Ensure DB cluster can be deleted
-        working-directory: ${{ env.tf_dir }}
         run: |
           set -e
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
@@ -53,11 +55,12 @@ jobs:
           fi
 
       - name: Delete cluster
-        working-directory: ${{ env.tf_dir }}
         run: |
           terraform destroy -var-file="env/${{ inputs.environment }}.tfvars" \
           -var="image_digest=notneededfordestroy" -auto-approve
+
   destroy-backend:
+    name: Destroy backend
     runs-on: ubuntu-latest
     needs: destroy-resources
     permissions:


### PR DESCRIPTION
In the GitHub Actions workflows, this uses the `defaults` option to set the working directory to the `terraform/app` directory by default so we don't need to override it for each step in the workflow.

See
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/setting-a-default-shell-and-working-directory for more information on how this works.