### PR TITLE
Improve performance reporting by avoiding unnecessary preloading

### DIFF
--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -10,20 +10,15 @@ class Reports::CareplusExporter
 
   def call
     CSV.generate(headers:, write_headers: true) do |csv|
-      organisation
-        .sessions
-        .has_programme(programme)
-        .find_each do |session|
-          patient_sessions_for_session(session).each do |patient_session|
-            rows(patient_session:).each { |row| csv << row }
-          end
+      vaccination_records
+        .group_by(&:patient)
+        .each do |patient, vaccination_records|
+          rows(patient:, vaccination_records:).each { |row| csv << row }
         end
     end
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
-  end
+  def self.call(...) = new(...).call
 
   private_class_method :new
 
@@ -68,21 +63,21 @@ class Reports::CareplusExporter
     ]
   end
 
-  def patient_sessions_for_session(session)
+  def vaccination_records
     scope =
-      session
-        .patient_sessions
+      VaccinationRecord
+        .kept
+        .where(session: { organisation: }, programme:)
+        .administered
+        .order(:performed_at)
         .includes(
-          :location,
-          patient: [
-            :school,
-            :vaccination_records,
-            { consents: %i[parent patient] }
-          ],
-          session: :programmes
+          :batch,
+          :vaccine,
+          patient: {
+            consents: :parent
+          },
+          session: :location
         )
-        .where.not(vaccination_records: { id: nil })
-        .merge(VaccinationRecord.administered)
 
     if start_date.present?
       scope =
@@ -113,49 +108,34 @@ class Reports::CareplusExporter
     scope
   end
 
-  def rows(patient_session:)
-    patient = patient_session.patient
-
-    vaccination_records =
-      patient
-        .latest_vaccination_records(programme:)
-        .select do
-          it.administered? && it.session_id == patient_session.session_id
-        end
-
-    if vaccination_records.any?
-      [existing_row(patient:, patient_session:, vaccination_records:)]
-    else
-      []
-    end
-  end
-
-  def existing_row(patient:, patient_session:, vaccination_records:)
-    first_vaccination = vaccination_records.first
-
-    [
-      patient.nhs_number,
-      patient.family_name,
-      patient.given_name,
-      patient.date_of_birth.strftime("%d/%m/%Y"),
-      patient.restricted? ? "" : patient.address_line_1,
-      patient.latest_consents(programme:).first&.name || "",
-      99, # Ethnicity, 99 is "Not known"
-      first_vaccination.performed_at.strftime("%d/%m/%Y"),
-      first_vaccination.performed_at.strftime("%H:%M"),
-      patient_session.location.school? ? "SC" : "CL", # Venue Type
-      patient_session.location.dfe_number || organisation.careplus_venue_code, # Venue Code
-      "IN", # Staff Type
-      "LW5PM", # Staff Code
-      "Y", # Attended; Did not attends do not get recorded on GP systems
-      "", # Reason Not Attended; Always blank
-      "", # Suspension End Date; Doesn't need to be used
-      *vaccine_fields(vaccination_records, 0),
-      *vaccine_fields(vaccination_records, 1),
-      *vaccine_fields(vaccination_records, 2),
-      *vaccine_fields(vaccination_records, 3),
-      *vaccine_fields(vaccination_records, 4)
-    ]
+  def rows(patient:, vaccination_records:)
+    vaccination_records
+      .group_by(&:session)
+      .map do |session, records|
+        [
+          patient.nhs_number,
+          patient.family_name,
+          patient.given_name,
+          patient.date_of_birth.strftime("%d/%m/%Y"),
+          patient.restricted? ? "" : patient.address_line_1,
+          patient.latest_consents(programme:).first&.name || "",
+          99, # Ethnicity, 99 is "Not known"
+          records.first.performed_at.strftime("%d/%m/%Y"),
+          records.first.performed_at.strftime("%H:%M"),
+          session.location.school? ? "SC" : "CL", # Venue Type
+          session.location.dfe_number || organisation.careplus_venue_code, # Venue Code
+          "IN", # Staff Type
+          "LW5PM", # Staff Code
+          "Y", # Attended; Did not attends do not get recorded on GP systems
+          "", # Reason Not Attended; Always blank
+          "", # Suspension End Date; Doesn't need to be used
+          *vaccine_fields(records, 0),
+          *vaccine_fields(records, 1),
+          *vaccine_fields(records, 2),
+          *vaccine_fields(records, 3),
+          *vaccine_fields(records, 4)
+        ]
+      end
   end
 
   def blank_vaccine_fields

