### PR TITLE
Install ruby-prof

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :development do
   gem "prettier_print", require: false
   gem "rladr"
   gem "rubocop-govuk", require: false
+  gem "ruby-prof", require: false
   gem "rufo", require: false
   gem "solargraph", require: false
   gem "solargraph-rails", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,8 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.1)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     flipper (1.3.4)
       concurrent-ruby (< 2)
     flipper-active_record (1.3.4)
@@ -569,6 +570,7 @@ GEM
       rubocop (~> 1.0)
     rubocop-rspec (3.3.0)
       rubocop (~> 1.61)
+    ruby-prof (1.7.1)
     ruby-progressbar (1.13.0)
     rubyXL (3.4.33)
       nokogiri (>= 1.10.8)
@@ -767,6 +769,7 @@ DEPENDENCIES
   rspec-html-matchers
   rspec-rails
   rubocop-govuk
+  ruby-prof
   ruby-progressbar
   rubyXL
   rubyzip


### PR DESCRIPTION
This makes the profiling Gem available in development which can be used to check why parts of the code are slow.