### PR TITLE
Create modularized ecs services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,9 @@ USER 1000:1000
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
-# Start server via Thruster by default, this can be overwritten at runtime
+# Start web server by default, this can be overwritten by environment variable
 EXPOSE 4000
 ENV HTTP_PORT=4000
-CMD ["./bin/thrust", "./bin/rails", "server"]
+ENV GOOD_JOB_PROBE_PORT=4000
+ENV SERVER_TYPE=web
+CMD ["./bin/docker-start"]

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -6,8 +6,8 @@ if [ -z "${LD_PRELOAD+x}" ]; then
   export LD_PRELOAD
 fi
 
-# If running the rails server then create or migrate existing database
-if [ "${@: -2:1}" == "./bin/rails" ] && [ "${@: -1:1}" == "server" ]; then
+# When starting the container then create or migrate existing database
+if [ "$1" == "./bin/docker-start" ]; then
   ./bin/rails db:prepare:ignore_concurrent_migration_exceptions
 fi
 

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ "$SERVER_TYPE" == "web" ]; then
+  echo "Starting web server..."
+  exec "$SCRIPT_DIR"/thrust "$SCRIPT_DIR"/rails server
+elif [ "$SERVER_TYPE" == "good-job" ]; then
+  echo "Starting good-job server..."
+  exec "$SCRIPT_DIR"/bundle exec good_job start
+else
+  echo "SERVER_TYPE variable: '$SERVER_TYPE' unknown. Allowed values ['web','good-job']"
+exit 1
+fi

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,7 +75,7 @@ module ManageVaccinations
     config.active_model.i18n_customize_full_message = true
 
     config.active_job.queue_adapter = :good_job
-    config.good_job.execution_mode = :async
+    config.good_job.execution_mode = :external
 
     config.view_component.default_preview_layout = "component_preview"
     config.view_component.preview_controller = "ComponentPreviewsController"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,6 +81,9 @@ Rails.application.configure do
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"
 
+  # Set up GoodJob for async execution in development mode
+  config.good_job.execution_mode = :async
+
   # Enable strict loading to catch N+1 problems.
   config.active_record.strict_loading_by_default = true
   config.active_record.strict_loading_mode = :n_plus_one_only

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -57,7 +57,8 @@ environment ENV.fetch("RAILS_ENV", "development")
 # processes).
 workers Settings.web_concurrency
 
-if Settings.web_concurrency > 1
+if Settings.web_concurrency > 1 &&
+     Rails.configuration.good_job.execution_mode != :external
   # Cleanly shut down GoodJob when Puma is shut down.
   # See https://github.com/bensheldon/good_job#execute-jobs-async--in-process
   MAIN_PID = Process.pid

