### PR TITLE
Simplify patient-organisation relationship

### DIFF
--- a/app/components/app_patient_cohort_table_component.html.erb
+++ b/app/components/app_patient_cohort_table_component.html.erb
@@ -18,7 +18,7 @@
         <% row.with_cell do %>
           <span class="nhsuk-table-responsive__heading">Actions</span>
           <%= form_with model: @patient, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-            <%= f.hidden_field :organisation_id, value: "" %>
+            <%= f.hidden_field :organisation_id, value: organisation.id %>
             <%= f.govuk_submit "Remove from cohort", class: "app-button--secondary-warning app-button--small" %>
           <% end %>
         <% end %>

--- a/app/components/app_patient_cohort_table_component.rb
+++ b/app/components/app_patient_cohort_table_component.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
 class AppPatientCohortTableComponent < ViewComponent::Base
-  def initialize(patient)
+  def initialize(patient, current_user:)
     super
 
     @patient = patient
+    @current_user = current_user
   end
 
   private
 
-  attr_reader :patient
+  attr_reader :patient, :current_user
 
-  delegate :organisation, :year_group, to: :patient
+  delegate :year_group, to: :patient
+
+  def organisation
+    @organisation ||=
+      if current_user.selected_organisation.patients.include?(patient)
+        current_user.selected_organisation
+      end
+  end
 end

--- a/app/controllers/cohorts_controller.rb
+++ b/app/controllers/cohorts_controller.rb
@@ -11,7 +11,7 @@ class CohortsController < ApplicationController
     birth_academic_years = @programme.birth_academic_years
 
     @patient_count_by_birth_academic_year =
-      patients_in_cohort
+      patients_in_organisation
         .where(birth_academic_year: birth_academic_years)
         .group(:birth_academic_year)
         .count
@@ -24,7 +24,7 @@ class CohortsController < ApplicationController
     @birth_academic_year = Integer(params[:id])
 
     patients =
-      patients_in_cohort
+      patients_in_organisation
         .where(birth_academic_year: @birth_academic_year)
         .not_deceased
         .includes(:school)
@@ -39,7 +39,7 @@ class CohortsController < ApplicationController
     @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 
-  def patients_in_cohort
-    Patient.where(organisation: current_user.selected_organisation)
+  def patients_in_organisation
+    current_user.selected_organisation.patients
   end
 end

--- a/app/controllers/patients/edit_controller.rb
+++ b/app/controllers/patients/edit_controller.rb
@@ -43,10 +43,14 @@ class Patients::EditController < ApplicationController
   def existing_patient
     @existing_patient ||=
       if nhs_number.present?
-        policy_scope(Patient)
-          .or(Patient.where(organisation: nil))
-          .includes(parent_relationships: :parent)
-          .find_by(nhs_number:)
+        policy_scope(Patient).includes(parent_relationships: :parent).find_by(
+          nhs_number:
+        ) ||
+          Patient
+            .where
+            .missing(:patient_sessions)
+            .includes(parent_relationships: :parent)
+            .find_by(nhs_number:)
       end
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -32,19 +32,14 @@ class PatientsController < ApplicationController
   end
 
   def update
-    old_organisation = @patient.organisation
-
     organisation_id = params.dig(:patient, :organisation_id).presence
 
     ActiveRecord::Base.transaction do
-      @patient.update!(organisation_id:)
-
-      if organisation_id.nil?
-        @patient
-          .patient_sessions
-          .where(session: old_organisation.sessions)
-          .destroy_all_if_safe
-      end
+      @patient
+        .patient_sessions
+        .joins(:session)
+        .where(session: { organisation_id: })
+        .destroy_all_if_safe
     end
 
     path =
