### PR TITLE
Download school moves

### DIFF
--- a/app/controllers/school_moves/exports_controller.rb
+++ b/app/controllers/school_moves/exports_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class SchoolMoves::ExportsController < ApplicationController
+  before_action :set_school_move_export
+
+  include WizardControllerConcern
+
+  skip_after_action :verify_policy_scoped
+
+  def create
+    @school_move_export.reset!
+
+    redirect_to school_move_export_path(Wicked::FIRST_STEP)
+  end
+
+  def show
+    render_wizard
+  end
+
+  def update
+    @school_move_export.assign_attributes(update_params)
+
+    render_wizard @school_move_export
+  end
+
+  def download
+    send_data(
+      @school_move_export.csv_data,
+      filename: @school_move_export.csv_filename
+    )
+  end
+
+  def finish_wizard_path
+    download_school_move_export_path
+  end
+
+  def set_school_move_export
+    @school_move_export =
+      SchoolMoveExport.new(request_session: session, current_user:)
+  end
+
+  def set_steps
+    self.steps = @school_move_export.wizard_steps
+  end
+
+  def update_params
+    params
+      .fetch(:school_move_export, {})
+      .permit(:date_from, :date_to)
+      .merge(wizard_step: current_step)
+  end
+end

--- a/app/lib/reports/csv_school_moves.rb
+++ b/app/lib/reports/csv_school_moves.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class Reports::CSVSchoolMoves
+  HEADERS = %i[
+    NHS_REF
+    SURNAME
+    FORENAME
+    GENDER
+    DOB
+    ADDRESS1
+    ADDRESS2
+    ADDRESS3
+    TOWN
+    POSTCODE
+    COUNTY
+    ETHNIC_OR
+    ETHNIC_DESCRIPTION
+    NATIONAL_URN_NO
+    BASE_NAME
+    STARTDATE
+    STUD_ID
+    DES_NUMBER
+  ].freeze
+
+  def initialize(school_move_log_entries)
+    @school_move_log_entries = school_move_log_entries
+  end
+
+  def call
+    CSV.generate(headers: HEADERS, write_headers: true) do |csv|
+      school_move_log_entries.each do |log_entry|
+        csv << row(log_entry.school, log_entry.patient)
+      end
+    end
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :school_move_log_entries
+
+  def row(school, patient)
+    [
+      patient.nhs_number,
+      patient.family_name,
+      patient.given_name,
+      patient.gender_code.humanize,
+      patient.date_of_birth.to_fs(:govuk),
+      patient.address_line_1,
+      patient.address_line_2,
+      nil,
+      patient.address_town,
+      patient.address_postcode,
+      nil,
+      nil,
+      nil,
+      school_urn(school, patient),
+      school&.name,
+      school&.created_at&.to_fs(:govuk),
+      nil,
+      nil
+    ]
+  end
+
+  def school_urn(school, patient)
+    if school
+      school.urn
+    elsif patient.home_educated?
+      "999999"
+    else
+      patient.school&.urn || "888888"
+    end
+  end
+end

