### PR TITLE
Set PDS job priority when importing records

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -172,9 +172,13 @@ module CSVImportable
         # should reduce the risk of this.
 
         if patient.nhs_number.nil?
-          PatientNHSNumberLookupJob.set(wait: 2 * index).perform_later(patient)
+          PatientNHSNumberLookupJob.set(
+            priority: 25,
+            wait: 2 * index
+          ).perform_later(patient)
         else
           PatientUpdateFromPDSJob.set(
+            priority: 25,
             wait: 2 * index,
             queue: :imports
           ).perform_later(patient)


### PR DESCRIPTION
When importing patient records, we enqueue a job to PDS to ensure the patients are up to date with their equivelant record in PDS.

Currently, these jobs end up with the same priority as all other jobs (`0`) which leads to them being picked up ahead of other higher priotity jobs (such as sending emails, matching consent, or other imports).

Instead, we can set the priority to a lower value (arbritarily picked as `25`) to ensure they are only processed after all other jobs.