### PR TITLE
Prepare restriction of AWS permissions for github workflows

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -11,6 +11,9 @@ on:
 concurrency:
   group: build-and-push-image-${{ inputs.git-sha || github.sha }}
 
+env:
+  PUSH_IMAGE_TO_PRODUCTION: ${{ github.ref_name == 'main' }}
+
 jobs:
   check-image-presence:
     name: Check if images already exist
@@ -18,7 +21,7 @@ jobs:
     permissions:
       id-token: write
     outputs:
-      build-needed: ${{ steps.check-image.outputs.build-needed }}
+      build-needed: ${{ steps.check-dev-image.outputs.build-needed || steps.check-prod-image.outputs.build-needed }}
     steps:
       - name: Configure AWS Dev Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -26,25 +29,28 @@ jobs:
           role-to-assume: arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure
           aws-region: eu-west-2
       - name: Check if dev image exists
+        id: check-dev-image
         run: |
           if aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ inputs.git-sha || github.sha }} > /dev/null 2>&1; then
             echo "Dev image with given tag already exists"
           else
             echo "Dev image does not exist. Build needed"
-            echo "BUILD_NEEDED=true" >> $GITHUB_ENV
+            echo "build-needed=true" >> $GITHUB_OUTPUT
           fi
       - name: Configure AWS Production credentials
+        if: env.PUSH_IMAGE_TO_PRODUCTION == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure
           aws-region: eu-west-2
       - name: Check if production image exists
-        id: check-image
+        if: env.PUSH_IMAGE_TO_PRODUCTION == 'true'
+        id: check-prod-image
         run: |
-          if [ -e $BUILD_NEEDED ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ inputs.git-sha || github.sha }} > /dev/null 2>&1; then
-            echo "Production and dev images with given tag already exist. No build needed"
+          if aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ inputs.git-sha || github.sha }} > /dev/null 2>&1; then
+            echo "Production image with given tag already exists"
           else
-            echo "At least one image does not exist. Build needed"
+            echo "Production image does not exist. Build needed"
             echo "build-needed=true" >> $GITHUB_OUTPUT
           fi
 
@@ -64,16 +70,29 @@ jobs:
         with:
           name: image
           path: image.tar
+  define-matrix:
+    name: Determine AWS roles to push the image
+    runs-on: ubuntu-latest
+    needs: check-image-presence
+    outputs:
+      aws-roles: ${{ steps.determine-aws-roles.outputs.aws-roles }}
+    steps:
+      - name: Set aws roles
+        id: determine-aws-roles
+        run: |
+          if [ ${{ env.PUSH_IMAGE_TO_PRODUCTION }} = 'true' ]; then
+            echo 'aws-roles=["arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure", "arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure"]' >> $GITHUB_OUTPUT
+          else
+            echo 'aws-roles=["arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure"]' >> $GITHUB_OUTPUT
+          fi
   push:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, define-matrix]
     permissions:
       id-token: write
     strategy:
       matrix:
-        aws-role:
-          - arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure
-          - arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure
+        aws-role: ${{ fromJSON(needs.define-matrix.outputs.aws-roles) }}
     steps:
       - name: Download Docker image
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -3,9 +3,13 @@ name: Build and push image
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      git-sha:
+        description: The git commit sha to build the image from.
+        type: string
 
 concurrency:
-  group: build-and-push-image-${{ github.sha }}
+  group: build-and-push-image-${{ inputs.git-sha || github.sha }}
 
 jobs:
   check-image-presence:
@@ -23,7 +27,7 @@ jobs:
           aws-region: eu-west-2
       - name: Check if dev image exists
         run: |
-          if aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
+          if aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ inputs.git-sha || github.sha }} > /dev/null 2>&1; then
             echo "Dev image with given tag already exists"
           else
             echo "Dev image does not exist. Build needed"
@@ -37,7 +41,7 @@ jobs:
       - name: Check if production image exists
         id: check-image
         run: |
-          if [ -e $BUILD_NEEDED ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ github.sha }} > /dev/null 2>&1; then
+          if [ -e $BUILD_NEEDED ] && aws ecr describe-images --repository-name mavis/webapp --image-ids imageTag=${{ inputs.git-sha || github.sha }} > /dev/null 2>&1; then
             echo "Production and dev images with given tag already exist. No build needed"
           else
             echo "At least one image does not exist. Build needed"
@@ -86,6 +90,6 @@ jobs:
       - name: Load Docker image
         run: docker load -i image.tar
       - name: Tag Docker image
