### PR TITLE
Allow build and deployment with single workflow

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -5,7 +5,43 @@ on:
   workflow_call:
 
 jobs:
+  check-image-presence:
+    name: Check if images already exist
+    runs-on: ubuntu-latest
+    outputs:
+      build_needed: ${{ steps.check_image.outputs.BUILD_NEEDED }}
+    steps:
+      - name: Configure AWS Dev Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::393416225559:role/GitHubActionsRole
+          aws-region: eu-west-2
+      - name: Check if dev image exists
+        run: |
+          if aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
+            echo "Dev image with given tag already exists"
+          else
+            echo "Dev image does not exist. Build needed"
+            echo "BUILD_NEEDED=true" >> $GITHUB_ENV
+          fi
+      - name: Configure AWS Prod credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::820242920762:role/GitHubActionsRole
+          aws-region: eu-west-2
+      - name: Check if prod image exists
+        id: check_image
+        run: |
+          if [ -e $BUILD_NEEDED ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
+            echo "Prod and dev images with given tag already exist. No build needed"
+          else
+            echo "At least one image does not exist. Build needed"
+            echo "BUILD_NEEDED=true" >> $GITHUB_ENV
+          fi
+
   build:
+    needs: check-image-presence
+    if: ${{ needs.check-images-presence.outputs.build_needed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: build-and-push-image-${{ github.sha }}
+
 jobs:
   check-image-presence:
     name: Check if images already exist
@@ -24,8 +27,6 @@ jobs:
             echo "Dev image with given tag already exists"
           else
             echo "Dev image does not exist. Build needed"
-            echo "$(aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }})"
-          
             echo "BUILD_NEEDED=true" >> $GITHUB_ENV
           fi
       - name: Configure AWS Prod credentials
@@ -40,8 +41,6 @@ jobs:
             echo "Prod and dev images with given tag already exist. No build needed"
           else
             echo "At least one image does not exist. Build needed"
-            echo "$(aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }})"
-
             echo "BUILD_NEEDED=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write
     outputs:
-      build-needed: ${{ steps.check-image.outputs.BUILD_NEEDED }}
+      build-needed: ${{ steps.check-image.outputs.build-needed }}
     steps:
       - name: Configure AWS Dev Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -41,7 +41,7 @@ jobs:
             echo "Production and dev images with given tag already exist. No build needed"
           else
             echo "At least one image does not exist. Build needed"
-            echo "BUILD_NEEDED=true" >> $GITHUB_OUTPUT
+            echo "build-needed=true" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -8,6 +8,8 @@ jobs:
   check-image-presence:
     name: Check if images already exist
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     outputs:
       build_needed: ${{ steps.check_image.outputs.BUILD_NEEDED }}
     steps:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Configure AWS Dev Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::393416225559:role/GitHubActionsRole
+          role-to-assume: arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure
           aws-region: eu-west-2
       - name: Check if dev image exists
         run: |
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS Prod credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::820242920762:role/GitHubActionsRole
+          role-to-assume: arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure
           aws-region: eu-west-2
       - name: Check if prod image exists
         id: check_image
@@ -69,8 +69,8 @@ jobs:
     strategy:
       matrix:
         aws-role:
-          - arn:aws:iam::820242920762:role/GitHubActionsRole
-          - arn:aws:iam::393416225559:role/GitHubActionsRole
+          - arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure
+          - arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure
     steps:
       - name: Download Docker image
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -24,6 +24,8 @@ jobs:
             echo "Dev image with given tag already exists"
           else
             echo "Dev image does not exist. Build needed"
+            echo "$(aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }})"
+          
             echo "BUILD_NEEDED=true" >> $GITHUB_ENV
           fi
       - name: Configure AWS Prod credentials
@@ -38,6 +40,8 @@ jobs:
             echo "Prod and dev images with given tag already exist. No build needed"
           else
             echo "At least one image does not exist. Build needed"
+            echo "$(aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }})"
+
             echo "BUILD_NEEDED=true" >> $GITHUB_ENV
           fi
 

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -47,7 +47,7 @@ jobs:
 
   build:
     needs: check-image-presence
-    if: ${{ needs.check-images-presence.outputs.build_needed == 'true' }}
+    if: needs.check-image-presence.outputs.build_needed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -42,7 +42,7 @@ jobs:
             echo "At least one image does not exist. Build needed"
             echo "$(aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }})"
 
-            echo "BUILD_NEEDED=true" >> $GITHUB_ENV
+            echo "BUILD_NEEDED=true" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write
     outputs:
-      build_needed: ${{ steps.check_image.outputs.BUILD_NEEDED }}
+      build-needed: ${{ steps.check-image.outputs.build-needed }}
     steps:
       - name: Configure AWS Dev Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -27,26 +27,26 @@ jobs:
             echo "Dev image with given tag already exists"
           else
             echo "Dev image does not exist. Build needed"
-            echo "BUILD_NEEDED=true" >> $GITHUB_ENV
+            echo "build-needed=true" >> $GITHUB_ENV
           fi
-      - name: Configure AWS Prod credentials
+      - name: Configure AWS Production credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure
           aws-region: eu-west-2
-      - name: Check if prod image exists
-        id: check_image
+      - name: Check if production image exists
+        id: check-image
         run: |
-          if [ -e $BUILD_NEEDED ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
-            echo "Prod and dev images with given tag already exist. No build needed"
+          if [ -e $build-needed ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
+            echo "Production and dev images with given tag already exist. No build needed"
           else
             echo "At least one image does not exist. Build needed"
-            echo "BUILD_NEEDED=true" >> $GITHUB_OUTPUT
+            echo "build-needed=true" >> $GITHUB_OUTPUT
           fi
 
   build:
     needs: check-image-presence
-    if: needs.check-image-presence.outputs.build_needed == 'true'
+    if: needs.check-image-presence.outputs.build-needed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       id-token: write
     outputs:
-      build-needed: ${{ steps.check-image.outputs.build-needed }}
+      build-needed: ${{ steps.check-image.outputs.BUILD_NEEDED }}
     steps:
       - name: Configure AWS Dev Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -27,7 +27,7 @@ jobs:
             echo "Dev image with given tag already exists"
           else
             echo "Dev image does not exist. Build needed"
-            echo "build-needed=true" >> $GITHUB_ENV
+            echo "BUILD_NEEDED=true" >> $GITHUB_ENV
           fi
       - name: Configure AWS Production credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -37,11 +37,11 @@ jobs:
       - name: Check if production image exists
         id: check-image
         run: |
-          if [ -e $build-needed ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
+          if [ -e $BUILD_NEEDED ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
             echo "Production and dev images with given tag already exist. No build needed"
           else
             echo "At least one image does not exist. Build needed"
-            echo "build-needed=true" >> $GITHUB_OUTPUT
+            echo "BUILD_NEEDED=true" >> $GITHUB_OUTPUT
           fi
 
   build:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -8,11 +8,8 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-  build-and-push-image:
-    needs: test
-    uses: ./.github/workflows/build-and-push-image.yml
   deploy-mavis:
-    needs: build-and-push-image
+    needs: test
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -17,4 +17,3 @@ jobs:
     uses: ./.github/workflows/deploy-mavis.yml
     with:
       environment: ${{ matrix.environment }}
-      image_tag: ${{ github.sha }}

--- a/.github/workflows/deploy-mavis.yml
+++ b/.github/workflows/deploy-mavis.yml
@@ -10,10 +10,6 @@ on:
       environment:
         required: true
         type: string
-      image_tag:
-        description: Docker image tag of the image to deploy
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -28,10 +24,6 @@ on:
           - training
           - production
           - copilotmigration
-      image_tag:
-        description: Docker image tag of the image to deploy
-        required: true
-        type: string
 
 jobs:
   build-and-push-image:
@@ -46,4 +38,4 @@ jobs:
     uses: ./.github/workflows/deploy-application.yml
     with:
       environment: ${{ inputs.environment }}
-      image_tag: ${{ inputs.image_tag }}
+      image_tag: ${{ github.sha }}

--- a/.github/workflows/deploy-mavis.yml
+++ b/.github/workflows/deploy-mavis.yml
@@ -34,7 +34,10 @@ on:
         type: string
 
 jobs:
+  build-and-push-image:
+    uses: ./.github/workflows/build-and-push-image.yml
   deploy-infrastructure:
+    needs: build-and-push-image
     uses: ./.github/workflows/deploy-infrastructure.yml
     with:
       environment: ${{ inputs.environment }}

--- a/terraform/resources/github_actions_policy.json
+++ b/terraform/resources/github_actions_policy.json
@@ -79,6 +79,7 @@
         "ecr:BatchCheckLayerAvailability",
         "ecr:BatchGetImage",
         "ecr:CompleteLayerUpload",
+        "ecr:DescribeImages",
         "ecr:GetAuthorizationToken",
         "ecr:GetDownloadUrlForLayer",
         "ecr:InitiateLayerUpload",


### PR DESCRIPTION
By including the build step into `deploy-mavis.yml`, it's possible to deploy branches within a single workflow. Previously, this required to run two workflow, first the build-and-push-image workflow and then the deploy-mavis workflow.

The `build-and-push-image.yml` workflow now checks if an image already exists and only builds it if it's not yet present in both ECR repositories. Apart from general efficiency, this allows us to run the workflow as part of production deployments where we generally don't want to build a new image and rather deploy an image that already exists and was tested on other environments.