### PR TITLE
Track school open/closed status

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -13,6 +13,7 @@
 #  gias_local_authority_code :integer
 #  name                      :text             not null
 #  ods_code                  :string
+#  status                    :integer          default("unknown"), not null
 #  type                      :integer          not null
 #  url                       :text
 #  urn                       :string
@@ -47,6 +48,11 @@ class Location < ApplicationRecord
   has_many :sessions
 
   has_one :organisation, through: :team
+
+  # This is based on the school statuses from the DfE GIAS data.
+  enum :status,
+       { unknown: 0, open: 1, closed: 2, opening: 3, closing: 4 },
+       default: :unknown
 
   enum :type,
        { school: 0, generic_clinic: 1, community_clinic: 2, gp_practice: 3 }

--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -133,10 +133,13 @@ class Onboarding
     validates :existing_team, absence: true
     validates :location, presence: true
     validates :team, presence: true
+    validates :status, inclusion: %w[open opening]
 
     def location
       @location ||= Location.school.find_by(urn:)
     end
+
+    delegate :status, to: :location, allow_nil: true
 
     def existing_team
       location&.team

--- a/db/migrate/20250414092500_add_status_to_locations.rb
+++ b/db/migrate/20250414092500_add_status_to_locations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddStatusToLocations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :locations, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_03_155909) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_14_092500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -456,6 +456,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_03_155909) do
     t.bigint "team_id"
     t.integer "gias_local_authority_code"
     t.integer "gias_establishment_number"
+    t.integer "status", default: 0, null: false
     t.index ["ods_code"], name: "index_locations_on_ods_code", unique: true
     t.index ["team_id"], name: "index_locations_on_team_id"
     t.index ["urn"], name: "index_locations_on_urn", unique: true

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -116,6 +116,7 @@ namespace :schools do
           ),
           address_town: row["Town"],
           address_postcode: row["Postcode"],
+          status: Integer(row["EstablishmentStatus (code)"]),
           url: process_url.call(row["SchoolWebsite"].presence),
           year_groups: process_year_groups.call(row)
         )
@@ -132,6 +133,7 @@ namespace :schools do
                                gias_establishment_number
                                gias_local_authority_code
                                name
+                               status
                                url
                                year_groups
                              ]
@@ -155,6 +157,7 @@ namespace :schools do
                              gias_establishment_number
                              gias_local_authority_code
                              name
+                             status
                              url
                              year_groups
                            ]

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -13,6 +13,7 @@
 #  gias_local_authority_code :integer
 #  name                      :text             not null
 #  ods_code                  :string
+#  status                    :integer          default("unknown"), not null
 #  type                      :integer          not null
 #  url                       :text
 #  urn                       :string
@@ -45,6 +46,8 @@ FactoryBot.define do
     url { Faker::Internet.url }
 
     team { organisation ? association(:team, organisation:) : nil }
+
+    traits_for_enum :status
 
     factory :community_clinic do
       type { :community_clinic }

--- a/spec/fixtures/files/onboarding/invalid.yaml
+++ b/spec/fixtures/files/onboarding/invalid.yaml
@@ -7,3 +7,4 @@ teams:
 
 schools:
   unknown_team: [123456, 234567]
+  team_1: [567890]

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -13,6 +13,7 @@
 #  gias_local_authority_code :integer
 #  name                      :text             not null
 #  ods_code                  :string
+#  status                    :integer          default("unknown"), not null
 #  type                      :integer          not null
 #  url                       :text
 #  urn                       :string

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -7,11 +7,13 @@ describe Onboarding do
 
   let!(:programme) { create(:programme, :hpv) }
   # rubocop:disable RSpec/IndexedLet
-  let!(:school1) { create(:school, :secondary, urn: "123456") }
-  let!(:school2) { create(:school, :secondary, urn: "234567") }
-  let!(:school3) { create(:school, :secondary, urn: "345678") }
-  let!(:school4) { create(:school, :secondary, urn: "456789") }
+  let!(:school1) { create(:school, :secondary, :open, urn: "123456") }
+  let!(:school2) { create(:school, :secondary, :open, urn: "234567") }
+  let!(:school3) { create(:school, :secondary, :open, urn: "345678") }
+  let!(:school4) { create(:school, :secondary, :open, urn: "456789") }
   # rubocop:enable RSpec/IndexedLet
+
+  before { create(:school, :secondary, :closed, urn: "567890") }
 
   context "with a valid configuration file" do
     let(:filename) { "onboarding/valid.yaml" }
@@ -71,6 +73,7 @@ describe Onboarding do
           "organisation.privacy_policy_url": ["can't be blank"],
           "school.0.team": ["can't be blank"],
           "school.1.team": ["can't be blank"],
+          "school.2.status": ["is not included in the list"],
           "team.email": ["can't be blank"],
           "team.name": ["can't be blank"],
           clinics: ["can't be blank"],


### PR DESCRIPTION
This adds a new column on the locations table for tracking the status of the location (either open, close, opening and closing) which maps closely with the DfE GIAS data, but could also be applied to other location types so there's no need to name the enum specific to schools.

Adding this allows us to validate that all the schools are open before onboarding an organisation.

This is a proposed alternative to #3391 which runs when an onboarding process runs rather than checking the YAML files against the DfE data in the repo.