### PR TITLE
Set `MAVIS__PDS__WAIT_BETWEEN_JOBS` environment variable

### DIFF
--- a/terraform/app/ssm_parameters.tf
+++ b/terraform/app/ssm_parameters.tf
@@ -1,0 +1,12 @@
+resource "aws_ssm_parameter" "pds_wait_between_jobs" {
+  name = "/${var.environment}/pds_wait_between_jobs"
+  type = "String"
+
+  # This value is the default, but can be customised in the AWS console
+  # directly and isn't managed by Terraform.
+  value = "2"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -214,7 +214,11 @@ locals {
     {
       name      = "RAILS_MASTER_KEY"
       valueFrom = var.rails_master_key_path
-    }
+    },
+    {
+      name      = "MAVIS__PDS__WAIT_BETWEEN_JOBS",
+      valueFrom = aws_ssm_parameter.pds_wait_between_jobs.name,
+    },
   ]
 }
 


### PR DESCRIPTION
This adds a new environment variable to the task definition that allows us to configure the wait time between when PDS jobs are enqueued without needing a deployment, by storing the value in the parameter store.

https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3329 is the change to the application code which added the setting.