### PR TITLE
Accumulate gender on import

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -47,6 +47,12 @@ class PatientImportRow
         existing_patient.registration = attributes.delete(:registration)
       end
 
+      if attributes[:gender_code].in?(%w[male female not_specified]) &&
+           !existing_patient.gender_code.in?(%w[male female not_specified]) &&
+           attributes[:gender_code] != existing_patient.gender_code
+        existing_patient.gender_code = attributes.delete(:gender_code)
+      end
+
       if address_postcode.present? &&
            address_postcode.to_postcode != existing_patient.address_postcode
         attributes.merge!(

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -216,6 +216,62 @@ describe ClassImportRow do
         end
       end
     end
+
+    context "with an existing patient without gender" do
+      let(:data) { valid_data.merge("CHILD_GENDER" => "male") }
+
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "not_known",
+          given_name: "Jimmy",
+          date_of_birth: Date.new(2010, 1, 1)
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "saves the incoming gender" do
+        expect(patient).to have_attributes(gender_code: "male")
+      end
+
+      it "doesn't stage the gender differences" do
+        expect(patient.pending_changes).to be_empty
+      end
+    end
+
+    context "with an existing patient already with gender" do
+      let(:data) { valid_data.merge("CHILD_GENDER" => "male") }
+
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "female",
+          given_name: "Jimmy",
+          nhs_number: "1234567890",
+          address_line_1: "10 Downing Street",
+          address_line_2: "",
+          address_town: "London",
+          birth_academic_year: 2009,
+          date_of_birth: Date.new(2010, 1, 1),
+          registration: "8AB"
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "does not save the incoming gender" do
+        expect(patient).to have_attributes(gender_code: "female")
+      end
+
+      it "does stage the gender differences" do
+        expect(patient.pending_changes).to include("gender_code" => "male")
+      end
+    end
   end
 
   describe "#to_parent_relationships" do

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -221,6 +221,64 @@ describe CohortImportRow do
         expect(patient.pending_changes).to include("registration" => "8AB")
       end
     end
+
+    context "with an existing patient without gender" do
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "not_known",
+          given_name: "Jimmy",
+          nhs_number: "1234567890",
+          address_line_1: "10 Downing Street",
+          address_line_2: "",
+          address_town: "London",
+          birth_academic_year: 2009,
+          date_of_birth: Date.new(2010, 1, 1),
+          registration: "8AB"
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "saves the incoming gender" do
+        expect(patient).to have_attributes(gender_code: "male")
+      end
+
+      it "doesn't stage the gender differences" do
+        expect(patient.pending_changes).to be_empty
+      end
+    end
+
+    context "with an existing patient already with gender" do
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "female",
+          given_name: "Jimmy",
+          nhs_number: "1234567890",
+          address_line_1: "10 Downing Street",
+          address_line_2: "",
+          address_town: "London",
+          birth_academic_year: 2009,
+          date_of_birth: Date.new(2010, 1, 1),
+          registration: "8AB"
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "does not save the incoming gender" do
+        expect(patient).to have_attributes(gender_code: "female")
+      end
+
+      it "does stage the gender differences" do
+        expect(patient.pending_changes).to include("gender_code" => "male")
+      end
+    end
   end
 
   describe "#to_school_move" do


### PR DESCRIPTION
During an import, if the existing patient's gender is `nil`, `not_known` or `not_specified`, and the incoming value is different, then Mavis will now automatically accept the new value without staging it and asking for a review.