### PR TITLE
Add mock data generators for testing

### DIFF
--- a/lib/generate/consents.rb
+++ b/lib/generate/consents.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module Generate
+  class Consents
+    attr_reader :organisation, :programme
+
+    def initialize(
+      organisation:,
+      programme: nil,
+      session: nil,
+      refused: 0,
+      given: 0,
+      given_needs_triage: 0
+    )
+      @organisation = organisation
+      @programme = programme || organisation.programmes.sample
+      @session = session
+      @refused = refused
+      @given = given
+      @given_needs_triage = given_needs_triage
+    end
+
+    def call
+      create_consent_with_response(:refused, @refused)
+      create_consent_with_response(:given, @given)
+      create_consent_given_needs_triage(@given_needs_triage)
+    end
+
+    def self.call(...) = new(...).call
+
+    private
+
+    def patients
+      (@session.presence || organisation)
+        .patients
+        .includes(:parents, :consents, consents: :parent)
+        .in_programmes([programme])
+        .select { it.consents.empty? && it.parents.any? }
+    end
+
+    def random_patients(count)
+      patients
+        .shuffle
+        .take(count)
+        .tap do
+          if it.size < count
+            raise "Not enough patients without consent and with parents to generate consents"
+          end
+        end
+    end
+
+    def session_for(patient)
+      patient
+        .sessions
+        .eager_load(:location)
+        .merge(Location.school)
+        .has_programme(programme)
+        .sample
+    end
+
+    def create_consent_with_response(response, count)
+      available_patient_sessions =
+        random_patients(count).map { [it, session_for(it)] }
+
+      available_patient_sessions.each do |patient, session|
+        consent = FactoryBot.create(:consent, response, patient:, programme:)
+        FactoryBot.create(
+          :consent_form,
+          organisation:,
+          programmes: [programme],
+          session:,
+          consent:,
+          response:
+        )
+      end
+    end
+
+    def create_consent_given_needs_triage(count)
+      available_patient_sessions =
+        random_patients(count).map { [it, session_for(it)] }
+
+      available_patient_sessions.each do |patient, session|
+        consent =
+          FactoryBot.create(
+            :consent,
+            :given,
+            :needing_triage,
+            patient:,
+            programme:
+          )
+        FactoryBot.create(
+          :consent_form,
+          organisation:,
+          programmes: [programme],
+          session:,
+          consent:,
+          response: "given"
+        )
+      end
+    end
+  end
+end

