### PR TITLE
Don't link to vaccination records

### DIFF
--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -1,5 +1,5 @@
 <div class="nhsuk-table__panel-with-heading-tab">
-  <h3 class="nhsuk-table__heading-tab"><%= t("children", count: @count) %></h3>
+  <h3 class="nhsuk-table__heading-tab"><%= t("children", count:) %></h3>
 
   <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
     <% table.with_head do |head| %>
@@ -12,7 +12,7 @@
     <% end %>
 
     <% table.with_body do |body| %>
-      <% @patients.each do |patient| %>
+      <% patients.each do |patient| %>
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Name and NHS number</span>

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -11,15 +11,11 @@ class AppPatientTableComponent < ViewComponent::Base
 
   private
 
-  def can_link_to?(patient)
-    allowed_patient_ids.include?(patient.id)
-  end
+  attr_reader :patients, :current_user, :count
 
-  def allowed_patient_ids
-    # FIXME: Can we use helpers.policy_scope here?
-    # We can remove this once we show a page for the patient that contains
-    # limited information for the old organisation.
-    @allowed_patient_ids ||=
-      PatientPolicy::Scope.new(@current_user, Patient).resolve.ids
+  def can_link_to?(record) = allowed_ids.include?(record.id)
+
+  def allowed_ids
+    @allowed_ids ||= PatientPolicy::Scope.new(current_user, Patient).resolve.ids
   end
 end

--- a/app/components/app_vaccination_record_table_component.html.erb
+++ b/app/components/app_vaccination_record_table_component.html.erb
@@ -1,5 +1,6 @@
 <div class="nhsuk-table__panel-with-heading-tab">
-  <h3 class="nhsuk-table__heading-tab"><%= heading %></h3>
+  <h3 class="nhsuk-table__heading-tab"><%= pluralize(count, "vaccination record") %></h3>
+
   <%= govuk_table(html_attributes: { class: "nhsuk-table-responsive" }) do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
@@ -15,7 +16,13 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Full name</span>
-            <%= govuk_link_to vaccination_record.patient.full_name, programme_vaccination_record_path(vaccination_record.programme, vaccination_record) %>
+
+            <% if can_link_to?(vaccination_record) %>
+              <%= link_to vaccination_record.patient.full_name,
+                          programme_vaccination_record_path(vaccination_record.programme, vaccination_record) %>
+            <% else %>
+              <%= vaccination_record.patient.full_name %>
+            <% end %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/components/app_vaccination_record_table_component.rb
+++ b/app/components/app_vaccination_record_table_component.rb
@@ -1,22 +1,25 @@
 # frozen_string_literal: true
 
 class AppVaccinationRecordTableComponent < ViewComponent::Base
-  def initialize(vaccination_records, count:, new_records: false)
+  def initialize(vaccination_records, current_user:, count:)
     super
 
     @vaccination_records = vaccination_records
+    @current_user = current_user
     @count = count
-    @new_records = new_records
   end
 
   private
 
-  attr_reader :vaccination_records, :new_records
+  attr_reader :vaccination_records, :current_user, :count
 
-  def heading
-    pluralize(
-      @count,
-      new_records ? "new vaccination record" : "vaccination record"
-    )
+  def can_link_to?(record) = allowed_ids.include?(record.id)
+
+  def allowed_ids
+    @allowed_ids ||=
+      VaccinationRecordPolicy::Scope
+        .new(@current_user, VaccinationRecord)
+        .resolve
+        .ids
   end
 end

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -148,7 +148,7 @@
   <% end %>
 
   <% if @vaccination_records.present? %>
-    <%= render AppVaccinationRecordTableComponent.new(@vaccination_records, count: @pagy.count) %>
+    <%= render AppVaccinationRecordTableComponent.new(@vaccination_records, current_user:, count: @pagy.count) %>
   <% end %>
 
   <%= govuk_pagination(pagy: @pagy) %>

--- a/app/views/vaccination_records/index.html.erb
+++ b/app/views/vaccination_records/index.html.erb
@@ -14,7 +14,7 @@
 
 <%= govuk_button_link_to "Import vaccination records", new_immunisation_import_path, class: "app-button--secondary nhsuk-u-margin-bottom-0" %>
 
-<%= render AppVaccinationRecordTableComponent.new(@vaccination_records, count: @pagy.count) %>
+<%= render AppVaccinationRecordTableComponent.new(@vaccination_records, current_user:, count: @pagy.count) %>
 
 <%= govuk_pagination(pagy: @pagy) %>
 

--- a/spec/components/app_vaccination_record_table_component_spec.rb
+++ b/spec/components/app_vaccination_record_table_component_spec.rb
@@ -3,7 +3,9 @@
 describe AppVaccinationRecordTableComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(vaccination_records, count:) }
+  let(:component) do
+    described_class.new(vaccination_records, current_user:, count:)
+  end
 
   let(:programme) { create(:programme) }
   let(:vaccination_records) do
@@ -28,6 +30,8 @@ describe AppVaccinationRecordTableComponent do
       create_list(:vaccination_record, 5, :not_administered, programme:)
   end
 
+  let(:current_user) { create(:nurse) }
+
   let(:count) { 10 }
 
   it "renders a heading tab" do
@@ -35,19 +39,6 @@ describe AppVaccinationRecordTableComponent do
       ".nhsuk-table__heading-tab",
       text: "10 vaccination records"
     )
-  end
-
-  context "with new records" do
-    let(:component) do
-      described_class.new(vaccination_records, count:, new_records: true)
-    end
-
-    it "renders a heading tab with the word new" do
-      expect(rendered).to have_css(
-        ".nhsuk-table__heading-tab",
-        text: "10 new vaccination records"
-      )
-    end
   end
 
   it "renders the headers" do
@@ -73,5 +64,13 @@ describe AppVaccinationRecordTableComponent do
     )
     expect(rendered).to have_css(".nhsuk-table__cell", text: "28 May 2000")
     expect(rendered).to have_css(".nhsuk-table__cell", text: "1 September 2020")
+  end
+
+  context "with a vaccination record not performed by the organisation" do
+    before { vaccination_records.first.patient.update!(organisation: nil) }
+
+    it "doesn't render a link" do
+      expect(rendered).not_to have_link("SMITH, John")
+    end
   end
 end


### PR DESCRIPTION
If the user doesn't have permission to see those vaccination records.

If a user clicks on this link they are taken to a 404 error page which is not a good user experience, we should instead hide the link.

This follows on from similar functionality that was added to the patient table in a055b1a5646e0c5a309dc7430b5e0da9060f4fc5.