### PR TITLE
Ensure conflicting consent has correct session status

### DIFF
--- a/app/models/patient_session/session_status.rb
+++ b/app/models/patient_session/session_status.rb
@@ -92,7 +92,8 @@ class PatientSession::SessionStatus < ApplicationRecord
   end
 
   def status_should_be_refused?
-    vaccination_record&.refused? || latest_consents.any?(&:response_refused?)
+    vaccination_record&.refused? ||
+      (latest_consents.any? && latest_consents.all?(&:response_refused?))
   end
 
   def status_should_be_absent_from_session?

--- a/spec/models/patient_session/session_status_spec.rb
+++ b/spec/models/patient_session/session_status_spec.rb
@@ -91,6 +91,17 @@ describe PatientSession::SessionStatus do
       it { should be(:refused) }
     end
 
+    context "with conflicting consent" do
+      before do
+        create(:consent, :refused, patient:, programme:)
+
+        parent = create(:parent_relationship, patient:).parent
+        create(:consent, :given, patient:, programme:, parent:)
+      end
+
+      it { should be(:none_yet) }
+    end
+
     context "when triaged as do not vaccinate" do
       before { create(:triage, :do_not_vaccinate, patient:, programme:) }
 


### PR DESCRIPTION
This fixes a regression that was added in the performance work where a patient's session status was being set to "Refused" if the consent is conflicting, which is not correct. Instead, the patient should be left as "No outcome yet", because the consent needs to be resolved as either given or refused.