### PR TITLE
Use only today's prescreening data for VaccinateForm initialisation

### DIFF
--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -57,16 +57,16 @@ class AppPatientPageComponent < ViewComponent::Base
 
   def default_vaccinate_form
     pre_screening =
-      patient_session.pre_screenings.order(created_at: :desc).first
+      patient_session
+        .pre_screenings
+        .joins(:session_date)
+        .merge(SessionDate.today)
+        .order(created_at: :desc)
+        .first
 
     VaccinateForm.new(
       feeling_well: pre_screening&.feeling_well,
-      knows_vaccination: pre_screening&.knows_vaccination,
-      no_allergies: pre_screening&.no_allergies,
-      not_already_had: pre_screening&.not_already_had,
-      not_pregnant: pre_screening&.not_pregnant,
-      not_taking_medication: pre_screening&.not_taking_medication,
-      pre_screening_notes: pre_screening&.notes || ""
+      not_pregnant: pre_screening&.not_pregnant
     )
   end
 end

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -81,8 +81,17 @@ class VaccinateForm
         not_taking_medication: not_taking_medication || false,
         notes: pre_screening_notes,
         performed_by: current_user,
-        programme_id:
+        programme_id:,
+        session_date_id: session_date_id
       )
+  end
+
+  def session_date_id
+    patient_session
+      .session
+      .session_dates
+      .find { |sd| sd.value == Date.current }
+      &.id
   end
 
   def valid_administered_values

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -82,16 +82,12 @@ class VaccinateForm
         notes: pre_screening_notes,
         performed_by: current_user,
         programme_id:,
-        session_date_id: session_date_id
+        session_date_id:
       )
   end
 
   def session_date_id
-    patient_session
-      .session
-      .session_dates
-      .find { |sd| sd.value == Date.current }
-      &.id
+    patient_session.session.session_dates.today.first&.id
   end
 
   def valid_administered_values

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -17,23 +17,27 @@
 #  patient_session_id    :bigint           not null
 #  performed_by_user_id  :bigint           not null
 #  programme_id          :bigint           not null
+#  session_date_id       :bigint           not null
 #
 # Indexes
 #
 #  index_pre_screenings_on_patient_session_id    (patient_session_id)
 #  index_pre_screenings_on_performed_by_user_id  (performed_by_user_id)
 #  index_pre_screenings_on_programme_id          (programme_id)
+#  index_pre_screenings_on_session_date_id       (session_date_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_date_id => session_dates.id)
 #
 class PreScreening < ApplicationRecord
   audited associated_with: :patient_session
 
   belongs_to :patient_session
+  belongs_to :session_date
   belongs_to :programme
   belongs_to :performed_by,
              class_name: "User",

--- a/app/models/session_date.rb
+++ b/app/models/session_date.rb
@@ -22,6 +22,7 @@ class SessionDate < ApplicationRecord
   belongs_to :session
 
   has_many :session_attendances, dependent: :restrict_with_error
+  has_many :pre_screenings, dependent: :restrict_with_error
 
   scope :for_session, -> { where("session_id = sessions.id") }
 

--- a/db/migrate/20250403155909_add_session_date_id_to_pre_screenings.rb
+++ b/db/migrate/20250403155909_add_session_date_id_to_pre_screenings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AddSessionDateIdToPreScreenings < ActiveRecord::Migration[6.1]
+  def up
+    add_reference :pre_screenings, :session_date, foreign_key: true, null: true
+
+    PreScreening.find_each do |pre_screening|
+      session = pre_screening.patient_session.session
+      matching_session_date =
+        session.session_dates.find_by(value: pre_screening.created_at.to_date)
+
+      if matching_session_date.present?
+        pre_screening.update_column(:session_date_id, matching_session_date.id)
+      else
+        raise ActiveRecord::IrreversibleMigration,
+              "No matching session_date found for PreScreening id: #{pre_screening.id}"
+      end
+    end
+
+    change_column_null :pre_screenings, :session_date_id, false
+  end
+
+  def down
+    remove_reference :pre_screenings, :session_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_02_093102) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_03_155909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -639,9 +639,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_02_093102) do
     t.bigint "programme_id", null: false
     t.boolean "not_taking_medication", null: false
     t.boolean "not_pregnant", null: false
+    t.bigint "session_date_id", null: false
     t.index ["patient_session_id"], name: "index_pre_screenings_on_patient_session_id"
     t.index ["performed_by_user_id"], name: "index_pre_screenings_on_performed_by_user_id"
     t.index ["programme_id"], name: "index_pre_screenings_on_programme_id"
+    t.index ["session_date_id"], name: "index_pre_screenings_on_session_date_id"
   end
 
   create_table "programmes", force: :cascade do |t|
@@ -906,6 +908,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_02_093102) do
   add_foreign_key "patients", "organisations"
   add_foreign_key "pre_screenings", "patient_sessions"
   add_foreign_key "pre_screenings", "programmes"
+  add_foreign_key "pre_screenings", "session_dates"
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"
   add_foreign_key "school_move_log_entries", "locations", column: "school_id"
   add_foreign_key "school_move_log_entries", "patients"

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -125,4 +125,79 @@ describe AppPatientPageComponent do
       it { should_not have_css("a", text: "Edit Gillick competence") }
     end
   end
