### PR TITLE
Avoid unnecessary preloading

### DIFF
--- a/app/components/app_imports_navigation_component.rb
+++ b/app/components/app_imports_navigation_component.rb
@@ -43,7 +43,7 @@ class AppImportsNavigationComponent < ViewComponent::Base
 
     unique_import_issues =
       (vaccination_records_with_issues + patients_with_issues).uniq do |record|
-        record.is_a?(VaccinationRecord) ? record.patient : record
+        record.is_a?(VaccinationRecord) ? record.patient_id : record.id
       end
 
     count = unique_import_issues.count

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -54,7 +54,12 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def vaccination_record
-    @vaccination_record ||= patient.latest_vaccination_records(programme:).last
+    @vaccination_record ||=
+      patient
+        .vaccination_records
+        .includes(:batch, :performed_by_user, :vaccine)
+        .order(performed_at: :desc)
+        .find_by(programme:)
   end
 
   def triage
@@ -71,7 +76,7 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def vaccine_summary
-    type = vaccination_record.programme.name
+    type = programme.name
     batch = vaccination_record.batch&.name
     brand =
       (vaccination_record.vaccine || vaccination_record.batch&.vaccine)&.brand

--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -63,7 +63,13 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def triage
-    @triage ||= patient.latest_triage(programme:)
+    @triage ||=
+      patient
+        .triages
+        .not_invalidated
+        .includes(:performed_by)
+        .order(created_at: :desc)
+        .find_by(programme:)
   end
 
   def session_attendance

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -16,7 +16,7 @@
 <% if display_gillick_assessment_card? %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Gillick assessment" } %>
-    <% if (gillick_assessment = patient_session.gillick_assessment(programme)) %>
+    <% if gillick_assessment %>
       <% if gillick_assessment.gillick_competent? %>
         <p class="app-status app-status--aqua-green">
           <svg class="nhsuk-icon nhsuk-icon__tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -96,7 +96,7 @@
   <% end %>
 <% end %>
 
-<% patient.latest_vaccination_records(programme:).each do |vaccination_record| %>
+<% vaccination_records.find_each do |vaccination_record| %>
   <%= render AppCardComponent.new do |c| %>
     <% c.with_heading { "Vaccination details" } %>
     <%= render AppVaccinationRecordSummaryComponent.new(vaccination_record, current_user:) %>

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -67,7 +67,7 @@
 
 <% if display_health_questions? %>
   <%= render AppHealthAnswersCardComponent.new(
-        patient.latest_consents(programme:),
+        consents,
         heading: "All answers to health questions",
       ) %>
 <% end %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -36,6 +36,14 @@ class AppPatientPageComponent < ViewComponent::Base
     patient_session.session.today? && helpers.policy(GillickAssessment).new?
   end
 
+  def vaccination_records
+    patient
+      .vaccination_records
+      .where(programme:)
+      .includes(:batch, :location, :performed_by_user, :programme, :vaccine)
+      .order(:performed_at)
+  end
+
   def default_vaccinate_form
     pre_screening = patient_session.pre_screenings.last
 

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -28,12 +28,19 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def display_gillick_assessment_card?
-    patient_session.gillick_assessment(programme) ||
-      gillick_assessment_can_be_recorded?
+    gillick_assessment.present? || gillick_assessment_can_be_recorded?
   end
 
   def gillick_assessment_can_be_recorded?
     patient_session.session.today? && helpers.policy(GillickAssessment).new?
