### PR TITLE
Add support for uploading SystmOne vaccination records

### DIFF
--- a/app/lib/vaccination_description_string_parser.rb
+++ b/app/lib/vaccination_description_string_parser.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class VaccinationDescriptionStringParser
+  def initialize(string)
+    @string = string
+  end
+
+  def call
+    return nil if string.blank?
+
+    known_programme = KNOWN_PROGRAMMES.keys.find { string.starts_with?(it) }
+
+    programme_name = KNOWN_PROGRAMMES[known_programme]
+    return nil if known_programme.present? && programme_name.nil?
+
+    vaccine_name = (string.split(" ").first if known_programme.blank?)
+    return nil if known_programme.blank? && vaccine_name.blank?
+
+    dose_sequence_string =
+      if vaccine_name.present?
+        string[vaccine_name.length..]
+      elsif known_programme.present?
+        string[known_programme.length..]
+      end
+
+    dose_sequence =
+      begin
+        Integer(dose_sequence_string)
+      rescue ArgumentError, TypeError
+        dose_sequence_string&.strip&.presence
+      end
+
+    { programme_name:, vaccine_name:, dose_sequence: }.compact
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :string
+
+  KNOWN_PROGRAMMES = {
+    "Flu" => "Flu",
+    "HPV" => "HPV",
+    "Human Papillomavirus" => "HPV",
+    "MMR" => "MMR",
+    "Measles/Mumps/Rubella" => "MMR",
+    "MenACWY" => "MenACWY",
+    "Meningococcal conjugate A,C, W135 + Y" => "MenACWY",
+    "Td/IPV" => "Td/IPV"
+  }.freeze
+end

--- a/spec/fixtures/immunisation_import/systm_one.csv
+++ b/spec/fixtures/immunisation_import/systm_one.csv
@@ -1,0 +1,2 @@
+Date of birth,NHS number,Vaccination area code,Vaccination batch number,BATCH_EXPIRY_DATE,Vaccination reason,Vaccination type,First name,Postcode,Sex,Surname,Event date,Event location type,Event time,Organisation ID,School,School code,Patient Count
+20100912,7420180008,,123013325,20220730,,Cervarix 1,Chyna,LE3 2DA,Female,Pickle,20240514,School,,,Eton College,110158,

--- a/spec/lib/vaccination_description_string_parser_spec.rb
+++ b/spec/lib/vaccination_description_string_parser_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+describe VaccinationDescriptionStringParser do
+  subject(:call) { described_class.call(string) }
+
+  context "with an empty string" do
+    let(:string) { "" }
+
+    it { should be_nil }
+  end
+
+  {
+    "Flu" => {
+      programme_name: "Flu"
+    },
+    "Human Papillomavirus 1" => {
+      programme_name: "HPV",
+      dose_sequence: 1
+    },
+    "Td/IPV 2nd Scheduled Booster" => {
+      programme_name: "Td/IPV",
+      dose_sequence: "2nd Scheduled Booster"
+    },
+    "Meningococcal conjugate A,C, W135 + Y 1" => {
+      programme_name: "MenACWY",
+      dose_sequence: 1
+    },
+    "Measles/Mumps/Rubella 1" => {
+      programme_name: "MMR",
+      dose_sequence: 1
+    },
+    "Revaxis 1" => {
+      vaccine_name: "Revaxis",
+      dose_sequence: 1
+    },
+    "Gardasil9 1" => {
+      vaccine_name: "Gardasil9",
+      dose_sequence: 1
+    },
+    "MenQuadfi 1" => {
+      vaccine_name: "MenQuadfi",
+      dose_sequence: 1
+    }
+  }.each do |input, output|
+    context "with #{input}" do
+      let(:string) { input }
+
+      it { should eq(output) }
+    end
+  end
+end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -70,12 +70,12 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors[:base]).to contain_exactly(
           "<code>VACCINATED</code> is required",
-          "<code>DATE_OF_VACCINATION</code> is required",
-          "<code>PERSON_DOB</code> is required",
-          "<code>PERSON_FORENAME</code> is required",
+          "<code>DATE_OF_VACCINATION</code> or <code>Event date</code> is required",
+          "<code>PERSON_DOB</code> or <code>Date of birth</code> is required",
+          "<code>PERSON_FORENAME</code> or <code>First name</code> is required",
           "<code>PERSON_GENDER_CODE</code> or <code>PERSON_GENDER</code> is required",
-          "<code>PERSON_SURNAME</code> is required",
-          "<code>PERSON_POSTCODE</code> is required",
+          "<code>PERSON_SURNAME</code> or <code>Surname</code> is required",
+          "<code>PERSON_POSTCODE</code> or <code>Postcode</code> is required",
           "<code>PROGRAMME</code> is required",
           "<code>REASON_NOT_VACCINATED</code> is required"
         )
@@ -93,7 +93,7 @@ describe ImmunisationImportRow do
         it "doesn't require a postcode" do
           expect(immunisation_import_row).to be_invalid
           expect(immunisation_import_row.errors[:base]).not_to include(
-            "<code>PERSON_POSTCODE</code> is required"
+            "<code>PERSON_POSTCODE</code> or <code>Postcode</code> is required"
           )
         end
       end
