### PR TITLE
Allow fractional wait time between PDS jobs

### DIFF
--- a/app/jobs/bulk_update_patients_from_pds_job.rb
+++ b/app/jobs/bulk_update_patients_from_pds_job.rb
@@ -11,7 +11,7 @@ class BulkUpdatePatientsFromPDSJob < ApplicationJob
     return unless Settings.pds.enqueue_bulk_updates
 
     patients = Patient.with_nhs_number.not_invalidated.not_deceased
-    wait_between_jobs = Settings.pds.wait_between_jobs.to_i
+    wait_between_jobs = Settings.pds.wait_between_jobs.to_f
 
     GoodJob::Bulk.enqueue do
       patients

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -148,7 +148,7 @@ module CSVImportable
   def update_from_pds
     return unless Settings.pds.enqueue_bulk_updates
 
-    wait_between_jobs = Settings.pds.wait_between_jobs.to_i
+    wait_between_jobs = Settings.pds.wait_between_jobs.to_f
 
     GoodJob::Bulk.enqueue do
       patients.find_each.with_index do |patient, index|

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -75,7 +75,7 @@ nhs_api:
 pds:
   enqueue_bulk_updates: true
   raise_unknown_gp_practice: true
-  wait_between_jobs: 2
+  wait_between_jobs: 2.0
 
 splunk:
   enabled: true


### PR DESCRIPTION
This allows us to specify the wait time between PDS jobs in fractional seconds to give us more flexibility in terms of controlling this.