### PR TITLE
Only approve deployment of services once

### DIFF
--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -46,6 +46,7 @@ jobs:
   prepare-deployment:
     name: Prepare deployment
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
     steps:
@@ -85,7 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-deployment
     if: inputs.server_types == 'web' || inputs.server_types == 'all'
-    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
     steps:
@@ -117,7 +117,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare-deployment
     if: inputs.server_types == 'good-job' || inputs.server_types == 'all'
-    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Approving the deployment of each individual service is overkill
 - Move approval into prepare-deployment stage to only approve once