@@ -68,7 +63,6 @@ class PatientsController < ApplicationController
     @patient =
       policy_scope(Patient).includes(
         :gp_practice,
-        :organisation,
         :school,
         consents: %i[parent patient],
         parent_relationships: :parent,

--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -95,13 +95,6 @@ class PatientMerger
       patient_to_destroy.cohort_imports.clear
       patient_to_destroy.immunisation_imports.clear
 
-      # Add patient back to the cohort if the patient to destroy was in the cohort.
-      if patient_to_keep.organisation_id.nil?
-        patient_to_keep.update!(
-          organisation_id: patient_to_destroy.organisation_id
-        )
-      end
-
       patient_to_destroy.reload.destroy!
 
       StatusUpdater.call(patient: patient_to_keep)

--- a/app/lib/reports/school_moves_exporter.rb
+++ b/app/lib/reports/school_moves_exporter.rb
@@ -50,7 +50,7 @@ class Reports::SchoolMovesExporter
       begin
         historical_patients =
           Patient
-            .where.not(organisation:)
+            .where.not(id: organisation.patients.select(:id))
             .where(
               SchoolMoveLogEntry
                 .where("patient_id = patients.id")

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -39,17 +39,17 @@ class Organisation < ApplicationRecord
   has_many :locations
   has_many :organisation_programmes,
            -> { joins(:programme).order(:"programmes.type") }
-  has_many :patients
   has_many :sessions
   has_many :teams
 
   has_many :community_clinics, through: :teams
   has_many :locations, through: :teams
   has_many :patient_sessions, through: :sessions
+  has_many :patients, through: :patient_sessions
   has_many :programmes, through: :organisation_programmes
   has_many :schools, through: :teams
-  has_many :vaccines, through: :programmes
   has_many :vaccination_records, through: :sessions
+  has_many :vaccines, through: :programmes
 
   has_and_belongs_to_many :users
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -384,7 +384,6 @@ class Patient < ApplicationRecord
       given_name: consent_form.given_name,
       home_educated: consent_form.home_educated,
       nhs_number: consent_form.nhs_number,
-      organisation: consent_form.organisation,
       preferred_family_name: consent_form.preferred_family_name,
       preferred_given_name: consent_form.preferred_given_name,
       school: consent_form.school

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -28,7 +28,6 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  gp_practice_id            :bigint
-#  organisation_id           :bigint
 #  school_id                 :bigint
 #
 # Indexes
@@ -39,13 +38,11 @@
 #  index_patients_on_names_family_first   (family_name,given_name)
 #  index_patients_on_names_given_first    (given_name,family_name)
 #  index_patients_on_nhs_number           (nhs_number) UNIQUE
-#  index_patients_on_organisation_id      (organisation_id)
 #  index_patients_on_school_id            (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (gp_practice_id => locations.id)
-#  fk_rails_...  (organisation_id => organisations.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 class Patient < ApplicationRecord

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -351,6 +351,8 @@ class Patient < ApplicationRecord
     update_column(:invalidated_at, Time.current)
   end
 
+  def not_in_organisation? = patient_sessions.empty?
+
   def dup_for_pending_changes
     dup.tap do |new_patient|
       new_patient.nhs_number = nil

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -53,11 +53,10 @@ class Patient < ApplicationRecord
   include PendingChangesConcern
   include Schoolable
 
-  audited associated_with: :organisation
+  audited
   has_associated_audits
 
   belongs_to :gp_practice, class_name: "Location", optional: true
-  belongs_to :organisation, optional: true
 
   has_many :access_log_entries
   has_many :consent_notifications
@@ -74,11 +73,12 @@ class Patient < ApplicationRecord
   has_many :vaccination_records, -> { kept }
   has_many :vaccination_statuses
 
-  has_many :parents, through: :parent_relationships
   has_many :gillick_assessments, through: :patient_sessions
+  has_many :parents, through: :parent_relationships
   has_many :pre_screenings, through: :patient_sessions
   has_many :session_attendances, through: :patient_sessions
   has_many :sessions, through: :patient_sessions
+  has_many :organisations, through: :sessions
 
   has_many :sessions_for_current_academic_year,
            -> { for_current_academic_year },

--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -33,7 +33,7 @@ class PatientImport < ApplicationRecord
 
     if (school_move = row.to_school_move(patient))
       if (patient.school.nil? && !patient.home_educated) ||
-           patient.organisation.nil?
+           patient.not_in_organisation?
         @school_moves_to_confirm.add(school_move)
       else
         @school_moves_to_save.add(school_move)

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -64,11 +64,7 @@ class SchoolMove < ApplicationRecord
   private
 
   def update_patient!
-    patient.update!(
-      home_educated:,
-      organisation: school&.organisation || organisation,
-      school:
-    )
+    patient.update!(home_educated:, school:)
   end
 
   def update_sessions!

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -20,7 +20,7 @@
 
 <%= render AppCardComponent.new do |c| %>
   <% c.with_heading { "Cohorts" } %>
-  <%= render AppPatientCohortTableComponent.new(@patient) %>
+  <%= render AppPatientCohortTableComponent.new(@patient, current_user:) %>
 <% end %>
 
 <%= render AppCardComponent.new do |c| %>

--- a/db/migrate/20250408195356_remove_organisation_from_patient.rb
+++ b/db/migrate/20250408195356_remove_organisation_from_patient.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveOrganisationFromPatient < ActiveRecord::Migration[8.0]
+  def change
+    remove_reference :patients, :organisation, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -617,14 +617,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_070424) do
     t.datetime "updated_from_pds_at"
     t.bigint "gp_practice_id"
     t.integer "birth_academic_year", null: false
-    t.bigint "organisation_id"
     t.index ["family_name", "given_name"], name: "index_patients_on_names_family_first"
     t.index ["family_name"], name: "index_patients_on_family_name_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["given_name", "family_name"], name: "index_patients_on_names_given_first"
     t.index ["given_name"], name: "index_patients_on_given_name_trigram", opclass: :gin_trgm_ops, using: :gin
     t.index ["gp_practice_id"], name: "index_patients_on_gp_practice_id"
     t.index ["nhs_number"], name: "index_patients_on_nhs_number", unique: true
-    t.index ["organisation_id"], name: "index_patients_on_organisation_id"
     t.index ["school_id"], name: "index_patients_on_school_id"
   end
 
@@ -908,7 +906,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_070424) do
   add_foreign_key "patient_vaccination_statuses", "programmes"
   add_foreign_key "patients", "locations", column: "gp_practice_id"
   add_foreign_key "patients", "locations", column: "school_id"
