### PR TITLE
Update terraform address of ecs_task_definition

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Get image digest
         run: |
           DIGEST="${{ inputs.docker_sha }}"
-          if terraform state list | grep -q 'aws_ecs_task_definition.task_definition'; then
-            DIGEST=$(terraform state show aws_ecs_task_definition.task_definition | grep -oP '(?<=mavis/webapp@)sha256:[0-9a-z]{64}')
+          if terraform state list | grep -q 'module.web_service.aws_ecs_task_definition.this'; then
+            DIGEST=$(terraform state show module.web_service.aws_ecs_task_definition.this | grep -oP '(?<=mavis/webapp@)sha256:[0-9a-z]{64}')
             echo "Existing task definition found, using image digest from the state: $DIGEST"
           elif [ -z "$DIGEST" ]; then
             echo "Aborting infrastructure deployment: Missing existing task definition or image digest input parameter"


### PR DESCRIPTION
* With the introduction of the terraform module for the ECS services, the resource address of the ecs_task_definition has changed. This needs to be updated in the deployment workflow accordingly