### PR TITLE
Reduce risk of race condition when registering attendance

### DIFF
--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -32,12 +32,13 @@ class Sessions::RegisterController < ApplicationController
   end
 
   def create
-    session_attendance = authorize @patient_session.todays_attendance
-
-    ActiveRecord::Base.transaction do
-      session_attendance.update!(attending: params[:status] == "present")
-      StatusUpdater.call(patient: @patient_session.patient)
-    end
+    session_attendance =
+      ActiveRecord::Base.transaction do
+        record = authorize @patient_session.todays_attendance
+        record.update!(attending: params[:status] == "present")
+        StatusUpdater.call(patient: @patient_session.patient)
+        record
+      end
 
     name = @patient_session.patient.full_name
 


### PR DESCRIPTION
This moves the fetch of any existing session attendance record in to the transaction which I think should reduce the risk of a race condition which we're sometimes seeing occur in production:

https://good-machine.sentry.io/issues/6499367797/