### PR TITLE
Make gap between PDS jobs configurable

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -11,6 +11,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
     return unless Settings.pds.enqueue_bulk_updates
 
     patients = Patient.with_nhs_number.not_invalidated.not_deceased
+    wait_between_jobs = Settings.pds.wait_between_jobs.to_i
 
     GoodJob::Bulk.enqueue do
       patients
@@ -26,7 +27,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
 
           PatientUpdateFromPDSJob.set(
             priority: 50,
-            wait: 2 * index
+            wait: index * wait_between_jobs
           ).perform_later(patient)
         end
     end

--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -17,7 +17,8 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
         .where(updated_from_pds_at: nil)
         .or(patients.where("updated_from_pds_at < ?", 12.hours.ago))
         .order("updated_from_pds_at ASC NULLS FIRST")
-        .each_with_index do |patient, index|
+        .find_each
+        .with_index do |patient, index|
           # Schedule with a delay to preemptively handle rate limit issues.
           # This shouldn't be necessary, but we're finding that Good Job
           # has occasional race condition issues, and spreading out the jobs

--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -15,7 +15,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
     GoodJob::Bulk.enqueue do
       patients
         .where(updated_from_pds_at: nil)
-        .or(patients.where("updated_from_pds_at < ?", 6.hours.ago))
+        .or(patients.where("updated_from_pds_at < ?", 12.hours.ago))
         .order("updated_from_pds_at ASC NULLS FIRST")
         .each_with_index do |patient, index|
           # Schedule with a delay to preemptively handle rate limit issues.

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -172,7 +172,7 @@ module CSVImportable
     return unless Settings.pds.enqueue_bulk_updates
 
     GoodJob::Bulk.enqueue do
-      patients.each_with_index do |patient, index|
+      patients.find_each.with_index do |patient, index|
         # Schedule with a delay to preemptively handle rate limit issues.
         # This shouldn't be necessary, but we're finding that Good Job
         # has occasional race condition issues, and spreading out the jobs

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -75,6 +75,7 @@ nhs_api:
 pds:
   enqueue_bulk_updates: true
   raise_unknown_gp_practice: true
+  wait_between_jobs: 2
 
 splunk:
   enabled: true


### PR DESCRIPTION
We're modifying the way Good Job is deployed to hopefully reduce contention by reducing the number of parallel jobs processing at any one time. This should allow us to reduce the artificial gap we've imposed between PDS jobs and process patients at a quicker rate.

By making the value configurable we can change the gap between jobs without needing to deploy changes to the code.