### PR TITLE
Timeline records UI

### DIFF
--- a/app/assets/stylesheets/_timeline.scss
+++ b/app/assets/stylesheets/_timeline.scss
@@ -1,0 +1,74 @@
+.timeline {
+  position: relative;
+  margin-bottom: govuk-spacing(4);
+  margin-left: govuk-spacing(2);
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: govuk-spacing(2);
+    left: 0;
+    width: 5px;
+    height: 100%;
+    background-color: $govuk-brand-colour;
+  }
+}
+
+.timeline__item {
+  position: relative;
+  padding-bottom: govuk-spacing(6);
+  padding-left: govuk-spacing(4);
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: govuk-spacing(2);
+    left: 0;
+    width: 15px;
+    height: 5px;
+    background-color: $govuk-brand-colour;
+  }
+}
+
+.timeline__item--date {
+  position: relative;
+  padding-left: govuk-spacing(4);
+  padding-bottom: govuk-spacing(6);
+  margin-top: govuk-spacing(1);
+  margin-bottom: 0;
+  @include govuk-font($size: 16);
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: -9.5px;
+    top: 50%;
+    transform: translateY(-125%);
+    display: block;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: $govuk-brand-colour;
+  }
+}
+
+.timeline__header {
+  margin-bottom: govuk-spacing(1);
+}
+
+.timeline__title {
+  display: inline;
+  @include govuk-font($size: 16);
+}
+
+.timeline__byline {
+  display: inline;
+  margin: 0;
+  color: $govuk-secondary-text-colour;
+  @include govuk-font($size: 16);
+}
+
+.timeline__description {
+  margin-top: govuk-spacing(4);
+  @include govuk-font($size: 16);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -78,6 +78,7 @@ $color_app-dark-orange: color.scale(
 @import "tag";
 @import "typography";
 @import "utilities";
+@import "timeline";
 
 // Fix checkbox check sizing
 .nhsuk-checkboxes__label::after {

--- a/app/components/app_timeline_filter_component.html.erb
+++ b/app/components/app_timeline_filter_component.html.erb
@@ -1,0 +1,174 @@
+<%= render AppCardComponent.new(filters: true) do |card| %>
+    <% card.with_heading { "Customise timeline" } %>
+    <%= form_with url: @url,
+                  method: :get,
+                  data: { module: "autosubmit",
+                          turbo: "true",
+                          turbo_action: "replace" },
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_fieldset legend: { text: "Events to display:", size: "s" } do %>
+            <% event_options.keys.each do |value| %>
+                <%= f.govuk_check_boxes_fieldset :event_names, legend: { hidden: true } do %>
+                    <%= f.govuk_check_box :event_names,
+                                          value,
+                                          label: { text: value.to_s.humanize },
+                                          checked: value.to_s.in?(params[:event_names] || event_options.keys.map(&:to_s)),
+                                          "data-autosubmit-target": "field",
+                                          "data-action": "autosubmit#submit",
+                                          "data-turbo-permanent": "true" %>
+                    
+                    <% available_fields = timeline_fields[value.to_sym] || [] %>
+                    <% if available_fields.any? && value.to_s.in?(params[:event_names]) %>
+                        <div class="nhsuk-checkboxes__conditional nhsuk-u-margin-bottom-2">
+                            <% available_fields.each do |field| %>
+                                <%= f.govuk_check_box "detail_config[#{value}]",
+                                                      field,
+                                                      small: true,
+                                                      label: { text: field },
+                                                      checked: field.to_s.in?(params.dig("detail_config", value) || []),
+                                                      "data-autosubmit-target": "field",
+                                                      "data-action": "autosubmit#submit",
+                                                      "data-turbo-permanent": "true" %>
+                            <% end %>
+                        </div>
+                    <% end %>
+                <% end %>
+            <% end %>
+
+            <%= f.govuk_check_boxes_fieldset :audit_config, legend: { hidden: true } do %>
+                <%= f.govuk_check_box :event_names, "audits",
+                                      label: { text: "Audits" },
+                                      checked: "audits".in?(params[:event_names]),
+                                      "data-autosubmit-target": "field",
+                                      "data-action": "autosubmit#submit",
+                                      "data-turbo-permanent": "true" %>
+                <% if "audits".in?(params[:event_names]) %>
+                    <div class="nhsuk-checkboxes__conditional nhsuk-u-margin-bottom-2">
+                        <%= f.govuk_check_box "audit_config[include_associated_audits]", true, false,
+                                              multiple: false,
+                                              label: { text: "include associated audits" },
+                                              checked: params.dig(:audit_config, :include_associated_audits) == "true",
+                                              "data-autosubmit-target": "field",
+                                              "data-action": "autosubmit#submit",
+                                              "data-turbo-permanent": "true" %>
+
+                        <%= f.govuk_check_box "audit_config[include_filtered_audit_changes]", true, false,
+                                              multiple: false,
+                                              label: { text: "include filtered audit changes" },
+                                              checked: params.dig(:audit_config, :include_filtered_audit_changes) == "true",
+                                              "data-autosubmit-target": "field",
+                                              "data-action": "autosubmit#submit",
+                                              "data-turbo-permanent": "true" %>
+                    </div>
+                <% end %>
+            <% end %>
+
+            <%= f.govuk_check_box :event_names, "org_cohort_imports",
+                                  label: { text: "Cohort Imports for Organisation-#{@patient.organisation.id} excluding Patient" },
+                                  checked: "org_cohort_imports".in?(params[:event_names]),
+                                  "data-autosubmit-target": "field",
+                                  "data-action": "autosubmit#submit",
+                                  "data-turbo-permanent": "true" %>
+
+            <% (@additional_class_imports).each do |session_id, import_ids| %>
+                <%= f.govuk_check_box :event_names, "add_class_imports_#{session_id}",
+                                      label: { text: "Class Imports for Session-#{session_id} excluding Patient" },
+                                      checked: "add_class_imports_#{session_id}".in?(params[:event_names]),
+                                      "data-autosubmit-target": "field",
+                                      "data-action": "autosubmit#submit",
+                                      "data-turbo-permanent": "true" %>
+            <% end %>
+
+            
+            <%= f.govuk_radio_buttons_fieldset :compare_option, legend: { text: "Compare with another patient:", size: "s" } do %>
+            <%= f.govuk_radio_button :compare_option,
+                                     nil,
+                                     label: { text: "Do not compare" },
+                                     checked: params[:compare_option].blank?,
+                                     "data-autosubmit-target": "field",
+                                     "data-action": "autosubmit#submit",
+                                     "data-turbo-permanent": "true" %>
+            
+            <% if class_imports.present? %>
+                <%= f.govuk_radio_button :compare_option,
+                                         "class_import",
+                                         label: { text: "From a Class Import" },
+                                         checked: params[:compare_option] == "class_import",
+                                         "data-autosubmit-target": "field",
+                                         "data-action": "autosubmit#submit",
+                                         "data-turbo-permanent": "true" do %>
+                <% class_imports.each do |import| %>
+                    <%= f.govuk_radio_button :compare_option_class_import,
+                                             import,
+                                             label: { text: "ClassImport-#{import}" },
+                                             checked: params[:compare_option_class_import].to_s == import.to_s,
+                                             "data-autosubmit-target": "field",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+                <% end %>
+                <% end %>
+            <% end %>
+            
+            <% if cohort_imports.present? %>
+                <%= f.govuk_radio_button :compare_option,
+                                         "cohort_import",
+                                         label: { text: "From a Cohort Import" },
+                                         checked: params[:compare_option] == "cohort_import",
+                                         "data-autosubmit-target": "field",
+                                         "data-action": "autosubmit#submit",
+                                         "data-turbo-permanent": "true" do %>
+                <% cohort_imports.each do |import| %>
+                    <%= f.govuk_radio_button :compare_option_cohort_import,
+                                             import,
+                                             label: { text: "CohortImport-#{import}" },
+                                             checked: params[:compare_option_cohort_import].to_s == import.to_s,
+                                             "data-autosubmit-target": "field",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+                <% end %>
+                <% end %>
+            <% end %>
+            
+            <% if sessions.present? %>
+                <%= f.govuk_radio_button :compare_option,
+                                         "session",
+                                         label: { text: "In a Session" },
+                                         checked: params[:compare_option] == "session" do %>
+                <% sessions.each do |session| %>
+                    <%= f.govuk_radio_button :compare_option_session,
+                                             session,
+                                             label: { text: "Session-#{session}" },
+                                             checked: params[:compare_option_session].to_s == session.to_s && params[:compare_option] == "session",
+                                             "data-autosubmit-target": "field",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+                <% end %>
+                <% end %>
+            <% end %>
+            
+            <%= f.govuk_radio_button :compare_option,
+                                     "manual_entry",
+                                     label: { text: "With a specific Patient-ID" },
+                                     checked: params[:compare_option] == "manual_entry" do %>
+                <%= f.govuk_number_field :manual_patient_id,
+                                         label: { hidden: true },
+                                         width: 10,
+                                         "data-autosubmit-target": "field",
+                                         "data-action": "autosubmit#submit",
+                                         "data-turbo-permanent": "true" %>
+            <% end %>
+            <% end %>
+            
+            <%= govuk_button_link_to "Reset filters",
+                                     @reset_url,
+                                     class: "govuk-button govuk-button--secondary nhsuk-u-display-block app-button--small",
+                                     secondary: true,
+                                     "data-autosubmit-target": "reset",
+                                     "data-action": "autosubmit#submit",
+                                     "data-turbo-permanent": "true" %>
+            <%= f.govuk_submit "Filter",
+                               "data-autosubmit-target": "filter",
+                               "data-turbo-permanent": "true" %>
+        <% end %>
+    <% end %>
+<% end %>

--- a/app/components/app_timeline_filter_component.rb
+++ b/app/components/app_timeline_filter_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AppTimelineFilterComponent < ViewComponent::Base
+  def initialize(
+    url:,
+    patient:,
+    event_options:,
+    timeline_fields:,
+    additional_class_imports:,
+    class_imports:,
+    cohort_imports:,
+    sessions:,
+    reset_url:
+  )
+    super
+    @url = url
+    @patient = patient
+    @event_options = event_options
+    @timeline_fields = timeline_fields
+    @additional_class_imports = additional_class_imports
+    @class_imports = class_imports
+    @cohort_imports = cohort_imports
+    @sessions = sessions
+    @reset_url = reset_url
+  end
+
+  attr_reader :url,
+              :patient,
+              :event_options,
+              :timeline_fields,
+              :additional_class_imports,
+              :class_imports,
+              :cohort_imports,
+              :sessions,
+              :reset_url
+end

--- a/app/components/app_timeline_table_component.html.erb
+++ b/app/components/app_timeline_table_component.html.erb
@@ -1,0 +1,30 @@
+<% if @comparison %>
+  <h3 class="timeline__heading">
+    Patient-<%= @patient_id %>
+  </h3>
+<% end %>
+<div class="timeline">
+  <% @events.each do |date, events| %>
+    <div class="timeline__item timeline__item--date">
+      <div class="timeline__header">
+        <h2 class="timeline__title">
+          <%= content_tag(:strong, date) %>
+        </h2>
+      </div>
+    </div>
+
+    <% events.each do |event| %>
+      <div class="timeline__item">
+        <div class="timeline__header">
+          <h3 class="timeline__title">
+            <%= govuk_tag(text: event[:event_type], colour: tag_colour(event[:event_type])) %> at <%= format_time(event[:created_at]) %>
+          </h3>
+        </div>
+        <p class="timeline__byline">id: <%= event[:id] %></p>
+        <div class="timeline__description">
+          <%= format_event_details(event[:details]) %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/app_timeline_table_component.rb
+++ b/app/components/app_timeline_table_component.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class AppTimelineTableComponent < ViewComponent::Base
+  EVENT_COLOUR_MAPPING = {
+    "CohortImport" => "blue",
+    "ClassImport" => "purple",
+    "PatientSession" => "green",
+    "Consent" => "yellow",
+    "Triage" => "red",
+    "VaccinationRecord" => "grey",
+    "SchoolMove" => "orange",
+    "SchoolMoveLogEntry" => "pink"
+  }.freeze
+
+  def initialize(events:, patient_id:, comparison: false)
+    super
+    @events = events
+    @patient_id = patient_id
+    @comparison = comparison
+  end
+
+  def format_time(date_time)
+    date_time.strftime("%H:%M:%S")
+  end
+
+  def format_event_details(details)
+    return "" if details.blank?
+
+    if details.is_a?(Hash)
+      formatted =
+        # stree-ignore
+        details.map do |key, value|
+          if value.is_a?(Hash)
+            nested =
+              value
+                .map { |sub_key, sub_value|
+                  nested_value =
+                    sub_value.is_a?(String) ? sub_value : sub_value.inspect
+                  "<div style='margin-left: 1em;'><strong>#{sub_key}:</strong> #{nested_value}</div>"
+                }
+                .join
+            "<div><strong>#{key}:</strong> #{nested}</div>"
+          else
+            "<div><strong>#{key}:</strong> #{value}</div>"
+          end
+        end
+
+      formatted.join.html_safe
+    else
+      details.to_s.html_safe
+    end
+  end
+
+  def tag_colour(event_type)
+    return "light-blue" if event_type.end_with?("-Audit")
+    EVENT_COLOUR_MAPPING.fetch(event_type, "grey")
+  end
+end

--- a/app/controllers/inspect/timeline/patients_controller.rb
+++ b/app/controllers/inspect/timeline/patients_controller.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+module Inspect
+  module Timeline
+    class PatientsController < ApplicationController
+      skip_after_action :verify_policy_scoped
+      skip_before_action :authenticate_user!
+      before_action :set_patient
+
+      layout "full"
+
+      DEFAULT_EVENT_NAMES = %w[
+        consents
+        school_moves
+        school_move_log_entries
+        audits
+        patient_sessions
+        triages
+        vaccination_records
+        class_imports
+        cohort_imports
+      ].freeze
+
+      def show
+        params.reverse_merge!(event_names: DEFAULT_EVENT_NAMES)
+        params[:audit_config] ||= {}
+
+        event_names = params[:event_names]
+        compare_option = params[:compare_option] || nil
+
+        if params[:detail_config].blank?
+          default_details = TimelineRecords::DEFAULT_DETAILS_CONFIG
+          new_params =
+            params.to_unsafe_h.merge("detail_config" => default_details)
+          redirect_to inspect_timeline_patient_path(new_params) and return
+        end
+
+        audit_config = {
+          include_associated_audits:
+            params[:audit_config][:include_associated_audits],
+          include_filtered_audit_changes:
+            params[:audit_config][:include_filtered_audit_changes]
+        }
+
+        @patient_timeline =
+          TimelineRecords.new(
+            @patient,
+            detail_config: build_details_config,
+            audit_config: audit_config
+          ).load_grouped_events(event_names)
+
+        @no_events_message = true if @patient_timeline.empty?
+
+        if compare_option
+          @compare_patient = sample_patient(params[:compare_option])
+        end
+
+        if @compare_patient == :invalid_patient
+          @invalid_patient_id = true
+        elsif @compare_patient
+          @compare_patient_timeline =
+            TimelineRecords.new(
+              @compare_patient,
+              detail_config: build_details_config,
+              audit_config: audit_config
+            ).load_grouped_events(event_names)
+
+          @no_events_compare_message = true if @compare_patient_timeline.empty?
+        end
+      end
+
+      private
+
+      def set_patient
+        @patient = Patient.find(params[:id])
+        timeline = TimelineRecords.new(@patient)
+        @patient_events = timeline.patient_events(@patient)
+        @additional_events = timeline.additional_events(@patient)
+      end
+
+      # TODO: Fix so that a new comparison patient isn't sampled every time
+      #       a filter option is changed and the page is reloaded.
+      def sample_patient(compare_option)
+        case compare_option
+        when "class_import"
+          class_import = params[:compare_option_class_import]
+          Patient
+            .joins(:class_imports)
+            .where(class_imports: { id: class_import.id })
+            .where.not(id: @patient.id)
+            .sample
+        when "cohort_import"
+          cohort_import = params[:compare_option_cohort_import]
+          Patient
+            .joins(:cohort_imports)
+            .where(cohort_imports: { id: cohort_import.id })
+            .where.not(id: @patient.id)
+            .sample
+        when "session"
+          session_id = params[:compare_option_session]
+          Patient
+            .joins(:patient_sessions)
+            .where(patient_sessions: { session_id: session_id })
+            .where.not(id: @patient.id)
+            .sample
+        when "manual_entry"
+          begin
+            Patient.find(params[:manual_patient_id])
+          rescue ActiveRecord::RecordNotFound
+            :invalid_patient
+          end
+        else
+          raise ArgumentError,
+                "Invalid patient comparison option: #{compare_option}"
+        end
+      end
+
+      def build_details_config
+        details_params = params[:detail_config] || {}
+        details_params = details_params.to_unsafe_h unless details_params.is_a?(
+          Hash
+        )
+
+        details_params.each_with_object({}) do |(event_type, fields), hash|
+          selected_fields = Array(fields).reject(&:blank?).map(&:to_sym)
+          hash[event_type.to_sym] = selected_fields
+        end
+      end
+    end
+  end
+end

--- a/app/views/inspect/timeline/patients/show.html.erb
+++ b/app/views/inspect/timeline/patients/show.html.erb
@@ -1,0 +1,87 @@
+<%= h1 page_title: @patient.initials do %>
+  <%= "Inspect Patient-#{@patient.id}" %>
+<% end %>
+
+<code>
+  <%= "Rails console: Patient.find(#{@patient.id})" %>
+</code>
+
+<% if params[:event_names].include?("audits") && @patient_timeline %>
+  <%= govuk_inset_text do %>
+    <p class="nhsuk-body">
+      Only audited changes that do not involve PII are included
+    </p>
+  <% end %>
+<% end %>
+
+<div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+  
+  <div class="nhsuk-grid-column-one-third app-grid-column--sticky">
+      <%= render AppTimelineFilterComponent.new(
+            url: inspect_timeline_patient_path,
+            patient: @patient,
+            event_options: TimelineRecords::DEFAULT_DETAILS_CONFIG,
+            timeline_fields: TimelineRecords::AVAILABLE_DETAILS_CONFIG,
+            class_imports: @patient_events[:class_imports],
+            cohort_imports: @patient_events[:cohort_imports],
+            sessions: @patient_events[:sessions],
+            additional_class_imports: @additional_events[:class_imports],
+            reset_url: inspect_timeline_patient_path(
+              event_names: Inspect::Timeline::PatientsController::DEFAULT_EVENT_NAMES,
+              detail_config: TimelineRecords::DEFAULT_DETAILS_CONFIG,
+              compare_option: nil,
+            ),
+          ) %>
+  </div>
+
+  <div class="nhsuk-grid-column-two-thirds">
+    <% if @no_events_message %>
+      <%= render AppWarningCalloutComponent.new(
+            heading: "No events found",
+            description: "Patient-#{@patient.id} doesn't have the following events recorded: " +
+                         "#{params[:event_names].map(&:humanize).join(", ")}".html_safe,
+          ) %>
+    <% else %>
+        <% if @compare_patient_timeline || @invalid_patient_id || @no_events_compare_message %>
+          <div class="nhsuk-grid-column-one-half">
+            <%= render AppTimelineTableComponent.new(
+                  events: @patient_timeline,
+                  patient_id: @patient.id,
+                  comparison: @compare_patient.present?,
+                ) %>
+          </div>
+
+          <% if @invalid_patient_id %>
+            <div class="nhsuk-grid-column-one-half">
+              <%= render AppWarningCalloutComponent.new(
+                    heading: "Invalid patient ID",
+                    description: "Patient-#{params[:manual_patient_id]} doesn't exist",
+                  ) %>
+            </div>
+          <% elsif @no_events_compare_message %>
+            <div class="nhsuk-grid-column-one-half">
+              <%= render AppWarningCalloutComponent.new(
+                    heading: "No events found for comparison patient",
+                    description: "Patient-#{@compare_patient.id} doesn't have the following events recorded: " +
+                                 "#{params[:event_names].map(&:humanize).join(", ")}".html_safe,
+                  ) %>
+            </div>
+          <% elsif @compare_patient_timeline %>
+            <div class="nhsuk-grid-column-one-half">
+              <%= render AppTimelineTableComponent.new(
+                    events: @compare_patient_timeline,
+                    patient_id: @compare_patient.id,
+                    comparison: true,
+                  ) %>
+            </div>
+          <% end %>
+        <% else %>
+          <%= render AppTimelineTableComponent.new(
+                events: @patient_timeline,
+                patient_id: @patient.id,
+                comparison: false,
+              ) %>
+        <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,6 +328,9 @@ Rails.application.routes.draw do
   constraints -> { !Rails.env.production? } do
     namespace :inspect do
       get "graph/:object_type/:object_id", to: "graphs#show"
+      namespace :timeline do
+        resources :patients, only: [:show]
+      end
     end
   end
 end

--- a/lib/timeline_records.rb
+++ b/lib/timeline_records.rb
@@ -1,0 +1,288 @@
+# frozen_string_literal: true
+
+class TimelineRecords
+  DEFAULT_DETAILS_CONFIG = {
+    cohort_imports: [],
+    class_imports: [],
+    patient_sessions: %i[session_id],
+    school_moves: %i[school_id source],
+    school_move_log_entries: %i[school_id user_id],
+    consents: %i[response route],
+    triages: %i[status performed_by_user_id],
+    vaccination_records: %i[outcome session_id]
+  }.freeze
+
+  AVAILABLE_DETAILS_CONFIG = {
+    cohort_imports: %i[rows_count status uploaded_by_user_id],
+    class_imports: %i[rows_count year_groups uploaded_by_user_id session_id],
+    patient_sessions: %i[session_id],
+    school_moves: %i[source school_id home_educated],
+    school_move_log_entries: %i[user_id school_id home_educated],
+    consents: %i[
+      programme_id
+      response
+      route
+      parent_id
+      withdrawn_at
+      invalidated_at
+    ],
+    triages: %i[status performed_by_user_id programme_id invalidated_at],
+    vaccination_records: %i[
+      outcome
+      performed_by_user_id
+      programme_id
+      session_id
+      vaccine_id
+    ]
+  }.freeze
+
+  DEFAULT_AUDITS_CONFIG = {
+    include_associated_audits: true,
+    include_filtered_audit_changes: false
+  }.freeze
+
+  ALLOWED_AUDITED_CHANGES = %i[
+    patient_id
+    session_id
+    programme_id
+    vaccine_id
+    organisation_id
+    school_id
+    gp_practice_id
+    uploaded_by_user_id
+    performed_by_user_id
+    user_id
+    parent_id
+    status
+    outcome
+    response
+    route
+    date_of_death_recorded_at
+    restricted_at
+    invalidated_at
+    withdrawn_at
+    rows_count
+    year_groups
+    home_educated
+    source
+  ].freeze
+
+  def initialize(patient, detail_config: {}, audit_config: {})
+    @patient = patient
+    @patient_id = @patient.id
+    @patient_events = patient_events(@patient)
+    @additional_events = additional_events(@patient)
+    @detail_config = extract_detail_config(detail_config)
+    @events = []
+    @audit_config = audit_config
+  end
+
+  def generate_timeline_console(*event_names, truncate_columns: true)
+    load_grouped_events(event_names)
+    format_timeline_console(truncate_columns)
+  end
+
+  def additional_events(patient)
+    patient_imports = patient_events(patient)[:class_imports]
+    class_imports =
+      ClassImport.where(session_id: patient_events(patient)[:sessions])
+    class_imports =
+      class_imports.where.not(id: patient_imports) if patient_imports.present?
+    {
+      class_imports:
+        class_imports
+          .group_by(&:session_id)
+          .transform_values { |imports| imports.map(&:id) },
+      cohort_imports:
+        patient
+          .organisation
+          .cohort_imports
+          .map(&:id)
+          .reject { |id| patient_events(patient)[:cohort_imports].include?(id) }
+    }
+  end
+
+  def patient_events(patient)
+    {
+      class_imports: patient.class_imports.map(&:id),
+      cohort_imports: patient.cohort_imports.map(&:id),
+      sessions: patient.sessions.map(&:id)
+    }
+  end
+
+  def extract_detail_config(detail_config)
+    detail_config.deep_symbolize_keys
+  end
+
+  def details
+    @details ||= DEFAULT_DETAILS_CONFIG.merge(@detail_config)
+  end
+
+  def audits
+    @audits ||= DEFAULT_AUDITS_CONFIG.merge(@audit_config)
+  end
+
+  def load_events(event_names)
+    event_names.each do |event_name|
+      event_type = event_name.to_sym
+
+      if details.key?(event_type)
+        fields = details[event_type]
+        records = @patient.send(event_type)
+        records = Array(records)
+
+        records.each do |record|
+          event_details =
+            fields.each_with_object({}) do |field, hash|
+              field_value = record.send(field)
+              hash[field.to_s] = field_value.nil? ? "nil" : field_value
+            end
+          @events << {
+            event_type: record.class.name,
+            id: record.id,
+            details: event_details,
+            created_at: record.created_at
+          }
+        end
+      else
+        custom_event_handler(event_type)
+      end
+    end
+    @events.sort_by! { |event| event[:created_at] }.reverse!
+  end
+
+  def load_grouped_events(event_names)
+    load_events(event_names)
+    @grouped_events_by_date =
+      @events.group_by do |event|
+        event[:created_at].strftime(Date::DATE_FORMATS[:long])
+      end
+    @grouped_events =
+      @grouped_events_by_date.sort_by { |date, _events| date }.reverse!.to_h
+  end
+
+  private
+
+  def custom_event_handler(event_type)
+    case event_type
+    when :org_cohort_imports
+      @events += org_cohort_imports_events
+    when /^add_class_imports_\d+$/ # e.g. add_class_imports_123
+      session_id = event_type.to_s.split("_").last
+      @events += add_class_imports_events(session_id)
+    when :audits
+      @events += audits_events
+    else
+      puts "No handler for event type: #{event_type}"
+    end
+  end
+
+  def org_cohort_imports_events
+    CohortImport
+      .where(id: @additional_events[:cohort_imports])
+      .map do |cohort_import|
+        {
+          event_type: "CohortImport",
+          id: cohort_import.id,
+          details: "excluding patient",
+          created_at: cohort_import.created_at
+        }
+      end
+  end
+
+  def add_class_imports_events(session_id)
+    ClassImport
+      .where(id: @additional_events[:class_imports][session_id.to_i])
+      .map do |class_import|
+        {
+          event_type: "ClassImport",
+          id: class_import.id,
+          details: {
+            session_id: "#{class_import.session_id}, excluding patient"
+          },
+          created_at: class_import.created_at.to_time
+        }
+      end
+  end
+
+  def audits_events
+    audit_events =
+      (
+        if audits[:include_associated_audits]
+          @patient.own_and_associated_audits
+        else
+          @patient.audits
+        end
+      )
+
+    audit_events.map do |audit|
+      filtered_changes =
+        audit
+          .audited_changes
+          .each_with_object({}) do |(key, value), hash|
+            if ALLOWED_AUDITED_CHANGES.include?(key.to_sym)
+              hash[key] = value
+            elsif audits[:include_filtered_audit_changes]
+              hash[key] = "[FILTERED]"
+            end
+          end
+
+      event_type = "#{audit.auditable_type}-Audit"
+
+      event_details = { action: audit.action }
+      event_details[
+        :audited_changes
+      ] = filtered_changes.deep_symbolize_keys unless filtered_changes.empty?
+
+      {
+        event_type: event_type,
+        id: audit.id,
+        details: event_details,
+        created_at: audit.created_at
+      }
+    end
+  end
+
+  def format_timeline_console(truncate_columns)
+    event_type_width = 25
+    details_width = 50
+    header_format =
+      if truncate_columns
+        "%-12s %-10s %-#{event_type_width}s %-12s %-#{details_width}s"
+      else
+        "%-12s %-10s %-20s %-10s %-s"
+      end
+    puts sprintf(
+           header_format,
+           "DATE",
+           "TIME",
+           "EVENT_TYPE",
+           "EVENT-ID",
+           "DETAILS"
+         )
+    puts "-" * 115
+
+    @grouped_events.each do |date, events|
+      puts "=== #{date} ===\n" + "-" * 115
+      events.each do |event|
+        time = event[:created_at].strftime("%H:%M:%S")
+        event_type = event[:event_type].to_s
+        event_id = event[:id].to_s
+        details_string =
+          if event[:details].is_a?(Hash)
+            event[:details].map { |k, v| "#{k}: #{v}" }.join(", ")
+          else
+            event[:details].to_s
+          end
+        if truncate_columns
+          event_type = event_type.ljust(event_type_width)[0...event_type_width]
+          details = details_string.ljust(details_width)[0...details_width]
+        else
+          details = details_string
+        end
+        puts sprintf(header_format, "", time, event_type, event_id, details)
+      end
+    end
+    nil
+  end
+end

--- a/spec/features/timeline_records_spec.rb
+++ b/spec/features/timeline_records_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe "TimelineRecords UI" do
+  scenario "Endpoint doesn't exist in prod" do
+    given_i_am_in_production
+
+    when_i_visit_the_timeline_endpoint
+    then_i_should_see_a_404_error
+  end
+
+  scenario "Endpoint is rendered in test" do
+    given_i_am_in_test
+    given_a_patient_exists
+
+    when_i_visit_the_timeline_endpoint
+    then_i_should_see_the_page_rendered
+  end
+
+  def given_i_am_in_production
+    allow(Rails).to receive(:env).and_return("production".inquiry)
+  end
+
+  def given_i_am_in_test
+    # Already implicitly in test
+  end
+
+  def given_a_patient_exists
+    create(:patient, id: 1)
+  end
+
+  def when_i_visit_the_timeline_endpoint
+    visit "/inspect/timeline/patients/1"
+  end
+
+  def then_i_should_see_a_404_error
+    expect(page.status_code).to eq(404)
+  end
+
+  def then_i_should_see_the_page_rendered
+    expect(page.status_code).to eq(200)
+    expect(page.html).to include("Inspect Patient-1")
+  end
+end

--- a/spec/lib/timeline_records_spec.rb
+++ b/spec/lib/timeline_records_spec.rb
@@ -1,0 +1,465 @@
+# frozen_string_literal: true
+
+describe TimelineRecords do
+  subject(:timeline) do
+    described_class.new(patient, detail_config: detail_config)
+  end
+
+  let(:programme) { create(:programme, :hpv) }
+  let(:detail_config) { {} }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
+  let(:class_import) { create(:class_import, session:) }
+  let(:cohort_import) { create(:cohort_import, organisation:) }
+  let(:cohort_import_additional) { create(:cohort_import, organisation:) }
+  let(:class_import_additional) { create(:class_import, session:) }
+  let(:user) { create(:user) }
+  let(:patient) do
+    create(
+      :patient,
+      given_name: "Alex",
+      year_group: 8,
+      address_postcode: "SW1A 1AA",
+      class_imports: [class_import],
+      organisation: organisation
+    )
+  end
+  let(:school_move) { create(:school_move, :to_school, patient: patient) }
+  let(:school_move_log_entry) do
+    create(:school_move_log_entry, patient: patient)
+  end
+  let(:patient_session) do
+    create(:patient_session, patient: patient, session: session)
+  end
+  let(:triage) do
+    create(
+      :triage,
+      patient: patient,
+      programme:,
+      status: :ready_to_vaccinate,
+      performed_by: user
+    )
+  end
+  let(:consent) do
+    create(
+      :consent,
+      patient: patient,
+      response: :given,
+      programme:,
+      created_at: Date.new(2025, 1, 1)
+    )
+  end
+  let(:consent_audit) do
+    consent.audits.create!(
+      audited_changes: {
+        response: %w[nil given]
+      },
+      associated_type: Patient,
+      associated_id: patient.id
+    )
+  end
+  let(:vaccination_record) do
+    create(
+      :vaccination_record,
+      patient:,
+      programme:,
+      session:,
+      performed_at: Time.zone.local(2025, 2, 1)
+    )
+  end
+
+  describe "#load_events" do
+    before do
+      patient.triages << triage
+      patient.consents << consent
+      patient.sessions << session
+      patient.school_moves << school_move
+      patient.school_move_log_entries << school_move_log_entry
+      patient.vaccination_records << vaccination_record
+      patient.cohort_imports << cohort_import
+    end
+
+    context "with default details configuration" do
+      it "loads consent events with default fields" do
+        timeline.send(:load_events, ["consents"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Consent"
+        expect(event[:details]).to eq(
+          { "response" => consent.response, "route" => consent.route }
+        )
+      end
+
+      it "loads triage events with default fields" do
+        timeline.send(:load_events, ["triages"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Triage"
+        expect(event[:details]).to eq(
+          { "status" => triage.status, "performed_by_user_id" => user.id }
+        )
+      end
+
+      it "loads cohort_import events with default fields" do
+        timeline.send(:load_events, ["cohort_imports"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "CohortImport"
+        expect(event[:details]).to eq({})
+      end
+
+      it "loads class_import events with default fields" do
+        timeline.send(:load_events, ["class_imports"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "ClassImport"
+        expect(event[:details]).to eq({})
+      end
+
+      it "loads session events with default fields" do
+        timeline.send(:load_events, ["patient_sessions"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "PatientSession"
+        expect(event[:details]).to eq({ "session_id" => session.id })
+      end
+
+      it "loads school_move events with default fields" do
+        timeline.send(:load_events, ["school_moves"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "SchoolMove"
+        expect(event[:details]).to eq(
+          {
+            "school_id" => school_move.school_id,
+            "source" => school_move.source
+          }
+        )
+      end
+
+      it "loads school_move_log_entry events with default fields" do
+        timeline.send(:load_events, ["school_move_log_entries"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "SchoolMoveLogEntry"
+        expect(event[:details]).to eq(
+          {
+            "school_id" => school_move_log_entry.school_id,
+            "user_id" => school_move_log_entry.user_id
+          }
+        )
+      end
+
+      it "loads vaccination events with default fields" do
+        timeline.send(:load_events, ["vaccination_records"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "VaccinationRecord"
+        expect(event[:details]).to eq(
+          {
+            "outcome" => vaccination_record.outcome,
+            "session_id" => vaccination_record.session_id
+          }
+        )
+      end
+    end
+
+    context "with custom details configuration" do
+      let(:detail_config) { { consents: %i[route], triages: %i[status] } }
+
+      before do
+        patient.consents << consent
+        patient.triages << triage
+      end
+
+      it "loads consent events with custom fields" do
+        timeline.send(:load_events, ["consents"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Consent"
+        expect(event[:details]).to eq({ "route" => consent.route })
+      end
+
+      it "loads triage events with custom fields" do
+        timeline.send(:load_events, ["triages"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Triage"
+        expect(event[:details]).to eq({ "status" => triage.status })
+      end
+    end
+
+    context "with custom event handler" do
+      before do
+        patient.sessions = [session]
+        patient.cohort_imports = [cohort_import]
+        additional_events = {
+          class_imports: {
+            session.id => [class_import_additional.id]
+          },
+          cohort_imports: [cohort_import_additional.id]
+        }
+        timeline.instance_variable_set(:@additional_events, additional_events)
+      end
+
+      it "calls custom event handler for add_class_imports" do
+        timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "ClassImport"
+        expect(event[:id]).to eq class_import_additional.id
+        expect(event[:details]).to eq(
+          { session_id: "#{session.id}, excluding patient" }
+        )
+      end
+
+      it "calls custom event handler for org_cohort_imports" do
+        timeline.send(:load_events, ["org_cohort_imports"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "CohortImport"
+        expect(event[:id]).to eq cohort_import_additional.id
+        expect(event[:details]).to eq "excluding patient"
+      end
+    end
+  end
+
+  describe "#load_add_class_imports_events" do
+    before do
+      patient.sessions = [session]
+      additional_events = {
+        class_imports: {
+          session.id => [class_import_additional.id]
+        }
+      }
+      timeline.instance_variable_set(:@additional_events, additional_events)
+    end
+
+    it "returns an array of events" do
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events).to be_an Array
+    end
+
+    it "includes the class import event" do
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events.size).to eq 1
+      event = events.first
+      expect(event[:event_type]).to eq "ClassImport"
+      expect(event[:id]).to eq class_import_additional.id
+      expect(event[:details]).to eq(
+        { session_id: "#{session.id}, excluding patient" }
+      )
+      expect(event[:created_at]).to eq class_import_additional.created_at
+    end
+
+    it "handles multiple additional class imports" do
+      another_additional_class_import =
+        create(:class_import, session:, created_at: 1.minute.from_now)
+      additional_events = {
+        class_imports: {
+          session.id => [
+            class_import_additional.id,
+            another_additional_class_import.id
+          ]
+        }
+      }
+      timeline.instance_variable_set(:@additional_events, additional_events)
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events.size).to eq 2
+      expect(events.map { |event| event[:id] }).to contain_exactly(
+        class_import_additional.id,
+        another_additional_class_import.id
+      )
+    end
+
+    it "handles no additional class imports" do
+      additional_events = { class_imports: { session.id => [] } }
+      timeline.instance_variable_set(:@additional_events, additional_events)
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events).to be_empty
+    end
+
+    it "handles a nil session id" do
+      events = timeline.send(:load_events, ["add_class_imports_nil"])
+      expect(events).to be_empty
+    end
+  end
+
+  describe "#audits_events" do
+    context "with default settings" do
+      let(:timeline) { described_class.new(patient) }
+
+      it "returns an array of events" do
+        patient.audits.create!(
+          audited_changes: {
+            organisation_id: [nil, 1],
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events).to be_an Array
+      end
+
+      it "includes the audit event" do
+        patient.audits.create!(
+          audited_changes: {
+            organisation_id: [nil, 1],
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 2 # create is the first audit
+        event = events.first
+        expect(event[:event_type]).to eq "Patient-Audit"
+        expect(event[:details][:audited_changes][:organisation_id]).to eq(
+          [nil, 1]
+        )
+        expect(event[:created_at]).to eq patient.audits.second.created_at
+      end
+
+      it "does not include audited changes that are not allowed" do
+        patient.audits.create!(
+          audited_changes: {
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 2
+        expect(events.first[:event_type]).to eq "Patient-Audit"
+        expect(events.first[:details]).to eq({ action: nil })
+      end
+
+      it "includes associated audits by default" do
+        consent.audits << consent_audit
+        events = timeline.load_events(["audits"])
+        associated_event = events.find { |e| e[:id] == consent_audit.id }
+        expect(associated_event).to be_present
+        expect(associated_event[:event_type]).to eq "Consent-Audit"
+      end
+    end
+
+    context "with include_associated_audits: false" do
+      let(:timeline) do
+        described_class.new(
+          patient,
+          audit_config: {
+            include_associated_audits: false
+          }
+        )
+      end
+
+      it "does not include associated audits" do
+        consent.audits << consent_audit
+        events = timeline.load_events(["audits"])
+        associated_event = events.find { |e| e[:id] == consent_audit.id }
+        expect(associated_event).to be_nil
+      end
+
+      it "still includes patient audits" do
+        patient.audits.create!(audited_changes: { organisation_id: [nil, 1] })
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 2
+        expect(events.first[:event_type]).to eq "Patient-Audit"
+      end
+    end
+
+    context "with include_filtered_audit_changes: true" do
+      let(:timeline) do
+        described_class.new(
+          patient,
+          audit_config: {
+            include_filtered_audit_changes: true
+          }
+        )
+      end
+
+      it "includes filtered changes with [FILTERED] value" do
+        patient.audits.create!(
+          audited_changes: {
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events.first[:details][:audited_changes][:given_name]).to eq(
+          "[FILTERED]"
+        )
+      end
+    end
+  end
+
+  describe "#additional_events" do
+    let(:cohort_imports_with_patient) do
+      create_list(:cohort_import, 2, organisation: session.organisation)
+    end
+    let(:cohort_imports_without_patient) do
+      create_list(:cohort_import, 1, organisation: session.organisation)
+    end
+
+    before do
+      class_import_additional.session_id = session.id
+      patient.sessions = [session]
+      patient.class_imports = [class_import]
+      patient.cohort_imports = cohort_imports_with_patient
+      patient.organisation.cohort_imports =
+        cohort_imports_with_patient + cohort_imports_without_patient
+    end
+
+    context "with class imports" do
+      it "returns a hash with class imports and cohort imports" do
+        result = timeline.additional_events(patient)
+        expect(result).to be_a(Hash)
+        expect(result.keys).to eq(%i[class_imports cohort_imports])
+      end
+
+      it "returns class imports that the patient is not in, for sessions that the patient is in" do
+        result = timeline.additional_events(patient)
+        expect(result[:class_imports]).to be_a(Hash)
+        expect(result[:class_imports].keys).to eq([session.id])
+        expect(result[:class_imports][session.id]).to eq(
+          [class_import_additional.id]
+        )
+      end
+    end
+
+    context "with cohort imports" do
+      it "returns cohort imports that the patient is not in, for organisations that the patient is in" do
+        result = timeline.additional_events(patient)
+        expect(result[:cohort_imports]).to eq(
+          cohort_imports_without_patient.map(&:id)
+        )
+      end
+    end
+  end
+
+  describe "#patient_events" do
+    let(:class_imports) { create_list(:class_import, 3, session: session) }
+    let(:cohort_imports) do
+      create_list(:cohort_import, 3, organisation: session.organisation)
+    end
+
+    before do
+      patient.class_imports = class_imports
+      patient.cohort_imports = cohort_imports
+    end
+
+    context "with class imports" do
+      it "returns a hash with class imports, cohort imports, and sessions" do
+        result = timeline.patient_events(patient)
+        expect(result).to be_a(Hash)
+        expect(result.keys).to eq(%i[class_imports cohort_imports sessions])
+      end
+
+      it "returns an array of class import IDs" do
+        result = timeline.patient_events(patient)
+        expect(result[:class_imports]).to eq(class_imports.map(&:id))
+      end
+    end
+
+    context "with cohort imports" do
+      it "returns an array of cohort import IDs" do
+        result = timeline.patient_events(patient)
+        expect(result[:cohort_imports]).to eq(cohort_imports.map(&:id))
+      end
+    end
+  end
+end


### PR DESCRIPTION
An endpoint which serves a UI used to view events related to a patient record.

This is a tool designed for use by the Ops Support people, to visualise the patient data without having to use the console.

The information that can be displayed for each 'event' is as follows:
```
cohort_imports: %i[rows_count status uploaded_by_user_id],
class_imports: %i[rows_count year_groups uploaded_by_user_id session_id],
patient_sessions: %i[session_id],
school_moves: %i[source school_id home_educated],
school_move_log_entries: %i[user_id school_id home_educated],
consents: %i[programme_id response route parent_id withdrawn_at invalidated_at],
triages: %i[status performed_by_user_id programme_id invalidated_at],
vaccination_records: %i[outcome performed_by_user_id programme_id session_id vaccine_id]
```

And the following audited changes are allowed:
```
patient_id
session_id
programme_id
vaccine_id
organisation_id
school_id
gp_practice_id

uploaded_by_user_id
performed_by_user_id
user_id
parent_id

status
outcome
response
route

date_of_death_recorded_at
restricted_at
invalidated_at
withdrawn_at

rows_count
year_groups
home_educated
source
```

![image](https://github.com/user-attachments/assets/d5720fc7-de75-4ae1-a089-20dc0b87d325)