-  add_foreign_key "patients", "organisations"
   add_foreign_key "pre_screenings", "patient_sessions"
   add_foreign_key "pre_screenings", "programmes"
   add_foreign_key "pre_screenings", "session_dates"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -126,7 +126,7 @@ def create_session(
       end
 
       # Add extra consent forms with a successful NHS number lookup
-      temporary_patient = FactoryBot.build(:patient, organisation:)
+      temporary_patient = FactoryBot.build(:patient)
       FactoryBot.create(
         :consent_form,
         :recorded,
@@ -210,7 +210,7 @@ def create_imports(user, organisation)
 end
 
 def create_school_moves(organisation)
-  patients = Patient.where(organisation:).sample(10)
+  patients = organisation.patients.sample(10)
 
   patients.each do |patient|
     if [true, false].sample

--- a/spec/components/app_patient_cohort_table_component_spec.rb
+++ b/spec/components/app_patient_cohort_table_component_spec.rb
@@ -1,18 +1,23 @@
 # frozen_string_literal: true
 
 describe AppPatientCohortTableComponent do
-  subject(:rendered) { render_inline(component) }
+  subject { render_inline(component) }
 
-  let(:component) { described_class.new(patient) }
+  let(:component) { described_class.new(patient, current_user:) }
+
+  let(:current_user) { create(:nurse) }
 
   context "without a cohort" do
-    let(:patient) { create(:patient, organisation: nil) }
+    let(:patient) { create(:patient) }
 
     it { should have_content("No cohorts") }
   end
 
   context "with a cohort" do
-    let(:patient) { create(:patient, year_group: 8) }
+    let(:organisation) { current_user.selected_organisation }
+    let(:session) { create(:session, organisation:) }
+
+    let(:patient) { create(:patient, year_group: 8, session:) }
 
     it { should have_content("Year 8") }
     it { should have_content("Remove from cohort") }

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -66,16 +66,21 @@ describe AppPatientTableComponent do
     expect(rendered).not_to have_text("SW1B 1AA")
   end
 
-  it "renders links" do
-    expect(rendered).to have_link("SMITH, John")
-  end
-
   context "with a patient not in the cohort" do
-    before { patients.first.update!(organisation: nil) }
-
     it "doesn't render a link" do
       expect(rendered).not_to have_link("SMITH, John")
       expect(rendered).to have_content("Child has moved out of the area")
+    end
+  end
+
+  context "with a patient in the cohort" do
+    let(:organisation) { current_user.selected_organisation }
+    let(:session) { create(:session, organisation:) }
+
+    before { create(:patient_session, patient: patients.first, session:) }
+
+    it "renders links" do
+      expect(rendered).to have_link("SMITH, John")
     end
   end
 end

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -4,7 +4,7 @@ describe AppVaccinationRecordTableComponent do
   subject(:rendered) { render_inline(component) }
 
   let(:component) do
-    described_class.new(vaccination_records, current_user:, count:)
+    described_class.new(vaccination_records, current_user:, count: 10)
   end
 
   let(:programme) { create(:programme) }
@@ -31,8 +31,6 @@ describe AppVaccinationRecordTableComponent do
   end
 
   let(:current_user) { create(:nurse) }
-
-  let(:count) { 10 }
 
   it "renders a heading tab" do
     expect(rendered).to have_css(
@@ -67,10 +65,15 @@ describe AppVaccinationRecordTableComponent do
   end
 
   context "with a vaccination record not performed by the organisation" do
-    before { vaccination_records.first.patient.update!(organisation: nil) }
-
-    it "doesn't render a link" do
-      expect(rendered).not_to have_link("SMITH, John")
+    before do
+      vaccination_records.first.patient.patient_sessions.destroy_all
+      vaccination_records.first.update!(
+        session: nil,
+        location_name: "Unknown",
+        performed_ods_code: nil
+      )
     end
+
+    it { should_not have_link("SMITH, John") }
   end
 end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -28,7 +28,6 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  gp_practice_id            :bigint
-#  organisation_id           :bigint
 #  school_id                 :bigint
 #
 # Indexes
@@ -39,13 +38,11 @@
 #  index_patients_on_names_family_first   (family_name,given_name)
 #  index_patients_on_names_given_first    (given_name,family_name)
 #  index_patients_on_nhs_number           (nhs_number) UNIQUE
-#  index_patients_on_organisation_id      (organisation_id)
 #  index_patients_on_school_id            (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (gp_practice_id => locations.id)
-#  fk_rails_...  (organisation_id => organisations.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -61,11 +61,11 @@ FactoryBot.define do
       location_name { nil }
       in_attendance { false }
       random_nhs_number { false }
-    end
 
-    organisation do
-      session&.organisation || school&.organisation ||
-        association(:organisation, programmes:)
+      organisation do
+        session&.organisation || school&.organisation ||
+          create(:organisation, programmes:)
+      end
     end
 
     nhs_number do

--- a/spec/features/cohorts_index_spec.rb
+++ b/spec/features/cohorts_index_spec.rb
@@ -21,24 +21,12 @@ describe "Cohorts index" do
   end
 
   def and_there_are_patients_in_different_year_groups
-    # Create patients in year 8 and 9
-    # For year 8 in 2024, birth academic year is 2010
-    # For year 9 in 2024, birth academic year is 2009
-    create(
-      :patient,
-      organisation: @organisation,
-      date_of_birth: Date.new(2009, 9, 1)
-    )
-    create(
-      :patient,
-      organisation: @organisation,
-      date_of_birth: Date.new(2009, 9, 1)
-    )
-    create(
-      :patient,
-      organisation: @organisation,
-      date_of_birth: Date.new(2008, 9, 1)
-    )
+    session =
+      create(:session, organisation: @organisation, programmes: [@programme])
+
+    create(:patient, session:, year_group: 9)
+    create(:patient, session:, year_group: 9)
+    create(:patient, session:, year_group: 10)
   end
 
   def when_i_visit_the_cohorts_page

--- a/spec/features/edit_parent_spec.rb
+++ b/spec/features/edit_parent_spec.rb
@@ -41,7 +41,8 @@ describe "Edit parent" do
     organisation = create(:organisation)
     @nurse = create(:nurse, organisation:)
 
-    @patient = create(:patient, organisation:)
+    session = create(:session, organisation:)
+    @patient = create(:patient, session:)
 
     @parent = create(:parent)
 

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -82,7 +82,7 @@ describe "Child record imports duplicates" do
         address_town: "London",
         address_postcode: "SW11 1AA",
         school: nil, # Unknown school, should be silently updated
-        organisation: @organisation
+        session: @session
       )
 
     @second_patient =
@@ -98,7 +98,7 @@ describe "Child record imports duplicates" do
         address_town: "London",
         address_postcode: "SW11 1AA",
         school: @school,
-        organisation: @organisation
+        session: @session
       )
 
     @third_patient =
@@ -114,7 +114,6 @@ describe "Child record imports duplicates" do
         address_town: "London",
         address_postcode: "SW1A 1AA",
         school: @school,
-        organisation: @organisation,
         session: @session
       )
   end

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -81,7 +81,8 @@ describe "Class list imports duplicates" do
         address_line_2: "",
         address_town: "London",
         address_postcode: "SW1A 1AA",
