### PR TITLE
Support importing SystmOne gender codes

### DIFF
--- a/app/components/app_import_format_details_component.rb
+++ b/app/components/app_import_format_details_component.rb
@@ -90,12 +90,7 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
           "#{tag.strong("Required")}, must use either #{tag.i("YYYYMMDD")} or " \
             "#{tag.i("DD/MM/YYYY")} format."
       },
-      {
-        name: "PERSON_GENDER_CODE",
-        notes:
-          "#{tag.strong("Required")}, must be #{tag.i("Not known")}, " \
-            "#{tag.i("Male")}, #{tag.i("Female")}, #{tag.i("Not specified")}."
-      },
+      person_gender_code,
       {
         name: "PERSON_POSTCODE",
         notes:
@@ -159,6 +154,21 @@ class AppImportFormatDetailsComponent < ViewComponent::Base
       { name: "CHILD_ADDRESS_LINE_2", notes: "Optional" },
       { name: "CHILD_TOWN", notes: "Optional" }
     ]
+  end
+
+  def person_gender_code
+    codes = ImmunisationImportRow::GENDER_CODES.keys.sort.map { tag.i(_1) }
+
+    codes_sentence =
+      codes.to_sentence(
+        last_word_connector: " or ",
+        two_words_connector: " or "
+      )
+
+    {
+      name: "PERSON_GENDER_CODE",
+      notes: "#{tag.strong("Required")}, must be one of #{codes_sentence}."
+    }
   end
 
   def parent_columns

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 class Reports::SystmOneExporter
-  GENDER_CODE_MAPPINGS = {
-    male: "M",
-    female: "F",
-    not_specified: "U",
-    not_known: "U"
-  }.with_indifferent_access.freeze
-
   VACCINE_DOSE_MAPPINGS = {
     "Gardasil 9" => {
       "1" => "Y19a4",
@@ -140,7 +133,7 @@ class Reports::SystmOneExporter
   end
 
   def gender_code(code)
-    GENDER_CODE_MAPPINGS[code]
+    SystmOne::GENDER_CODES.key(code) || "U"
   end
 
   # TODO: These mappings are valid for Hertforshire, but may not be correct for

--- a/app/lib/systm_one.rb
+++ b/app/lib/systm_one.rb
@@ -12,4 +12,6 @@ module SystmOne
     "Right anterior forearm" => "right_arm_lower_position",
     "Right lateral thigh" => "right_thigh"
   }.freeze
+
+  GENDER_CODES = { "M" => "male", "F" => "female", "U" => "not_known" }.freeze
 end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -351,9 +351,17 @@ class ImmunisationImportRow
     patient_date_of_birth&.academic_year
   end
 
+  GENDER_CODES = {
+    "male" => "male",
+    "female" => "female",
+    "not known" => "not_known",
+    "not specified" => "not_specified"
+  }.merge(SystmOne::GENDER_CODES.transform_keys(&:downcase)).freeze
+
   def patient_gender_code
-    gender_code = @data["PERSON_GENDER_CODE"] || @data["PERSON_GENDER"]
-    gender_code&.strip&.downcase&.gsub(" ", "_")
+    if (value = @data["PERSON_GENDER_CODE"].presence || @data["PERSON_GENDER"])
+      GENDER_CODES[value.strip.downcase] || value
+    end
   end
 
   def patient_postcode

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1364,14 +1364,32 @@ describe ImmunisationImportRow do
         it { should eq("not_known") }
       end
 
+      context "with a 'u' value" do
+        let(:data) { { key => "U" } }
+
+        it { should eq("not_known") }
+      end
+
       context "with a 'male' value" do
         let(:data) { { key => "Male" } }
 
         it { should eq("male") }
       end
 
+      context "with an 'm' value" do
+        let(:data) { { key => "M" } }
+
+        it { should eq("male") }
+      end
+
       context "with a 'female' value" do
         let(:data) { { key => "Female" } }
+
+        it { should eq("female") }
+      end
+
+      context "with a 'f' value" do
+        let(:data) { { key => "F" } }
 
         it { should eq("female") }
       end


### PR DESCRIPTION
This updates the vaccination record importer to support the gender codes that we export in the SystmOne format. This should improve compatibility when it comes to importing vaccination records with organisations that use SystmOne.

<img width="730" alt="Screenshot 2025-04-02 at 11 05 13" src="https://github.com/user-attachments/assets/183198eb-d2bb-45c1-929b-e101646be8e5" />
