### PR TITLE
Make GOOD_JOB_MAX_THREADS configurable

### DIFF
--- a/terraform/app/iam_policy_documents.tf
+++ b/terraform/app/iam_policy_documents.tf
@@ -53,6 +53,7 @@ data "aws_iam_policy_document" "ecs_secrets_access" {
     actions = ["ssm:GetParameters"]
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}",
+      aws_ssm_parameter.good_job_max_threads.arn,
       aws_ssm_parameter.pds_wait_between_jobs.arn
     ]
     effect = "Allow"

--- a/terraform/app/ssm_parameters.tf
+++ b/terraform/app/ssm_parameters.tf
@@ -1,3 +1,17 @@
+resource "aws_ssm_parameter" "good_job_max_threads" {
+  name = "/${var.environment}/good_job_max_threads"
+  type = "String"
+
+  # This value is the default, but can be customised in the AWS console
+  # directly and isn't managed by Terraform.
+  value = "5"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+
 resource "aws_ssm_parameter" "pds_wait_between_jobs" {
   name = "/${var.environment}/pds_wait_between_jobs"
   type = "String"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -211,6 +211,10 @@ locals {
       name      = "MAVIS__PDS__WAIT_BETWEEN_JOBS",
       valueFrom = aws_ssm_parameter.pds_wait_between_jobs.name,
     },
+    {
+      name      = "GOOD_JOB_MAX_THREADS",
+      valueFrom = aws_ssm_parameter.good_job_max_threads.name,
+    },
   ]
 }
 


### PR DESCRIPTION
This makes this variable configurable by adding it as a parameter and then exposing the variable as an environment variable.

This should allow us to customise the Good Job configuration without needing a code change and deploy.