### PR TITLE
Add `CSVParser` and `CSVParser::Field`

### DIFF
--- a/app/lib/csv_parser.rb
+++ b/app/lib/csv_parser.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CSVParser
+  def initialize(data)
+    @data = data
+  end
+
+  def call
+    CSV.parse(
+      data,
+      converters:,
+      empty_value: nil,
+      encoding:,
+      header_converters:,
+      headers: true,
+      skip_blanks: true,
+      strip: true
+    )
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :data
+
+  def encoding
+    return nil if data.blank?
+
+    encoding = CharlockHolmes::EncodingDetector.detect(data)
+    return nil if encoding.nil?
+
+    encoding[:ruby_encoding]
+  end
+
+  def converters
+    proc { |value| value&.strip.presence }
+  end
+
+  def header_converters
+    proc { |value| value.strip.downcase.tr("-", "_").tr(" ", "_").to_sym }
+  end
+end

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -478,7 +478,7 @@ class Reports::OfflineSessionExporter
       @allowed_formula = allowed_formula
     end
 
-    ALPHABET = %w[A B C D E F G H I J K L M N O P Q R S T U V W X Y Z].freeze
+    ALPHABET = ("A".."Z").to_a.freeze
     CELL_COLUMNS = ALPHABET + ALPHABET.product(ALPHABET).map { _1 + _2 }
 
     def add_data_validation_to(sheet:, column_index:, row_index:)

--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -13,7 +13,7 @@ class CohortImportRow < PatientImportRow
   end
 
   def school_urn
-    @data[:child_school_urn]
+    @data[:child_school_urn]&.to_s
   end
 
   private

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -66,33 +66,10 @@ module CSVImportable
     rows_count > 15
   end
 
-  def detect_encoding
-    return nil if csv_data.blank?
-
-    encoding = CharlockHolmes::EncodingDetector.detect(csv_data)
-    return nil if encoding.nil?
-
-    encoding[:ruby_encoding]
-  end
-
   def load_data!
     return if invalid?
 
-    converters = proc { |value| value&.strip.presence }
-    header_converters =
-      proc { |value| value.strip.downcase.tr("-", "_").tr(" ", "_").to_sym }
-
-    self.data ||=
-      CSV.parse(
-        csv_data,
-        converters:,
-        empty_value: nil,
-        encoding: detect_encoding,
-        header_converters:,
-        headers: true,
-        skip_blanks: true,
-        strip: true
-      )
+    self.data ||= CSVParser.call(csv_data)
     self.rows_count = data.count
   rescue CSV::MalformedCSVError
     self.csv_is_malformed = true

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -216,7 +216,7 @@ class ImmunisationImportRow
   end
 
   def administered
-    if (vaccinated = @data[:vaccinated]&.downcase).present?
+    if (vaccinated = @data[:vaccinated]&.to_s&.downcase).present?
       if "yes".start_with?(vaccinated)
         true
       elsif "no".start_with?(vaccinated)
@@ -232,7 +232,7 @@ class ImmunisationImportRow
   end
 
   def batch_number
-    @data[:batch_number]
+    @data[:batch_number]&.to_s
   end
 
   REASONS = {
@@ -245,11 +245,11 @@ class ImmunisationImportRow
   }.freeze
 
   def reason
-    REASONS[@data[:reason_not_vaccinated]&.downcase]
+    REASONS[@data[:reason_not_vaccinated]&.to_s&.downcase]
   end
 
   def notes
-    @data[:notes]
+    @data[:notes]&.to_s
   end
 
   DELIVERY_SITES = {
@@ -267,7 +267,7 @@ class ImmunisationImportRow
   }.freeze
 
   def delivery_site
-    DELIVERY_SITES[@data[:anatomical_site]&.downcase]
+    DELIVERY_SITES[@data[:anatomical_site]&.to_s&.downcase]
   end
 
   def delivery_method
@@ -301,7 +301,7 @@ class ImmunisationImportRow
   }.freeze
 
   def dose_sequence
-    value = @data[:dose_sequence]&.gsub(/\s/, "")&.upcase
+    value = @data[:dose_sequence]&.to_s&.gsub(/\s/, "")&.upcase
 
     return default_dose_sequence if value.blank?
 
@@ -310,22 +310,22 @@ class ImmunisationImportRow
     return dose_sequences[value] if dose_sequences&.include?(value)
 
     begin
-      Integer(@data[:dose_sequence])
+      Integer(@data[:dose_sequence]&.to_s)
     rescue ArgumentError, TypeError
       nil
     end
   end
 
   def vaccine_given
-    @data[:vaccine_given]
+    @data[:vaccine_given]&.to_s
   end
 
   def patient_first_name
-    @data[:person_forename]
+    @data[:person_forename]&.to_s
   end
 
   def patient_last_name
