### PR TITLE
Fix bug where searching with no results would raise an error

### DIFF
--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -27,8 +27,9 @@ class SendClinicInitialInvitationsJob < ApplicationJob
 
     session
       .patient_sessions
+      .joins(:patient)
       .includes_programmes
-      .preload(
+      .includes(
         :session_notifications,
         patient: %i[consents parents vaccination_records]
       )

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -71,10 +71,13 @@ class PatientSession < ApplicationRecord
           joins(:patient).merge(Patient.in_programmes(programmes))
         end
 
-  scope :search_by_name, ->(name) { merge(Patient.search_by_name(name)) }
+  scope :search_by_name,
+        ->(name) { joins(:patient).merge(Patient.search_by_name(name)) }
 
   scope :search_by_year_groups,
-        ->(year_groups) { merge(Patient.search_by_year_groups(year_groups)) }
+        ->(year_groups) do
+          joins(:patient).merge(Patient.search_by_year_groups(year_groups))
+        end
 
   scope :search_by_date_of_birth_year,
         ->(year) do
@@ -100,8 +103,7 @@ class PatientSession < ApplicationRecord
           )
         end
 
-  scope :includes_programmes,
-        -> { eager_load(:patient).preload(session: :programmes) }
+  scope :includes_programmes, -> { preload(:patient, session: :programmes) }
 
   scope :has_consent_status,
         ->(status, programme:) do

--- a/spec/features/patient_search_spec.rb
+++ b/spec/features/patient_search_spec.rb
@@ -34,8 +34,35 @@ describe "Patient search" do
     then_i_see_patients_by_date_of_birth
   end
 
+  scenario "Search result returns no patients" do
+    given_that_i_am_signed_in
+
+    when_i_visit_the_session_consent_tab
+    and_i_search_for_a_name_that_doesnt_exist
+    then_i_see_no_results
+
+    when_i_visit_the_session_triage_tab
+    and_i_search_for_a_name_that_doesnt_exist
+    then_i_see_no_results
+
+    when_i_visit_the_session_register_tab
+    and_i_search_for_a_name_that_doesnt_exist
+    then_i_see_no_results
+
+    when_i_visit_the_session_record_tab
+    and_i_search_for_a_name_that_doesnt_exist
+    then_i_see_no_results
+
+    when_i_visit_the_session_outcome_tab
+    and_i_search_for_a_name_that_doesnt_exist
+    then_i_see_no_results
+  end
+
   def given_that_i_am_signed_in
     organisation = create(:organisation, :with_one_nurse)
+
+    location = create(:school, name: "Waterloo Road")
+    @session = create(:session, location:, organisation:)
 
     [
       %w[Aaron Smith],
@@ -44,14 +71,14 @@ describe "Patient search" do
       %w[Cassidy Wilson],
       %w[Bob Taylor]
     ].each do |(given_name, family_name)|
-      create(:patient, given_name:, family_name:, organisation:)
+      create(:patient, given_name:, family_name:, session: @session)
     end
 
     create(
       :patient,
       given_name: "Salvor",
       family_name: "Hardin",
-      organisation:,
+      session: @session,
       nhs_number: nil
     )
 
@@ -59,7 +86,7 @@ describe "Patient search" do
       :patient,
       given_name: "Hari",
       family_name: "Seldon",
-      organisation:,
+      session: @session,
       date_of_birth: Date.new(2013, 1, 1)
     )
 
@@ -171,5 +198,34 @@ describe "Patient search" do
     expect(page).not_to have_content("WILSON, Cassidy")
     expect(page).not_to have_content("HARDIN, Salvor")
     expect(page).to have_content("SELDON, Hari")
+  end
+
+  def when_i_visit_the_session_consent_tab
+    visit session_consent_path(@session)
+  end
+
+  def when_i_visit_the_session_triage_tab
+    visit session_triage_path(@session)
+  end
+
+  def when_i_visit_the_session_register_tab
+    visit session_register_path(@session)
+  end
+
+  def when_i_visit_the_session_record_tab
+    visit session_record_path(@session)
+  end
+
+  def when_i_visit_the_session_outcome_tab
+    visit session_outcome_path(@session)
+  end
+
+  def and_i_search_for_a_name_that_doesnt_exist
+    fill_in "Search", with: "Name doesn't exist"
+    click_on "Search"
+  end
+
+  def then_i_see_no_results
+    expect(page).to have_content("No children matching search criteria found")
   end
 end


### PR DESCRIPTION
This fixes a bug where searching for patients on the session tabs which results in no patients being returned, the user would see an error page instead of no results.

This was happening as the `includes` statement on the patient was incorrectly generating a SQL query that relied on a parameter being present but wasn't passing the parameter in. I haven't got to the bottom of exactly why this was wrong, but it seems to me to potentially be a bug in ActiveRecord.

Fixing this involves switching to using `preload` instead of `includes`, and putting an explicit `joins` where we need to query on the patient directly.

The original bug was present in version 2.1.2, but was only present on the session outcome tabs, this was made worse in https://github.com/nhsuk/manage-vaccinations-in-schools/commit/75b6f476ea848e58551a40ba2735f2a6a883e974 which applied the bug to all the tabs on the session page.

- Sentry issue from 2.1.2: https://good-machine.sentry.io/issues/6528353258/
- Further regression: https://good-machine.sentry.io/issues/6536786279/