### PR TITLE
Support batches without expiration dates

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -258,7 +258,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
 
   def batch_expiry_value
     highlight_if(
-      @batch.expiry.to_fs(:long),
+      @batch.expiry&.to_fs(:long) || "Unknown",
       @vaccination_record.batch_id_changed?
     )
   end

--- a/app/forms/batch_form.rb
+++ b/app/forms/batch_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class BatchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :batch
+
+  attribute :name, :string
+  attribute :expiry, :date
+
+  validates :name, presence: true, format: { with: /\A[A-Za-z0-9]+\z/ }
+
+  validates :expiry,
+            comparison: {
+              greater_than: -> { Date.current },
+              less_than: -> { Date.current + 15.years }
+            }
+
+  def save
+    valid? && batch.update(name: name, expiry: expiry)
+  end
+end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -6,7 +6,7 @@
 #
 #  id              :bigint           not null, primary key
 #  archived_at     :datetime
-#  expiry          :date             not null
+#  expiry          :date
 #  name            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -43,8 +43,8 @@ class Batch < ApplicationRecord
   validates :name, presence: true, format: { with: /\A[A-Za-z0-9]+\z/ }
 
   validates :expiry,
-            presence: true,
             uniqueness: {
-              scope: %i[organisation_id name vaccine_id]
+              scope: %i[organisation_id name vaccine_id],
+              allow_nil: true
             }
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -37,8 +37,10 @@ class Batch < ApplicationRecord
 
   scope :order_by_name_and_expiration, -> { order(expiry: :asc, name: :asc) }
 
-  scope :expired, -> { where("expiry <= ?", Time.current) }
-  scope :not_expired, -> { where("expiry > ?", Time.current) }
+  scope :expired,
+        -> { where(expiry: nil).or(where("expiry <= ?", Time.current)) }
+  scope :not_expired,
+        -> { where.not(expiry: nil).where("expiry > ?", Time.current) }
 
   validates :name, presence: true, format: { with: /\A[A-Za-z0-9]+\z/ }
 

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -47,11 +47,4 @@ class Batch < ApplicationRecord
             uniqueness: {
               scope: %i[organisation_id name vaccine_id]
             }
-
-  validates :expiry,
-            comparison: {
-              greater_than: -> { Date.current },
-              less_than: -> { Date.current + 15.years }
-            },
-            unless: :archived?
 end

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -31,8 +31,6 @@ class Batch < ApplicationRecord
   belongs_to :organisation
   belongs_to :vaccine
 
-  has_many :vaccination_records, -> { kept }
-
   has_and_belongs_to_many :immunisation_imports
 
   has_one :programme, through: :vaccine

--- a/app/models/dps_export_row.rb
+++ b/app/models/dps_export_row.rb
@@ -156,7 +156,7 @@ class DPSExportRow
   end
 
   def expiry_date
-    vaccination_record.batch.expiry.to_fs(:dps)
+    vaccination_record.batch.expiry&.to_fs(:dps)
   end
 
   def route_of_vaccination_code

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -31,9 +31,6 @@ class ImmunisationImportRow
   validates :batch_number, presence: { if: :batch_expiry_date }
 
   validates :batch_expiry_date,