-        school: @location
+        school: @location,
+        session: @session
       )
 
     @second_patient =
@@ -96,7 +97,8 @@ describe "Class list imports duplicates" do
         address_line_2: "",
         address_town: "London",
         address_postcode: "SW1A 2BB",
-        school: @location
+        school: @location,
+        session: @session
       )
 
     @third_patient =
@@ -105,7 +107,8 @@ describe "Class list imports duplicates" do
         given_name: "Jenny",
         family_name: "Block",
         nhs_number: "9990000034",
-        school: @location
+        school: @location,
+        session: @session
       )
   end
 

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -5,7 +5,6 @@ describe "Manage children" do
 
   scenario "Viewing children" do
     given_patients_exist
-    and_the_patient_belongs_to_a_session
     and_the_patient_is_vaccinated
 
     when_i_click_on_children
@@ -82,7 +81,6 @@ describe "Manage children" do
 
   scenario "Removing a child from a cohort" do
     given_patients_exist
-    and_the_patient_belongs_to_a_session
 
     when_i_click_on_children
     and_i_click_on_a_child
@@ -140,60 +138,76 @@ describe "Manage children" do
 
   def given_patients_exist
     school = create(:school, organisation: @organisation)
+
+    session =
+      create(
+        :session,
+        location: school,
+        organisation: @organisation,
+        programmes: [@programme]
+      )
+
     @patient =
       create(
         :patient,
-        organisation: @organisation,
+        session:,
         given_name: "John",
         family_name: "Smith",
         school:
       )
