### PR TITLE
Rename `disable_pds` variable 

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -8,7 +8,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
   good_job_control_concurrency_with perform_limit: 1
 
   def perform
-    return unless Settings.pds.perform_jobs
+    return unless Settings.pds.enqueue_bulk_updates
 
     patients = Patient.with_nhs_number.not_invalidated.not_deceased
 

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -162,7 +162,7 @@ module CSVImportable
   end
 
   def update_from_pds
-    return unless Settings.pds.perform_jobs
+    return unless Settings.pds.enqueue_bulk_updates
 
     GoodJob::Bulk.enqueue do
       patients.each_with_index do |patient, index|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,7 +73,7 @@ nhs_api:
 <%= Rails.application.credentials.nhs_api&.jwt_private_key&.gsub(/^/, "    ") %>
 
 pds:
-  perform_jobs: true
+  enqueue_bulk_updates: true
   raise_unknown_gp_practice: true
 
 splunk:

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -23,7 +23,7 @@ nhs_api:
   disable_authentication: true
 
 pds:
-  perform_jobs: false
+  enqueue_bulk_updates: false
 
 splunk:
   enabled: false

--- a/terraform/app/env/copilotmigration.tfvars
+++ b/terraform/app/env/copilotmigration.tfvars
@@ -16,9 +16,9 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "copilotmigration.mavistesting.com"
 }
 
-enable_splunk = false
-enable_cis2   = false
-enable_pds    = false
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 minimum_replicas = 3
 appspec_bucket   = "nhse-mavis-appspec-bucket-copilotmigration"

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -15,9 +15,9 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_splunk = false
-enable_cis2   = false
-enable_pds    = false
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 http_hosts = {
   MAVIS__HOST                        = "preview.mavistesting.com"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -18,9 +18,9 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_splunk = false
-enable_cis2   = false
-enable_pds    = false
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -150,10 +150,10 @@ variable "enable_cis2" {
   nullable    = false
 }
 
-variable "enable_pds" {
+variable "enable_pds_enqueue_bulk_updates" {
   type        = bool
-  default     = true
-  description = "Boolean toggle to determine whether the PDS feature should be enabled."
+  default     = false
+  description = "Whether PDS jobs that update patients in bulk should execute or not. This is disabled in non-production environments to avoid making unnecessary requests to PDS."
   nullable    = false
 }
 
@@ -198,8 +198,8 @@ locals {
       value = var.enable_cis2 ? "true" : "false"
     },
     {
-      name  = "MAVIS__PDS__PERFORM_JOBS"
-      value = var.enable_pds ? "true" : "false"
+      name  = "MAVIS__PDS__ENQUEUE_BULK_UPDATES"
+      value = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
     },
     {
       name  = "MAVIS__SPLUNK__ENABLED"


### PR DESCRIPTION
This name wasn't very clear as to exactly what would be enabled/disabled by setting the value. Instead, I've renamed the variable in Terraform and the associated variable in Rails to make it clear that it's referring only the jobs which update patients in bulk to reduce the number of unnecessary PDS API calls.