-            presence: {
-              if: :batch_number
-            },
             comparison: {
               greater_than: -> { Date.new(Date.current.year - 15, 1, 1) },
               less_than: -> { Date.new(Date.current.year + 15, 1, 1) },
@@ -459,18 +456,17 @@ class ImmunisationImportRow
   end
 
   def batch
-    unless valid? && administered && vaccine && batch_expiry_date &&
-             batch_number.present?
-      return
-    end
+    return unless valid?
 
     @batch ||=
-      Batch.create_with(archived_at: Time.current).find_or_create_by!(
-        expiry: batch_expiry_date,
-        name: batch_number,
-        organisation:,
-        vaccine:
-      )
+      if administered && vaccine && batch_number.present?
+        Batch.create_with(archived_at: Time.current).find_or_create_by!(
+          expiry: batch_expiry_date,
+          name: batch_number,
+          organisation:,
+          vaccine:
+        )
+      end
   end
 
   def organisation_ods_code

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -30,8 +30,6 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class Vaccine < ApplicationRecord
-  self.inheritance_column = nil
-
   audited associated_with: :programme
   has_associated_audits
 

--- a/app/views/batches/edit.html.erb
+++ b/app/views/batches/edit.html.erb
@@ -10,7 +10,7 @@
   <%= page_title %>
 <% end %>
 
-<%= form_with model: @batch, url: vaccine_batch_path(@vaccine, @batch), method: :put do |f| %>
+<%= form_with model: @form, url: vaccine_batch_path(@vaccine, @batch), method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_date_field :expiry,

--- a/app/views/batches/new.html.erb
+++ b/app/views/batches/new.html.erb
@@ -6,15 +6,16 @@
 
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l">
-    <%= @batch.vaccine.brand %>
+    <%= @vaccine.brand %>
   </span>
   <%= page_title %>
 <% end %>
 
-<%= form_with model: @batch, url: vaccine_batches_path(@vaccine), method: :post do |f| %>
+<%= form_with model: @form, url: vaccine_batches_path(@vaccine), method: :post do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_text_field :name, label: { text: "Batch" }, width: 10 %>
+
   <%= f.govuk_date_field :expiry,
                          legend: { text: "Expiry date", size: "s" },
                          hint: { text: "For example, 27 10 2025" },

--- a/app/views/draft_vaccination_records/batch.html.erb
+++ b/app/views/draft_vaccination_records/batch.html.erb
@@ -13,7 +13,9 @@
     <% @batches.each do |batch| %>
       <% label = proc do %>
         <span class="app-u-monospace"><%= batch.name %></span>
-        (expires <%= batch.expiry.to_fs(:long) %>)
+        <% if (expiry = batch.expiry) %>
+          (expires <%= expiry.to_fs(:long) %>)
+        <% end %>
       <% end %>
       <%= f.govuk_radio_button(:batch_id, batch.id, label:) do %>
         <% unless @draft_vaccination_record.editing? %>

--- a/app/views/sessions/record/batch.html.erb
+++ b/app/views/sessions/record/batch.html.erb
@@ -14,7 +14,9 @@
     <% @batches.each_with_index do |batch, index| %>
       <% label = proc do %>
         <span class="app-u-monospace"><%= batch.name %></span>
-        (expires <%= batch.expiry.to_fs(:long) %>)
+        <% if (expiry = batch.expiry) %>
+          (expires <%= expiry.to_fs(:long) %>)
+        <% end %>
       <% end %>
       <%= f.govuk_radio_button :id, batch.id, label:, link_errors: index.zero? %>
     <% end %>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -33,7 +33,7 @@
                 <% end %>
               <% end %>
               <% row.with_cell(text: batch.created_at.to_date.to_fs(:long)) %>
-              <% row.with_cell(text: batch.expiry.to_fs(:long)) %>
+              <% row.with_cell(text: batch.expiry&.to_fs(:long) || "Unknown") %>
               <% row.with_cell do %>
                 <ul class="app-action-list">
                   <li class="app-action-list__item">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,19 @@ en:
         vaccine_given: <code>VACCINE_GIVEN</code>
     errors:
       models:
+        batch_form:
+          attributes:
+            expiry:
+              blank: Enter an expiry date
+              greater_than: Enter an expiry date after %{count}
+              less_than: Enter an expiry date before %{count}
+              missing_day: Enter a day
+              missing_month: Enter a month
+              missing_year: Enter a year
+              taken: This batch already exists
+            name:
+              blank: Enter a batch
+              invalid: Enter a batch with only letters and numbers
         class_import_row:
           format: "%{attribute}: %{message}"
           attributes:
@@ -425,19 +438,6 @@ en:
           nasal: Nasal spray
     errors:
       models:
-        batch:
-          attributes:
-            expiry:
-              blank: Enter an expiry date
-              greater_than: Enter an expiry date after %{count}
-              less_than: Enter an expiry date before %{count}
-              missing_day: Enter a day
-              missing_month: Enter a month
-              missing_year: Enter a year
-              taken: This batch already exists
-            name:
-              blank: Enter a batch
-              invalid: Enter a batch with only letters and numbers
         class_import:
           attributes:
             csv:

--- a/db/migrate/20250402093102_change_batch_expiry_not_null.rb
+++ b/db/migrate/20250402093102_change_batch_expiry_not_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeBatchExpiryNotNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :batches, :expiry, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_27_101002) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_02_093102) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -59,7 +59,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_27_101002) do
 
   create_table "batches", force: :cascade do |t|
     t.string "name", null: false
-    t.date "expiry", null: false
+    t.date "expiry"
     t.bigint "vaccine_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -32,10 +32,13 @@ FactoryBot.define do
     vaccine
 
     name { "#{prefix}#{Faker::Number.number(digits: 4)}" }
-    expiry { Faker::Time.forward(days: 50, period: :morning) }
 
     trait :expired do
-      expiry { Date.yesterday }
+      expiry { Faker::Time.backward(days: 50, period: :evening) }
+    end
+
+    trait :not_expired do
+      expiry { Faker::Time.forward(days: 50, period: :morning) }
     end
 
     trait :archived do

