### PR TITLE
Reduce preloading in school consent jobs

### DIFF
--- a/app/jobs/school_consent_reminders_job.rb
+++ b/app/jobs/school_consent_reminders_job.rb
@@ -7,17 +7,11 @@ class SchoolConsentRemindersJob < ApplicationJob
     sessions =
       Session
         .send_consent_reminders
-        .includes(
-          :programmes,
-          patient_sessions: {
-            patient: %i[consents consent_notifications parents]
-          }
-        )
-        .preload(:session_dates)
-        .eager_load(:location)
+        .joins(:location)
+        .includes(:session_dates, :programmes, :patient_sessions, :location)
         .merge(Location.school)
 
-    sessions.each do |session|
+    sessions.find_each(batch_size: 1) do |session|
       next unless session.open_for_consent?
 
       session.patient_sessions.each do |patient_session|


### PR DESCRIPTION
This reduces the amount of preloading performed in the school consent request and reminders jobs to try and fix out-of-memory issues we're seeing in production. This has been run once in production and the job has ran successfully.