### PR TITLE
Replace non-breaking space characters

### DIFF
--- a/app/lib/csv_parser.rb
+++ b/app/lib/csv_parser.rb
@@ -86,7 +86,11 @@ class CSVParser
   end
 
   def encoding
-    @encoding ||=
+    "#{detect_encoding}:UTF-8" if detect_encoding
+  end
+
+  def detect_encoding
+    @detect_encoding ||=
       begin
         return nil if data.blank?
 

--- a/app/lib/csv_parser.rb
+++ b/app/lib/csv_parser.rb
@@ -103,11 +103,13 @@ class CSVParser
       row = info.line
       header = unconverted_headers[info.index]
 
-      Field.new(value&.strip.presence, column, row, header)
+      Field.new(value&.tr("\u00A0", " ")&.strip.presence, column, row, header)
     end
   end
 
   def header_converters
-    proc { |value| value.strip.downcase.tr("-", "_").tr(" ", "_").to_sym }
+    proc do |value|
+      value.downcase.tr("-", "_").tr(" ", "_").tr("\u00A0", " ").strip.to_sym
+    end
   end
 end

--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -21,4 +21,14 @@ describe CSVParser do
     expect(row[:another_header].cell).to eq("B2")
     expect(row[:another_header].header).to eq("Another-Header")
   end
+
+  context "with a non-breaking space" do
+    let(:data) { "header\u00A0\nvalue\u00A0" }
+
+    it "removes the characters" do
+      row = table.first
+
+      expect(row[:header].value).to eq("value")
+    end
+  end
 end


### PR DESCRIPTION
When importing a CSV file we can replace these characters with a normal space character and then strip any trailing and leading whitespace. This will help to normalise the data coming in to the service, and avoids issues where users upload files in non-breaking space characters in the column headers and the file fails to import. This was discovered by one of our testers where Excel seems to include these characters when generating CSV files in certain situations.