### PR TITLE
Ensure pipeline jobs exit with failure

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -64,6 +64,7 @@ jobs:
         id: terraform-output
         working-directory: terraform/app
         run: |
+          set -e
           terraform init -backend-config=env/${{ inputs.environment }}-backend.hcl -reconfigure
           terraform output -json | jq -r '
           "s3_bucket=" + .s3_bucket.value,
@@ -101,6 +102,7 @@ jobs:
           aws-region: eu-west-2
       - name: Trigger CodeDeploy deployment
         run: |
+          set -e
           source ${{ runner.temp }}/DEPLOYMENT_ENVS
           deployment_id=$(aws deploy create-deployment \
           --application-name "$application" --deployment-group-name "$application_group" \
@@ -109,6 +111,7 @@ jobs:
           echo "deployment_id=$deployment_id" >> $GITHUB_ENV
       - name: Wait up to 30 minutes for deployment to complete
         run: |
+          set -e
           aws deploy wait deployment-successful --deployment-id "$deployment_id"
           echo "Deployment successful"
 
@@ -135,6 +138,7 @@ jobs:
         run: sudo snap install --classic aws-cli
       - name: Trigger ECS Deployment
         run: |
+          set -e
           source ${{ runner.temp }}/DEPLOYMENT_ENVS
           DEPLOYMENT_ID=$(aws ecs update-service --cluster $cluster_name --service $good_job_service \
           --task-definition $good_job_task_definition --force-new-deployment \
@@ -143,6 +147,7 @@ jobs:
           echo "deployment_id=$DEPLOYMENT_ID" >> $GITHUB_ENV
       - name: Wait for deployment to complete
         run: |
+          set -e
           source ${{ runner.temp }}/DEPLOYMENT_ENVS
           DEPLOYMENT_STATE=IN_PROGRESS
           while [ "$DEPLOYMENT_STATE" == "IN_PROGRESS" ]; do

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -65,11 +65,13 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Pull Docker image
         run: |
+          set -e
           DOCKER_IMAGE="${{ steps.login-ecr.outputs.registry }}/mavis/webapp:${IMAGE_TAG}"
           docker pull "$DOCKER_IMAGE"
           echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
       - name: Extract image digest
         run: |
+          set -e
           DOCKER_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$DOCKER_IMAGE")
           DIGEST="${DOCKER_DIGEST#*@}"
           echo "DIGEST=$DIGEST" >> $GITHUB_ENV

--- a/.github/workflows/destroy-infrastructure.yml
+++ b/.github/workflows/destroy-infrastructure.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Delete cluster
         run: |
+          set -e
           terraform destroy -var-file="env/${{ inputs.environment }}.tfvars" \
           -var="image_digest=notneededfordestroy" -auto-approve
 
@@ -77,6 +78,7 @@ jobs:
           sudo snap install --classic aws-cli
       - name: Delete terraform backend elements
         run: |
+          set -e
           TF_STATE_FILE=nhse-mavis-terraform-state/terraform-${{ inputs.environment }}.tfstate
           aws s3 rm s3://$TF_STATE_FILE
           aws dynamodb delete-item --table-name mavis-terraform-state-lock \


### PR DESCRIPTION
 - Using `set -e` consistently will ensure we detect the failure of a job at the right location