-    @data[:person_surname]
+    @data[:person_surname]&.to_s
   end
 
   def patient_date_of_birth
@@ -337,44 +337,45 @@ class ImmunisationImportRow
   end
 
   def patient_gender_code
-    gender_code = @data[:person_gender_code] || @data[:person_gender]
+    gender_code =
+      @data[:person_gender_code]&.to_s || @data[:person_gender]&.to_s
     gender_code&.downcase&.gsub(" ", "_")
   end
 
   def patient_postcode
-    if (postcode = @data[:person_postcode]).present?
+    if (postcode = @data[:person_postcode]&.to_s).present?
       UKPostcode.parse(postcode).to_s
     end
   end
 
   def patient_nhs_number
-    @data[:nhs_number]&.gsub(/\s/, "")
+    @data[:nhs_number]&.to_s&.gsub(/\s/, "")
   end
 
   def performed_ods_code
-    @data[:organisation_code]&.upcase
+    @data[:organisation_code]&.to_s&.upcase
   end
 
   def programme_name
-    @data[:programme]
+    @data[:programme]&.to_s
   end
 
   def session_id
-    Integer(@data[:session_id])
+    Integer(@data[:session_id]&.to_s)
   rescue ArgumentError, TypeError
     nil
   end
 
   def school_name
-    @data[:school_name]
+    @data[:school_name]&.to_s
   end
 
   def clinic_name
-    @data[:clinic_name]
+    @data[:clinic_name]&.to_s
   end
 
   def school_urn
-    @data[:school_urn]
+    @data[:school_urn]&.to_s
   end
 
   def date_of_vaccination
@@ -386,26 +387,26 @@ class ImmunisationImportRow
   end
 
   def care_setting
-    Integer(@data[:care_setting])
+    Integer(@data[:care_setting]&.to_s)
   rescue ArgumentError, TypeError
     nil
   end
 
   def performed_by_user
     @performed_by_user ||=
-      if (email = @data[:performing_professional_email])
+      if (email = @data[:performing_professional_email]&.to_s)
         User.find_by(email:)
       end
   end
 
   def performed_by_given_name
     @performed_by_given_name ||=
-      (@data[:performing_professional_forename] if performed_by_user.nil?)
+      (@data[:performing_professional_forename]&.to_s if performed_by_user.nil?)
   end
 
   def performed_by_family_name
     @performed_by_family_name ||=
-      (@data[:performing_professional_surname] if performed_by_user.nil?)
+      (@data[:performing_professional_surname]&.to_s if performed_by_user.nil?)
   end
 
   def uuid
@@ -529,7 +530,7 @@ class ImmunisationImportRow
   DATE_FORMATS = %w[%Y%m%d %Y-%m-%d %d/%m/%Y].freeze
 
   def parse_date(key)
-    value = @data[key]
+    value = @data[key]&.to_s
     return nil if value.nil?
 
     parsed_dates =
@@ -545,7 +546,7 @@ class ImmunisationImportRow
   TIME_FORMATS = %w[%H:%M:%S %H:%M %H%M%S %H%M %H].freeze
 
   def parse_time(key)
-    value = @data[key]
+    value = @data[key]&.to_s
     return nil if value.nil?
 
     parsed_times =

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -228,7 +228,7 @@ class ImmunisationImportRow
   end
 
   def batch_expiry_date
-    parse_date(:batch_expiry_date)
+    @data[:batch_expiry_date]&.to_date
   end
 
   def batch_number
@@ -309,11 +309,7 @@ class ImmunisationImportRow
 
     return dose_sequences[value] if dose_sequences&.include?(value)
 
-    begin
-      Integer(@data[:dose_sequence]&.to_s)
-    rescue ArgumentError, TypeError
-      nil
-    end
+    @data[:dose_sequence]&.to_i
   end
 
   def vaccine_given
@@ -329,7 +325,7 @@ class ImmunisationImportRow
   end
 
   def patient_date_of_birth
-    parse_date(:person_dob)
+    @data[:person_dob]&.to_date
   end
 
   def patient_birth_academic_year
@@ -343,9 +339,7 @@ class ImmunisationImportRow
   end
 
   def patient_postcode
-    if (postcode = @data[:person_postcode]&.to_s).present?
-      UKPostcode.parse(postcode).to_s
-    end
+    @data[:person_postcode]&.to_postcode
   end
 
   def patient_nhs_number
@@ -361,9 +355,7 @@ class ImmunisationImportRow
   end
 
   def session_id
-    Integer(@data[:session_id]&.to_s)
-  rescue ArgumentError, TypeError
-    nil
+    @data[:session_id]&.to_i
   end
 
   def school_name
@@ -379,17 +371,15 @@ class ImmunisationImportRow
   end
 
   def date_of_vaccination
