### PR TITLE
Remove "Report" action required

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -80,13 +80,18 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
   def action_required
     return unless %i[register record].include?(context)
 
+    next_activities =
+      patient_session.programmes.filter_map do |programme|
+        status = patient_session.next_activity(programme:)
+        next if status.nil?
+
+        "#{I18n.t(status, scope: :activity)} for #{programme.name}"
+      end
+
+    return if next_activities.empty?
+
     tag.ul(class: "nhsuk-list nhsuk-list--bullet") do
-      safe_join(
-        patient_session.programmes.map do |programme|
-          status = patient_session.next_activity(programme:)
-          tag.li("#{I18n.t(status, scope: :activity)} for #{programme.name}")
-        end
-      )
+      safe_join(next_activities.map { tag.li(it) })
     end
   end
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -189,7 +189,7 @@ class PatientSession < ApplicationRecord
   end
 
   def next_activity(programme:)
-    return :report if patient.vaccination_status(programme:).vaccinated?
+    return nil if patient.vaccination_status(programme:).vaccinated?
 
     return :record if patient.consent_given_and_safe_to_vaccinate?(programme:)
 

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -97,7 +97,7 @@ describe "MenACWY and Td/IPV vaccination" do
     )
 
     click_on "Record vaccinations"
-    expect(page).to have_content("Report for MenACWY")
+    expect(page).not_to have_content("for MenACWY")
     expect(page).to have_content("Record vaccination for Td/IPV")
 
     click_link @patient.full_name

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -123,7 +123,7 @@ describe PatientSession do
         create(:patient_vaccination_status, :vaccinated, patient:, programme:)
       end
 
-      it { should be(:report) }
+      it { should be_nil }
     end
 
     context "with an un-administered vaccination record" do


### PR DESCRIPTION
Previously when vaccination a patient's next action status would show as "Report for [programme]". We don't currently have a mechanism for reporting and in the future it's likely to be automated anyway, so we can remove this and instead show nothing to make it clear that no action is required.

## Screenshots

<img width="782" alt="Screenshot 2025-04-22 at 19 48 08" src="https://github.com/user-attachments/assets/d5540fb3-cd60-426e-ad58-cb75c6169b7e" />
<img width="789" alt="Screenshot 2025-04-22 at 19 48 04" src="https://github.com/user-attachments/assets/c2aad25e-9b3c-4b7a-bf20-c3a731f753b6" />
