### PR TITLE
Overwrite db/data/dfe-schools.zip

### DIFF
--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -45,7 +45,8 @@ namespace :schools do
       download_button = download_form.button_with(value: "Results.zip")
       puts "'Results.zip' link found, downloading the file..."
       download_file = agent.click(download_button)
-      download_file.save("db/data/dfe-schools.zip")
+      puts "Overwriting db/data/dfe-schools.zip"
+      download_file.save!("db/data/dfe-schools.zip")
       puts "File downloaded successfully to db/data/dfe-schools.zip"
     else
       puts "Download button never appeared, aborting"


### PR DESCRIPTION
When downloading the latest version of the schools data we should make sure to overwrite the version already contained in the repo otherwise running, for example, `schools:import` will use the file in the repo and not the latest version just downloaded.