-        run: docker tag mavis:latest "${{ steps.login-ecr.outputs.registry }}/mavis/webapp":"${{ github.sha }}"
+        run: docker tag mavis:latest "${{ steps.login-ecr.outputs.registry }}/mavis/webapp":"${{ inputs.git-sha || github.sha }}"
       - name: Push Docker image
-        run: docker push "${{ steps.login-ecr.outputs.registry }}/mavis/webapp":"${{ github.sha }}"
+        run: docker push "${{ steps.login-ecr.outputs.registry }}/mavis/webapp":"${{ inputs.git-sha || github.sha }}"

--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -33,6 +33,10 @@ on:
       server_types:
         required: true
         type: string
+      git_sha_to_deploy:
+        description: The git commit SHA to deploy.
+        required: true
+        type: string
 
 concurrency:
   group: deploy-application-${{ inputs.environment }}
@@ -52,6 +56,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_sha_to_deploy || github.sha }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.image_tag || github.sha }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -110,6 +112,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.image_tag || github.sha }}
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy
-run-name: Deploy to ${{ inputs.environment }}
+run-name: Deploy ${{ inputs.git_ref_to_deploy || github.ref_name }} to ${{ inputs.environment }}
 
 concurrency:
   group: deploy-${{ inputs.environment }}
@@ -15,6 +15,12 @@ on:
         type: string
   workflow_dispatch:
     inputs:
+      git_ref_to_deploy:
+        description:
+          | # Use blank unicode character (U+2800) to force line-break
+          Use code from: ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+          (Git ref to deploy, for example, a tag, branch name or commit SHA. Will use workflow ref if not provided.)
+        type: string
       environment:
         description: Deployment environment
         required: true
@@ -38,16 +44,34 @@ on:
         default: all
 
 jobs:
+  determine-git-sha:
+    runs-on: ubuntu-latest
+    outputs:
+      git-sha: ${{ steps.get-git-sha.outputs.git-sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref_to_deploy || github.sha }}
+      - name: Get git sha
+        id: get-git-sha
+        run: echo "git-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
   build-and-push-image:
+    needs: determine-git-sha
     uses: ./.github/workflows/build-and-push-image.yml
+    with:
+      git-sha: ${{ needs.determine-git-sha.outputs.git-sha }}
   deploy-infrastructure:
-    needs: build-and-push-image
+    needs: [build-and-push-image, determine-git-sha]
     uses: ./.github/workflows/deploy-infrastructure.yml
     with:
       environment: ${{ inputs.environment }}
+      image_tag: ${{ needs.determine-git-sha.outputs.git-sha }}
   deploy-application:
-    needs: deploy-infrastructure
+    needs: [deploy-infrastructure, determine-git-sha]
     uses: ./.github/workflows/deploy-application.yml
     with:
       environment: ${{ inputs.environment }}
+      image_tag: ${{ needs.determine-git-sha.outputs.git-sha }}
       server_types: ${{ inputs.server_types }}
+      git_sha_to_deploy: ${{ needs.determine-git-sha.outputs.git-sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,10 +68,9 @@ jobs:
       environment: ${{ inputs.environment }}
       image_tag: ${{ needs.determine-git-sha.outputs.git-sha }}
   deploy-application:
-    needs: [deploy-infrastructure, determine-git-sha]
+    needs: deploy-infrastructure
     uses: ./.github/workflows/deploy-application.yml
     with:
       environment: ${{ inputs.environment }}
-      image_tag: ${{ needs.determine-git-sha.outputs.git-sha }}
       server_types: ${{ inputs.server_types }}
       git_sha_to_deploy: ${{ needs.determine-git-sha.outputs.git-sha }}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ candidate. Now it's time to deploy. Start with a deploy to `training` or
 `preview` to ensure the tagged version is correct. Once that's done you can
 deploy to production.
 
+Use the `deploy.yml` workflow to run the deployments. For the production deployment,
+it's important to start the workflow from the `main` branch and specify the tag to deploy
+as input. This is because only workflows from the `main` branch can authenticate with the
+production AWS account.
+
 #### When `release` and `main` have diverged
 
 There are cases when `release` won't be fast-forwardable to the release


### PR DESCRIPTION
We want to restrict the IAM role used by the Github workflows such that it can only be assumed by workflow runs from the main and release branches. This causes the problem that deployment workflows run from tags could not assume the role anymore.

To mitigate this issue and still allow deploying specific tags, this PR allows to specify the git tag that shall be deployed in a dedicated field. While the workflow can be run from main or release, this still allows to deploy a specific git tag. If no value is set, it defaults to the regular behaviour.