### PR TITLE
Accept import capitalisation differences

### DIFF
--- a/app/models/concerns/pending_changes_concern.rb
+++ b/app/models/concerns/pending_changes_concern.rb
@@ -6,15 +6,31 @@ module PendingChangesConcern
   included { attribute :pending_changes, :jsonb, default: {} }
 
   def stage_changes(attributes)
+    need_save = false
+
     new_pending_changes =
       attributes.each_with_object({}) do |(attr, new_value), staged_changes|
         current_value = public_send(attr)
-        staged_changes[attr.to_s] = new_value if new_value != current_value
+
+        if normalise_for_comparison(new_value) ==
+             normalise_for_comparison(current_value)
+          if new_value != current_value
+            public_send("#{attr}=", new_value)
+            pending_changes.delete(attr.to_s)
+            need_save = true
+          end
+        else
+          staged_changes[attr.to_s] = new_value
+        end
       end
 
-    if new_pending_changes.any?
+    if new_pending_changes.any? || need_save
       update!(pending_changes: pending_changes.merge(new_pending_changes))
     end
+  end
+
+  def normalise_for_comparison(value)
+    value.respond_to?(:downcase) ? value.downcase : value
   end
 
   def with_pending_changes

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -332,6 +332,21 @@ describe ClassImport do
       end
     end
 
+    context "with an existing parent matching the name but a different case" do
+      let!(:existing_parent) do
+        create(:parent, full_name: "JOHN smith", email: "john@example.com")
+      end
+
+      it "doesn't create an additional parent" do
+        expect { process! }.to change(Parent, :count).by(4)
+      end
+
+      it "changes the parent's name to the incoming version" do
+        process!
+        expect(existing_parent.reload.full_name).to eq("John Smith")
+      end
+    end
+
     context "with an existing patient in a different school" do
       let(:patient) do
         create(:patient, nhs_number: "9990000018", school: create(:school))

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -298,7 +298,7 @@ describe CohortImport do
     end
 
     context "with an existing patient matching the name but a different case" do
-      before do
+      let!(:existing_patient) do
         create(
           :patient,
           given_name: "JIMMY",
@@ -311,6 +311,37 @@ describe CohortImport do
 
       it "doesn't create an additional patient" do
         expect { process! }.to change(Patient, :count).by(2)
+      end
+
+      it "doesn't stage the changes to the names" do
+        process!
+        expect(existing_patient.reload.pending_changes).not_to have_key(
+          "given_name"
+        )
+        expect(existing_patient.reload.pending_changes).not_to have_key(
+          "family_name"
+        )
+      end
+
+      it "automatically accepts the incoming case differences" do
+        process!
+        expect(existing_patient.reload.given_name).to eq("Jimmy")
+        expect(existing_patient.reload.family_name).to eq("Smith")
+      end
+    end
+
+    context "with an existing parent matching the name but a different case" do
+      let!(:existing_parent) do
+        create(:parent, full_name: "JOHN smith", email: "john@example.com")
+      end
+
+      it "doesn't create an additional parent" do
+        expect { process! }.to change(Parent, :count).by(2)
+      end
+
+      it "changes the parent's name to the incoming version" do
+        process!
+        expect(existing_parent.reload.full_name).to eq("John Smith")
       end
     end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1487,6 +1487,33 @@ describe ImmunisationImportRow do
         end
       end
 
+      context "with an existing matching patient but mismatching capitalisation, without NHS number" do
+        let(:data) do
+          valid_data.except("NHS_NUMBER").merge(
+            {
+              "PERSON_FORENAME" => "RON",
+              "PERSON_SURNAME" => "WEASLEY",
+              "PERSON_POSTCODE" => "sw1a 1aa"
+            }
+          )
+        end
+
+        let!(:existing_patient) do
+          create(
+            :patient,
+            given_name: "Ron",
+            family_name: "Weasley",
+            date_of_birth: Date.parse(date_of_birth),
+            address_postcode:,
+            nhs_number: "9990000018"
+          )
+        end
+
+        it "still matches to a patient" do
+          expect(patient).to eq(existing_patient)
+        end
+      end
+
       describe "#address_postcode" do
         subject { patient.address_postcode }
 


### PR DESCRIPTION
Implement some extra logic when importing, which:
- automatically accepts any capitalisation differences in relevant import fields, without staging the changes for review
- matches patients whose postcode only differs by capitalisation
- saves all incoming parental information to the existing matched parent

[MAV-926](https://nhsd-jira.digital.nhs.uk/browse/MAV-926)