--- a/spec/factories/batches.rb
+++ b/spec/factories/batches.rb
@@ -6,7 +6,7 @@
 #
 #  id              :bigint           not null, primary key
 #  archived_at     :datetime
-#  expiry          :date             not null
+#  expiry          :date
 #  name            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -76,7 +76,15 @@ FactoryBot.define do
     end
 
     batch do
-      association(:batch, organisation:, vaccine:, strategy: :create) if vaccine
+      if vaccine
+        association(
+          :batch,
+          :not_expired,
+          organisation:,
+          vaccine:,
+          strategy: :create
+        )
+      end
     end
 
     performed_by

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -31,9 +31,19 @@ describe "MenACWY and Td/IPV vaccination" do
     location = create(:school)
 
     @menacwy_batch =
-      create(:batch, organisation:, vaccine: programmes.first.vaccines.first)
+      create(
+        :batch,
+        :not_expired,
+        organisation:,
+        vaccine: programmes.first.vaccines.first
+      )
     @td_ipv_batch =
-      create(:batch, organisation:, vaccine: programmes.second.vaccines.first)
+      create(
+        :batch,
+        :not_expired,
+        organisation:,
+        vaccine: programmes.second.vaccines.first
+      )
 
     @session = create(:session, organisation:, programmes:, location:)
 

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -257,7 +257,12 @@ describe "Edit vaccination record" do
     @original_batch =
       create(:batch, organisation: @organisation, vaccine: @vaccine)
     @replacement_batch =
-      create(:batch, organisation: @organisation, vaccine: @vaccine)
+      create(
+        :batch,
+        :not_expired,
+        organisation: @organisation,
+        vaccine: @vaccine
+      )
 
     location = create(:school)
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -72,7 +72,8 @@ describe "HPV vaccination" do
     end
 
     @active_vaccine = programme.vaccines.active.first
-    @active_batch = create(:batch, organisation:, vaccine: @active_vaccine)
+    @active_batch =
+      create(:batch, :not_expired, organisation:, vaccine: @active_vaccine)
     @archived_batch =
       create(:batch, :archived, organisation:, vaccine: @active_vaccine)
 

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -41,7 +41,8 @@ describe "HPV vaccination" do
     end
 
     active_vaccine = programme.vaccines.active.first
-    @active_batch = create(:batch, organisation:, vaccine: active_vaccine)
+    @active_batch =
+      create(:batch, :not_expired, organisation:, vaccine: active_vaccine)
 
     @session =
       create(:session, organisation:, programmes: [programme], location:)

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -62,7 +62,7 @@ describe "HPV vaccination" do
     end
 
     vaccine = programmes.first.vaccines.active.first
-    @batch = create(:batch, organisation: @organisation, vaccine:)
+    @batch = create(:batch, :not_expired, organisation: @organisation, vaccine:)
 
     create(:gp_practice, ods_code: "Y12345")
 

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -67,7 +67,8 @@ describe "MenACWY vaccination" do
     end
 
     @active_vaccine = programme.vaccines.active.first
-    @active_batch = create(:batch, organisation:, vaccine: @active_vaccine)
+    @active_batch =
+      create(:batch, :not_expired, organisation:, vaccine: @active_vaccine)
     @archived_batch =
       create(:batch, :archived, organisation:, vaccine: @active_vaccine)
 

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -67,7 +67,8 @@ describe "Td/IPV vaccination" do
     end
 
     @active_vaccine = programme.vaccines.active.first
-    @active_batch = create(:batch, organisation:, vaccine: @active_vaccine)
+    @active_batch =
+      create(:batch, :not_expired, organisation:, vaccine: @active_vaccine)
     @archived_batch =
       create(:batch, :archived, organisation:, vaccine: @active_vaccine)
 

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -31,7 +31,7 @@ describe "Vaccination" do
     batches =
       programmes.map do |programme|
         programme.vaccines.flat_map do |vaccine|
-          create_list(:batch, 2, organisation:, vaccine:)
+          create_list(:batch, 2, :not_expired, organisation:, vaccine:)
         end
       end
 

