### PR TITLE
Refactor how PDS update jobs are queued

### DIFF
--- a/app/jobs/enqueue_update_patients_from_pds_job.rb
+++ b/app/jobs/enqueue_update_patients_from_pds_job.rb
@@ -8,28 +8,14 @@ class EnqueueUpdatePatientsFromPDSJob < ApplicationJob
   good_job_control_concurrency_with perform_limit: 1
 
   def perform
-    return unless Settings.pds.enqueue_bulk_updates
+    scope = Patient.with_nhs_number.not_invalidated.not_deceased
 
-    patients = Patient.with_nhs_number.not_invalidated.not_deceased
-    wait_between_jobs = Settings.pds.wait_between_jobs.to_f
-
-    GoodJob::Bulk.enqueue do
-      patients
+    patients =
+      scope
         .where(updated_from_pds_at: nil)
-        .or(patients.where("updated_from_pds_at < ?", 12.hours.ago))
+        .or(scope.where("updated_from_pds_at < ?", 12.hours.ago))
         .order("updated_from_pds_at ASC NULLS FIRST")
-        .find_each
-        .with_index do |patient, index|
-          # Schedule with a delay to preemptively handle rate limit issues.
-          # This shouldn't be necessary, but we're finding that Good Job
-          # has occasional race condition issues, and spreading out the jobs
-          # should reduce the risk of this.
 
-          PatientUpdateFromPDSJob.set(
-            priority: 50,
-            wait: index * wait_between_jobs
-          ).perform_later(patient)
-        end
-    end
+    UpdatePatientsFromPDS.call(patients, priority: 50, queue: :pds)
   end
 end

--- a/app/lib/update_patients_from_pds.rb
+++ b/app/lib/update_patients_from_pds.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class UpdatePatientsFromPDS
+  def initialize(patients, priority:, queue:)
+    @patients = patients
+    @priority = priority
+    @queue = queue
+  end
+
+  def call
+    return unless enqueue?
+
+    GoodJob::Bulk.enqueue do
+      patients.find_each.with_index do |patient, index|
+        # Schedule with a delay to preemptively handle rate limit issues.
+        # This shouldn't be necessary, but we're finding that Good Job
+        # has occasional race condition issues, and spreading out the jobs
+        # should reduce the risk of this.
+
+        if patient.nhs_number.nil?
+          PatientNHSNumberLookupJob.set(
+            priority:,
+            queue:,
+            wait: index * wait_between_jobs
+          ).perform_later(patient)
+        else
+          PatientUpdateFromPDSJob.set(
+            priority:,
+            queue:,
+            wait: index * wait_between_jobs
+          ).perform_later(patient)
+        end
+      end
+    end
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :patients, :priority, :queue
+
+  def settings
+    @settings ||= Settings.pds
+  end
+
+  def enqueue?
+    @enqueue ||= settings.enqueue_bulk_updates
+  end
+
+  def wait_between_jobs
+    @wait_between_jobs ||= settings.wait_between_jobs.to_f
+  end
+end

--- a/spec/lib/update_patients_from_pds_spec.rb
+++ b/spec/lib/update_patients_from_pds_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+describe UpdatePatientsFromPDS do
+  subject(:call) { described_class.call(patients, priority:, queue:) }
+
+  let(:patients) { Patient.order(:created_at) }
+  let(:priority) { 0 }
+  let(:queue) { :default }
+
+  after { Settings.reload! }
+
+  before do
+    create_list(:patient, 2)
+    create_list(:patient, 2, nhs_number: nil)
+  end
+
+  context "when disabled" do
+    before { Settings.pds.enqueue_bulk_updates = false }
+
+    it "queues no jobs" do
+      expect { call }.not_to have_enqueued_job
+    end
+  end
+
+  it "queues a job for each patient without an NHS number" do
+    expect { call }.to have_enqueued_job(PatientNHSNumberLookupJob)
+      .on_queue(:default)
+      .exactly(2)
+      .times
+  end
+
+  it "queues a job for each patient with an NHS number" do
+    expect { call }.to have_enqueued_job(PatientUpdateFromPDSJob)
+      .on_queue(:default)
+      .exactly(2)
+      .times
+  end
+
+  it "schedules the jobs with a gap between them" do
+    freeze_time do
+      expect { call }.to have_enqueued_job(PatientUpdateFromPDSJob).at(
+        Time.current
+      ).and have_enqueued_job(PatientUpdateFromPDSJob).at(
+              Time.current + 2.seconds
+            ).and have_enqueued_job(PatientNHSNumberLookupJob).at(
+                    Time.current + 4.seconds
+                  ).and have_enqueued_job(PatientNHSNumberLookupJob).at(
+                          Time.current + 6.seconds
+                        )
+    end
+  end
+end


### PR DESCRIPTION
This adds a service class that handles logic related to queuing PDS update jobs to avoid code duplication. Currently we run similar code in two places, during an import and during the bulk enqueue job.

Instead, we can move this code in to a single class which handles all the logic related to scheduling the correct jobs to reduce duplication and improve maintainability.

I also think this will make performance testing easier by being able to use this class in a Rails console.