-    create_list(:patient, 9, organisation: @organisation, school:)
+    create_list(:patient, 9, session:)
+
+    another_session =
+      create(:session, organisation: @organisation, programmes: [@programme])
 
     @existing_patient =
       create(
         :patient,
+        session: another_session,
         given_name: "Jane",
-        family_name: "Doe",
-        organisation: @organisation
+        family_name: "Doe"
       )
   end
 
   def given_an_invalidated_patient_exists
+    session =
+      create(:session, organisation: @organisation, programmes: [@programme])
+
     @patient =
       create(
         :patient,
         :invalidated,
-        organisation: @organisation,
+        session:,
         given_name: "John",
         family_name: "Smith"
       )
 
-    create(:patient, organisation: @organisation, nhs_number: nil)
+    create(:patient, session:, nhs_number: nil)
   end
 
   def and_the_patient_is_vaccinated
     create(:vaccination_record, patient: @patient, programme: @programme)
   end
 
-  def and_the_patient_belongs_to_a_session
+  def when_a_deceased_patient_exists
     session =
       create(:session, organisation: @organisation, programmes: [@programme])
-    create(:patient_session, session:, patient: @patient)
-  end
 
-  def when_a_deceased_patient_exists
-    @deceased_patient = create(:patient, :deceased, organisation: @organisation)
+    @deceased_patient = create(:patient, :deceased, session:)
   end
 
   def when_an_invalidated_patient_exists
-    @invalidated_patient =
-      create(:patient, :invalidated, organisation: @organisation)
+    session =
+      create(:session, organisation: @organisation, programmes: [@programme])
+
+    @invalidated_patient = create(:patient, :invalidated, session:)
   end
 
   def when_a_restricted_patient_exists
