### PR TITLE
Revert "must be blank" content

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -489,7 +489,7 @@ class ImmunisationImportRow
         end
       end
     elsif batch_expiry.present?
-      errors.add(batch_expiry.header, "is not required")
+      errors.add(batch_expiry.header, "must be blank")
     end
   end
 
@@ -510,7 +510,7 @@ class ImmunisationImportRow
         end
       end
     elsif batch_name.present?
-      errors.add(batch_name.header, "is not required")
+      errors.add(batch_name.header, "must be blank")
     end
   end
 
@@ -608,7 +608,7 @@ class ImmunisationImportRow
         end
       end
     elsif delivery_site.present?
-      errors.add(delivery_site.header, "is not required")
+      errors.add(delivery_site.header, "must be blank")
     end
   end
 
@@ -854,7 +854,7 @@ class ImmunisationImportRow
   def validate_reason_not_administered
     if administered
       if reason_not_administered.present?
-        errors.add(reason_not_administered.header, "is not required")
+        errors.add(reason_not_administered.header, "must be blank")
       end
     elsif reason_not_administered.present?
       if reason_not_administered_value.blank?

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -334,7 +334,7 @@ class PatientImportRow
 
   def validate_parent_1_relationship
     if parent_1_relationship.present? && !parent_1_exists?
-      errors.add(parent_1_relationship.header, "is not required")
+      errors.add(parent_1_relationship.header, "must be blank")
     end
   end
 
@@ -361,7 +361,7 @@ class PatientImportRow
 
   def validate_parent_2_relationship
     if parent_2_relationship.present? && !parent_2_exists?
-      errors.add(parent_2_relationship.header, "is not required")
+      errors.add(parent_2_relationship.header, "must be blank")
     end
   end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -230,7 +230,7 @@ describe ImmunisationImportRow do
       it "has errors" do
         expect(immunisation_import_row).to be_invalid
         expect(immunisation_import_row.errors["REASON_NOT_VACCINATED"]).to eq(
-          ["is not required"]
+          ["must be blank"]
         )
       end
     end


### PR DESCRIPTION
This reverts the content when a field has been provided and shouldn't have a value to use the previous content "must be blank" was which changed in 72f65e36aacd6c0dc480dff47b200f2856c0f8d5.