### PR TITLE
Use last available answer from today for initialising pre-screening questions

### DIFF
--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -56,19 +56,21 @@ class AppPatientPageComponent < ViewComponent::Base
   end
 
   def default_vaccinate_form
-    pre_screening =
+    today_pre_screenings =
       patient_session
         .pre_screenings
         .joins(:session_date)
         .merge(SessionDate.today)
         .order(created_at: :desc)
-        .first
+
+    feeling_well = today_pre_screenings.any?(&:feeling_well) || nil
+    not_pregnant = today_pre_screenings.any?(&:not_pregnant) || nil
 
     VaccinateForm.new(
       patient_session:,
       programme:,
-      feeling_well: pre_screening&.feeling_well,
-      not_pregnant: pre_screening&.not_pregnant
+      feeling_well:,
+      not_pregnant:
     )
   end
 end


### PR DESCRIPTION
Update pre-screening initialisation logic to retrieve the most recent answer for each question from the same day, instead of only using the last pre-screening performed. This ensures that relevant answers are translated across pre-screenings, even if a specific vaccine does not have a particular question.