--- a/app/lib/reports/csv_school_moves.rb
+++ b/app/lib/reports/csv_school_moves.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Reports::CSVSchoolMoves
+  include Reports::ExportFormatters
+
   HEADERS = %i[
     NHS_REF
     SURNAME
@@ -28,7 +30,7 @@ class Reports::CSVSchoolMoves
 
   def call
     CSV.generate(headers: HEADERS, write_headers: true) do |csv|
-      school_move_log_entries.each do |log_entry|
+      school_move_log_entries.find_each do |log_entry|
         csv << row(log_entry.school, log_entry.patient)
       end
     end
@@ -42,7 +44,7 @@ class Reports::CSVSchoolMoves
 
   attr_reader :school_move_log_entries
 
-  def row(school, patient)
+  def row(location, patient)
     [
       patient.nhs_number,
       patient.family_name,
@@ -57,21 +59,11 @@ class Reports::CSVSchoolMoves
       nil,
       nil,
       nil,
-      school_urn(school, patient),
-      school&.name,
-      school&.created_at&.to_fs(:govuk),
+      school_urn(location:, patient:),
+      location&.name,
+      location&.created_at&.to_fs(:govuk),
       nil,
       nil
     ]
-  end
-
-  def school_urn(school, patient)
-    if school
-      school.urn
-    elsif patient.home_educated?
-      "999999"
-    else
-      patient.school&.urn || "888888"
-    end
   end
 end

--- a/app/lib/reports/export_formatters.rb
+++ b/app/lib/reports/export_formatters.rb
@@ -4,7 +4,7 @@ module Reports::ExportFormatters
   extend ActiveSupport::Concern
 
   def school_urn(location:, patient:)
-    if location.school?
+    if location&.school?
       location.urn
     elsif patient.home_educated?
       "999999"

--- a/app/models/school_move_export.rb
+++ b/app/models/school_move_export.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+class SchoolMoveExport
+  include RequestSessionPersistable
+  include WizardStepConcern
+
+  attribute :date_from, :date
+  attribute :date_to, :date
+
+  def wizard_steps
+    %i[dates confirm].freeze
+  end
+
+  delegate :count, to: :school_moves
+
+  def self.request_session_key
+    "school_move_export"
+  end
+
+  def csv_data
+    Reports::CSVSchoolMoves.call(school_moves)
+  end
+
+  def csv_filename
+    name_parts = ["school_moves_export"]
+    name_parts << date_from.to_fs(:govuk) if date_from.present?
+    name_parts << "to" if date_from.present? && date_to.present?
+    name_parts << date_to.to_fs(:govuk) if date_to.present?
+
+    "#{name_parts.join("_")}.csv"
+  end
+
+  def date_from_formatted
+    if date_from.present?
+      date_from.strftime("%d %B %Y")
+    else
+      "Earliest recorded vaccination"
+    end
+  end
+
+  def date_to_formatted
+    if date_to.present?
+      date_to.strftime("%d %B %Y")
+    else
+      "Latest recorded vaccination"
+    end
+  end
+
+  private
+
+  def school_moves
+    scope =
+      SchoolMoveLogEntry.where(
+        patient: @current_user.selected_organisation.patients
+      )
+
+    if date_from.present?
+      scope =
+        scope.where(
+          "school_move_log_entries.created_at >= ?",
+          date_from.beginning_of_day
+        )
+    end
+
+    if date_to.present?
+      scope =
+        scope.where(
+          "school_move_log_entries.created_at <= ?",
+          date_to.end_of_day
+        )
+    end
+
+    scope
+  end
+
+  def reset_unused_fields
+  end
+end

--- a/app/views/school_moves/exports/confirm.html.erb
+++ b/app/views/school_moves/exports/confirm.html.erb
@@ -1,0 +1,33 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(wizard_path(:dates), name: "school_moves_export") %>
+<% end %>
+
+<span class="nhsuk-caption-l">School moves</span>
+<%= h1 "Check and confirm" %>
+
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading { "Requested download" } %>
+
+  <%= govuk_summary_list do |summary_list|
+        summary_list.with_row do |row|
+          row.with_key { "From" }
+          row.with_value { @school_move_export.date_from_formatted }
+          row.with_action(text: "Change", href: wizard_path(:dates))
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Until" }
+          row.with_value { @school_move_export.date_to_formatted }
+          row.with_action(text: "Change", href: wizard_path(:dates))
+        end
+      
+        summary_list.with_row do |row|
+          row.with_key { "Records" }
+          row.with_value { @school_move_export.count.to_s }
+        end
+      end %>
+<% end %>
+
+<%= form_with model: @school_move_export, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_submit "Download CSV" %>
+<% end %>

--- a/app/views/school_moves/exports/dates.html.erb
+++ b/app/views/school_moves/exports/dates.html.erb
@@ -1,0 +1,30 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(school_moves_path, name: "school_moves_export") %>
+<% end %>
+
+<span class="nhsuk-caption-l">School moves</span>
+<%= h1 "Download school moves" %>
+
+<p class="nhsuk-body">
+  You can download a record of school moves as a CSV file. Only school
+  moves that have been reviewed and confirmed will be included.
+</p>
+
+<p class="nhsuk-body">
+  You can then review the new information and confirm the school move or ignore it.
+</p>
+
+<h3>Select a date range</h3>
+
+<%= form_with model: @school_move_export, url: wizard_path, method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_date_field :date_from,
+                         legend: { text: "From (optional)" },
+                         hint: { text: "For example, 27 3 2024" } %>
+
+  <%= f.govuk_date_field :date_to,
+                         legend: { text: "To (optional)" },
+                         hint: { text: "For example, 16 6 2025" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/school_moves/index.html.erb
+++ b/app/views/school_moves/index.html.erb
@@ -1,4 +1,14 @@
-<%= h1 t(".title"), size: "xl" %>
+<%= h1 "School moves", size: "xl" %>
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+    <p>When imported records or a new consent response indicates that a child has changed
+      school, Mavis flags this as a school move.</p>
+    <p>You can then review the new information and confirm the school move or ignore it.</p>
+
+    <%= govuk_button_to "Download records", school_move_exports_path, class: "app-button--secondary nhsuk-u-margin-bottom-5" %>
+  </div>
+</div>
 
 <% if @school_moves.any? %>
   <div class="nhsuk-table__panel-with-heading-tab">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,12 @@ Rails.application.routes.draw do
   end
 
   resources :school_moves, path: "school-moves", only: %i[index show update]
+  resources :school_move_exports,
+            path: "school-moves/exports",
+            controller: "school_moves/exports",
+            only: %i[create show update] do
+    get "download", on: :member
+  end
 
   resources :sessions, only: %i[edit index show], param: :slug do
     resource :consent, only: :show, controller: "sessions/consent"

--- a/spec/features/download_school_moves_spec.rb
+++ b/spec/features/download_school_moves_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+describe "Download school moves" do
+  scenario "no dates given" do
+    given_i_am_signed_in
+    and_school_moves_exist
+    and_i_go_school_moves
+    when_i_click_on_download_records
+    and_i_click_continue
+    then_i_should_see_a_confirmation_page
+    when_i_click_download_csv
+    then_i_get_a_csv_file_with_expected_row_count(2)
+  end
+
+  scenario "dates supplied" do
+    given_i_am_signed_in
+    and_school_moves_exist
+    and_i_go_school_moves
+    when_i_click_on_download_records
+    when_i_enter_some_dates
+    then_i_should_see_a_confirmation_page_with_dates
+    when_i_click_download_csv
+    then_i_get_a_csv_file_with_expected_row_count(1)
+  end
+
+  def given_i_am_signed_in
+    organisation = create(:organisation, :with_one_nurse)
+    @session = create(:session, organisation:)
+    @patients =
+      create_list(
+        :patient,
+        2,
+        :consent_given_triage_not_needed,
+        :in_attendance,
+        session: @session
+      )
+
+    sign_in organisation.users.first
+  end
+
+  def and_school_moves_exist
+    create(:school_move_log_entry, patient: @patients.first)
+    create(
+      :school_move_log_entry,
+      patient: @patients.second,
+      created_at: Time.zone.local(2024, 6, 15) # Middle of the date range
+    )
+  end
+
+  def and_i_go_school_moves
+    visit school_moves_path
+  end
+
+  def when_i_click_on_download_records
+    click_on "Download records"
+  end
+
+  def and_i_click_continue
+    click_on "Continue"
+  end
+
+  def when_i_click_download_csv
+    click_on "Download CSV"
+  end
+
+  def then_i_get_a_csv_file_with_expected_row_count(expected_count)
+    expect(page).to have_content(Reports::CSVSchoolMoves::HEADERS.join(","))
+    csv_content = CSV.parse(page.body, headers: true)
+    expect(csv_content.size).to eq(expected_count)
+  end
+
+  def when_i_enter_some_dates
+    within all(".nhsuk-fieldset")[0] do
+      fill_in "Day", with: "01"
+      fill_in "Month", with: "01"
+      fill_in "Year", with: "2024"
+    end
+
+    within all(".nhsuk-fieldset")[1] do
+      fill_in "Day", with: "31"
+      fill_in "Month", with: "12"
+      fill_in "Year", with: "2024"
+    end
+
+    click_on "Continue"
+  end
+
+  def then_i_should_see_a_confirmation_page
+    check_summary_list_row("From", "Earliest recorded vaccination")
+    check_summary_list_row("Until", "Latest recorded vaccination")
+    check_summary_list_row("Records", "2")
+  end
+
+  def then_i_should_see_a_confirmation_page_with_dates
+    check_summary_list_row("From", "01 January 2024")
+    check_summary_list_row("Until", "31 December 2024")
+    check_summary_list_row("Records", "1")
+  end
+
+  def check_summary_list_row(key, value)
+    within(".nhsuk-summary-list") do
+      expect(page).to have_css(".nhsuk-summary-list__key", text: key)
+      expect(page).to have_css(".nhsuk-summary-list__value", text: value)
+    end
+  end
+end

--- a/spec/lib/reports/csv_school_moves_spec.rb
+++ b/spec/lib/reports/csv_school_moves_spec.rb
@@ -1,47 +1,51 @@
 # frozen_string_literal: true
 
 describe Reports::CSVSchoolMoves do
-  subject(:csv) { described_class.call([school_move]) }
+  subject(:csv) { described_class.call(SchoolMoveLogEntry.all) }
 
-  let(:patient) { create(:patient, school: old_school) }
-  let(:old_school) { create(:school, :secondary) }
-  let(:new_school) { create(:school, :secondary) }
-  let(:school_move) do
-    create(:school_move_log_entry, patient:, school: new_school)
-  end
+  let(:rows) { CSV.parse(csv, headers: true) }
 
   describe ".call" do
-    let(:rows) { CSV.parse(csv, headers: true) }
+    context "with a standard school move" do
+      let(:old_school) { create(:school, :secondary) }
+      let(:new_school) { create(:school, :secondary) }
 
-    it "returns a CSV with the school moves data" do
-      expect(rows.first.to_hash).to include(
-        {
-          "NHS_REF" => patient.nhs_number,
-          "SURNAME" => patient.family_name,
-          "FORENAME" => patient.given_name,
-          "GENDER" => patient.gender_code.humanize,
-          "DOB" => patient.date_of_birth.to_fs(:govuk),
-          "ADDRESS1" => patient.address_line_1,
-          "ADDRESS2" => patient.address_line_2,
-          "ADDRESS3" => nil,
-          "TOWN" => patient.address_town,
-          "POSTCODE" => patient.address_postcode,
-          "COUNTY" => nil,
-          "ETHNIC_OR" => nil,
-          "ETHNIC_DESCRIPTION" => nil,
-          "NATIONAL_URN_NO" => new_school.urn,
-          "BASE_NAME" => new_school.name,
-          "STARTDATE" => new_school.created_at.to_fs(:govuk),
-          "STUD_ID" => nil,
-          "DES_NUMBER" => nil
-        }
-      )
+      before do
+        patient = create(:patient, school: old_school)
+        create(:school_move_log_entry, patient: patient, school: new_school)
+      end
+
+      it "returns a CSV with the school moves data" do
+        expect(rows.first.to_hash).to include(
+          {
+            "NHS_REF" => SchoolMoveLogEntry.last.patient.nhs_number,
+            "SURNAME" => SchoolMoveLogEntry.last.patient.family_name,
+            "FORENAME" => SchoolMoveLogEntry.last.patient.given_name,
+            "GENDER" => SchoolMoveLogEntry.last.patient.gender_code.humanize,
+            "DOB" =>
+              SchoolMoveLogEntry.last.patient.date_of_birth.to_fs(:govuk),
+            "ADDRESS1" => SchoolMoveLogEntry.last.patient.address_line_1,
+            "ADDRESS2" => SchoolMoveLogEntry.last.patient.address_line_2,
+            "ADDRESS3" => nil,
+            "TOWN" => SchoolMoveLogEntry.last.patient.address_town,
+            "POSTCODE" => SchoolMoveLogEntry.last.patient.address_postcode,
+            "COUNTY" => nil,
+            "ETHNIC_OR" => nil,
+            "ETHNIC_DESCRIPTION" => nil,
+            "NATIONAL_URN_NO" => new_school.urn,
+            "BASE_NAME" => new_school.name,
+            "STARTDATE" => new_school.created_at.to_fs(:govuk),
+            "STUD_ID" => nil,
+            "DES_NUMBER" => nil
+          }
+        )
+      end
     end
 
     context "when moving to home education" do
-      let(:patient) { create(:patient, :home_educated) }
-      let(:school_move) do
-        create(:school_move_log_entry, :home_educated, patient:)
+      before do
+        patient = create(:patient, :home_educated)
+        create(:school_move_log_entry, :home_educated, patient: patient)
       end
 
       it "returns '999999' as the URN" do
@@ -50,9 +54,9 @@ describe Reports::CSVSchoolMoves do
     end
 
     context "when moving to an unknown school" do
-      let(:patient) { create(:patient, school: nil) }
-      let(:school_move) do
-        create(:school_move_log_entry, :unknown_school, patient:)
+      before do
+        patient = create(:patient, school: nil)
+        create(:school_move_log_entry, :unknown_school, patient: patient)
       end
 
       it "returns '888888' as the URN" do

--- a/spec/lib/reports/csv_school_moves_spec.rb
+++ b/spec/lib/reports/csv_school_moves_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe Reports::CSVSchoolMoves do
+  subject(:csv) { described_class.call([school_move]) }
+
+  let(:patient) { create(:patient, school: old_school) }
+  let(:old_school) { create(:school, :secondary) }
+  let(:new_school) { create(:school, :secondary) }
+  let(:school_move) do
+    create(:school_move_log_entry, patient:, school: new_school)
+  end
+
+  describe ".call" do
+    let(:rows) { CSV.parse(csv, headers: true) }
+
+    it "returns a CSV with the school moves data" do
+      expect(rows.first.to_hash).to include(
+        {
+          "NHS_REF" => patient.nhs_number,
+          "SURNAME" => patient.family_name,
+          "FORENAME" => patient.given_name,
+          "GENDER" => patient.gender_code.humanize,
+          "DOB" => patient.date_of_birth.to_fs(:govuk),
+          "ADDRESS1" => patient.address_line_1,
+          "ADDRESS2" => patient.address_line_2,
+          "ADDRESS3" => nil,
+          "TOWN" => patient.address_town,
+          "POSTCODE" => patient.address_postcode,
+          "COUNTY" => nil,
+          "ETHNIC_OR" => nil,
+          "ETHNIC_DESCRIPTION" => nil,
+          "NATIONAL_URN_NO" => new_school.urn,
+          "BASE_NAME" => new_school.name,
+          "STARTDATE" => new_school.created_at.to_fs(:govuk),
+          "STUD_ID" => nil,
+          "DES_NUMBER" => nil
+        }
+      )
+    end
+
+    context "when moving to home education" do
+      let(:patient) { create(:patient, :home_educated) }
+      let(:school_move) do
+        create(:school_move_log_entry, :home_educated, patient:)
+      end
+
+      it "returns '999999' as the URN" do
+        expect(rows.first["NATIONAL_URN_NO"]).to eq("999999")
+      end
+    end
+
+    context "when moving to an unknown school" do
+      let(:patient) { create(:patient, school: nil) }
+      let(:school_move) do
+        create(:school_move_log_entry, :unknown_school, patient:)
+      end
+
+      it "returns '888888' as the URN" do
+        expect(rows.first["NATIONAL_URN_NO"]).to eq("888888")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
This PR introduces functionality to export school moves data to a CSV format. This feature is designed to assist new users in keeping their existing systems up-to-date during the transition period to full adoption.

### Changes proposed in this pull request
- New service object to generate CSV exports of school move data
- New controller and views to handle date range input and confirmation page

### Screenshots
| School Moves (1) | Date Range Input (2) | Confirmation and download (3) |
|------------------|---------------------------|---------------------|
|  <img width="1122" alt="Screenshot 2025-04-04 at 09 55 36" src="https://github.com/user-attachments/assets/76d2ed06-c2a3-4b8f-9f74-9fdaf56cf041" /> | <img width="1004" alt="Screenshot 2025-04-04 at 09 57 20" src="https://github.com/user-attachments/assets/99f1e03c-678d-414c-b9aa-7e11cf0a3820" /> | <img width="1058" alt="Screenshot 2025-04-04 at 09 57 57" src="https://github.com/user-attachments/assets/87ed20c5-f1a6-4c06-8520-c80e5cc08fe0" /> |
