### PR TITLE
Avoid sending consent reminders to new patients

### DIFF
--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -44,6 +44,8 @@ class ConsentNotification < ApplicationRecord
   scope :has_programme,
         ->(programme) { joins(:programmes).where(programmes: programme) }
 
+  scope :reminder, -> { initial_reminder.or(subsequent_reminder) }
+
   def reminder?
     initial_reminder? || subsequent_reminder?
   end


### PR DESCRIPTION
When patients join a session half way through a number dates, currently the parents will receive reminders for any session dates prior to when the patient joined. In some cases, this can lead to reminders being sent daily for a number of days.

Instead, we can ignore any session dates that exist prior to the patient being added to the session, and in this case, "added to the session" means when the patient received their first consent request.

This means that patients won't receive unnecessary reminders in most cases, but I think there is the opportunity for further improvements later with regards to the reminders schedule.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1003)