### PR TITLE
Ignore exceptions related to team-only API keys

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -35,5 +35,15 @@ Sentry.init do |config|
     )
 
   config.before_send =
-    lambda { |event, _hint| combined_filter.filter(event.to_hash) }
+    lambda do |event, hint|
+      if !Rails.env.production? &&
+           hint[:exception].is_a?(Notifications::Client::BadRequestError) &&
+           hint[:exception].message.include?(
+             "Can’t send to this recipient using a team-only API key"
+           )
+        nil
+      else
+        combined_filter.filter(event.to_hash)
+      end
+    end
 end


### PR DESCRIPTION
In non-production environments, this is an exception we get fairly regularly as the GOV.UK Notify API key that we use is limited to team members only.

This adds a new filter to the Sentry handler which filters out these exceptions, unless the environment is production, to avoid sending unnecessarily high numbers of errors to Sentry.