### PR TITLE
Remove BATCH_EXPIRY_DATE from SystmOne fixture

### DIFF
--- a/spec/fixtures/immunisation_import/systm_one.csv
+++ b/spec/fixtures/immunisation_import/systm_one.csv
@@ -1,2 +1,2 @@
-Date of birth,NHS number,Vaccination area code,Vaccination batch number,BATCH_EXPIRY_DATE,Vaccination reason,Vaccination type,First name,Postcode,Sex,Surname,Event date,Event location type,Event time,Organisation ID,School,School code,Patient Count
-20100912,7420180008,,123013325,20220730,,Cervarix 1,Chyna,LE3 2DA,Female,Pickle,20240514,School,,,Eton College,110158,
+Date of birth,NHS number,Vaccination area code,Vaccination batch number,Vaccination reason,Vaccination type,First name,Postcode,Sex,Surname,Event date,Event location type,Event time,Organisation ID,School,School code,Patient Count
+20100912,7420180008,,123013325,,Cervarix 1,Chyna,LE3 2DA,Female,Pickle,20240514,School,,,Eton College,110158,


### PR DESCRIPTION
This was only needed temporarily before we supported batches without expiration dates and shouldn't be present in any SystmOne files that we import.