### PR TITLE
Maintain a list of supported feature flags

### DIFF
--- a/app/lib/feature_flag_factory.rb
+++ b/app/lib/feature_flag_factory.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class FeatureFlagFactory
+  def self.call
+    names =
+      YAML.safe_load(File.read(Rails.root.join("config/feature_flags.yml")))
+
+    names.each { Flipper.add(it) unless Flipper.exist?(it) }
+
+    Flipper.features.each do |feature|
+      feature.remove unless feature.name.to_s.in?(names)
+    end
+  end
+end

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -9,6 +9,7 @@ fi
 # When starting the container then create or migrate existing database
 if [ "$1" == "./bin/docker-start" ]; then
   ./bin/rails db:prepare:ignore_concurrent_migration_exceptions
+  ./bin/rails feature_flags:seed
 fi
 
 exec "${@}"

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,0 +1,7 @@
+- basic_auth
+- dev_tools
+- mesh_jobs
+- offline_working
+- report_gillick_notify_parents
+- school_moves_export
+- systm_one_import

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,9 +8,7 @@ end
 Faker::Config.locale = "en-GB"
 
 def set_feature_flags
-  %i[dev_tools mesh_jobs cis2].each do |feature_flag|
-    Flipper.add(feature_flag) unless Flipper.exist?(feature_flag)
-  end
+  FeatureFlagFactory.call
 end
 
 def seed_vaccines

--- a/lib/tasks/feature_flags.rake
+++ b/lib/tasks/feature_flags.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :feature_flags do
+  desc "Seeds all the feature flags ensuring they are visible in the UI."
+  task seed: :environment do
+    FeatureFlagFactory.call
+  end
+end

--- a/spec/lib/feature_flag_factory_spec.rb
+++ b/spec/lib/feature_flag_factory_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe FeatureFlagFactory do
+  subject(:call) { described_class.call }
+
+  context "with no feature flags" do
+    it "creates missing feature flags" do
+      expect { call }.to change(Flipper, :features).from([])
+    end
+  end
+
+  context "with existing feature flags" do
+    # These need to match features in `config/feature_flags.yml`.
+    before do
+      Flipper.enable(:basic_auth)
+      Flipper.disable(:dev_tools)
+    end
+
+    it "doesn't enable or disable the flags" do
+      expect(Flipper.enabled?(:basic_auth)).to be(true)
+      expect(Flipper.enabled?(:dev_tools)).to be(false)
+
+      call
+
+      expect(Flipper.enabled?(:basic_auth)).to be(true)
+      expect(Flipper.enabled?(:dev_tools)).to be(false)
+    end
+  end
+
+  context "with unused feature flags" do
+    before { Flipper.add(:unused) }
+
+    it "removes the unused feature flags" do
+      expect(Flipper.exist?(:unused)).to be(true)
+
+      call
+
+      expect(Flipper.exist?(:unused)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
This ensures that all the feature flags that are possible to be enabled/disabled are shown in the Flipper UI in all environments by adding a class which manages the creation and deletion of feature flags according to a YAML file stored in the repo.