### PR TITLE
Avoid N+1 issue on school moves page

### DIFF
--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -11,8 +11,8 @@ class SchoolMovesController < ApplicationController
   def index
     school_moves =
       policy_scope(SchoolMove).includes(
-        :school,
         :organisation,
+        school: :organisation,
         patient: :school
       ).order(:updated_at)
 


### PR DESCRIPTION
Instead of querying the organisation, we can instead just compare the IDs which avoids an unnecessary query to the database.