### PR TITLE
Don't require VACCINATED column

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -377,7 +377,8 @@ class ImmunisationImportRow
       elsif "no".start_with?(vaccinated.to_s.downcase)
         false
       end
-    elsif vaccine.present?
+    elsif vaccine_name.present? ||
+          combined_vaccination_and_dose_sequence.present?
       true
     end
   end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -102,6 +102,40 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "when missing VACCINATED but a vaccine has been given" do
+      let(:data) { { "VACCINE_GIVEN" => "A vaccine" } }
+
+      it "doesn't require a VACCINATED column" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:base]).not_to include(
+          "<code>VACCINATED</code> is required"
+        )
+      end
+    end
+
+    context "when missing VACCINATED but a vaccination type has been given" do
+      let(:data) { { "Vaccination type" => "HPV 1" } }
+
+      it "requires a VACCINATED column" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors[:base]).to include(
+          "<code>VACCINATED</code> is required"
+        )
+      end
+
+      context "when SystmOne is enabled" do
+        before { Flipper.enable(:systm_one_import) }
+        after { Flipper.disable(:systm_one_import) }
+
+        it "doesn't require a VACCINATED column" do
+          expect(immunisation_import_row).to be_invalid
+          expect(immunisation_import_row.errors[:base]).not_to include(
+            "<code>VACCINATED</code> is required"
+          )
+        end
+      end
+    end
+
     context "when missing fields" do
       let(:data) { { "VACCINATED" => "Y" } }
 


### PR DESCRIPTION
If the file which has been uploaded has a `VACCINE_GIVEN` or `Vaccination type` column, we can assume that the record has been administered.

This was already the case, but only the vaccine that the user provided is valid. If the vaccine was invalid, this lead to a confusing scenario where the user would see a validation error about the vaccine being invalid and a validation error about missing `VACCINATED`. This is wrong, once the vaccine has been fixed, the second validation error about the `VACCINATED` column would go away, so there's no need to show it to the user in the first place.