### PR TITLE
Create ecs service module

### DIFF
--- a/terraform/app/modules/ecs_service/main.tf
+++ b/terraform/app/modules/ecs_service/main.tf
@@ -1,0 +1,100 @@
+resource "aws_security_group" "this" {
+  name        = "${var.server_type}-service-${var.environment}"
+  description = "Security Group for communication with ECS Service"
+  vpc_id      = var.network_params.vpc_id
+  lifecycle {
+    ignore_changes = [description]
+  }
+}
+
+resource "aws_security_group_rule" "egress_all" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.this.id
+}
+
+resource "aws_ecs_service" "this" {
+  name                              = "mavis-${var.environment}-${var.server_type}"
+  cluster                           = var.cluster_id
+  task_definition                   = aws_ecs_task_definition.this.arn
+  desired_count                     = var.desired_count
+  launch_type                       = "FARGATE"
+  enable_execute_command            = true
+  health_check_grace_period_seconds = 60
+
+  network_configuration {
+    subnets         = var.network_params.subnets
+    security_groups = [aws_security_group.this.id]
+  }
+  deployment_controller {
+    type = var.deployment_controller
+  }
+  dynamic "deployment_circuit_breaker" {
+    for_each = var.deployment_controller == "ECS" ? [1] : []
+    content {
+      enable   = true
+      rollback = true
+    }
+  }
+  dynamic "load_balancer" {
+    for_each = var.loadbalancer != null ? [1] : []
+    content {
+      target_group_arn = var.loadbalancer.target_group_arn
+      container_name   = var.container_name
+      container_port   = var.loadbalancer.container_port
+    }
+  }
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+  lifecycle {
+    ignore_changes = [
+      task_definition,
+      load_balancer,
+      # desired_count TODO: Uncomment once we include autoscaling
+    ]
+    create_before_destroy = true
+  }
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "mavis-${var.server_type}-task-definition-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_config.cpu
+  memory                   = var.task_config.memory
+  execution_role_arn       = var.task_config.execution_role_arn
+  task_role_arn            = var.task_config.task_role_arn
+  container_definitions = jsonencode([
+    {
+      name      = var.container_name
+      image     = var.task_config.docker_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = 4000
+          hostPort      = 4000
+        }
+      ]
+      environment = concat(var.task_config.environment, [{ name = "SERVER_TYPE", value = var.server_type }])
+      secrets     = var.task_config.secrets
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = var.task_config.log_group_name
+          awslogs-region        = var.task_config.region
+          awslogs-stream-prefix = "${var.environment}-${var.server_type}-logs"
+        }
+      }
+      healthCheck = {
+        command     = var.task_config.health_check_command
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 10
+      }
+    }
+  ])
+}

--- a/terraform/app/modules/ecs_service/outputs.tf
+++ b/terraform/app/modules/ecs_service/outputs.tf
@@ -1,0 +1,17 @@
+output "security_group_id" {
+  value       = aws_security_group.this.id
+  description = "The ID of the security group for the ECS service"
+}
+
+output "service" {
+  value = {
+    id   = aws_ecs_service.this.id
+    name = aws_ecs_service.this.name
+  }
+  description = "Essential attributes of the ECS service"
+}
+
+output "task_definition" {
+  value       = aws_ecs_task_definition.this.family
+  description = "Essential attributes of the ECS task definition"
+}

--- a/terraform/app/modules/ecs_service/variables.tf
+++ b/terraform/app/modules/ecs_service/variables.tf
@@ -1,0 +1,79 @@
+variable "environment" {
+  type        = string
+  description = "Application environment (for example production or staging)"
+  nullable    = false
+}
+
+variable "server_type" {
+  type        = string
+  description = "Type of server to be deployed. This is set as an environment variable in the main container, and is used to determine how the application is launched"
+  nullable    = false
+}
+
+variable "desired_count" {
+  type        = number
+  description = "The initial amount of instances when creating the service"
+  nullable    = false
+}
+
+variable "task_config" {
+  type = object({
+    environment = list(object({
+      name  = string
+      value = string
+    }))
+    secrets = list(object({
+      name      = string
+      valueFrom = string
+    }))
+    cpu                  = number
+    memory               = number
+    docker_image         = string
+    execution_role_arn   = string
+    task_role_arn        = string
+    log_group_name       = string
+    region               = string
+    health_check_command = list(string)
+  })
+  description = "Task configuration variables for the task definition ECS service"
+  nullable    = false
+}
+
+variable "cluster_id" {
+  type        = string
+  description = "The ID of the ECS cluster."
+  nullable    = false
+}
+
+variable "network_params" {
+  type = object({
+    subnets = list(string)
+    vpc_id  = string
+  })
+  description = "Network configuration for the ECS service"
+  nullable    = false
+}
+
+variable "loadbalancer" {
+  type = object({
+    target_group_arn = string
+    container_port   = number
+  })
+  description = "Load balancer configuration for the ECS service if the service should be user-facing"
+  default     = null
+  nullable    = true
+}
+
+variable "deployment_controller" {
+  type        = string
+  description = "Deployment controller type for the ECS service"
+  default     = "ECS"
+  nullable    = false
+}
+
+variable "container_name" {
+  type        = string
+  description = "Name of the essential container in the task. Also the container which is serviced by the load balancer if applicable."
+  default     = "application"
+  nullable    = false
+}


### PR DESCRIPTION
Create a new module for ecs services. This allows us to simply add additional service types, e.g. such as a background service for good-job