### PR TITLE
Make `MAVIS__PDS__ENQUEUE_BULK_UPDATES` configurable

### DIFF
--- a/terraform/app/env/copilotmigration.tfvars
+++ b/terraform/app/env/copilotmigration.tfvars
@@ -16,9 +16,8 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "copilotmigration.mavistesting.com"
 }
 
-enable_splunk                   = false
-enable_cis2                     = false
-enable_pds_enqueue_bulk_updates = false
+enable_splunk = false
+enable_cis2   = false
 
 appspec_bucket        = "nhse-mavis-appspec-bucket-copilotmigration"
 minimnum_web_replicas = 2

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -15,9 +15,8 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_splunk                   = false
-enable_cis2                     = false
-enable_pds_enqueue_bulk_updates = false
+enable_splunk = false
+enable_cis2   = false
 
 http_hosts = {
   MAVIS__HOST                        = "preview.mavistesting.com"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -15,8 +15,7 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_cis2                     = false
-enable_pds_enqueue_bulk_updates = false
+enable_cis2 = false
 
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -18,9 +18,8 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_splunk                   = false
-enable_cis2                     = false
-enable_pds_enqueue_bulk_updates = false
+enable_splunk = false
+enable_cis2   = false
 
 http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"

--- a/terraform/app/iam_policy_documents.tf
+++ b/terraform/app/iam_policy_documents.tf
@@ -54,6 +54,7 @@ data "aws_iam_policy_document" "ecs_secrets_access" {
     resources = [
       "arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}",
       aws_ssm_parameter.good_job_max_threads.arn,
+      aws_ssm_parameter.pds_enqueue_bulk_jobs.arn,
       aws_ssm_parameter.pds_wait_between_jobs.arn
     ]
     effect = "Allow"

--- a/terraform/app/ssm_parameters.tf
+++ b/terraform/app/ssm_parameters.tf
@@ -11,6 +11,18 @@ resource "aws_ssm_parameter" "good_job_max_threads" {
   }
 }
 
+resource "aws_ssm_parameter" "pds_enqueue_bulk_jobs" {
+  name = "/${var.environment}/pds_enqueue_bulk_jobs"
+  type = "String"
+
+  # This value is the default, but can be customised in the AWS console
+  # directly and isn't managed by Terraform.
+  value = "true"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
 
 resource "aws_ssm_parameter" "pds_wait_between_jobs" {
   name = "/${var.environment}/pds_wait_between_jobs"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -143,13 +143,6 @@ variable "enable_cis2" {
   nullable    = false
 }
 
-variable "enable_pds_enqueue_bulk_updates" {
-  type        = bool
-  default     = false
-  description = "Whether PDS jobs that update patients in bulk should execute or not. This is disabled in non-production environments to avoid making unnecessary requests to PDS."
-  nullable    = false
-}
-
 variable "enable_splunk" {
   type        = bool
   default     = true
@@ -190,10 +183,6 @@ locals {
       value = var.enable_cis2 ? "true" : "false"
     },
     {
-      name  = "MAVIS__PDS__ENQUEUE_BULK_UPDATES"
-      value = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
-    },
-    {
       name  = "MAVIS__SPLUNK__ENABLED"
       value = var.enable_splunk ? "true" : "false"
     }
@@ -206,6 +195,10 @@ locals {
     {
       name      = "RAILS_MASTER_KEY"
       valueFrom = var.rails_master_key_path
+    },
+    {
+      name      = "MAVIS__PDS__ENQUEUE_BULK_UPDATES"
+      valueFrom = aws_ssm_parameter.pds_enqueue_bulk_jobs.name,
     },
     {
       name      = "MAVIS__PDS__WAIT_BETWEEN_JOBS",


### PR DESCRIPTION
This makes this variable configurable by adding it as a parameter and then exposing the variable as an environment variable.

This would then allow us to enable/disable this part of the service per environment while also being able to temporarily turn it on and off.

This will start by enabling it in all environments and then we can turn it off.