-    @restricted_patient =
-      create(:patient, :restricted, organisation: @organisation)
+    session =
+      create(:session, organisation: @organisation, programmes: [@programme])
+
+    @restricted_patient = create(:patient, :restricted, session:)
   end
 
   def when_i_click_on_children

--- a/spec/features/parent_relationships_spec.rb
+++ b/spec/features/parent_relationships_spec.rb
@@ -22,7 +22,8 @@ describe "Parent relationships" do
     organisation = create(:organisation)
     @nurse = create(:nurse, organisation:)
 
-    @patient = create(:patient, organisation:)
+    session = create(:session, organisation:)
+    @patient = create(:patient, session:)
 
     @parent = create(:parent)
 

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -184,22 +184,5 @@ describe PatientMerger do
         )
       end
     end
-
-    it "doesn't change the cohort" do
-      expect { call }.not_to(change { patient_to_keep.reload.organisation })
-    end
-
-    context "if the patient to keep is not in the cohort" do
-      let(:organisation) { create(:organisation) }
-
-      let(:patient_to_keep) { create(:patient, organisation: nil) }
-      let(:patient_to_destroy) { create(:patient, organisation:) }
-
-      it "adds the patient back in to the cohort" do
-        expect { call }.to change { patient_to_keep.reload.organisation }.to(
-          organisation
-        )
-      end
-    end
   end
 end

--- a/spec/lib/reports/school_moves_exporter_spec.rb
+++ b/spec/lib/reports/school_moves_exporter_spec.rb
@@ -92,7 +92,8 @@ describe Reports::SchoolMovesExporter do
 
     context "when moving to home education" do
       before do
-        patient = create(:patient, :home_educated, organisation:)
+        session = create(:session, organisation:)
+        patient = create(:patient, :home_educated, session:)
         create(:school_move_log_entry, :home_educated, patient:)
       end
 
@@ -103,7 +104,8 @@ describe Reports::SchoolMovesExporter do
 
     context "when moving to an unknown school" do
       before do
-        patient = create(:patient, school: nil, organisation:)
+        session = create(:session, organisation:)
+        patient = create(:patient, school: nil, session:)
         create(:school_move_log_entry, :unknown_school, patient:)
       end
 
@@ -123,7 +125,8 @@ describe Reports::SchoolMovesExporter do
         create(:school, :secondary, organisation: organisation_b)
       end
 
-      let(:patient) { create(:patient, organisation: organisation_b) }
+      let(:session) { create(:session, organisation: organisation_b) }
+      let(:patient) { create(:patient, session:) }
 
       let(:created_at_a) { 1.week.ago }
       let(:created_at_b) { Time.current }

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -334,7 +334,12 @@ describe ClassImport do
 
     context "with an existing patient in a different school" do
       let(:patient) do
-        create(:patient, nhs_number: "9990000018", school: create(:school))
+        create(
+          :patient,
+          nhs_number: "9990000018",
+          school: create(:school),
+          session: create(:session, programmes:)
+        )
       end
 
       it "proposes a school move for the child" do

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -172,8 +172,7 @@ describe CohortImport do
         school: location,
         address_line_1: "10 Downing Street",
         address_town: "London",
-        address_postcode: "SW1A 1AA",
-        organisation:
+        address_postcode: "SW1A 1AA"
       )
 
       expect(Patient.first.parents).to be_empty
@@ -186,8 +185,7 @@ describe CohortImport do
         school: location,
         address_line_1: "10 Downing Street",
         address_town: "London",
-        address_postcode: "SW1A 1AA",
-        organisation:
+        address_postcode: "SW1A 1AA"
       )
 
       expect(Patient.second.parents.count).to eq(1)
@@ -208,8 +206,7 @@ describe CohortImport do
         school: nil,
         address_line_1: "11 Downing Street",
         address_town: "London",