+
+  context "when a pre_screening from today's session date is present" do
+    subject(:vaccinate_form) { component.default_vaccinate_form }
+
+    let(:today) { Date.current }
+    let(:patient_session) do
+      create(:patient_session, :session_in_progress, programmes:)
+    end
+    let(:session_date_today) { SessionDate.find_or_create_by(value: today) }
+    let!(:pre_screening_today) do
+      create(
+        :pre_screening,
+        patient_session: patient_session,
+        session_date: session_date_today,
+        feeling_well: true,
+        knows_vaccination: false,
+        no_allergies: true,
+        not_already_had: false,
+        not_pregnant: true,
+        not_taking_medication: true,
+        notes: "Today's prescreening"
+      )
+    end
+
+    it "initializes VaccinateForm with today's pre_screening data" do
+      expect(vaccinate_form.feeling_well).to be(
+        pre_screening_today.feeling_well
+      )
+      expect(vaccinate_form.not_pregnant).to be(
+        pre_screening_today.not_pregnant
+      )
+    end
+
+    it "does not copy over vaccine-dependent responses to VaccinateForm" do
+      expect(vaccinate_form.knows_vaccination).to be_nil
+      expect(vaccinate_form.no_allergies).to be_nil
+      expect(vaccinate_form.not_already_had).to be_nil
+      expect(vaccinate_form.not_taking_medication).to be_nil
+      expect(vaccinate_form.pre_screening_notes).to be_nil
+    end
+  end
+
+  context "when no pre_screening from today's session date is present" do
+    subject(:vaccinate_form) { component.default_vaccinate_form }
+
+    let(:today) { Date.current }
+    let(:patient_session) do
+      create(:patient_session, :session_in_progress, programmes:)
+    end
+    let(:session_date_yesterday) { create(:session_date, value: today - 1) }
+    let(:pre_screening_yesterday) do
+      create(
+        :pre_screening,
+        patient_session: patient_session,
+        session_date: session_date_yesterday,
+        feeling_well: true,
+        knows_vaccination: true,
+        no_allergies: true,
+        not_already_had: true,
+        not_pregnant: true,
+        not_taking_medication: true,
+        notes: "Yesterday's prescreening"
+      )
+    end
+
+    it "initializes VaccinateForm with blank pre_screening data" do
+      expect(vaccinate_form.feeling_well).to be_nil
+      expect(vaccinate_form.knows_vaccination).to be_nil
+      expect(vaccinate_form.no_allergies).to be_nil
+      expect(vaccinate_form.not_already_had).to be_nil
+      expect(vaccinate_form.not_pregnant).to be_nil
+      expect(vaccinate_form.not_taking_medication).to be_nil
+      expect(vaccinate_form.pre_screening_notes).to be_nil
+    end
+  end
 end

--- a/spec/factories/pre_screenings.rb
+++ b/spec/factories/pre_screenings.rb
@@ -17,23 +17,27 @@
 #  patient_session_id    :bigint           not null
 #  performed_by_user_id  :bigint           not null
 #  programme_id          :bigint           not null
+#  session_date_id       :bigint           not null
 #
 # Indexes
 #
 #  index_pre_screenings_on_patient_session_id    (patient_session_id)
 #  index_pre_screenings_on_performed_by_user_id  (performed_by_user_id)
 #  index_pre_screenings_on_programme_id          (programme_id)
+#  index_pre_screenings_on_session_date_id       (session_date_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_date_id => session_dates.id)
 #
 FactoryBot.define do
   factory :pre_screening do
     patient_session
     programme { patient_session.programmes.first }
+    session_date { patient_session.session.session_dates.first }
     performed_by
 
     trait :allows_vaccination do

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -15,7 +15,7 @@ describe "MenACWY and Td/IPV vaccination" do
 
     when_i_switch_to_td_ipv
     then_i_see_the_td_ipv_vaccination_form
-    and_i_check_the_patient_is_not_pregnant
+    and_i_check_the_pre_screening_questions_again
     and_i_record_the_vaccination(@td_ipv_batch)
     then_i_see_the_patient_is_vaccinated_for_td_ipv
 
@@ -112,9 +112,11 @@ describe "MenACWY and Td/IPV vaccination" do
     expect(page).to have_content("ready for their Td/IPV vaccination?")
   end
 
-  def and_i_check_the_patient_is_not_pregnant
-    # The other pre-screening questions should be pre-checked
-    # from the MenACWY vaccination.
+  def and_i_check_the_pre_screening_questions_again
+    check "know what the vaccination is for, and are happy to have it"
+    check "have not already had the vaccination"
+    check "have no allergies which would prevent vaccination"
+    check "are not taking any medication which prevents vaccination"
     check "are not pregnant"
   end
 

--- a/spec/models/pre_screening_spec.rb
+++ b/spec/models/pre_screening_spec.rb
@@ -17,18 +17,21 @@
 #  patient_session_id    :bigint           not null
 #  performed_by_user_id  :bigint           not null
 #  programme_id          :bigint           not null
+#  session_date_id       :bigint           not null
 #
 # Indexes
 #
 #  index_pre_screenings_on_patient_session_id    (patient_session_id)
 #  index_pre_screenings_on_performed_by_user_id  (performed_by_user_id)
 #  index_pre_screenings_on_programme_id          (programme_id)
+#  index_pre_screenings_on_session_date_id       (session_date_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (patient_session_id => patient_sessions.id)
 #  fk_rails_...  (performed_by_user_id => users.id)
 #  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (session_date_id => session_dates.id)
 #
 describe PreScreening do
   subject(:pre_screening) { build(:pre_screening) }


### PR DESCRIPTION
This change updates the logic for initialising VaccinateForm so that it only considers PreScreening records with a SessionDate of Date.current. Only vaccine-independent questions will be copied over from previous pre-screenings, the others (and the notes field) will be blank. 
If no PreScreening from today's session is available, the form will remain blank.

Changes include:
• Implementing a data migration to associate PreScreening with a SessionDate.
• Updating the query logic to join on session_date and filter by today's date.
• Being selective about which fields of the PreScreening to copy over.
• Tests to verify that only today's screening data is used.