### PR TITLE
Avoid crash when editing response method

### DIFF
--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -14,8 +14,8 @@
 <%= render AppCardComponent.new do |card| %>
   <% card.with_heading { "Consent" } %>
   <%= render AppConsentSummaryComponent.new(@draft_consent, change_links: {
-                                                              response: wizard_path(:agree),
-                                                              route: wizard_path(:route),
+                                                              response: wizard_path("agree"),
+                                                              route: wizard_path(@draft_consent.via_self_consent? ? "who" : "route"),
                                                             }) %>
 <% end %>
 

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -199,6 +199,10 @@ describe "Self-consent" do
     click_on "Continue"
 
     # confirmation page
+    click_on "Change response method"
+    choose "Child (Gillick competent)"
+    5.times { click_on "Continue" }
+
     click_on "Confirm"
 
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")


### PR DESCRIPTION
When submitting self-consent via Gillick assessment, we should be able to change the response method without the service displaying an error page.

At the moment, this takes the user back through the entire flow, but this is the case for all the other change links so I think that should be fixed in a further enhancement. Also, going back through the entire journey is currently the only way to change whether the parents should be notified or not so some design work is needed as well.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-966)