### PR TITLE
Remove pregnancy pre-screening for HPV

### DIFF
--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -69,13 +69,9 @@ class VaccinateForm
     draft_vaccination_record.save # rubocop:disable Rails/SaveBang
   end
 
-  def ask_not_taking_medication?
-    programme.doubles?
-  end
+  def ask_not_taking_medication? = programme.doubles?
 
-  def ask_not_pregnant?
-    programme.hpv? || programme.td_ipv?
-  end
+  def ask_not_pregnant? = programme.td_ipv?
 
   private
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -240,7 +240,6 @@ describe "End-to-end journey" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -98,7 +98,6 @@ describe "HPV vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -52,7 +52,6 @@ describe "HPV vaccination" do
     check "know what the vaccination is for, and are happy to have it"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     choose "No"
     click_button "Continue"

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -68,7 +68,6 @@ describe "HPV vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     # vaccination
     choose "Yes"

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -59,7 +59,6 @@ describe "HPV vaccination" do
     check "know what the vaccination is for, and are happy to have it"
     check "have not already had the vaccination"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     # vaccination
     choose "No"

--- a/spec/features/hpv_vaccination_pre_screening_spec.rb
+++ b/spec/features/hpv_vaccination_pre_screening_spec.rb
@@ -43,7 +43,6 @@ describe "HPV vaccination" do
     check "know what the vaccination is for, and are happy to have it"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
   end
 
   def and_i_choose_that_the_patient_is_ready_to_vaccinate

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -71,7 +71,6 @@ describe "Vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     # vaccination
     choose "Yes"
@@ -108,7 +107,6 @@ describe "Vaccination" do
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
-    check "are not pregnant"
 
     # vaccination
     choose "Yes"


### PR DESCRIPTION
The question is not required for clinical decisions. It’s a legacy question from when it was contraindicated to receive. There is no rationale to have it there.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-976)

## Screenshot

<img width="849" alt="Screenshot 2025-04-23 at 08 44 54" src="https://github.com/user-attachments/assets/778f794a-0162-4d61-90f3-73e8eabda862" />