+  end
+
+  def gillick_assessment
+    @gillick_assessment ||=
+      patient_session
+        .gillick_assessments
+        .order(created_at: :desc)
+        .find_by(programme:)
   end
 
   def vaccination_records

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -52,7 +52,8 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def default_vaccinate_form
-    pre_screening = patient_session.pre_screenings.last
+    pre_screening =
+      patient_session.pre_screenings.order(created_at: :desc).first
 
     VaccinateForm.new(
       feeling_well: pre_screening&.feeling_well,

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -24,7 +24,7 @@ class AppPatientPageComponent < ViewComponent::Base
   delegate :patient, :session, to: :patient_session
 
   def display_health_questions?
-    patient.latest_consents(programme:).any?(&:response_given?)
+    consents.any?(&:response_given?)
   end
 
   def display_gillick_assessment_card?
@@ -33,6 +33,10 @@ class AppPatientPageComponent < ViewComponent::Base
 
   def gillick_assessment_can_be_recorded?
     patient_session.session.today? && helpers.policy(GillickAssessment).new?
+  end
+
+  def consents
+    @consents ||= ConsentGrouper.call(patient.consents, programme:)
   end
 
   def gillick_assessment

--- a/app/components/app_patient_vaccination_table_component.rb
+++ b/app/components/app_patient_vaccination_table_component.rb
@@ -14,8 +14,8 @@ class AppPatientVaccinationTableComponent < ViewComponent::Base
   def vaccination_records
     patient
       .vaccination_records
-      .select(&:administered?)
-      .sort_by(&:performed_at)
-      .reverse
+      .administered
+      .includes(:location, :programme, :vaccine)
+      .order(performed_at: :desc)
   end
 end

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -6,11 +6,10 @@ class AppSessionActionsComponent < ViewComponent::Base
     <%= govuk_summary_list(rows:) %>
   ERB
 
-  def initialize(session, patient_sessions:)
+  def initialize(session)
     super
 
     @session = session
-    @patient_sessions = patient_sessions
   end
 
   def render?
@@ -19,7 +18,9 @@ class AppSessionActionsComponent < ViewComponent::Base
 
   private
 
-  attr_reader :session, :patient_sessions
+  attr_reader :session
+
+  delegate :patient_sessions, to: :session
 
   delegate :programmes, to: :session
 

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -110,6 +110,9 @@ class AppSessionActionsComponent < ViewComponent::Base
       session.programmes.index_with do |programme|
         patient_sessions
           .has_registration_status(%w[attending completed])
+          .includes(
+            patient: %i[consent_statuses triage_statuses vaccination_statuses]
+          )
           .count do |patient_session|
             patient_session.patient.consent_given_and_safe_to_vaccinate?(
               programme:

--- a/app/components/app_session_details_summary_component.rb
+++ b/app/components/app_session_details_summary_component.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 class AppSessionDetailsSummaryComponent < ViewComponent::Base
-  def initialize(session, patient_sessions:)
+  def initialize(session)
     super
 
     @session = session
-    @patient_sessions = patient_sessions
   end
 
   def call
@@ -14,7 +13,9 @@ class AppSessionDetailsSummaryComponent < ViewComponent::Base
 
   private
 
-  attr_reader :session, :patient_sessions
+  attr_reader :session
+
+  delegate :patient_sessions, to: :session
 
   delegate :programmes, to: :session
 

--- a/app/components/app_simple_status_banner_component.rb
+++ b/app/components/app_simple_status_banner_component.rb
@@ -85,10 +85,12 @@ class AppSimpleStatusBannerComponent < ViewComponent::Base
   end
 
   def who_refused
-    patient
-      .latest_consents(programme:)
-      .select(&:response_refused?)
-      .last
+    consents =
+      patient.consents.where(programme:).not_invalidated.includes(:parent)
+
+    ConsentGrouper
+      .call(consents, programme:)
+      .find(&:response_refused?)
       &.who_responded
   end
 

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -48,7 +48,7 @@ module VaccinationMailerConcern
     return [] unless patient.send_notifications?
 
     programme = vaccination_record.programme
-    consents = patient.latest_consents(programme:)
+    consents = ConsentGrouper.call(patient.consents, programme:)
 
     parents =
       if consents.any?(&:via_self_consent?)

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -105,10 +105,10 @@ class ConsentsController < ApplicationController
 
   def set_patient_session
     @patient_session =
-      policy_scope(PatientSession).includes(
-        :gillick_assessments,
-        session: :programmes
-      ).find_by!(session: @session, patient_id: params[:patient_id])
+      policy_scope(PatientSession).includes(session: :programmes).find_by!(
+        session: @session,
+        patient_id: params[:patient_id]
+      )
   end
 
   def set_programme

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -49,7 +49,6 @@ class PatientSessionsController < ApplicationController
       policy_scope(PatientSession)
         .eager_load(:location, :session, patient: %i[gp_practice school])
         .preload(
-          :gillick_assessments,
           :session_attendances,
           patient: {
             consents: %i[parent],

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -55,10 +55,7 @@ class PatientSessionsController < ApplicationController
             consents: %i[parent],
             parent_relationships: :parent,
             triage_statuses: :programme,
-            triages: :performed_by,
-            vaccination_records: {
-              vaccine: :programme
-            }
+            triages: :performed_by
           },
           session: :programmes
         )

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -71,7 +71,6 @@ class PatientsController < ApplicationController
         :gp_practice,
         :organisation,
         :school,
-        :triages,
         consents: %i[parent patient],
         parent_relationships: :parent,
         patient_sessions: %i[location session_attendances]

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -43,13 +43,8 @@ class PatientsController < ApplicationController
       if organisation_id.nil?
         @patient
           .patient_sessions
-          .includes(
-            :gillick_assessments,
-            :session_attendances,
-            :vaccination_records
-          )
           .where(session: old_organisation.sessions)
-          .find_each(&:destroy_if_safe!)
+          .destroy_all_if_safe
       end
     end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -80,8 +80,7 @@ class PatientsController < ApplicationController
         :triages,
         consents: %i[parent patient],
         parent_relationships: :parent,
-        patient_sessions: %i[location session_attendances],
-        vaccination_records: [{ vaccine: :programme }]
+        patient_sessions: %i[location session_attendances]
       ).find(params[:id])
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -68,7 +68,6 @@ class PatientsController < ApplicationController
   def set_patient
     @patient =
       policy_scope(Patient).includes(
-        :gillick_assessments,
         :gp_practice,
         :organisation,
         :school,

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -32,17 +32,7 @@ class ProgrammesController < ApplicationController
       policy_scope(Session)
         .has_programme(@programme)
         .for_current_academic_year
-        .eager_load(:location)
-        .preload(
-          :session_dates,
-          patient_sessions: [
-            :gillick_assessments,
-            :session_attendances,
-            {
-              patient: %i[consent_statuses triage_statuses vaccination_records]
-            }
-          ]
-        )
+        .includes(:location, :session_dates)
         .order("locations.name")
   end
 

--- a/app/controllers/sessions/consent_controller.rb
+++ b/app/controllers/sessions/consent_controller.rb
@@ -14,7 +14,10 @@ class Sessions::ConsentController < ApplicationController
     @programmes = @session.programmes
 
     scope =
-      @session.patient_sessions.preload_for_status.in_programmes(@programmes)
+      @session
+        .patient_sessions
+        .includes(patient: :consent_statuses, session: :programmes)
+        .in_programmes(@programmes)
 
     patient_sessions = @form.apply(scope, programme: @programmes)
     @pagy, @patient_sessions = pagy(patient_sessions)

--- a/app/controllers/sessions/outcome_controller.rb
+++ b/app/controllers/sessions/outcome_controller.rb
@@ -14,7 +14,10 @@ class Sessions::OutcomeController < ApplicationController
     @programmes = @session.programmes
 
     scope =
-      @session.patient_sessions.preload_for_status.in_programmes(@programmes)
+      @session
+        .patient_sessions
+        .includes(:patient, :session_statuses, session: :programmes)
+        .in_programmes(@programmes)
 
     patient_sessions = @form.apply(scope, programme: @programmes)
     @pagy, @patient_sessions = pagy(patient_sessions)

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -18,7 +18,9 @@ class Sessions::RecordController < ApplicationController
     scope =
       @session
         .patient_sessions
-        .preload_for_status
+        .includes(
+          patient: %i[consent_statuses triage_statuses vaccination_statuses]
+        )
         .in_programmes(@session.programmes)
         .has_registration_status(%w[attending completed])
 

--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -16,7 +16,7 @@ class Sessions::TriageController < ApplicationController
     scope =
       @session
         .patient_sessions
-        .preload_for_status
+        .includes(patient: :triage_statuses, session: :programmes)
         .in_programmes(@programmes)
         .has_triage_status(@statuses, programme: @programmes)
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -29,15 +29,7 @@ class SessionsController < ApplicationController
 
   def show
     respond_to do |format|
-      format.html do
-        @patient_sessions =
-          @session
-            .patient_sessions
-            .includes(:patient)
-            .in_programmes(@session.programmes)
-
-        render layout: "full"
-      end
+      format.html { render layout: "full" }
 
       format.xlsx do
         filename =

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -33,8 +33,8 @@ class SessionsController < ApplicationController
         @patient_sessions =
           @session
             .patient_sessions
+            .includes(:patient)
             .in_programmes(@session.programmes)
-            .preload_for_status
 
         render layout: "full"
       end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -23,9 +23,8 @@ class TriagesController < ApplicationController
     if @triage.save(context: :consent)
       StatusUpdater.call(patient: @patient)
 
-      @patient
-        .reload
-        .latest_consents(programme: @triage.programme)
+      ConsentGrouper
+        .call(@patient.reload.consents, programme: @programme)
         .each { send_triage_confirmation(@patient_session, it) }
 
       flash[:success] = {
@@ -56,7 +55,6 @@ class TriagesController < ApplicationController
         .patients
         .includes(
           :consent_statuses,
-          :consents,
           :school,
           :triage_statuses,
           :vaccination_statuses,

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -66,11 +66,7 @@ class TriagesController < ApplicationController
   end
 
   def set_patient_session
-    @patient_session =
-      @patient
-        .patient_sessions
-        .includes(:gillick_assessments)
-        .find_by!(session: @session)
+    @patient_session = @patient.patient_sessions.find_by!(session: @session)
   end
 
   def set_programme

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -54,7 +54,14 @@ class TriagesController < ApplicationController
     @patient =
       @session
         .patients
-        .includes(:consents, :school, parent_relationships: :parent)
+        .includes(
+          :consent_statuses,
+          :consents,
+          :school,
+          :triage_statuses,
+          :vaccination_statuses,
+          parent_relationships: :parent
+        )
         .find_by(id: params[:patient_id])
   end
 
@@ -62,7 +69,6 @@ class TriagesController < ApplicationController
     @patient_session =
       @patient
         .patient_sessions
-        .preload_for_status
         .includes(:gillick_assessments)
         .find_by!(session: @session)
   end

--- a/app/controllers/triages_controller.rb
+++ b/app/controllers/triages_controller.rb
@@ -54,12 +54,7 @@ class TriagesController < ApplicationController
     @patient =
       @session
         .patients
-        .includes(
-          :consents,
-          :school,
-          :vaccination_records,
-          parent_relationships: :parent
-        )
+        .includes(:consents, :school, parent_relationships: :parent)
         .find_by(id: params[:patient_id])
   end
 

--- a/app/controllers/vaccination_records_controller.rb
+++ b/app/controllers/vaccination_records_controller.rb
@@ -76,11 +76,7 @@ class VaccinationRecordsController < ApplicationController
           :location,
           :performed_by_user,
           :programme,
-          patient: [
-            :gp_practice,
-            :school,
-            { consents: :parent, parent_relationships: :parent }
-          ],
+          patient: [:gp_practice, :school, { parent_relationships: :parent }],
           session: %i[session_dates],
           vaccine: :programme
         )

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -87,7 +87,6 @@ class VaccinationsController < ApplicationController
   def set_patient_session
     @patient_session =
       PatientSession.includes(
-        :gillick_assessments,
         :registration_status,
         :session_attendances,
         :organisation,

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -86,19 +86,16 @@ class VaccinationsController < ApplicationController
 
   def set_patient_session
     @patient_session =
-      @patient
-        .patient_sessions
-        .includes(
-          :gillick_assessments,
-          :session_attendances,
-          :organisation,
-          patient: {
-            consents: :parent,
-            parent_relationships: :parent
-          }
-        )
-        .preload_for_status
-        .find_by!(session: @session)
+      PatientSession.includes(
+        :gillick_assessments,
+        :registration_status,
+        :session_attendances,
+        :organisation,
+        patient: {
+          consents: :parent,
+          parent_relationships: :parent
+        }
+      ).find_by!(patient: @patient, session: @session)
   end
 
   def set_programme

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -87,11 +87,7 @@ class VaccinationsController < ApplicationController
   def set_patient_session
     @patient_session =
       PatientSession.includes(
-        :registration_status,
-        :session_attendances,
-        :organisation,
         patient: {
-          consents: :parent,
           parent_relationships: :parent
         }
       ).find_by!(patient: @patient, session: @session)

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -72,7 +72,7 @@ class VaccinateForm
 
   def pre_screening
     @pre_screening ||=
-      PreScreening.new(
+      patient_session.pre_screenings.build(
         feeling_well: feeling_well || false,
         knows_vaccination: knows_vaccination || false,
         no_allergies: no_allergies || false,
@@ -80,7 +80,6 @@ class VaccinateForm
         not_pregnant: not_pregnant || false,
         not_taking_medication: not_taking_medication || false,
         notes: pre_screening_notes,
-        patient_session:,
         performed_by: current_user,
         programme_id:
       )

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -9,7 +9,7 @@ class SchoolSessionRemindersJob < ApplicationJob
     patient_sessions =
       PatientSession
         .includes(
-          patient: [:parents, :triages, { consents: %i[parent patient] }],
+          patient: [:parents, { consents: %i[parent patient] }],
           session: :programmes
         )
         .eager_load(:session)

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -10,12 +10,7 @@ class SchoolSessionRemindersJob < ApplicationJob
       PatientSession
         .includes(
           :gillick_assessments,
-          patient: [
-            :parents,
-            :triages,
-            :vaccination_records,
-            { consents: %i[parent patient] }
-          ],
+          patient: [:parents, :triages, { consents: %i[parent patient] }],
           session: :programmes
         )
         .eager_load(:session)

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -9,7 +9,6 @@ class SchoolSessionRemindersJob < ApplicationJob
     patient_sessions =
       PatientSession
         .includes(
-          :gillick_assessments,
           patient: [:parents, :triages, { consents: %i[parent patient] }],
           session: :programmes
         )

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -203,7 +203,6 @@ class DraftConsent
     PatientSessionPolicy::Scope
       .new(@current_user, PatientSession)
       .resolve
-      .preload_for_status
       .find_by(id: patient_session_id)
   end
 

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -169,7 +169,6 @@ class DraftVaccinationRecord
     VaccinationRecordPolicy::Scope
       .new(@current_user, VaccinationRecord)
       .resolve
-      .includes(patient: { consents: :parent })
       .find_by(id: editing_id)
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -73,7 +73,7 @@ class Patient < ApplicationRecord
   has_many :school_moves
   has_many :session_notifications
   has_many :triage_statuses
-  has_many :triages, -> { order(:created_at) }
+  has_many :triages
   has_many :vaccination_records, -> { kept }
   has_many :vaccination_statuses
 
@@ -286,13 +286,6 @@ class Patient < ApplicationRecord
     # Use `find` to allow for preloading.
     triage_statuses.find { it.programme_id == programme.id } ||
       triage_statuses.build(programme:)
-  end
-
-  def latest_triage(programme:)
-    triages
-      .select { it.programme_id == programme.id }
-      .reject(&:invalidated?)
-      .max_by(&:created_at)
   end
 
   def vaccination_status(programme:)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -74,7 +74,7 @@ class Patient < ApplicationRecord
   has_many :session_notifications
   has_many :triage_statuses
   has_many :triages, -> { order(:created_at) }
-  has_many :vaccination_records, -> { kept.order(:performed_at) }
+  has_many :vaccination_records, -> { kept }
   has_many :vaccination_statuses
 
   has_many :parents, through: :parent_relationships
@@ -303,12 +303,6 @@ class Patient < ApplicationRecord
     # Use `find` to allow for preloading.
     vaccination_statuses.find { it.programme_id == programme.id } ||
       vaccination_statuses.build(programme:)
-  end
-
-  def latest_vaccination_records(programme:)
-    vaccination_records
-      .select { it.programme_id == programme.id }
-      .reject(&:discarded?)
   end
 
   def consent_given_and_safe_to_vaccinate?(programme:)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -79,9 +79,7 @@ class Patient < ApplicationRecord
 
   has_many :parents, through: :parent_relationships
   has_many :gillick_assessments, through: :patient_sessions
-  has_many :pre_screenings,
-           -> { order(:created_at) },
-           through: :patient_sessions
+  has_many :pre_screenings, through: :patient_sessions
   has_many :session_attendances, through: :patient_sessions
   has_many :sessions, through: :patient_sessions
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -65,7 +65,7 @@ class Patient < ApplicationRecord
   has_many :access_log_entries
   has_many :consent_notifications
   has_many :consent_statuses
-  has_many :consents, -> { order(:created_at) }
+  has_many :consents
   has_many :notify_log_entries
   has_many :parent_relationships
   has_many :patient_sessions
@@ -276,10 +276,6 @@ class Patient < ApplicationRecord
     # Use `find` to allow for preloading.
     consent_statuses.find { it.programme_id == programme.id } ||
       consent_statuses.build(programme:)
-  end
-
-  def latest_consents(programme:)
-    ConsentGrouper.call(consents, programme:)
   end
 
   def triage_status(programme:)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -438,13 +438,8 @@ class Patient < ApplicationRecord
   end
 
   def clear_sessions_for_current_academic_year!
-    patient_sessions
-      .includes(
-        :gillick_assessments,
-        :session_attendances,
-        :vaccination_records
-      )
-      .where(session: sessions_for_current_academic_year)
-      .find_each(&:destroy_if_safe!)
+    patient_sessions.where(
+      session: sessions_for_current_academic_year
+    ).destroy_all_if_safe
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -78,9 +78,7 @@ class Patient < ApplicationRecord
   has_many :vaccination_statuses
 
   has_many :parents, through: :parent_relationships
-  has_many :gillick_assessments,
-           -> { order(:created_at) },
-           through: :patient_sessions
+  has_many :gillick_assessments, through: :patient_sessions
   has_many :pre_screenings,
            -> { order(:created_at) },
            through: :patient_sessions

--- a/app/models/patient/consent_status.rb
+++ b/app/models/patient/consent_status.rb
@@ -24,9 +24,7 @@ class Patient::ConsentStatus < ApplicationRecord
   belongs_to :programme
 
   has_many :consents,
-           -> do
-             not_invalidated.response_provided.eager_load(:parent, :patient)
-           end,
+           -> { not_invalidated.response_provided.includes(:parent, :patient) },
            through: :patient
 
   enum :status,

--- a/app/models/patient/triage_status.rb
+++ b/app/models/patient/triage_status.rb
@@ -24,9 +24,7 @@ class Patient::TriageStatus < ApplicationRecord
   belongs_to :programme
 
   has_many :consents,
-           -> do
-             not_invalidated.response_provided.eager_load(:parent, :patient)
-           end,
+           -> { not_invalidated.response_provided.includes(:parent, :patient) },
            through: :patient
 
   has_many :triages,

--- a/app/models/patient/triage_status.rb
+++ b/app/models/patient/triage_status.rb
@@ -29,7 +29,9 @@ class Patient::TriageStatus < ApplicationRecord
            end,
            through: :patient
 
-  has_many :triages, -> { not_invalidated }, through: :patient
+  has_many :triages,
+           -> { not_invalidated.order(created_at: :desc) },
+           through: :patient
 
   has_many :vaccination_records,
            -> { kept.order(performed_at: :desc) },
@@ -92,6 +94,6 @@ class Patient::TriageStatus < ApplicationRecord
   end
 
   def latest_triage
-    @latest_triage ||= triages.select { it.programme_id == programme_id }.last
+    @latest_triage ||= triages.find { it.programme_id == programme_id }
   end
 end

--- a/app/models/patient/triage_status.rb
+++ b/app/models/patient/triage_status.rb
@@ -31,7 +31,9 @@ class Patient::TriageStatus < ApplicationRecord
 
   has_many :triages, -> { not_invalidated }, through: :patient
 
-  has_many :vaccination_records, -> { kept }, through: :patient
+  has_many :vaccination_records,
+           -> { kept.order(performed_at: :desc) },
+           through: :patient
 
   enum :status,
        {

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -24,9 +24,7 @@ class Patient::VaccinationStatus < ApplicationRecord
   belongs_to :programme
 
   has_many :consents,
-           -> do
-             not_invalidated.response_provided.eager_load(:parent, :patient)
-           end,
+           -> { not_invalidated.response_provided.includes(:parent, :patient) },
            through: :patient
 
   has_many :triages,

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -29,7 +29,9 @@ class Patient::VaccinationStatus < ApplicationRecord
            end,
            through: :patient
 
-  has_many :triages, -> { not_invalidated }, through: :patient
+  has_many :triages,
+           -> { not_invalidated.order(created_at: :desc) },
+           through: :patient
 
   has_many :vaccination_records,
            -> { kept.order(performed_at: :desc) },

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -31,7 +31,9 @@ class Patient::VaccinationStatus < ApplicationRecord
 
   has_many :triages, -> { not_invalidated }, through: :patient
 
-  has_many :vaccination_records, -> { kept }, through: :patient
+  has_many :vaccination_records,
+           -> { kept.order(performed_at: :desc) },
+           through: :patient
 
   enum :status,
        { none_yet: 0, vaccinated: 1, could_not_vaccinate: 2 },

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -67,18 +67,10 @@ class PatientSession < ApplicationRecord
           )
         end
 
-  scope :preload_for_status,
-        -> do
-          eager_load(:patient).preload(
-            :registration_status,
-            :session_statuses,
-            patient: %i[consent_statuses triage_statuses vaccination_statuses],
-            session: :programmes
-          )
-        end
-
   scope :in_programmes,
-        ->(programmes) { merge(Patient.in_programmes(programmes)) }
+        ->(programmes) do
+          joins(:patient).merge(Patient.in_programmes(programmes))
+        end
 
   scope :search_by_name, ->(name) { merge(Patient.search_by_name(name)) }
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -32,7 +32,7 @@ class PatientSession < ApplicationRecord
   belongs_to :session
 
   has_many :gillick_assessments
-  has_many :pre_screenings, -> { order(:created_at) }
+  has_many :pre_screenings
   has_many :session_statuses
   has_one :registration_status
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -145,6 +145,15 @@ class PatientSession < ApplicationRecord
           )
         end
 
+  scope :destroy_all_if_safe,
+        -> do
+          includes(
+            :gillick_assessments,
+            :session_attendances,
+            :vaccination_records
+          ).find_each(&:destroy_if_safe!)
+        end
+
   def safe_to_destroy?
     vaccination_records.empty? && gillick_assessments.empty? &&
       session_attendances.none?(&:attending?)

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -31,7 +31,7 @@ class PatientSession < ApplicationRecord
   belongs_to :patient
   belongs_to :session
 
-  has_many :gillick_assessments, -> { order(:created_at) }
+  has_many :gillick_assessments
   has_many :pre_screenings, -> { order(:created_at) }
   has_many :session_statuses
   has_one :registration_status
@@ -169,12 +169,6 @@ class PatientSession < ApplicationRecord
 
   def programmes
     session.programmes.select { it.year_groups.include?(patient.year_group) }
-  end
-
-  def gillick_assessment(programme)
-    gillick_assessments
-      .select { it.programme_id == programme.id }
-      .max_by(&:created_at)
   end
 
   def session_status(programme:)

--- a/app/models/patient_session/registration_status.rb
+++ b/app/models/patient_session/registration_status.rb
@@ -23,7 +23,9 @@ class PatientSession::RegistrationStatus < ApplicationRecord
   has_one :patient, through: :patient_session
   has_one :session, through: :patient_session
 
-  has_many :vaccination_records, -> { kept }, through: :patient
+  has_many :vaccination_records,
+           -> { kept.order(performed_at: :desc) },
+           through: :patient
 
   has_one :session_attendance,
           -> { today },

--- a/app/models/patient_session/session_status.rb
+++ b/app/models/patient_session/session_status.rb
@@ -31,7 +31,9 @@ class PatientSession::SessionStatus < ApplicationRecord
            end,
            through: :patient
 
-  has_many :triages, -> { not_invalidated }, through: :patient
+  has_many :triages,
+           -> { not_invalidated.order(created_at: :desc) },
+           through: :patient
 
   has_many :vaccination_records,
            -> { kept.order(performed_at: :desc) },

--- a/app/models/patient_session/session_status.rb
+++ b/app/models/patient_session/session_status.rb
@@ -26,9 +26,7 @@ class PatientSession::SessionStatus < ApplicationRecord
   has_one :patient, through: :patient_session
 
   has_many :consents,
-           -> do
-             not_invalidated.response_provided.eager_load(:parent, :patient)
-           end,
+           -> { not_invalidated.response_provided.includes(:parent, :patient) },
            through: :patient
 
   has_many :triages,

--- a/app/models/patient_session/session_status.rb
+++ b/app/models/patient_session/session_status.rb
@@ -33,7 +33,9 @@ class PatientSession::SessionStatus < ApplicationRecord
 
   has_many :triages, -> { not_invalidated }, through: :patient
 
-  has_many :vaccination_records, -> { kept }, through: :patient
+  has_many :vaccination_records,
+           -> { kept.order(performed_at: :desc) },
+           through: :patient
 
   has_one :session_attendance,
           -> { today },
@@ -116,7 +118,7 @@ class PatientSession::SessionStatus < ApplicationRecord
 
   def vaccination_record
     @vaccination_record ||=
-      vaccination_records.reverse.find do
+      vaccination_records.find do
         it.programme_id == programme_id &&
           it.session_id == patient_session.session_id
       end

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -64,14 +64,6 @@ class SchoolMove < ApplicationRecord
 
   private
 
-  def patient_sessions
-    patient.patient_sessions.includes(
-      :gillick_assessments,
-      :session_attendances,
-      :vaccination_records
-    )
-  end
-
   def update_patient!
     patient.update!(
       home_educated:,
@@ -81,7 +73,7 @@ class SchoolMove < ApplicationRecord
   end
 
   def update_sessions!
-    patient_sessions.find_each(&:destroy_if_safe!)
+    patient.patient_sessions.destroy_all_if_safe
 
     [school_session, generic_clinic_session].compact.each do |session|
       PatientSession.find_or_create_by!(patient:, session:)

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -57,8 +57,8 @@ class SessionNotification < ApplicationRecord
     parents =
       if type == :school_reminder
         patient_session.programmes.flat_map do |programme|
-          patient
-            .latest_consents(programme:)
+          ConsentGrouper
+            .call(patient.consents, programme:)
             .select(&:response_given?)
             .filter_map(&:parent)
         end

--- a/app/views/draft_consents/who.html.erb
+++ b/app/views/draft_consents/who.html.erb
@@ -11,7 +11,7 @@
   <%= page_title %>
 <% end %>
 
-<% gillick_competent = @patient_session.gillick_assessment(@programme)&.gillick_competent? %>
+<% gillick_competent = @patient_session.gillick_assessments.order(created_at: :desc).find_by(programme: @programme)&.gillick_competent? %>
 
 <%= form_with model: @draft_consent, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>

--- a/app/views/gillick_assessments/edit.html.erb
+++ b/app/views/gillick_assessments/edit.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(session_patient_programme_path(id: @patient.id), name: @patient.full_name) %>
 <% end %>
 
-<% page_title = @is_first_assessment ? "Assess Gillick competence" : "Edit Gillick competence" %>
+<% page_title = @gillick_assessment.persisted? ? "Edit Gillick competence" : "Assess Gillick competence" %>
 
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l">
@@ -60,5 +60,5 @@
 
   <%= f.govuk_text_area :notes, label: { text: "Assessment notes (optional)" } %>
 
-  <%= f.govuk_submit @is_first_assessment ? "Complete your assessment" : "Update your assessment" %>
+  <%= f.govuk_submit @gillick_assessment.persisted? ? "Update your assessment" : "Complete your assessment" %>
 <% end %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -27,14 +27,14 @@
 
       <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Session details</h3>
 
-      <%= render AppSessionDetailsSummaryComponent.new(@session, patient_sessions: @patient_sessions) %>
+      <%= render AppSessionDetailsSummaryComponent.new(@session) %>
 
       <% if @session.unscheduled? %>
         <% if policy(@session).edit? %>
           <%= govuk_button_link_to "Schedule sessions", edit_session_path(@session), class: "app-button--secondary" %>
         <% end %>
       <% else %>
-        <%= render AppSessionActionsComponent.new(@session, patient_sessions: @patient_sessions) %>
+        <%= render AppSessionActionsComponent.new(@session) %>
 
         <div class="app-button-group">
           <% if policy(@session).edit? %>

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -4,15 +4,7 @@ describe AppOutcomeBannerComponent do
   subject(:rendered) { render_inline(component) }
 
   let(:component) do
-    described_class.new(
-      patient_session:
-        PatientSession
-          .preload_for_status
-          .includes(patient: %i[triages vaccination_records])
-          .find(patient_session.id),
-      programme:,
-      current_user: user
-    )
+    described_class.new(patient_session:, programme:, current_user: user)
   end
 
   let(:user) { create(:user) }

--- a/spec/components/app_session_actions_component_spec.rb
+++ b/spec/components/app_session_actions_component_spec.rb
@@ -3,11 +3,10 @@
 describe AppSessionActionsComponent do
   subject { render_inline(component) }
 
-  let(:component) { described_class.new(session, patient_sessions:) }
+  let(:component) { described_class.new(session) }
 
   let(:programmes) { [create(:programme, :hpv)] }
   let(:session) { create(:session, programmes:) }
-  let(:patient_sessions) { session.patient_sessions }
 
   before do
     create(

--- a/spec/components/app_session_actions_component_spec.rb
+++ b/spec/components/app_session_actions_component_spec.rb
@@ -7,7 +7,7 @@ describe AppSessionActionsComponent do
 
   let(:programmes) { [create(:programme, :hpv)] }
   let(:session) { create(:session, programmes:) }
-  let(:patient_sessions) { session.patient_sessions.preload_for_status }
+  let(:patient_sessions) { session.patient_sessions }
 
   before do
     create(

--- a/spec/components/app_session_details_summary_component_spec.rb
+++ b/spec/components/app_session_details_summary_component_spec.rb
@@ -7,7 +7,7 @@ describe AppSessionDetailsSummaryComponent do
 
   let(:programme) { create(:programme, :hpv) }
   let(:session) { create(:session, programmes: [programme]) }
-  let(:patient_sessions) { session.patient_sessions.preload_for_status }
+  let(:patient_sessions) { session.patient_sessions }
 
   it { should have_text("Cohort\nNo children") }
   it { should have_text("Consent refused\nNo children") }

--- a/spec/components/app_session_details_summary_component_spec.rb
+++ b/spec/components/app_session_details_summary_component_spec.rb
@@ -3,11 +3,10 @@
 describe AppSessionDetailsSummaryComponent do
   subject { render_inline(component) }
 
-  let(:component) { described_class.new(session, patient_sessions:) }
+  let(:component) { described_class.new(session) }
 
   let(:programme) { create(:programme, :hpv) }
   let(:session) { create(:session, programmes: [programme]) }
-  let(:patient_sessions) { session.patient_sessions }
 
   it { should have_text("Cohort\nNo children") }
   it { should have_text("Consent refused\nNo children") }

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -109,7 +109,7 @@ describe SearchForm do
   end
 
   context "for patient sessions" do
-    let(:scope) { PatientSession.preload_for_status }
+    let(:scope) { PatientSession.all }
 
     it "doesn't raise an error" do
       expect { form.apply(scope) }.not_to raise_error

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -29,6 +29,7 @@ describe PatientSession do
   let(:session) { create(:session, programmes: [programme]) }
 
   it { should have_many(:gillick_assessments) }
+  it { should have_many(:pre_screenings) }
 
   describe "#safe_to_destroy?" do
     subject(:safe_to_destroy?) { patient_session.safe_to_destroy? }

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -28,7 +28,7 @@ describe PatientSession do
   let(:programme) { create(:programme) }
   let(:session) { create(:session, programmes: [programme]) }
 
-  it { should have_many(:gillick_assessments).order(:created_at) }
+  it { should have_many(:gillick_assessments) }
 
   describe "#safe_to_destroy?" do
     subject(:safe_to_destroy?) { patient_session.safe_to_destroy? }


### PR DESCRIPTION
This makes a number of small changes to the queries to avoid preloading objects where it's no longer necessary, particularly now that we have cached status models.

Some sessions can have lots of patient sessions (community clinics can sometimes have upwards of 50,000 patients in) and preloading all of this can be slow and require a large amount of memory.

Often at this scale, it seems to be more performant to not avoid N+1 queries, particularly depending on the page that is trying to be loaded.