### PR TITLE
update Brakeman gem to 7.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.1)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
Updates Brakeman to the latest version to resolve bin/lint warnings of packages being out of date.