--- a/terraform/app/autoscaling.tf
+++ b/terraform/app/autoscaling.tf
@@ -1,6 +1,6 @@
 resource "aws_appautoscaling_target" "ecs_target" {
   count              = var.enable_autoscaling ? 1 : 0
-  resource_id        = "service/${aws_ecs_cluster.cluster.name}/${aws_ecs_service.service.name}"
+  resource_id        = "service/${aws_ecs_cluster.cluster.name}/${module.web_service.service.name}"
   max_capacity       = var.maximum_replicas
   min_capacity       = var.minimum_replicas
   service_namespace  = "ecs"

--- a/terraform/app/codedeploy.tf
+++ b/terraform/app/codedeploy.tf
@@ -32,7 +32,7 @@ resource "aws_codedeploy_deployment_group" "blue_green_deployment_group" {
 
   ecs_service {
     cluster_name = aws_ecs_cluster.cluster.name
-    service_name = aws_ecs_service.service.name
+    service_name = module.web_service.service.name
   }
 
   load_balancer_info {
@@ -116,8 +116,8 @@ resource "aws_s3_object" "appspec_object" {
   key    = "appspec.yaml"
   acl    = "private"
   content = templatefile("templates/appspec.yaml.tpl", {
-    task_definition_arn = aws_ecs_task_definition.task_definition.arn
-    container_name      = jsondecode(aws_ecs_task_definition.task_definition.container_definitions)[0].name
+    task_definition_arn = module.web_service.task_definition.arn
+    container_name      = module.web_service.task_definition.arn
     container_port      = aws_lb_target_group.blue.port
   })
 

--- a/terraform/app/ecs.tf
+++ b/terraform/app/ecs.tf
@@ -130,15 +130,15 @@ resource "aws_ecs_cluster" "cluster" {
 module "web_service" {
   source = "./modules/ecs_service"
   task_config = {
-    environment         = local.task_envs
-    secrets             = local.task_secrets
-    cpu                 = 1024
-    memory              = 2048
-    docker_image        = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/${var.docker_image}@${var.image_digest}"
-    execution_role_arn  = aws_iam_role.ecs_task_execution_role.arn
-    task_role_arn       = aws_iam_role.ecs_task_role.arn
-    log_group_name      = aws_cloudwatch_log_group.ecs_log_group.name
-    region              = var.region
+    environment          = local.task_envs
+    secrets              = local.task_secrets
+    cpu                  = 1024
+    memory               = 2048
+    docker_image         = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/${var.docker_image}@${var.image_digest}"
+    execution_role_arn   = aws_iam_role.ecs_task_execution_role.arn
+    task_role_arn        = aws_iam_role.ecs_task_role.arn
+    log_group_name       = aws_cloudwatch_log_group.ecs_log_group.name
+    region               = var.region
     health_check_command = ["CMD-SHELL", "curl -f http://localhost:4000/up || exit 1"]
   }
   network_params = {
@@ -149,33 +149,33 @@ module "web_service" {
     target_group_arn = aws_lb_target_group.green.arn
     container_port   = 4000
   }
-  cluster_id  = aws_ecs_cluster.cluster.id
-  environment = var.environment
-  server_type = "web"
-  desired_count = var.minimum_replicas
+  cluster_id            = aws_ecs_cluster.cluster.id
+  environment           = var.environment
+  server_type           = "web"
+  desired_count         = var.minimum_replicas
   deployment_controller = "CODE_DEPLOY"
 }
 
 module "good_job_service" {
   source = "./modules/ecs_service"
   task_config = {
-    environment         = local.task_envs
-    secrets             = local.task_secrets
-    cpu                 = 1024
-    memory              = 2048
-    docker_image        = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/${var.docker_image}@${var.image_digest}"
-    execution_role_arn  = aws_iam_role.ecs_task_execution_role.arn
-    task_role_arn       = aws_iam_role.ecs_task_role.arn
-    log_group_name      = aws_cloudwatch_log_group.ecs_log_group.name
-    region              = var.region
+    environment          = local.task_envs
+    secrets              = local.task_secrets
+    cpu                  = 1024
+    memory               = 2048
+    docker_image         = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/${var.docker_image}@${var.image_digest}"
+    execution_role_arn   = aws_iam_role.ecs_task_execution_role.arn
+    task_role_arn        = aws_iam_role.ecs_task_role.arn
+    log_group_name       = aws_cloudwatch_log_group.ecs_log_group.name
+    region               = var.region
     health_check_command = ["CMD-SHELL", "curl -f http://localhost:4000 || exit 1"]
   }
   network_params = {
     subnets = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
     vpc_id  = aws_vpc.application_vpc.id
   }
-  cluster_id  = aws_ecs_cluster.cluster.id
-  environment = var.environment
-  server_type = "good-job"
+  cluster_id    = aws_ecs_cluster.cluster.id
+  environment   = var.environment
+  server_type   = "good-job"
   desired_count = 1
 }

--- a/terraform/app/iam_policy_documents.tf
+++ b/terraform/app/iam_policy_documents.tf
@@ -3,12 +3,12 @@
 data "aws_iam_policy_document" "codedeploy" {
   statement {
     actions   = ["ecs:DescribeServices", "ecs:UpdateServicePrimaryTaskSet"]
-    resources = [aws_ecs_service.service.id]
+    resources = [module.web_service.service.id]
     effect    = "Allow"
   }
   statement {
     actions   = ["ecs:CreateTaskSet", "ecs:DeleteTaskSet"]
-    resources = ["arn:aws:ecs:*:*:task-set/${aws_ecs_cluster.cluster.name}/${aws_ecs_service.service.name}/*"]
+    resources = ["arn:aws:ecs:*:*:task-set/${aws_ecs_cluster.cluster.name}/${module.web_service.service.name}/*"]
     effect    = "Allow"
   }
   statement {

--- a/terraform/app/modules/ecs_service/outputs.tf
+++ b/terraform/app/modules/ecs_service/outputs.tf
@@ -12,6 +12,10 @@ output "service" {
 }
 
 output "task_definition" {
-  value       = aws_ecs_task_definition.this.family
+  value = {
+    arn            = aws_ecs_task_definition.this.arn
+    family         = aws_ecs_task_definition.this.family
+    container_name = var.container_name
+  }
   description = "Essential attributes of the ECS task definition"
 }

--- a/terraform/app/outputs.tf
+++ b/terraform/app/outputs.tf
@@ -23,12 +23,13 @@ output "codedeploy_deployment_group_name" {
   value       = aws_codedeploy_deployment_group.blue_green_deployment_group.deployment_group_name
 }
 
-output "mavis_cluster_name" {
-  description = "The name of the ECS cluster"
-  value       = aws_ecs_cluster.cluster.name
-}
-
-output "mavis_service_name" {
-  description = "The name of the ECS service"
-  value       = aws_ecs_service.service.name
+output "ecs_variables" {
+  value = {
+    cluster_name = aws_ecs_cluster.cluster.name
+    good_job = {
+      service_name    = module.good_job_service.service.name
+      task_definition = module.good_job_service.task_definition
+    }
+  }
+  description = "Essential attributes of the ECS service"
 }

--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -11,6 +11,20 @@ resource "aws_security_group" "rds_security_group" {
   }
 }
 
+resource "aws_security_group_rule" "rds_ecs_ingress" {
+  count = length(local.ecs_sg_ids)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.rds_security_group.id
+  source_security_group_id = local.ecs_sg_ids[count.index]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+#TODO: Remove after release
 resource "aws_security_group_rule" "rds_ingress" {
   type                     = "ingress"
   from_port                = 5432
@@ -18,18 +32,6 @@ resource "aws_security_group_rule" "rds_ingress" {
   protocol                 = "tcp"
   security_group_id        = aws_security_group.rds_security_group.id
   source_security_group_id = aws_security_group.ecs_service_sg.id
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_security_group_rule" "ecs_rds_egress" {
-  type                     = "egress"
-  from_port                = 5432
-  to_port                  = 5432
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.rds_security_group.id
-  security_group_id        = aws_security_group.ecs_service_sg.id
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "rds_security_group" {
 }
 
 resource "aws_security_group_rule" "rds_ecs_ingress" {
-  count = length(local.ecs_sg_ids)
+  count                    = length(local.ecs_sg_ids)
   type                     = "ingress"
   from_port                = 5432
   to_port                  = 5432

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -123,13 +123,6 @@ variable "rails_master_key_path" {
   nullable    = false
 }
 
-variable "container_name" {
-  type        = string
-  default     = "mavis"
-  description = "Name of essential container in the task definition."
-  nullable    = false
-}
-
 variable "docker_image" {
   type        = string
   default     = "mavis/webapp"
@@ -165,7 +158,6 @@ variable "enable_splunk" {
 }
 
 locals {
-  container_name = "${var.container_name}-${var.environment}"
   is_production  = var.environment == "production"
 
   task_envs = [
@@ -252,4 +244,8 @@ variable "maximum_replicas" {
   type        = number
   default     = 2
   description = "Maximum amount of allowed replicas"
+}
+
+locals {
+  ecs_sg_ids = [ module.web_service.security_group_id, module.good_job_service.security_group_id]
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -158,7 +158,7 @@ variable "enable_splunk" {
 }
 
 locals {
-  is_production  = var.environment == "production"
+  is_production = var.environment == "production"
 
   task_envs = [
     {
@@ -247,5 +247,5 @@ variable "maximum_replicas" {
 }
 
 locals {
-  ecs_sg_ids = [ module.web_service.security_group_id, module.good_job_service.security_group_id]
+  ecs_sg_ids = [module.web_service.security_group_id, module.good_job_service.security_group_id]
 }


### PR DESCRIPTION
Create service to handle background tasks as well as create a user-facing service (thrust). This is also used as an opportunity to rename the existing service and move it into the module setup.
This is part of a PR chain with https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3321 as parent