-        address_postcode: "SW1A 1AA",
-        organisation:
+        address_postcode: "SW1A 1AA"
       )
 
       expect(Patient.third.parents.count).to eq(2)

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -332,8 +332,8 @@ describe CohortImport do
 
       it "automatically re-adds the patient to the cohort" do
         expect { process! }.to change {
-          existing_patient.reload.organisation
-        }.from(nil).to(organisation)
+          existing_patient.reload.organisations
+        }.from([]).to([organisation])
       end
 
       it "doesn't propose a school move" do

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1601,20 +1601,6 @@ describe ImmunisationImportRow do
         include_examples "with a value", "PERSON_GENDER"
         include_examples "with a value", "Sex"
       end
-
-      describe "#organisation" do
-        subject { patient.organisation }
-
-        let(:data) { valid_data }
-
-        it { should be_nil }
-
-        context "with an existing patient in the cohort" do
-          let(:patient) { create(:patient, nhs_number:) }
-
-          it { should eq(patient.organisation) }
-        end
-      end
     end
 
     describe "#performed_at" do

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -28,7 +28,6 @@
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  gp_practice_id            :bigint
-#  organisation_id           :bigint
 #  school_id                 :bigint
 #
 # Indexes
@@ -39,13 +38,11 @@
 #  index_patients_on_names_family_first   (family_name,given_name)
 #  index_patients_on_names_given_first    (given_name,family_name)
 #  index_patients_on_nhs_number           (nhs_number) UNIQUE
-#  index_patients_on_organisation_id      (organisation_id)
 #  index_patients_on_school_id            (school_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (gp_practice_id => locations.id)
-#  fk_rails_...  (organisation_id => organisations.id)
 #  fk_rails_...  (school_id => locations.id)
 #
 

--- a/spec/models/school_move_export_spec.rb
+++ b/spec/models/school_move_export_spec.rb
@@ -9,7 +9,7 @@ describe SchoolMoveExport do
   let(:current_user) { organisation.users.first }
   let(:organisation) { create(:organisation, :with_one_nurse) }
 
-  describe ".request_session_key" do
+  describe "#request_session_key" do
     it "returns the correct session key" do
       expect(described_class.request_session_key).to eq("school_move_export")
     end

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -85,26 +85,6 @@ describe SchoolMove do
       end
     end
 
-    shared_examples "sets the patient cohort" do
-      it "sets the patient cohort" do
-        expect { confirm! }.to change(patient, :organisation).from(nil)
-        expect(patient.organisation).to eq(organisation)
-      end
-    end
-
-    shared_examples "keeps the patient cohort" do
-      it "keeps the patient cohort" do
-        expect { confirm! }.not_to change(patient, :organisation)
-      end
-    end
-
-    shared_examples "changes the patient cohort" do
-      it "changes the patient cohort" do
-        expect { confirm! }.to change(patient, :organisation)
-        expect(patient.organisation).to eq(new_organisation)
-      end
-    end
-
     shared_examples "adds the patient to the new school session" do
       it "adds the patient to the new school session" do
         expect(patient.sessions).not_to include(new_session)
@@ -188,7 +168,6 @@ describe SchoolMove do
         end
 
         include_examples "creates a log entry"
-        include_examples "sets the patient cohort"
         include_examples "sets the patient school"
         include_examples "adds the patient to the new school session"
         include_examples "destroys the school move"
@@ -211,7 +190,6 @@ describe SchoolMove do
         end
 
         include_examples "creates a log entry"
-        include_examples "sets the patient cohort"
         include_examples "sets the patient school"
         include_examples "adds the patient to the new school session"
         include_examples "destroys the school move"
@@ -223,7 +201,6 @@ describe SchoolMove do
         end
 
         include_examples "creates a log entry"
-        include_examples "sets the patient cohort"
         include_examples "sets the patient to home-schooled"
         include_examples "adds the patient to the community clinics"
         include_examples "destroys the school move"
@@ -253,7 +230,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
           include_examples "adds the patient to the new school session"
           include_examples "destroys the school move"
@@ -277,7 +253,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
           include_examples "adds the patient to the new school session"
           include_examples "destroys the school move"
@@ -290,7 +265,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
-          include_examples "keeps the patient cohort"
           include_examples "removes the patient from the old school session"
           include_examples "adds the patient to the community clinics"
           include_examples "destroys the school move"
