### PR TITLE
Refactor use of ssm parameters

### DIFF
--- a/terraform/app/env/copilotmigration.tfvars
+++ b/terraform/app/env/copilotmigration.tfvars
@@ -16,8 +16,9 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "copilotmigration.mavistesting.com"
 }
 
-enable_splunk = false
-enable_cis2   = false
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 appspec_bucket        = "nhse-mavis-appspec-bucket-copilotmigration"
-minimnum_web_replicas = 2
+minimum_web_replicas  = 2

--- a/terraform/app/env/poc.tfvars
+++ b/terraform/app/env/poc.tfvars
@@ -15,5 +15,10 @@ http_hosts = {
   MAVIS__HOST                        = "poc.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "poc.mavistesting.com"
 }
+
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
+
 appspec_bucket        = "nhse-mavis-appspec-bucket-poc"
-minimnum_web_replicas = 2
+minimum_web_replicas  = 2

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -15,8 +15,9 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_splunk = false
-enable_cis2   = false
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 http_hosts = {
   MAVIS__HOST                        = "preview.mavistesting.com"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -15,7 +15,8 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_cis2 = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -18,8 +18,9 @@ resource_name = {
 rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
-enable_splunk = false
-enable_cis2   = false
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
 
 http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"

--- a/terraform/app/iam_policy_documents.tf
+++ b/terraform/app/iam_policy_documents.tf
@@ -51,12 +51,9 @@ data "aws_iam_policy_document" "ecs_secrets_access" {
   statement {
     sid     = "railsKeySid"
     actions = ["ssm:GetParameters"]
-    resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}",
-      aws_ssm_parameter.good_job_max_threads.arn,
-      aws_ssm_parameter.pds_enqueue_bulk_jobs.arn,
-      aws_ssm_parameter.pds_wait_between_jobs.arn
-    ]
+    resources = concat([
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}"
+    ], local.parameter_store_arns)
     effect = "Allow"
   }
   statement {

--- a/terraform/app/ssm_parameters.tf
+++ b/terraform/app/ssm_parameters.tf
@@ -1,38 +1,7 @@
-resource "aws_ssm_parameter" "good_job_max_threads" {
-  name = "/${var.environment}/good_job_max_threads"
-  type = "String"
+resource "aws_ssm_parameter" "environment_config" {
+  for_each = local.parameter_store_variables
+  name     = "/${var.environment}/env/${each.key}"
+  type     = "String"
 
-  # This value is the default, but can be customised in the AWS console
-  # directly and isn't managed by Terraform.
-  value = "5"
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
-resource "aws_ssm_parameter" "pds_enqueue_bulk_jobs" {
-  name = "/${var.environment}/pds_enqueue_bulk_jobs"
-  type = "String"
-
-  # This value is the default, but can be customised in the AWS console
-  # directly and isn't managed by Terraform.
-  value = "true"
-
-  lifecycle {
-    ignore_changes = [value]
-  }
-}
-
-resource "aws_ssm_parameter" "pds_wait_between_jobs" {
-  name = "/${var.environment}/pds_wait_between_jobs"
-  type = "String"
-
-  # This value is the default, but can be customised in the AWS console
-  # directly and isn't managed by Terraform.
-  value = "2"
-
-  lifecycle {
-    ignore_changes = [value]
-  }
+  value = each.value
 }

--- a/terraform/scripts/bootstrap.sh
+++ b/terraform/scripts/bootstrap.sh
@@ -106,7 +106,12 @@ http_hosts = {
   MAVIS__HOST                        = "$ENV.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "$ENV.mavistesting.com"
 }
-minimum_replicas     = 3
+
+enable_splunk                   = false
+enable_cis2                     = false
+enable_pds_enqueue_bulk_updates = false
+
+minimum_web_replicas = 3
 appspec_bucket       = "nhse-mavis-appspec-bucket-$ENV"
 
 EOF


### PR DESCRIPTION
- Ensure we use variable configs to be unique to an environment
  - For code to reflect deployed configurations
- One resource with for-each instead of multiple blocks (DRY)
- Remove lifecycle ignore_changes
  - Ensures regular sync between code and deployed configuration
  - Any persisted changes will end up being version controlled
- Disable PDS/CIS2/SPLUNK for POC environment