### PR TITLE
Patch application deployment workflow

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -68,9 +68,9 @@ jobs:
         working-directory: ${{ env.terraform-working-directory }}
         run: |
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
-          terraform plan -var="image_digest=$DIGEST" -target=aws_ecs_task_definition.task_definition \
+          terraform plan -target=aws_ecs_task_definition.task_definition \
           -target=aws_s3_object.appspec_object -var-file="env/${{ inputs.environment }}.tfvars" \
-          -out=${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
+          -var="image_digest=$DIGEST" -out=${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
       - name: Validate the changes
         run: |
           ./terraform/scripts/check_task_definition.sh ${{ runner.temp }}/tf_stdout
@@ -143,9 +143,8 @@ jobs:
         run: |
           source ${{ runner.temp }}/artifact/CODEDEPLOY_ENV
           deployment_id=$(aws deploy create-deployment \
-          --application-name $application --deployment-group-name $application_group \
-          --s3-location bucket=appspec-bucket-${{ inputs.environment }},key=appspec.yaml,bundleType=yaml \
-          | jq -r .deploymentId)
+          --application-name "$application" --deployment-group-name "$application_group" \
+          --s3-location bucket="$s3_bucket",key="$s3_key",bundleType=yaml | jq -r .deploymentId)
           echo "Deployment started: $deployment_id"
           echo "deployment_id=$deployment_id" >> $GITHUB_ENV
       - name: Wait up to 30 minutes for deployment to complete

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -23,4 +23,3 @@ http_hosts = {
 }
 minimum_replicas = 3
 appspec_bucket = "nhse-mavis-appspec-bucket-qa"
-image_digest="sha256:b35aa00cd4e61cc796f9c852291fb5ea188e33a08ce84a9ca1519b57c77d9a31"

--- a/terraform/scripts/check_task_definition.sh
+++ b/terraform/scripts/check_task_definition.sh
@@ -23,10 +23,10 @@ else
   echo "S3 bucket object is not being replaced, aborting."
   exit 1
 fi
-MODIFICATIONS=$(grep -E "[0-9]+ to add, [0-9]+ to change, [0-9]+ to destroy." test_less)
-ADDITIONS=$(echo "$MODIFICATIONS" | sed -E 's/.*([0-9]+) to add.*/\1/')
-CHANGES=$(echo "$MODIFICATIONS" | sed -E 's/.*([0-9]+) to change.*/\1/')
-DELETIONS=$(echo "$MODIFICATIONS" | sed -E 's/.*([0-9]+) to destroy.*/\1/')
+MODIFICATIONS=$(grep -E "[0-9]+ to add, [0-9]+ to change, [0-9]+ to destroy." "$tf_stdout") || exit 1
+ADDITIONS=$(echo "$MODIFICATIONS" | sed -E 's/.*([0-9]+) to add.*/\1/')  || exit 1
+CHANGES=$(echo "$MODIFICATIONS" | sed -E 's/.*([0-9]+) to change.*/\1/')  || exit 1
+DELETIONS=$(echo "$MODIFICATIONS" | sed -E 's/.*([0-9]+) to destroy.*/\1/') || exit 1
 if [[ $DELETIONS -gt $ADDITIONS ]]; then
   echo "More resources are being destroyed than created."
   echo "Other resources than task definition and s3 bucket object are being deleted, aborting."


### PR DESCRIPTION
- Should use bucket name output not hardcoded value
- Digest was in tfvars file which overwrote command-line argument
  - Remove from tfvars and restructure order to avoid overwrite in the future
- Script to exit on failed grep