--- a/app/lib/reports/export_formatters.rb
+++ b/app/lib/reports/export_formatters.rb
@@ -38,9 +38,7 @@ module Reports::ExportFormatters
     end
   end
 
-  def consent_details(patient:, programme:)
-    consents = patient.latest_consents(programme:)
-
+  def consent_details(consents:)
     values =
       consents.map do |consent|
         "#{consent.response.humanize} by #{consent.name} at #{consent.created_at}"
@@ -49,8 +47,7 @@ module Reports::ExportFormatters
     values.join(", ")
   end
 
-  def health_question_answers(patient:, programme:)
-    consents = patient.latest_consents(programme:)
+  def health_question_answers(consents:)
     health_answers = ConsolidatedHealthAnswers.new(consents).to_h
 
     values =

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -48,7 +48,7 @@ class Reports::OfflineSessionExporter
     workbook.add_worksheet(name: "Vaccinations") do |sheet|
       sheet.add_row(columns.map { _1.to_s.upcase })
 
-      patient_sessions.each do |patient_session|
+      patient_sessions.find_each do |patient_session|
         rows(patient_session:).each { |row| row.add_to(sheet:, cached_styles:) }
       end
 

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -12,7 +12,7 @@ class Reports::ProgrammeVaccinationsExporter
 
   def call
     CSV.generate(headers:, write_headers: true) do |csv|
-      vaccination_records.each do |vaccination_record|
+      vaccination_records.find_each do |vaccination_record|
         csv << row(vaccination_record:)
       end
     end

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -34,15 +34,13 @@ class Reports::SystmOneExporter
 
   def call
     CSV.generate(headers:, write_headers: true) do |csv|
-      vaccination_records.each do |vaccination_record|
+      vaccination_records.find_each do |vaccination_record|
         csv << row(vaccination_record:)
       end
     end
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
-  end
+  def self.call(...) = new(...).call
 
   private_class_method :new
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -103,7 +103,10 @@ class PatientSession < ApplicationRecord
 
   scope :order_by_name,
         -> do
-          order("LOWER(patients.family_name)", "LOWER(patients.given_name)")
+          joins(:patient).order(
+            "LOWER(patients.family_name)",
+            "LOWER(patients.given_name)"
+          )
         end
 
   scope :has_consent_status,

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -463,13 +463,13 @@ describe Reports::ProgrammeVaccinationsExporter do
           before do
             performed_by =
               create(:user, given_name: "Test", family_name: "Nurse")
-            updated_at = Date.new(2024, 1, 1)
+            created_at = Date.new(2024, 1, 1)
             create(
               :gillick_assessment,
               :competent,
               patient_session:,
               performed_by:,
-              updated_at:
+              created_at:
             )
 
             Flipper.enable(:report_gillick_notify_parents)


### PR DESCRIPTION
This avoids preloading (via `includes`) and instead fetches the data directly from the database where possible, using a more optimised version of the query to avoid preloading data which is then never used.

For example, preloading `patient.consents` gets all the consents across all the programmes, whereas for reporting we only care about the programme being reported on. It's not possible to nicely preload these using `includes` as the programme would need to be passed in as a parameter. Instead we can execute the query ourselves ensuring we only pull the necessary information.