### PR TITLE
Add hosting environment and send to Splunk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :test do
       git: "https://github.com/citizensadvice/capybara_accessible_selectors",
       branch: "main"
   gem "capybara-screenshot"
+  gem "climate_control"
   gem "cuprite"
   gem "its"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
     cgi (0.4.2)
     charlock_holmes (0.7.9)
     childprocess (5.0.0)
+    climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     config (5.5.2)
@@ -731,6 +732,7 @@ DEPENDENCIES
   capybara_accessible_selectors!
   caxlsx
   charlock_holmes
+  climate_control
   config
   cssbundling-rails
   csv

--- a/app/components/app_hosting_environment_component.rb
+++ b/app/components/app_hosting_environment_component.rb
@@ -7,14 +7,14 @@ class AppHostingEnvironmentComponent < ViewComponent::Base
         <strong class="nhsuk-tag nhsuk-tag--<%= colour %>">
           <%= title %>
         </strong>
-        <span><%= t("hosting_environment", name:) %></span>
+        <span><%= t("hosting_environment", name: title_in_sentence) %></span>
       </div>
     </div>
   ERB
 
-  def render?
-    !Rails.env.production?
-  end
+  def render? = !Rails.env.production?
+
+  delegate :title, :title_in_sentence, to: :HostingEnvironment
 
   ENVIRONMENT_COLOR = {
     development: "white",
@@ -24,25 +24,7 @@ class AppHostingEnvironmentComponent < ViewComponent::Base
     preview: "yellow"
   }.freeze
 
-  def pull_request
-    ENV.fetch("HEROKU_PR_NUMBER", false)
-  end
-
-  def title
-    pull_request ? "PR #{pull_request}" : environment.titleize
-  end
-
-  def name
-    return title if environment == "qa"
-
-    environment
-  end
-
   def colour
-    ENVIRONMENT_COLOR[environment.to_sym]
-  end
-
-  def environment
-    pull_request ? "review" : ENV.fetch("SENTRY_ENVIRONMENT", "development")
+    ENVIRONMENT_COLOR[HostingEnvironment.name.to_sym]
   end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module HostingEnvironment
+  class << self
+    def name
+      pull_request ? "review" : ENV.fetch("SENTRY_ENVIRONMENT", "development")
+    end
+
+    def title
+      pull_request ? "PR #{pull_request}" : name.titleize
+    end
+
+    def title_in_sentence
+      if pull_request || name == "qa"
+        title
+      else
+        name
+      end
+    end
+
+    private
+
+    def pull_request
+      ENV.fetch("HEROKU_PR_NUMBER", false)
+    end
+  end
+end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -10,6 +10,14 @@ module SplunkHttpPatch
   end
 end
 
+class MavisSplunkFormatter
+  def call(log, logger)
+    message = JSON.parse(logger.call(log, logger))
+    message["event"]["hosting_environment"] = HostingEnvironment.name
+    message.to_json
+  end
+end
+
 SemanticLogger::Appender::SplunkHttp.prepend(SplunkHttpPatch)
 
 if Settings.splunk.enabled
@@ -17,6 +25,7 @@ if Settings.splunk.enabled
     appender: :splunk_http,
     url: Settings.splunk.hec_endpoint,
     token: Settings.splunk.hec_token,
-    request_channel: SecureRandom.uuid
+    request_channel: SecureRandom.uuid,
+    formatter: MavisSplunkFormatter.new
   )
 end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+describe HostingEnvironment do
+  let(:hosting_environment) { nil }
+  let(:pr_number) { nil }
+
+  around do |example|
+    ClimateControl.modify(
+      SENTRY_ENVIRONMENT: hosting_environment,
+      HEROKU_PR_NUMBER: pr_number
+    ) { example.run }
+  end
+
+  describe "#name" do
+    subject { described_class.name }
+
+    context "when the environment variable is set" do
+      let(:hosting_environment) { "production" }
+
+      it { should eq("production") }
+    end
+
+    context "when the environment variable isn't set" do
+      it { should eq("development") }
+    end
+  end
+
+  describe "#title" do
+    subject { described_class.title }
+
+    context "when the environment variable is set" do
+      let(:hosting_environment) { "production" }
+
+      it { should eq("Production") }
+    end
+
+    context "when in the QA environment" do
+      let(:hosting_environment) { "qa" }
+
+      it { should eq("QA") }
+    end
+
+    context "when in a pull request environment" do
+      let(:hosting_environment) { "review" }
+      let(:pr_number) { "123" }
+
+      it { should eq("PR 123") }
+    end
+
+    context "when the environment variable isn't set" do
+      it { should eq("Development") }
+    end
+  end
+
+  describe "#title_in_sentence" do
+    subject { described_class.title_in_sentence }
+
+    context "when the environment variable is set" do
+      let(:hosting_environment) { "production" }
+
+      it { should eq("production") }
+    end
+
+    context "when in the QA environment" do
+      let(:hosting_environment) { "qa" }
+
+      it { should eq("QA") }
+    end
+
+    context "when in a pull request environment" do
+      let(:hosting_environment) { "review" }
+      let(:pr_number) { "123" }
+
+      it { should eq("PR 123") }
+    end
+
+    context "when the environment variable isn't set" do
+      it { should eq("development") }
+    end
+  end
+end


### PR DESCRIPTION
This refactors the logic used by banner displayed at the top of each non-production environment showing the current environment in to a module, `HostingEnvironment`, which can then be used in multiple contexts. Notably, this implements some of the functionality of #3233 where the hosting environment will now be passed to Splunk.

For now, this uses the existing `SENTRY_ENVIRONMENT` and `HEROKU_PR_NUMBER` environment variables, but we might want to customise these in the future to avoid coupling our logic with Sentry or Heroku.