-    @date_of_vaccination ||= parse_date(:date_of_vaccination)
+    @data[:date_of_vaccination]&.to_date
   end
 
   def time_of_vaccination
-    @time_of_vaccination ||= parse_time(:time_of_vaccination)
+    @data[:time_of_vaccination]&.to_time
   end
 
   def care_setting
-    Integer(@data[:care_setting]&.to_s)
-  rescue ArgumentError, TypeError
-    nil
+    @data[:care_setting]&.to_i
   end
 
   def performed_by_user
@@ -525,38 +515,6 @@ class ImmunisationImportRow
         end
       end
     end
-  end
-
-  DATE_FORMATS = %w[%Y%m%d %Y-%m-%d %d/%m/%Y].freeze
-
-  def parse_date(key)
-    value = @data[key]&.to_s
-    return nil if value.nil?
-
-    parsed_dates =
-      DATE_FORMATS.lazy.filter_map do |format|
-        Date.strptime(value, format)
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-    parsed_dates.first
-  end
-
-  TIME_FORMATS = %w[%H:%M:%S %H:%M %H%M%S %H%M %H].freeze
-
-  def parse_time(key)
-    value = @data[key]&.to_s
-    return nil if value.nil?
-
-    parsed_times =
-      TIME_FORMATS.lazy.filter_map do |format|
-        Time.zone.strptime(value, format)
-      rescue ArgumentError, TypeError
-        nil
-      end
-
-    parsed_times.first
   end
 
   def delivery_site_appropriate_for_vaccine

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -168,18 +168,12 @@ class PatientImportRow
   end
 
   def date_of_birth
-    Date.parse(@data[:child_date_of_birth]&.to_s)
-  rescue ArgumentError, TypeError
-    nil
+    @data[:child_date_of_birth]&.to_date
   end
 
   def birth_academic_year
-    if (year_group = @data[:child_year_group]&.to_s).present?
-      begin
-        Integer(year_group).to_birth_academic_year
-      rescue ArgumentError, TypeError
-        nil
-      end
+    if (year_group = @data[:child_year_group]).present?
+      year_group.to_i.to_birth_academic_year
     else
       date_of_birth&.academic_year
     end

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -148,33 +148,33 @@ class PatientImportRow
   end
 
   def nhs_number
-    @data[:child_nhs_number]&.gsub(/\s/, "")
+    @data[:child_nhs_number]&.to_s&.gsub(/\s/, "")
   end
 
   def first_name
-    @data[:child_first_name]
+    @data[:child_first_name]&.to_s
   end
 
   def last_name
-    @data[:child_last_name]
+    @data[:child_last_name]&.to_s
   end
 
   def preferred_first_name
-    @data[:child_preferred_first_name]
+    @data[:child_preferred_first_name]&.to_s
   end
 
   def preferred_last_name
-    @data[:child_preferred_last_name]
+    @data[:child_preferred_last_name]&.to_s
   end
 
   def date_of_birth
-    Date.parse(@data[:child_date_of_birth])
+    Date.parse(@data[:child_date_of_birth]&.to_s)
   rescue ArgumentError, TypeError
     nil
   end
 
   def birth_academic_year
-    if (year_group = @data[:child_year_group]).present?
+    if (year_group = @data[:child_year_group]&.to_s).present?
       begin
         Integer(year_group).to_birth_academic_year
       rescue ArgumentError, TypeError
@@ -190,59 +190,59 @@ class PatientImportRow
   end
 
   def registration
-    @data[:child_registration]
+    @data[:child_registration]&.to_s
   end
 
   def gender_code
-    @data[:child_gender]&.downcase&.gsub(" ", "_")
+    @data[:child_gender]&.to_s&.downcase&.gsub(" ", "_")
   end
 
   def address_line_1
-    @data[:child_address_line_1]
+    @data[:child_address_line_1]&.to_s
   end
 
   def address_line_2
-    @data[:child_address_line_2]
+    @data[:child_address_line_2]&.to_s
   end
 
   def address_town
-    @data[:child_town]
+    @data[:child_town]&.to_s
   end
 
   def address_postcode
-    @data[:child_postcode]
+    @data[:child_postcode]&.to_s
   end
 
   def parent_1_name
-    @data[:parent_1_name]
+    @data[:parent_1_name]&.to_s
   end
 
   def parent_1_relationship
-    @data[:parent_1_relationship]
+    @data[:parent_1_relationship]&.to_s
   end
 
   def parent_1_email
-    @data[:parent_1_email]&.downcase
+    @data[:parent_1_email]&.to_s&.downcase
   end
 
   def parent_1_phone
-    @data[:parent_1_phone]&.gsub(/\s/, "")
+    @data[:parent_1_phone]&.to_s&.gsub(/\s/, "")
   end
 
   def parent_2_name
