### PR TITLE
Add `PatientSession#includes_programmes`

### DIFF
--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -41,10 +41,7 @@ class ConsentFormsController < ApplicationController
         @consent_form.original_session
 
     patient_session =
-      PatientSession.includes(session: :programmes).find_by!(
-        patient: @patient,
-        session:
-      )
+      PatientSession.includes_programmes.find_by!(patient: @patient, session:)
 
     flash[:success] = {
       heading: "Consent matched for",

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -21,9 +21,10 @@ class PatientsController < ApplicationController
 
   def show
     @patient_sessions =
-      policy_scope(PatientSession).where(patient: @patient).includes(
-        session: %i[location programmes]
-      )
+      policy_scope(PatientSession)
+        .includes_programmes
+        .includes(session: :location)
+        .where(patient: @patient)
   end
 
   def log

--- a/app/controllers/sessions/consent_controller.rb
+++ b/app/controllers/sessions/consent_controller.rb
@@ -16,7 +16,8 @@ class Sessions::ConsentController < ApplicationController
     scope =
       @session
         .patient_sessions
-        .includes(patient: :consent_statuses, session: :programmes)
+        .includes_programmes
+        .includes(patient: :consent_statuses)
         .in_programmes(@programmes)
 
     patient_sessions = @form.apply(scope, programme: @programmes)

--- a/app/controllers/sessions/outcome_controller.rb
+++ b/app/controllers/sessions/outcome_controller.rb
@@ -16,7 +16,8 @@ class Sessions::OutcomeController < ApplicationController
     scope =
       @session
         .patient_sessions
-        .includes(:patient, :session_statuses, session: :programmes)
+        .includes_programmes
+        .includes(:session_statuses)
         .in_programmes(@programmes)
 
     patient_sessions = @form.apply(scope, programme: @programmes)

--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -19,10 +19,10 @@ class Sessions::RegisterController < ApplicationController
     scope =
       @session
         .patient_sessions
+        .includes_programmes
         .includes(
           :registration_status,
-          patient: %i[consent_statuses triage_statuses vaccination_statuses],
-          session: :programmes
+          patient: %i[consent_statuses triage_statuses vaccination_statuses]
         )
         .in_programmes(@session.programmes)
 

--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -16,7 +16,8 @@ class Sessions::TriageController < ApplicationController
     scope =
       @session
         .patient_sessions
-        .includes(patient: :triage_statuses, session: :programmes)
+        .includes_programmes
+        .includes(patient: :triage_statuses)
         .in_programmes(@programmes)
         .has_triage_status(@statuses, programme: @programmes)
 

--- a/app/jobs/school_session_reminders_job.rb
+++ b/app/jobs/school_session_reminders_job.rb
@@ -8,10 +8,8 @@ class SchoolSessionRemindersJob < ApplicationJob
 
     patient_sessions =
       PatientSession
-        .includes(
-          patient: [:parents, { consents: %i[parent patient] }],
-          session: :programmes
-        )
+        .includes_programmes
+        .includes(patient: [:parents, { consents: %i[parent patient] }])
         .eager_load(:session)
         .joins(:location)
         .merge(Location.school)

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -27,11 +27,10 @@ class SendClinicInitialInvitationsJob < ApplicationJob
 
     session
       .patient_sessions
-      .eager_load(:patient)
+      .includes_programmes
       .preload(
         :session_notifications,
-        patient: %i[consents parents vaccination_records],
-        session: :programmes
+        patient: %i[consents parents vaccination_records]
       )
       .where(patient: { school: })
       .reject { it.session_notifications.any? }

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -100,6 +100,8 @@ class PatientSession < ApplicationRecord
           )
         end
 
+  scope :includes_programmes, -> { includes(:patient, session: :programmes) }
+
   scope :has_consent_status,
         ->(status, programme:) do
           where(


### PR DESCRIPTION
This adds a convenience scope that preloads the necessary associated models on a `PatientSession` that are required to fetch the programmes for that patient session (the programmes offered at the session that the patient is eligible for).