### PR TITLE
Specify preloading rules explicitly

### DIFF
--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -100,7 +100,8 @@ class PatientSession < ApplicationRecord
           )
         end
 
-  scope :includes_programmes, -> { includes(:patient, session: :programmes) }
+  scope :includes_programmes,
+        -> { eager_load(:patient).preload(session: :programmes) }
 
   scope :has_consent_status,
         ->(status, programme:) do

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -10,6 +10,7 @@ describe "Manage attendance" do
     when_i_go_to_the_session
     and_i_click_on_the_register_tab
     then_i_see_the_register_tab
+    and_i_see_the_actions_required
 
     when_i_register_a_patient_as_attending
     then_i_see_the_attending_flash
@@ -80,6 +81,11 @@ describe "Manage attendance" do
 
   def then_i_see_the_register_tab
     expect(page).to have_content("Registration status")
+  end
+
+  def and_i_see_the_actions_required
+    # This should be shown once per patient (there are 3 patients).
+    expect(page).to have_content("Record vaccination for HPV").exactly(3).times
   end
 
   def when_i_register_a_patient_as_attending


### PR DESCRIPTION
There seems to be a scenario where the programmes for a session end up being duplicated if we rely only on `includes`. I haven't investigated exactly what's going on with the queries.

Instead, if we specify explicitly that we want to do a `preload`, this ensures that the programmes only appear once per programme.

This fixes a regression that was added in #3301 which manifests itself on the session registration page where the actions required end up being duplicated. I think it could be related to the fact that the programmes have an implicit order on the scope, and therefore need to be preloaded to avoid an outer join returning patients in different orders.

## Before

<img width="787" alt="Screenshot 2025-04-09 at 13 38 35" src="https://github.com/user-attachments/assets/ecd2678b-75fd-4626-8e1e-13938c8f4b13" />

## After

<img width="786" alt="Screenshot 2025-04-09 at 13 47 26" src="https://github.com/user-attachments/assets/4e224dd9-3326-4f1a-8ed6-7638a58d8078" />