@@ -603,7 +603,7 @@ describe ImmunisationImportRow do
           "<code>BATCH_EXPIRY_DATE</code> is required"
         )
         expect(immunisation_import_row.errors[:base]).to include(
-          "<code>BATCH_NUMBER</code> is required"
+          "<code>BATCH_NUMBER</code> or <code>Vaccination batch number</code> is required"
         )
       end
     end
@@ -1560,16 +1560,96 @@ describe ImmunisationImportRow do
   describe "#batch_name" do
     subject { immunisation_import_row.batch_name&.to_s }
 
-    context "without a value" do
-      let(:data) { {} }
-
-      it { should be_nil }
-    end
-
-    context "with a value" do
+    context "with a BATCH_NUMBER field" do
       let(:data) { { "BATCH_NUMBER" => "abc" } }
 
       it { should eq("abc") }
+    end
+
+    context "with a Vaccination Batch Number field" do
+      let(:data) { { "Vaccination Batch Number" => "abc" } }
+
+      it { should eq("abc") }
+    end
+  end
+
+  describe "#clinic_name" do
+    subject { immunisation_import_row.clinic_name&.to_s }
+
+    context "with a CLINIC_NAME field" do
+      let(:data) { { "CLINIC_NAME" => "Hospital" } }
+
+      it { should eq("Hospital") }
+    end
+
+    context "with an Event Done At field" do
+      let(:data) { { "Event Done At" => "Hospital" } }
+
+      it { should eq("Hospital") }
+    end
+  end
+
+  describe "#date_of_vaccination" do
+    subject { immunisation_import_row.date_of_vaccination&.to_s }
+
+    context "with a DATE_OF_VACCINATION field" do
+      let(:data) { { "DATE_OF_VACCINATION" => "01/01/2020" } }
+
+      it { should eq("01/01/2020") }
+    end
+
+    context "with an Event Date field" do
+      let(:data) { { "Event Date" => "01/01/2020" } }
+
+      it { should eq("01/01/2020") }
+    end
+  end
+
+  describe "#patient_date_of_birth" do
+    subject { immunisation_import_row.patient_date_of_birth&.to_s }
+
+    context "with a PERSON_DOB field" do
+      let(:data) { { "PERSON_DOB" => "01/01/2020" } }
+
+      it { should eq("01/01/2020") }
+    end
+
+    context "with a Date of Birth field" do
+      let(:data) { { "Date of Birth" => "01/01/2020" } }
+
+      it { should eq("01/01/2020") }
+    end
+  end
+
+  describe "#patient_first_name" do
+    subject { immunisation_import_row.patient_first_name&.to_s }
+
+    context "with a PERSON_FORENAME field" do
+      let(:data) { { "PERSON_FORENAME" => "Sally" } }
+
+      it { should eq("Sally") }
+    end
+
+    context "with a First name field" do
+      let(:data) { { "First name" => "Sally" } }
+
+      it { should eq("Sally") }
+    end
+  end
+
+  describe "#patient_last_name" do
+    subject { immunisation_import_row.patient_last_name&.to_s }
+
+    context "with a PERSON_SURNAME field" do
+      let(:data) { { "PERSON_SURNAME" => "Phillips" } }
+
+      it { should eq("Phillips") }
+    end
+
+    context "with a Surname field" do
+      let(:data) { { "Surname" => "Phillips" } }
+
+      it { should eq("Phillips") }
     end
   end
 
@@ -1587,5 +1667,37 @@ describe ImmunisationImportRow do
     let(:data) { { "PERFORMING_PROFESSIONAL_SURNAME" => "Smith" } }
 
     it { should eq("Smith") }
+  end
+
+  describe "#school_name" do
+    subject { immunisation_import_row.school_name&.to_s }
+
+    context "with a SCHOOL_NAME field" do
+      let(:data) { { "SCHOOL_NAME" => "Waterloo Road" } }
+
+      it { should eq("Waterloo Road") }
+    end
+
+    context "with a School field" do
+      let(:data) { { "School" => "Waterloo Road" } }
+
+      it { should eq("Waterloo Road") }
+    end
+  end
+
+  describe "#school_urn" do
+    subject { immunisation_import_row.school_urn&.to_s }
+
+    context "with a SCHOOL_URN field" do
+      let(:data) { { "SCHOOL_URN" => "123456" } }
+
+      it { should eq("123456") }
+    end
+
+    context "with a School Code field" do
+      let(:data) { { "School Code" => "123456" } }
+
+      it { should eq("123456") }
+    end
   end
 end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -110,6 +110,24 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "with an invalid vaccine for the programme" do
