### PR TITLE
Add training onboarding configuration for Leicestershire

### DIFF
--- a/config/onboarding/leicestershire-training.yaml
+++ b/config/onboarding/leicestershire-training.yaml
@@ -1,0 +1,60 @@
+organisation:
+  name: Leicestershire Partnership Trust School Aged Immunisation Service
+  email: lpt.sais@nhs.net
+  phone: 0300 3000 007
+  ods_code: RT5YA
+  careplus_venue_code: UNUSED
+  privacy_notice_url: https://www.leicspart.nhs.uk/privacy-policy/
+  privacy_policy_url: https://www.leicspart.nhs.uk/privacy-policy/
+  reply_to_id: 53938717-b6ce-4b08-9304-ad8c763a6189
+
+programmes: [hpv]
+
+teams:
+  generic:
+    name: Leicestershire Partnership Trust School Aged Immunisation Service
+    email: lpt.sais@nhs.net
+    phone: 0300 3000 007
+    reply_to_id: 53938717-b6ce-4b08-9304-ad8c763a6189
+
+users:
+  - email: nurse.lp1@example.com
+    password: nurse.lp1@example.com
+    given_name: Nurse
+    family_name: LP1
+  - email: nurse.lp2@example.com
+    password: nurse.lp2@example.com
+    given_name: Nurse
+    family_name: LP2
+  - email: nurse.lp3@example.com
+    password: nurse.lp3@example.com
+    given_name: Nurse
+    family_name: LP3
+  - email: nurse.lp4@example.com
+    password: nurse.lp4@example.com
+    given_name: Nurse
+    family_name: LP4
+  - email: nurse.lp5@example.com
+    password: nurse.lp5@example.com
+    given_name: Nurse
+    family_name: LP5
+
+schools:
+  generic:
+    - 141916
+    - 137931
+    - 148546
+    - 137115
+    - 138721
+    - 120277
+    - 138108
+    - 146108
+    - 147068
+    - 138628
+    - 140103
+
+# Organisations need at least 1 clinic, we're not sure right now
+# if Leicestershire will be managing clinics on Mavis.
+clinics:
+  generic:
+    - name: Leicestershire Partnership Trust SAIS Clinic


### PR DESCRIPTION
This is based on the production configuration that we will eventually need, but adds test users that will allow users to sign in and test Mavis without needing to be set up with CIS2.

This is based on #3305 but I needed to raise it as a branch in the repo (rather than a fork) so it can be deployed.