### PR TITLE
Refactor Terraform feature enable variables

### DIFF
--- a/terraform/app/env/copilotmigration.tfvars
+++ b/terraform/app/env/copilotmigration.tfvars
@@ -15,8 +15,10 @@ http_hosts = {
   MAVIS__HOST                        = "copilotmigration.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "copilotmigration.mavistesting.com"
 }
-splunk_enabled   = false
-cis2_enabled     = false
-pds_enabled      = false
+
+enable_splunk = false
+enable_cis2   = false
+enable_pds    = false
+
 minimum_replicas = 3
 appspec_bucket   = "nhse-mavis-appspec-bucket-copilotmigration"

--- a/terraform/app/env/copilotmigration.tfvars
+++ b/terraform/app/env/copilotmigration.tfvars
@@ -15,8 +15,8 @@ http_hosts = {
   MAVIS__HOST                        = "copilotmigration.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "copilotmigration.mavistesting.com"
 }
-splunk_enabled   = "false"
-cis2_enabled     = "false"
-pds_enabled      = "false"
+splunk_enabled   = false
+cis2_enabled     = false
+pds_enabled      = false
 minimum_replicas = 3
 appspec_bucket   = "nhse-mavis-appspec-bucket-copilotmigration"

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -14,9 +14,9 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = "false"
-cis2_enabled          = "false"
-pds_enabled           = "false"
+splunk_enabled        = false
+cis2_enabled          = false
+pds_enabled           = false
 http_hosts = {
   MAVIS__HOST                        = "preview.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "preview.mavistesting.com"

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -14,9 +14,11 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = false
-cis2_enabled          = false
-pds_enabled           = false
+
+enable_splunk = false
+enable_cis2   = false
+enable_pds    = false
+
 http_hosts = {
   MAVIS__HOST                        = "preview.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "preview.mavistesting.com"

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -14,9 +14,9 @@ resource_name = {
 }
 rails_env             = "production"
 rails_master_key_path = "/copilot/mavis/production/secrets/RAILS_MASTER_KEY"
-splunk_enabled        = "true"
-cis2_enabled          = "true"
-pds_enabled           = "true"
+splunk_enabled        = true
+cis2_enabled          = true
+pds_enabled           = true
 http_hosts = {
   MAVIS__HOST                        = "www.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "www.give-or-refuse-consent-for-vaccinations.nhs.uk"

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -14,9 +14,7 @@ resource_name = {
 }
 rails_env             = "production"
 rails_master_key_path = "/copilot/mavis/production/secrets/RAILS_MASTER_KEY"
-splunk_enabled        = true
-cis2_enabled          = true
-pds_enabled           = true
+
 http_hosts = {
   MAVIS__HOST                        = "www.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "www.give-or-refuse-consent-for-vaccinations.nhs.uk"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -14,9 +14,9 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = "true"
-cis2_enabled          = "false"
-pds_enabled           = "false"
+splunk_enabled        = true
+cis2_enabled          = false
+pds_enabled           = false
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "qa.mavistesting.com"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -14,9 +14,10 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = true
-cis2_enabled          = false
-pds_enabled           = false
+
+enable_cis2 = false
+enable_pds  = false
+
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "qa.mavistesting.com"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -14,9 +14,7 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = true
-cis2_enabled          = true
-pds_enabled           = true
+
 http_hosts = {
   MAVIS__HOST                        = "test.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "test.mavistesting.com"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -14,9 +14,9 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = "true"
-cis2_enabled          = "true"
-pds_enabled           = "true"
+splunk_enabled        = true
+cis2_enabled          = true
+pds_enabled           = true
 http_hosts = {
   MAVIS__HOST                        = "test.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "test.mavistesting.com"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -17,9 +17,9 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = "false"
-cis2_enabled          = "false"
-pds_enabled           = "false"
+splunk_enabled        = false
+cis2_enabled          = false
+pds_enabled           = false
 http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "training.give-or-refuse-consent-for-vaccinations.nhs.uk"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -17,9 +17,11 @@ resource_name = {
 }
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-splunk_enabled        = false
-cis2_enabled          = false
-pds_enabled           = false
+
+enable_splunk = false
+enable_cis2   = false
+enable_pds    = false
+
 http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "training.give-or-refuse-consent-for-vaccinations.nhs.uk"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -143,23 +143,23 @@ variable "image_digest" {
   nullable    = false
 }
 
-variable "cis2_enabled" {
+variable "enable_cis2" {
   type        = bool
-  default     = false
+  default     = true
   description = "Boolean toggle to determine whether the CIS2 feature should be enabled."
   nullable    = false
 }
 
-variable "pds_enabled" {
+variable "enable_pds" {
   type        = bool
-  default     = false
+  default     = true
   description = "Boolean toggle to determine whether the PDS feature should be enabled."
   nullable    = false
 }
 
-variable "splunk_enabled" {
+variable "enable_splunk" {
   type        = bool
-  default     = false
+  default     = true
   description = "Boolean toggle to determine whether the Splunk feature should be enabled."
   nullable    = false
 }
@@ -195,15 +195,15 @@ locals {
     },
     {
       name  = "MAVIS__CIS2__ENABLED"
-      value = var.cis2_enabled ? "true" : "false"
+      value = var.enable_cis2 ? "true" : "false"
     },
     {
       name  = "MAVIS__PDS__PERFORM_JOBS"
-      value = var.pds_enabled ? "true" : "false"
+      value = var.enable_pds ? "true" : "false"
     },
     {
       name  = "MAVIS__SPLUNK__ENABLED"
-      value = var.splunk_enabled ? "true" : "false"
+      value = var.enable_splunk ? "true" : "false"
     }
   ]
   task_secrets = [

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -142,23 +142,24 @@ variable "image_digest" {
   description = "The docker image digest for the essential container in the task definition."
   nullable    = false
 }
+
 variable "cis2_enabled" {
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Boolean toggle to determine whether the CIS2 feature should be enabled."
   nullable    = false
 }
 
 variable "pds_enabled" {
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Boolean toggle to determine whether the PDS feature should be enabled."
   nullable    = false
 }
 
 variable "splunk_enabled" {
-  type        = string
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Boolean toggle to determine whether the Splunk feature should be enabled."
   nullable    = false
 }
@@ -194,15 +195,15 @@ locals {
     },
     {
       name  = "MAVIS__CIS2__ENABLED"
-      value = var.cis2_enabled
+      value = var.cis2_enabled ? "true" : "false"
     },
     {
       name  = "MAVIS__PDS__PERFORM_JOBS"
-      value = var.pds_enabled
+      value = var.pds_enabled ? "true" : "false"
     },
     {
       name  = "MAVIS__SPLUNK__ENABLED"
-      value = var.splunk_enabled
+      value = var.splunk_enabled ? "true" : "false"
     }
   ]
   task_secrets = [


### PR DESCRIPTION
This makes a number of small changes to the three variables related to enabling/disabling features in various environments to improve the maintainability and understandability of the variables.

Specifically, this changes the data type to boolean, and inverses the logic such that all the features are enabled by default (ready for production) and need to be explicitly disabled in non-production environments.