--- a/lib/generate/patient_imports.rb
+++ b/lib/generate/patient_imports.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require "csv"
+
+Faker::Config.locale = "en-GB"
+
+# Use this to generate a cohort import CSV file for performance testing.
+#
+# Usage from the Rails console:
+#
+#     # By default it uses existing locations in the db.
+#     Generate::PatientImports.call
+#
+module Generate
+  class PatientImports
+    attr_reader :ods_code, :organisation, :programme, :urns, :patient_count
+
+    def initialize(
+      ods_code: "A9A5A",
+      programme: "hpv",
+      urns: nil,
+      patient_count: 10
+    )
+      @organisation = Organisation.find_by(ods_code:)
+      @programme = Programme.find_by(type: programme)
+      @urns =
+        urns ||
+          @organisation
+            .locations
+            .select { it.urn.present? }
+            .sample(3)
+            .pluck(:urn)
+      @patient_count = patient_count
+    end
+
+    def self.call(...) = new(...).call
+
+    def call
+      generate
+      write_cohort_import_csv
+      write_class_import_csv
+    end
+
+    def patients
+      @patients = patient_count.times.map { build_patient }
+    end
+
+    private
+
+    def cohort_import_csv_filepath
+      Rails.root.join(
+        "tmp/perf-test-cohort-import-#{organisation.ods_code}-#{programme.type}.csv"
+      )
+    end
+
+    def class_import_csv_filepath(school:)
+      Rails.root.join(
+        "tmp/perf-test-class-import-#{school.name}-#{school.sessions.first.slug}.csv"
+      )
+    end
+
+    def write_cohort_import_csv
+      CSV.open(cohort_import_csv_filepath, "w") do |csv|
+        csv << %w[
+          CHILD_ADDRESS_LINE_1
+          CHILD_ADDRESS_LINE_2
+          CHILD_POSTCODE
+          CHILD_TOWN
+          CHILD_PREFERRED_GIVEN_NAME
+          CHILD_DATE_OF_BIRTH
+          CHILD_FIRST_NAME
+          CHILD_LAST_NAME
+          CHILD_NHS_NUMBER
+          PARENT_1_EMAIL
+          PARENT_1_NAME
+          PARENT_1_PHONE
+          PARENT_1_RELATIONSHIP
+          PARENT_2_EMAIL
+          PARENT_2_NAME
+          PARENT_2_PHONE
+          PARENT_2_RELATIONSHIP
+          CHILD_SCHOOL_URN
+        ]
+
+        patients.each do |patient|
+          csv << [
+            patient.address_line_1,
+            patient.address_line_2,
+            patient.address_postcode,
+            patient.address_town,
+            patient.preferred_given_name,
+            patient.date_of_birth,
+            patient.given_name,
+            patient.family_name,
+            patient.nhs_number,
+            patient.parents.first&.email,
+            patient.parents.first&.full_name,
+            patient.parents.first&.phone,
+            patient.parent_relationships.first&.type,
+            patient.parents.second&.email,
+            patient.parents.second&.full_name,
+            patient.parents.second&.phone,
+            patient.parent_relationships.second&.type,
+            patient.school.urn
+          ]
+        end
+      end
+    end
+
+    def write_class_import_csv
+      patients
+        .group_by(&:school)
+        .each do |school, school_patients|
+          next if school.nil?
+
+          CSV.open(class_import_csv_filepath(school:), "w") do |csv|
+            csv << %w[
+              CHILD_POSTCODE
+              CHILD_DATE_OF_BIRTH
+              CHILD_FIRST_NAME
+              CHILD_LAST_NAME
+              PARENT_1_EMAIL
+              PARENT_1_PHONE
+              PARENT_2_EMAIL
+              PARENT_2_PHONE
+            ]
+
+            school_patients.each do |patient|
+              csv << [
+                patient.address_postcode,
+                patient.date_of_birth,
+                patient.given_name,
+                patient.family_name,
+                patient.parents.first&.email,
+                patient.parents.first&.phone,
+                patient.parents.second&.email,
+                patient.parents.second&.phone
+              ]
+            end
+          end
+        end
+    end
+
+    def programme_year_groups
+      Programme::YEAR_GROUPS_BY_TYPE[programme.type]
+    end
+
+    def schools_with_year_groups
+      @schools_with_year_groups ||=
+        organisation
+          .locations
+          .includes(:organisation, :sessions)
+          .select { (it.year_groups & programme_year_groups).any? }
+    end
+
+    def build_patient(year_group: nil)
+      school = schools_with_year_groups.sample
+      year_group ||= (school.year_groups & programme_year_groups).sample
+
+      FactoryBot
+        .build(
+          :patient,
+          school:,
+          date_of_birth: date_of_birth_for_year(year_group)
+        )
+        .tap do |patient|
+          patient.parents =
+            FactoryBot.build_list(:parent, 2, family_name: patient.family_name)
+          patient.parent_relationships =
+            patient.parents.map do
+              FactoryBot.build(:parent_relationship, parent: it)
+            end
+        end
+    end
+
+    def date_of_birth_for_year(
+      year_group,
+      academic_year: Date.current.academic_year
+    )
+      academic_year = academic_year.to_s
+      year_group = year_group.to_i
+
+      if year_group < 12
+        start_date = Date.new(academic_year.to_i - (year_group.to_i + 5), 9, 1)
+        end_date = Date.new(academic_year.to_i - (year_group.to_i + 4), 8, 31)
+        rand(start_date..end_date)
+      else
+        raise "Unknown year group: #{year_group}"
+      end
+    end
+  end
+end