-    @data[:parent_2_name]
+    @data[:parent_2_name]&.to_s
   end
 
   def parent_2_relationship
-    @data[:parent_2_relationship]
+    @data[:parent_2_relationship]&.to_s
   end
 
   def parent_2_email
-    @data[:parent_2_email]&.downcase
+    @data[:parent_2_email]&.to_s&.downcase
   end
 
   def parent_2_phone
-    @data[:parent_2_phone]&.gsub(/\s/, "")
+    @data[:parent_2_phone]&.to_s&.gsub(/\s/, "")
   end
 
   attr_reader :organisation, :year_groups

--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -9,8 +9,16 @@ describe CSVParser do
     expect(table.count).to eq(1)
 
     row = table.first
-    expect(row.to_h).to eq(
-      { a_header: "a value", another_header: "another value" }
-    )
+    expect(row[:a_header].value).to eq("a value")
+    expect(row[:a_header].column).to eq("A")
+    expect(row[:a_header].row).to eq(2)
+    expect(row[:a_header].cell).to eq("A2")
+    expect(row[:a_header].header).to eq("a header")
+
+    expect(row[:another_header].value).to eq("another value")
+    expect(row[:another_header].column).to eq("B")
+    expect(row[:another_header].row).to eq(2)
+    expect(row[:another_header].cell).to eq("B2")
+    expect(row[:another_header].header).to eq("Another-Header")
   end
 end

--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe CSVParser do
+  subject(:table) { described_class.call(data) }
+
+  let(:data) { "a header,Another-Header\n  a value  ,another value" }
+
+  it "parses and converts the values" do
+    expect(table.count).to eq(1)
+
+    row = table.first
+    expect(row.to_h).to eq(
+      { a_header: "a value", another_header: "another value" }
+    )
+  end
+end

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -3,7 +3,10 @@
 describe ClassImportRow do
   subject(:class_import_row) do
     described_class.new(
-      data: data.transform_keys { it.downcase.to_sym },
+      data:
+        data
+          .transform_keys { it.downcase.to_sym }
+          .transform_values { CSVParser::Field.new(it, nil, nil) },
       session:,
       year_groups: session.year_groups
     )

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -3,7 +3,10 @@
 describe CohortImportRow do
   subject(:cohort_import_row) do
     described_class.new(
-      data: data.transform_keys { it.downcase.to_sym },
+      data:
+        data
+          .transform_keys { it.downcase.to_sym }
+          .transform_values { CSVParser::Field.new(it, nil, nil) },
       organisation:
     )
   end

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -141,10 +141,6 @@ describe CohortImport do
         expect(cohort_import).to be_valid
         expect(cohort_import.rows.count).to eq(16)
       end
-
-      it "detected the encoding" do
-        expect(cohort_import.detect_encoding).to eq("ISO-8859-1")
-      end
     end
 
     describe "with an invalid file using ISO-8859-1 encoding" do
@@ -152,10 +148,6 @@ describe CohortImport do
 
       it "is invalid" do
         expect(cohort_import).to be_invalid
-      end
-
-      it "detected the encoding" do
-        expect(cohort_import.detect_encoding).to eq("ISO-8859-1")
       end
     end
   end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -3,7 +3,10 @@
 describe ImmunisationImportRow do
   subject(:immunisation_import_row) do
     described_class.new(
-      data: data.transform_keys { it.downcase.to_sym },
+      data:
+        data
+          .transform_keys { it.downcase.to_sym }
+          .transform_values { CSVParser::Field.new(it, nil, nil) },
       organisation:
     )
   end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1374,7 +1374,7 @@ describe ImmunisationImportRow do
     context "with an invalid postcode" do
       let(:data) { { "PERSON_POSTCODE" => "abc" } }
 
-      it { should eq("abc") }
+      it { should be_nil }
     end
 
     context "with a valid postcode" do

--- a/spec/support/shared_examples/a_csv_importable_model.rb
+++ b/spec/support/shared_examples/a_csv_importable_model.rb
@@ -46,12 +46,6 @@ shared_examples_for "a CSVImportable model" do
     end
   end
 
-  describe "#detect_encoding" do
-    it "returns an encoding" do
-      expect(subject.detect_encoding).to eq("ISO-8859-1")
-    end
-  end
-
   describe "#process!" do
     let(:today) { Time.zone.local(2025, 1, 1) }
 


### PR DESCRIPTION
This adds a new struct which handles the parsing of CSV fields (converting values to integers, dates and times) and stores additional information about the field (the row index, the column index, and the original header). This additional information will be used in a follow up PR to improve the error handling and validation by showing the original header to the user, which allows to easily handle multiple different file formats while presenting to the user the correct headers.

This follows on from #3317.