### PR TITLE
Support importing SystmOne anatomical sites

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -16,15 +16,6 @@ class Reports::SystmOneExporter
     }
   }.freeze
 
-  DELIVERY_SITE_MAPPINGS = {
-    left_arm_upper_position: "Left deltoid",
-    left_arm_lower_position: "Left anterior forearm",
-    left_thigh: "Left lateral thigh",
-    right_arm_upper_position: "Right deltoid",
-    right_arm_lower_position: "Right anterior forearm",
-    right_thigh: "Right lateral thigh"
-  }.with_indifferent_access.freeze
-
   def initialize(organisation:, programme:, start_date:, end_date:)
     @organisation = organisation
     @programme = programme
@@ -175,12 +166,9 @@ class Reports::SystmOneExporter
     end
   end
 
-  # TODO: These mappings are valid for Hertforshire, but may not be correct for
-  #       other SAIS teams. We'll need to check these are correct with new SAIS
-  #       teams.
   def site(vaccination_record)
     return if vaccination_record.not_administered?
 
-    DELIVERY_SITE_MAPPINGS.fetch(vaccination_record.delivery_site)
+    SystmOne::DELIVERY_SITES.key(vaccination_record.delivery_site)
   end
 end

--- a/app/lib/systm_one.rb
+++ b/app/lib/systm_one.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SystmOne
+  # TODO: These mappings are valid for Hertforshire, but may not be correct for
+  #       other SAIS teams. We'll need to check these are correct with new SAIS
+  #       teams.
+  DELIVERY_SITES = {
+    "Left deltoid" => "left_arm_upper_position",
+    "Left anterior forearm" => "left_arm_lower_position",
+    "Left lateral thigh" => "left_thigh",
+    "Right deltoid" => "right_arm_upper_position",
+    "Right anterior forearm" => "right_arm_lower_position",
+    "Right lateral thigh" => "right_thigh"
+  }.freeze
+end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -279,7 +279,7 @@ class ImmunisationImportRow
     "left buttock" => "left_buttock",
     "right buttock" => "right_buttock",
     "nasal" => "nose"
-  }.freeze
+  }.merge(SystmOne::DELIVERY_SITES.transform_keys(&:downcase)).freeze
 
   def delivery_site
     DELIVERY_SITES[@data["ANATOMICAL_SITE"]&.strip&.downcase]

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1195,6 +1195,42 @@ describe ImmunisationImportRow do
       it { should eq("right_buttock") }
     end
 
+    context "with a left deltoid anatomical site" do
+      let(:data) { { "ANATOMICAL_SITE" => "left deltoid" } }
+
+      it { should eq("left_arm_upper_position") }
+    end
+
+    context "with a left anterior forearm anatomical site" do
+      let(:data) { { "ANATOMICAL_SITE" => "left anterior forearm" } }
+
+      it { should eq("left_arm_lower_position") }
+    end
+
+    context "with a left lateral thigh anatomical site" do
+      let(:data) { { "ANATOMICAL_SITE" => "left lateral thigh" } }
+
+      it { should eq("left_thigh") }
+    end
+
+    context "with a right deltoid anatomical site" do
+      let(:data) { { "ANATOMICAL_SITE" => "right deltoid" } }
+
+      it { should eq("right_arm_upper_position") }
+    end
+
+    context "with a right anterior forearm anatomical site" do
+      let(:data) { { "ANATOMICAL_SITE" => "right anterior forearm" } }
+
+      it { should eq("right_arm_lower_position") }
+    end
+
+    context "with a right lateral thigh anatomical site" do
+      let(:data) { { "ANATOMICAL_SITE" => "right lateral thigh" } }
+
+      it { should eq("right_thigh") }
+    end
+
     context "with a nasal anatomical site" do
       let(:data) { { "ANATOMICAL_SITE" => "nasal" } }
 


### PR DESCRIPTION
This updates the vaccination record importer to support the anatomical sites that we export in the SystmOne format. This should improve compatibility when it comes to importing vaccination records with organisations that use SystmOne.