--- a/lib/generate/triages.rb
+++ b/lib/generate/triages.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Generate
+  class Triages
+    attr_reader :config, :organisation, :programme
+
+    def initialize(
+      organisation:,
+      programme: nil,
+      session: nil,
+      ready_to_vaccinate: 1,
+      do_not_vaccinate: 1
+    )
+      @organisation = organisation
+      @programme = programme || organisation.programmes.sample
+      @session = session
+      @ready_to_vaccinate = ready_to_vaccinate
+      @do_not_vaccinate = do_not_vaccinate
+    end
+
+    def call
+      create_triage_with_status(:ready_to_vaccinate, @ready_to_vaccinate)
+      create_triage_with_status(:do_not_vaccinate, @do_not_vaccinate)
+    end
+
+    def self.call(...) = new(...).call
+
+    private
+
+    def patients
+      (@session.presence || organisation)
+        .patients
+        .includes(:triage_statuses)
+        .in_programmes([programme])
+        .select { it.triage_status(programme:).required? }
+    end
+
+    def random_patients(count)
+      patients
+        .shuffle
+        .take(count)
+        .tap do
+          raise "Not enough patients to generate triages" if it.size < count
+        end
+    end
+
+    def user
+      @user ||= organisation.users.includes(:organisations).sample
+    end
+
+    def create_triage_with_status(status, count)
+      available_patients = random_patients(count)
+
+      available_patients.each do |patient|
+        FactoryBot.create(
+          :triage,
+          status,
+          patient:,
+          programme:,
+          performed_by: user,
+          organisation:
+        )
+      end
+    end
+  end
+end

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Generate
+  class VaccinationRecords
+    attr_reader :config, :organisation, :programme
+
+    def initialize(organisation:, programme: nil, session: nil, administered: 0)
+      @organisation = organisation
+      @programme = programme || organisation.programmes.sample
+      @session = session
+      @administered = administered
+    end
+
+    def call
+      create_vaccination_administered(@administered)
+    end
+
+    def self.call(...) = new(...).call
+
+    private
+
+    def patient_sessions
+      (@session.presence || organisation)
+        .patient_sessions
+        .joins(:patient)
+        .includes(
+          :session,
+          patient: [
+            :consents,
+            :triages,
+            :vaccination_records,
+            :parents,
+            { consents: :parent }
+          ]
+        )
+        .in_programmes([programme])
+        .select { it.patient.consent_given_and_safe_to_vaccinate?(programme:) }
+    end
+
+    def vaccine
+      @vaccine ||= programme.vaccines.includes(:batches).active.first
+    end
+
+    def batch
+      @batch ||= vaccine.batches.sample
+    end
+
+    def random_patient_sessions(count)
+      patient_sessions
+        .shuffle
+        .take(count)
+        .tap do
+          if it.size < count
+            raise "Not enough patients to generate vaccinations"
+          end
+        end
+    end
+
+    def location_name(session)
+      session.location.generic_clinic? ? session.location.name : ""
+    end
+
+    def user
+      @user ||= organisation.users.includes(:organisations).sample
+    end
+
+    def create_vaccination_administered(count)
+      available_patient_sessions = random_patient_sessions(count)
+
+      available_patient_sessions.each do |patient_session|
+        FactoryBot.create(:session_attendance, :present, patient_session:)
+
+        FactoryBot.create(
+          :vaccination_record,
+          :administered,
+          patient: patient_session.patient,
+          programme:,
+          performed_by: user,
+          session: patient_session.session,
+          vaccine:,
+          batch:,
+          location_name: location_name(patient_session.session)
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/generate/consents_spec.rb
+++ b/spec/lib/generate/consents_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+describe Generate::Consents do
+  let(:programme) { Programme.hpv&.first || create(:programme, :hpv) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:user) { create(:user, organisation:) }
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
+  let(:parents) { [create(:parent)] }
+  let(:patient) do
+    create(:patient, programmes: [programme], session:, parents:)
+  end
+  let(:config) { {} }
+
+  describe "consents refused" do
+    it "generates consents by default" do
+      user
+      patient
+
+      described_class.call(
+        organisation:,
+        programme:,
+        session:,
+        refused: 1,
+        given: 0,
+        given_needs_triage: 0
+      )
+      expect(Consent.response_refused.count).to eq 1
+      expect(
+        Consent.response_refused.count { it.consent_form.present? }
+      ).to eq 1
+    end
+  end
+
+  describe "consents given not needing triage" do
+    it "generates consents by default" do
+      user
+      patient
+
+      described_class.call(
+        organisation:,
+        programme:,
+        session:,
+        refused: 0,
+        given: 1,
+        given_needs_triage: 0
+      )
+
+      expect(Consent.response_given.count).to eq 1
+      expect(Consent.response_given.count { it.consent_form.present? }).to eq 1
+    end
+  end
+
+  describe "consents given needing triage" do
+    it "generates consents by default" do
+      user
+      patient
+
+      described_class.call(
+        organisation:,
+        programme:,
+        session:,
+        refused: 0,
+        given: 0,
+        given_needs_triage: 1
+      )
+
+      consents_given = Consent.response_given.select { it.triage_needed? }
+      expect(consents_given.count).to eq 1
+      expect(consents_given.count { it.consent_form.present? }).to eq 1
+    end
+  end
+end

--- a/spec/lib/generate/patient_imports_spec.rb
+++ b/spec/lib/generate/patient_imports_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Generate::PatientImports do
+  before do
+    organisation = create(:organisation, ods_code: "A9A5A")
+    programme = create(:programme, :hpv)
+    location =
+      create(
+        :school,
+        :secondary,
+        organisation:,
+        name: "Test School",
+        urn: "31337"
+      )
+    create(
+      :session,
+      organisation:,
+      slug: "slug",
+      location:,
+      programmes: [programme]
+    )
+  end
+
+  it "generates patients" do
+    expect(described_class.new.patients.count).to eq 10
+  end
+end

--- a/spec/lib/generate/triages_spec.rb
+++ b/spec/lib/generate/triages_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+describe Generate::Triages do
+  let(:programme) { Programme.hpv&.first || create(:programme, :hpv) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:user) { create(:user, organisation:) }
+  let(:patient) do
+    create(
+      :patient,
+      :consent_given_triage_needed,
+      programmes: [programme],
+      session:
+    )
+  end
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
+
+  describe "ready to vaccinate triages" do
+    it "creates one consent response" do
+      user
+      patient
+
+      described_class.call(
+        organisation:,
+        programme:,
+        session:,
+        ready_to_vaccinate: 1,
+        do_not_vaccinate: 0
+      )
+      expect(Triage.ready_to_vaccinate.count).to eq 1
+    end
+  end
+
+  describe "do not vaccinate triages" do
+    it "creates one consent response" do
+      user
+      patient
+
+      described_class.call(
+        organisation:,
+        programme:,
+        session:,
+        ready_to_vaccinate: 0,
+        do_not_vaccinate: 1
+      )
+      expect(Triage.do_not_vaccinate.count).to eq 1
+    end
+  end
+end

--- a/spec/lib/generate/vaccination_records_spec.rb
+++ b/spec/lib/generate/vaccination_records_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+describe Generate::VaccinationRecords do
+  let(:programme) { Programme.hpv&.first || create(:programme, :hpv) }
+  let(:organisation) { create(:organisation, programmes: [programme]) }
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
+  let(:user) { create(:user, organisation:) }
+  let(:patient) do
+    create(
+      :patient,
+      :consent_given_triage_not_needed,
+      programmes: [programme],
+      session:
+    )
+  end
+
+  describe "vaccinations administered" do
+    subject(:vaccinations_given) { VaccinationRecord.administered }
+
+    it "creates one vaccination record" do
+      user
+      patient
+
+      described_class.call(organisation:, administered: 1)
+      expect(VaccinationRecord.administered.count).to eq 1
+    end
+
+    context "no patients without vaccinations" do
+      it "raises an error" do
+        expect {
+          described_class.call(organisation:, administered: 1)
+        }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end

--- a/spec/models/patient/vaccination_status_spec.rb
+++ b/spec/models/patient/vaccination_status_spec.rb
@@ -24,7 +24,7 @@ describe Patient::VaccinationStatus do
     build(:patient_vaccination_status, patient:, programme:)
   end
 
-  let(:patient) { create(:patient) }
+  let(:patient) { create(:patient, programmes: [programme]) }
   let(:programme) { create(:programme) }
 
   it { should belong_to(:patient) }


### PR DESCRIPTION
The generators here were used for generating large volumes of data for importing into Mavis, and for automatically giving consents, performing triage and recording vaccinations for data in Mavis. This was used for the performance tests but can also be useful for other areas where test data is required. These generators include specs to try to ensure that they stay up-to-date with any code changes.