@@ -315,7 +289,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "changes the patient cohort"
           include_examples "removes the patient from the old school session"
           include_examples "adds the patient to the new school session"
           include_examples "destroys the school move"
@@ -338,7 +311,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
-          include_examples "changes the patient cohort"
           include_examples "removes the patient from the old school session"
           include_examples "adds the patient to the community clinics"
           include_examples "destroys the school move"
@@ -373,7 +345,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
           include_examples "destroys the school move"
         end
@@ -396,7 +367,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
           include_examples "destroys the school move"
         end
@@ -408,7 +378,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the old school session"
           include_examples "destroys the school move"
         end
@@ -432,7 +401,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "changes the patient cohort"
           include_examples "keeps the patient in the old school session"
           include_examples "destroys the school move"
         end
@@ -454,7 +422,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
-          include_examples "changes the patient cohort"
           include_examples "keeps the patient in the old school session"
           include_examples "destroys the school move"
         end
@@ -485,7 +452,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "adds the patient to the new school session"
           include_examples "destroys the school move"
@@ -509,7 +475,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "adds the patient to the new school session"
           include_examples "destroys the school move"
@@ -525,7 +490,6 @@ describe SchoolMove do
           end
 
           include_examples "creates a log entry"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -549,7 +513,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "changes the patient cohort"
           include_examples "removes the patient from the community clinics"
           include_examples "destroys the school move"
         end
@@ -581,7 +544,6 @@ describe SchoolMove do
           end
 
           include_examples "creates a log entry"
-          include_examples "changes the patient cohort"
           include_examples "adds the patient to the community clinics"
           include_examples "destroys the school move"
         end
@@ -616,7 +578,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -639,7 +600,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -653,7 +613,6 @@ describe SchoolMove do
             expect { confirm! }.not_to(change { patient.reload.home_educated })
           end
 
-          include_examples "keeps the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -677,7 +636,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -706,7 +664,6 @@ describe SchoolMove do
           end
 
           include_examples "creates a log entry"
-          include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -795,7 +752,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "changes the patient cohort"
           include_examples "removes the patient from the community clinics"
           include_examples "destroys the school move"
         end
@@ -824,7 +780,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
-          include_examples "changes the patient cohort"
           include_examples "adds the patient to the community clinics"
           include_examples "destroys the school move"
         end
@@ -915,7 +870,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient school"
-          include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end
@@ -941,7 +895,6 @@ describe SchoolMove do
 
           include_examples "creates a log entry"
           include_examples "sets the patient to home-schooled"
-          include_examples "changes the patient cohort"
           include_examples "keeps the patient in the community clinics"
           include_examples "destroys the school move"
         end

--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -9,7 +9,9 @@ describe PatientPolicy do
     let(:school) { create(:school, organisation:) }
     let(:user) { create(:user, organisation:) }
 
-    let(:patient_in_organisation) { create(:patient, organisation:) }
+    let(:patient_in_organisation) do
+      create(:patient, session: create(:session, organisation:))
+    end
     let(:patient_not_in_organisation) { create(:patient) }
 
     it { should include(patient_in_organisation) }


### PR DESCRIPTION
This simplifies the relationship between organisations and parents by removing the explicit patient reference to an organisation, instead the organisation's that the patient belongs to can be found by looking at the sessions the patient's belong to.

At the moment we experience a few bugs and other issues where patients will end up "out of cohort" but with a mismatch between the organisation they're part of and the sessions. For example, the current model makes it possible for a patient to be in an organisation but in no sessions, or in sessions but not in an organisation. These scenarios shouldn't happen in reality.

We know that currently the service doesn’t model the concept of a cohort correctly. Cohorts are more complicated than just "does this patient belong to the organisation" as cohorts relate to the specific academic year combined with whether the patient is new to the programme or a catch up. We expect to need to build functionality around this later to support the statistics, and in doing so we would need to introduce a new way of linking patients to organisations anyway, so removing the current explicit link doesn't prevent us from doing that.

Minimal changes to the tests have been needed, although it has highlighted more explicitly our existing bug around out of cohort patients not being brought back in to the cohort. We can fix that bug easily following this particular change.