### PR TITLE
Ignore health check transactions

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,6 +9,15 @@ Sentry.init do |config|
 
   config.traces_sample_rate = 0.2
 
+  config.before_send_transaction =
+    lambda do |event, _hint|
+      if event.transaction == "/up" || event.transaction.starts_with?("/health")
+        nil
+      else
+        event
+      end
+    end
+
   rails_filter_parameters =
     Rails.application.config.filter_parameters.map(&:to_s)
 


### PR DESCRIPTION
When sending transactions to Sentry for profiling and performance monitoring, we don't need to sent transactions related to health checks as these will be happening fairly regularly and don't provide much benefit being in Sentry.

Instead, we can skip these to ensure we're only sending useful information to Sentry.