### PR TITLE
Add NHS number format validation to imports

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -740,12 +740,13 @@ class ImmunisationImportRow
   end
 
   def validate_patient_nhs_number
-    if patient_nhs_number.present? && patient_nhs_number_value.length != 10
-      errors.add(
-        patient_nhs_number.header,
-        "Enter an NHS number with 10 characters."
-      )
-    end
+    return if patient_nhs_number.blank?
+
+    NHSNumberValidator.new(
+      allow_blank: true,
+      message: "should be a valid NHS number with 10 characters",
+      attributes: [patient_nhs_number.header]
+    ).validate_each(self, patient_nhs_number.header, patient_nhs_number_value)
   end
 
   def validate_patient_postcode

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -170,12 +170,7 @@ class Patient < ApplicationRecord
 
   validates :birth_academic_year, comparison: { greater_than_or_equal_to: 1990 }
 
-  validates :nhs_number,
-            uniqueness: true,
-            format: {
-              with: /\A(?:\d\s*){10}\z/
-            },
-            allow_nil: true
+  validates :nhs_number, nhs_number: true, uniqueness: true, allow_nil: true
 
   validates :address_postcode, postcode: { allow_nil: true }
 

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -303,12 +303,13 @@ class PatientImportRow
   end
 
   def validate_nhs_number
-    if nhs_number.present? && nhs_number_value.length != 10
-      errors.add(
-        nhs_number.header,
-        "should be a valid NHS number, like 999 888 7777"
-      )
-    end
+    return if nhs_number.blank?
+
+    NHSNumberValidator.new(
+      allow_blank: true,
+      message: "should be a valid NHS number with 10 characters",
+      attributes: [nhs_number.header]
+    ).validate_each(self, nhs_number.header, nhs_number_value)
   end
 
   def validate_parent_1_email

--- a/app/validators/nhs_number_validator.rb
+++ b/app/validators/nhs_number_validator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class NHSNumberValidator < ActiveModel::EachValidator
+  FORMAT = /\A(?:\d\s*){10}\z/
+
+  def validate_each(record, attribute, value)
+    if value.blank?
+      record.errors.add(attribute, :blank) unless options[:allow_blank]
+    elsif value.nil?
+      record.errors.add(attribute, :blank) unless options[:allow_nil]
+    elsif !FORMAT.match?(value)
+      record.errors.add(attribute, options[:message] || :invalid)
+    end
+  end
+end

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -74,6 +74,17 @@ describe ClassImportRow do
       end
     end
 
+    context "with an invalid NHS number" do
+      let(:data) { { "CHILD_NHS_NUMBER" => "TP01234567" } }
+
+      it "has errors" do
+        expect(class_import_row).to be_invalid
+        expect(class_import_row.errors["CHILD_NHS_NUMBER"]).to eq(
+          ["should be a valid NHS number with 10 characters"]
+        )
+      end
+    end
+
     context "with an invalid postcode" do
       let(:data) { valid_data.merge("CHILD_POSTCODE" => "not a postcode") }
 

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -86,6 +86,17 @@ describe CohortImportRow do
       end
     end
 
+    context "with an invalid NHS number" do
+      let(:data) { { "CHILD_NHS_NUMBER" => "TP01234567" } }
+
+      it "has errors" do
+        expect(cohort_import_row).to be_invalid
+        expect(cohort_import_row.errors["CHILD_NHS_NUMBER"]).to eq(
+          ["should be a valid NHS number with 10 characters"]
+        )
+      end
+    end
+
     context "with an invalid school URN" do
       let(:data) { valid_data.merge("CHILD_SCHOOL_URN" => "123456789") }
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -335,12 +335,12 @@ describe ImmunisationImportRow do
     end
 
     context "with an invalid NHS number" do
-      let(:data) { { "NHS_NUMBER" => "abc" } }
+      let(:data) { { "NHS_NUMBER" => "TP01234567" } }
 
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors["NHS_NUMBER"]).to eq(
-          ["Enter an NHS number with 10 characters."]
+          ["should be a valid NHS number with 10 characters"]
         )
       end
     end

--- a/spec/validators/nhs_number_validator_spec.rb
+++ b/spec/validators/nhs_number_validator_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe NHSNumberValidator do
+  subject(:model) { Validatable.new(nhs_number:) }
+
+  before do
+    stub_const("Validatable", Class.new).class_eval do
+      include ActiveModel::Model
+      attr_accessor :nhs_number
+      validates :nhs_number, nhs_number: true
+    end
+
+    stub_const("ValidatableAllowNil", Class.new).class_eval do
+      include ActiveModel::Model
+      attr_accessor :nhs_number
+      validates :nhs_number, nhs_number: { allow_nil: true }
+    end
+
+    stub_const("ValidatableAllowBlank", Class.new).class_eval do
+      include ActiveModel::Model
+      attr_accessor :nhs_number
+      validates :nhs_number, nhs_number: { allow_blank: true }
+    end
+  end
+
+  context "with a nil NHS number" do
+    let(:nhs_number) { nil }
+
+    it { should be_invalid }
+  end
+
+  context "with a blank NHS number" do
+    let(:nhs_number) { "" }
+
+    it { should be_invalid }
+  end
+
+  context "with an NHS number that's too short" do
+    let(:nhs_number) { "abc" }
+
+    it { should be_invalid }
+  end
+
+  context "with an invalid NHS number" do
+    let(:nhs_number) { "TP12345678" }
+
+    it { should be_invalid }
+  end
+
+  context "with a valid NHS number" do
+    let(:nhs_number) { "0123456789" }
+
+    it { should be_valid }
+  end
+
+  context "when allowing nil values" do
+    subject(:model) { ValidatableAllowNil.new(nhs_number:) }
+
+    let(:nhs_number) { nil }
+
+    it { should be_valid }
+  end
+
+  context "when allowing blank values" do
+    subject(:model) { ValidatableAllowBlank.new(nhs_number:) }
+
+    let(:nhs_number) { "" }
+
+    it { should be_valid }
+  end
+end


### PR DESCRIPTION
When importing historical immunisation records, we should ensure that the NHS number is validated in the same way that it would be if a patient was being created with that NHS number.

This has been implemented by adding a common NHS number validator which can be used in every model that needs to validate an NHS number.