### PR TITLE
Add required permission for training deployment

### DIFF
--- a/terraform/resources/github_actions_policy.json
+++ b/terraform/resources/github_actions_policy.json
@@ -107,6 +107,7 @@
         "elasticloadbalancing:DeleteTargetGroup",
         "elasticloadbalancing:DescribeListenerAttributes",
         "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerCertificates",
         "elasticloadbalancing:DescribeLoadBalancerAttributes",
         "elasticloadbalancing:DescribeLoadBalancers",
         "elasticloadbalancing:DescribeRules",


### PR DESCRIPTION
* This permission is needed for training deployment because training has two certificates instead of one