### PR TITLE
Exclude confirmation email updates from CSV report's RECORD_UPDATED_AT column

### DIFF
--- a/app/jobs/send_vaccination_confirmations_job.rb
+++ b/app/jobs/send_vaccination_confirmations_job.rb
@@ -23,7 +23,7 @@ class SendVaccinationConfirmationsJob < ApplicationJob
       .select { _1.academic_year == academic_year }
       .each do |vaccation_record|
         send_vaccination_confirmation(vaccation_record)
-        vaccation_record.update!(confirmation_sent_at: Time.current)
+        vaccation_record.update_column(:confirmation_sent_at, Time.current)
       end
   end
 end


### PR DESCRIPTION
This change ensures that the CSV report’s RECORD_UPDATED_AT column reflects only genuine updates to a VaccinationRecord. Previously, automated updates when vaccination confirmation emails were sent to parents modified the updated_at timestamp and affected the report. 