### PR TITLE
Ensure year group integer value is validated

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -369,7 +369,19 @@ class PatientImportRow
     field = year_group.presence || date_of_birth
 
     year_group_value = birth_academic_year_value&.to_year_group
-    return if year_group_value.nil?
+
+    if year_group_value.nil?
+      # We only need to add a validation error here is the file had an
+      # explicit year group, since otherwise the year group comes from the
+      # date of birth. If the date of birth is missing, there would already
+      # be a validation error for that.
+
+      if year_group.present?
+        errors.add(field.header, "is not a valid year group")
+      end
+
+      return
+    end
 
     unless year_group_value.in?(year_groups)
       errors.add(field.header, "is not part of this programme")

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -85,6 +85,18 @@ describe ClassImportRow do
         )
       end
     end
+
+    context "with an invalid year group" do
+      let(:data) { valid_data.merge("CHILD_YEAR_GROUP" => "abc") }
+
+      it "is invalid" do
+        expect(class_import_row).to be_invalid
+        expect(class_import_row.errors.size).to eq(1)
+        expect(class_import_row.errors["CHILD_YEAR_GROUP"]).to contain_exactly(
+          "is not a valid year group"
+        )
+      end
+    end
   end
 
   describe "#to_parents" do

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -98,6 +98,18 @@ describe CohortImportRow do
         )
       end
     end
+
+    context "with an invalid year group" do
+      let(:data) { valid_data.merge("CHILD_YEAR_GROUP" => "abc") }
+
+      it "is invalid" do
+        expect(cohort_import_row).to be_invalid
+        expect(cohort_import_row.errors.size).to eq(1)
+        expect(cohort_import_row.errors["CHILD_YEAR_GROUP"]).to contain_exactly(
+          "is not a valid year group"
+        )
+      end
+    end
   end
 
   describe "#to_parents" do


### PR DESCRIPTION
This ensures that when the user uploads a cohort or class list with a custom year group, we validate that the year group value is a valid integer rather than just ignoring.

This fixes a regression that was added in 5b88061e6ae26c94f1bd19571383d57755f0c4b2, although the error message is now clearer (previously it would have said "is not part of the programme").