+      let(:data) do
+        {
+          "PROGRAMME" => "HPV",
+          "VACCINE_GIVEN" => "AstraZeneca Fluenz Tetra LAIV"
+        }
+      end
+
+      let(:programmes) { [create(:programme, :flu), create(:programme, :hpv)] }
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(
+          immunisation_import_row.errors["VACCINE_GIVEN"]
+        ).to contain_exactly("is not given in the HPV programme")
+      end
+    end
+
     context "with an invalid reason not vaccinated" do
       let(:data) do
         { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => "unknown" }

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1095,6 +1095,18 @@ describe ImmunisationImportRow do
         it { should eq("Unknown") }
       end
 
+      context "with a known school and community location type" do
+        let(:data) do
+          valid_data.merge(
+            "SCHOOL_URN" => "123456",
+            "SCHOOL_NAME" => "Waterloo Road",
+            "Event Location Type" => "Hospital"
+          )
+        end
+
+        it { should eq("Unknown") }
+      end
+
       context "when home educated and community care setting" do
         let(:data) do
           valid_data.merge(
@@ -1114,6 +1126,19 @@ describe ImmunisationImportRow do
             "SCHOOL_NAME" => "",
             "CARE_SETTING" => "2",
             "CLINIC_NAME" => "A Clinic"
+          )
+        end
+
+        it { should eq("A Clinic") }
+      end
+
+      context "when home educated and community location type and a named clinic" do
+        let(:data) do
+          valid_data.merge(
+            "School Code" => "999999",
+            "School" => "",
+            "Event Location Type" => "Clinic",
+            "Event Done At" => "A Clinic"
           )
         end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -73,7 +73,7 @@ describe ImmunisationImportRow do
           "<code>DATE_OF_VACCINATION</code> or <code>Event date</code> is required",
           "<code>PERSON_DOB</code> or <code>Date of birth</code> is required",
           "<code>PERSON_FORENAME</code> or <code>First name</code> is required",
-          "<code>PERSON_GENDER_CODE</code> or <code>PERSON_GENDER</code> is required",
+          "<code>PERSON_GENDER_CODE</code>, <code>PERSON_GENDER</code> or <code>Sex</code> is required",
           "<code>PERSON_SURNAME</code> or <code>Surname</code> is required",
           "<code>PERSON_POSTCODE</code> or <code>Postcode</code> is required",
           "<code>PROGRAMME</code> is required",
@@ -158,7 +158,7 @@ describe ImmunisationImportRow do
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors["PERSON_GENDER_CODE"]).to eq(
-          ["Enter a gender or gender code."]
+          ["Enter a valid gender or gender code."]
         )
       end
     end
@@ -1406,6 +1406,20 @@ describe ImmunisationImportRow do
         end
 
         shared_examples "with a value" do |key|
+          context "with a 'unknown' value" do
+            let(:data) { valid_data_without_gender.merge(key => "Unknown") }
+
+            it { should eq("not_known") }
+          end
+
+          context "with a 'indeterminate' value" do
+            let(:data) do
+              valid_data_without_gender.merge(key => "Indeterminate")
+            end
+
+            it { should eq("not_known") }
+          end
+
           context "with a 'not known' value" do
             let(:data) { valid_data_without_gender.merge(key => "Not Known") }
 
@@ -1435,6 +1449,7 @@ describe ImmunisationImportRow do
 
         include_examples "with a value", "PERSON_GENDER_CODE"
         include_examples "with a value", "PERSON_GENDER"
+        include_examples "with a value", "Sex"
       end
 
       describe "#organisation" do
@@ -1634,6 +1649,28 @@ describe ImmunisationImportRow do
       let(:data) { { "First name" => "Sally" } }
 
       it { should eq("Sally") }
+    end
+  end
+
+  describe "#patient_gender_code" do
+    subject { immunisation_import_row.patient_gender_code&.to_s }
+
+    context "with a PERSON_GENDER_CODE field" do
+      let(:data) { { "PERSON_GENDER_CODE" => "male" } }
+
+      it { should eq("male") }
+    end
+
+    context "with a PERSON_GENDER field" do
+      let(:data) { { "PERSON_GENDER" => "female" } }
+
+      it { should eq("female") }
+    end
+
+    context "with a Sex field" do
+      let(:data) { { "Sex" => "unknown" } }
+
+      it { should eq("unknown") }
     end
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -76,7 +76,7 @@ describe ImmunisationImportRow do
           "<code>PERSON_GENDER_CODE</code>, <code>PERSON_GENDER</code> or <code>Sex</code> is required",
           "<code>PERSON_SURNAME</code> or <code>Surname</code> is required",
           "<code>PERSON_POSTCODE</code> or <code>Postcode</code> is required",
-          "<code>PROGRAMME</code> is required",
+          "<code>PROGRAMME</code> or <code>Vaccination type</code> is required",
           "<code>REASON_NOT_VACCINATED</code> is required"
         )
       end


### PR DESCRIPTION
This updates the import process to allow users to upload a file in the SystmOne format which has a different set of fields to the existing format. We haven't got a real example of this type of file for testing, so this is a best guess at how the format should be parsed.

We haven't updated any parts of the UI in this change, we might want to do this in a follow up PR to describe the two different formats.

To build this, the import mechanism required a substantial refactor, which is covered by:

- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3312
- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3317
- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3318
- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3325
- https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3326