### PR TITLE
Extract default target group to variable

### DIFF
--- a/terraform/app/ecs.tf
+++ b/terraform/app/ecs.tf
@@ -146,7 +146,7 @@ module "web_service" {
     vpc_id  = aws_vpc.application_vpc.id
   }
   loadbalancer = {
-    target_group_arn = aws_lb_target_group.green.arn
+    target_group_arn = local.ecs_initial_lb_target_group
     container_port   = 4000
   }
   cluster_id            = aws_ecs_cluster.cluster.id

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -26,3 +26,4 @@ http_hosts = {
 
 minimum_replicas = 3
 appspec_bucket   = "nhse-mavis-appspec-bucket-preview"
+ecs_initial_lb_target_group = "green"

--- a/terraform/app/loadbalancer.tf
+++ b/terraform/app/loadbalancer.tf
@@ -150,7 +150,7 @@ resource "aws_lb_listener_rule" "forward_to_app" {
   priority     = 50000
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.blue.arn
+    target_group_arn = local.default_lb_target_group_arn
   }
   condition {
     path_pattern {

--- a/terraform/app/loadbalancer.tf
+++ b/terraform/app/loadbalancer.tf
@@ -150,7 +150,7 @@ resource "aws_lb_listener_rule" "forward_to_app" {
   priority     = 50000
   action {
     type             = "forward"
-    target_group_arn = local.default_lb_target_group_arn
+    target_group_arn = local.ecs_initial_lb_target_group
   }
   condition {
     path_pattern {

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -246,13 +246,17 @@ variable "maximum_replicas" {
   description = "Maximum amount of allowed replicas"
 }
 
-variable "default_lb_target_group_arn" {
-  type = string
+variable "active_lb_target_group" {
+  type        = string
   description = "The actual loadbalancer target group is set by Codedeploy. However in scenarios where new resources behind the load balancer are created, terraform already needs to know the current target group. In this case, set the variable to the currently active target group."
-  default = null
+  default     = ""
+  validation {
+    condition     = contains(["blue", "green", ""], var.active_lb_target_group)
+    error_message = "Valid target groups: blue, green"
+  }
 }
 
 locals {
-  default_lb_target_group_arn = var.default_lb_target_group_arn == null ? aws_lb_target_group.blue.arn : var.default_lb_target_group_arn
-  ecs_sg_ids = [module.web_service.security_group_id, module.good_job_service.security_group_id]
+  default_lb_target_group_arn = var.active_lb_target_group == "green" ? aws_lb_target_group.green.arn : aws_lb_target_group.blue.arn
+  ecs_sg_ids                  = [module.web_service.security_group_id, module.good_job_service.security_group_id]
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -246,6 +246,13 @@ variable "maximum_replicas" {
   description = "Maximum amount of allowed replicas"
 }
 
+variable "default_lb_target_group_arn" {
+  type = string
+  description = "The actual loadbalancer target group is set by Codedeploy. However in scenarios where new resources behind the load balancer are created, terraform already needs to know the current target group. In this case, set the variable to the currently active target group."
+  default = null
+}
+
 locals {
+  default_lb_target_group_arn = var.default_lb_target_group_arn == null ? aws_lb_target_group.blue.arn : var.default_lb_target_group_arn
   ecs_sg_ids = [module.web_service.security_group_id, module.good_job_service.security_group_id]
 }

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -249,14 +249,14 @@ variable "maximum_replicas" {
 variable "active_lb_target_group" {
   type        = string
   description = "The actual loadbalancer target group is set by Codedeploy. However in scenarios where new resources behind the load balancer are created, terraform already needs to know the current target group. In this case, set the variable to the currently active target group."
-  default     = ""
+  default     = "blue"
   validation {
-    condition     = contains(["blue", "green", ""], var.active_lb_target_group)
+    condition     = contains(["blue", "green"], var.active_lb_target_group)
     error_message = "Valid target groups: blue, green"
   }
 }
 
 locals {
-  default_lb_target_group_arn = var.active_lb_target_group == "green" ? aws_lb_target_group.green.arn : aws_lb_target_group.blue.arn
+  ecs_initial_lb_target_group = var.active_lb_target_group == "green" ? aws_lb_target_group.green.arn : aws_lb_target_group.blue.arn
   ecs_sg_ids                  = [module.web_service.security_group_id, module.good_job_service.security_group_id]
 }


### PR DESCRIPTION
* In cases where a new ECS service is deployed, while the loadbalancer target group that is controlled by Codedeploy points to the "wrong" target group, terraform apply would result into an error that the new service is not attached to a valid target group.

* This can be taken care of by assigning the currently active target group to this variable

Previously, this could already be done by changing it temporarily in the terraform configuration, but having this as a variable allows for different values per environment

This is part of a PR chain with https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3323 as parent