### PR TITLE
Correct Leicestershire ODS code

### DIFF
--- a/config/onboarding/leicestershire-production.yaml
+++ b/config/onboarding/leicestershire-production.yaml
@@ -2,7 +2,7 @@ organisation:
   name: Leicestershire Partnership Trust School Aged Immunisation Service
   email: lpt.sais@nhs.net
   phone: 0300 3000 007
-  ods_code: RT5YA
+  ods_code: RT5
   careplus_venue_code: UNUSED
   privacy_notice_url: https://www.leicspart.nhs.uk/privacy-policy/
   privacy_policy_url: https://www.leicspart.nhs.uk/privacy-policy/

--- a/config/onboarding/leicestershire-training.yaml
+++ b/config/onboarding/leicestershire-training.yaml
@@ -2,7 +2,7 @@ organisation:
   name: Leicestershire Partnership Trust School Aged Immunisation Service
   email: lpt.sais@nhs.net
   phone: 0300 3000 007
-  ods_code: RT5YA
+  ods_code: RT5
   careplus_venue_code: UNUSED
   privacy_notice_url: https://www.leicspart.nhs.uk/privacy-policy/
   privacy_policy_url: https://www.leicspart.nhs.uk/privacy-policy/


### PR DESCRIPTION
The correct code for Leicestershire should be `RT5` and not `RT5YA`.