### PR TITLE
Allow ECS task access

### DIFF
--- a/terraform/app/iam_policy_documents.tf
+++ b/terraform/app/iam_policy_documents.tf
@@ -51,7 +51,10 @@ data "aws_iam_policy_document" "ecs_secrets_access" {
   statement {
     sid       = "railsKeySid"
     actions   = ["ssm:GetParameters"]
-    resources = ["arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}",
+      aws_ssm_parameter.pds_wait_between_jobs.arn
+    ]
     effect    = "Allow"
   }
   statement {


### PR DESCRIPTION
- We have created a configuration variable for an ECS task but not given the task access
  - This commit rectifies this