### PR TITLE
Handle no comparison option in sample_patient function

### DIFF
--- a/app/controllers/inspect/timeline/patients_controller.rb
+++ b/app/controllers/inspect/timeline/patients_controller.rb
@@ -81,6 +81,8 @@ module Inspect
       # TODO: Fix so that a new comparison patient isn't sampled every time
       #       a filter option is changed and the page is reloaded.
       def sample_patient(compare_option)
+        return nil if compare_option.blank? || compare_option == "on"
+
         case compare_option
         when "class_import"
           class_import = params[:compare_option_class_import]
@@ -110,8 +112,10 @@ module Inspect
             :invalid_patient
           end
         else
-          raise ArgumentError,
-                "Invalid patient comparison option: #{compare_option}"
+          raise ArgumentError, <<~MESSAGE
+          Invalid patient comparison option: #{compare_option}.
+          Supported options are: class_import, cohort_import, session, manual_entry
+        MESSAGE
         end
       end
 


### PR DESCRIPTION
Previously, the sample_patient function raised an exception when no comparison option was selected. This has been replaced with a return of nil for blank or "on" values, preventing unnecessary exceptions.