### PR TITLE
Prevent concurrent deployment workflows targeting same environment

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -29,6 +29,9 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: deploy-application-${{ inputs.environment }}
+
 env:
   aws-role: ${{ inputs.environment == 'production'
     && 'arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure'

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -27,6 +27,9 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: deploy-infrastructure-${{ inputs.environment }}
+
 env:
   aws_role: ${{ inputs.environment == 'production'
     && 'arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure'

--- a/.github/workflows/deploy-mavis.yml
+++ b/.github/workflows/deploy-mavis.yml
@@ -1,6 +1,9 @@
 name: Deploy Mavis on Environment
 run-name: Deploying Mavis on ${{ inputs.environment }}
 
+concurrency:
+  group: deploy-mavis-${{ inputs.environment }}
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
* Only one instance of deploy-mavis.yml can run at any time
* In the rare case where deploy-application.yml or deploy-infrastructure.yml is run directly, still prevent multiple concurrent workflows of the same type