--- a/spec/forms/batch_form_spec.rb
+++ b/spec/forms/batch_form_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe BatchForm do
+  subject(:form) { described_class.new }
+
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:expiry) }
+
+    it do
+      travel_to(Date.new(2024, 9, 1)) do
+        expect(form).to validate_comparison_of(:expiry).is_greater_than(
+          Date.new(2024, 9, 1)
+        )
+        expect(form).to validate_comparison_of(:expiry).is_less_than(
+          Date.new(2039, 9, 1)
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -99,7 +99,9 @@ describe Reports::OfflineSessionExporter do
       subject(:rows) { worksheet_to_hashes(workbook.worksheets[0]) }
 
       let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
-      let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
+      let(:batch) do
+        create(:batch, :not_expired, vaccine: programme.vaccines.active.first)
+      end
       let(:patient_session) { create(:patient_session, patient:, session:) }
       let(:patient) { create(:patient, year_group: 8) }
 
@@ -487,6 +489,7 @@ describe Reports::OfflineSessionExporter do
         subject(:validation) do
           create(
             :batch,
+            :not_expired,
             name: "BATCH12345",
             vaccine: programme.vaccines.active.first,
             organisation:
@@ -532,6 +535,7 @@ describe Reports::OfflineSessionExporter do
         create_list(
           :batch,
           2,
+          :not_expired,
           vaccine: programme.vaccines.active.first,
           organisation:
         )
@@ -539,7 +543,12 @@ describe Reports::OfflineSessionExporter do
 
       before do
         create(:patient, session:)
-        create(:batch, name: "OTHERBATCH", vaccine: create(:vaccine, :flu))
+        create(
+          :batch,
+          :not_expired,
+          name: "OTHERBATCH",
+          vaccine: create(:vaccine, :flu)
+        )
       end
 
       it "lists all the batch numbers for the programme" do
@@ -672,7 +681,9 @@ describe Reports::OfflineSessionExporter do
             school: create(:school, urn: "123456", name: "Waterloo Road")
           )
         end
-        let(:batch) { create(:batch, vaccine: programme.vaccines.active.first) }
+        let(:batch) do
+          create(:batch, :not_expired, vaccine: programme.vaccines.active.first)
+        end
         let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
         let!(:vaccination_record) do
           create(
@@ -769,6 +780,7 @@ describe Reports::OfflineSessionExporter do
         subject(:validation) do
           create(
             :batch,
+            :not_expired,
             name: "BATCH12345",
             vaccine: programme.vaccines.active.first,
             organisation:
@@ -814,6 +826,7 @@ describe Reports::OfflineSessionExporter do
         create_list(
           :batch,
           2,
+          :not_expired,
           vaccine: programme.vaccines.active.first,
           organisation:
         )
@@ -821,7 +834,12 @@ describe Reports::OfflineSessionExporter do
 
       before do
         create(:patient, session:)
-        create(:batch, name: "OTHERBATCH", vaccine: create(:vaccine, :flu))
+        create(
+          :batch,
+          :not_expired,
+          name: "OTHERBATCH",
+          vaccine: create(:vaccine, :flu)
+        )
       end
 
       it "lists all the batch numbers for the programme" do

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -52,17 +52,6 @@ describe Batch do
     it { should validate_presence_of(:expiry) }
 
     it do
-      travel_to(Date.new(2024, 9, 1)) do
-        expect(batch).to validate_comparison_of(:expiry).is_greater_than(
-          Date.new(2024, 9, 1)
-        )
-        expect(batch).to validate_comparison_of(:expiry).is_less_than(
-          Date.new(2039, 9, 1)
-        )
-      end
-    end
-
-    it do
       expect(batch).to validate_uniqueness_of(:expiry).scoped_to(
         :organisation_id,
         :name,

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -6,7 +6,7 @@
 #
 #  id              :bigint           not null, primary key
 #  archived_at     :datetime
-#  expiry          :date             not null
+#  expiry          :date
 #  name            :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
@@ -49,7 +49,6 @@ describe Batch do
     it { should be_valid }
 
     it { should validate_presence_of(:name) }
-    it { should validate_presence_of(:expiry) }
 
     it do
       expect(batch).to validate_uniqueness_of(:expiry).scoped_to(

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1654,5 +1654,11 @@ describe ImmunisationImportRow do
 
       it { should be_nil }
     end
+
+    context "without an expiry date" do
+      let(:data) { valid_data.merge("BATCH_EXPIRY_DATE" => "") }
+
+      it { should_not be_nil }
+    end
   end
 end


### PR DESCRIPTION
When uploading historical vaccination records it's not guaranteed that the batch expiration date will be provided with the batch number. Therefore, we need to handle batches without expiration dates.

This makes a number of changes to the service to allow for batches without expiration dates (specifically to ensure they will render correctly without the user seeing an error) and also updates the import process to support importing historical vaccination records without batches. Offline recording of vaccinations still requires a batch expiration date to be provided.

We also can't be sure that batches with the same number won't be reused, so we allow batches to exist with the same number, one with an expiration date and one without an expiration date. In the future we might be able to consolidate these batches in to one.