### PR TITLE
Add missing length validations

### DIFF
--- a/app/forms/batch_form.rb
+++ b/app/forms/batch_form.rb
@@ -9,7 +9,15 @@ class BatchForm
   attribute :name, :string
   attribute :expiry, :date
 
-  validates :name, presence: true, format: { with: /\A[A-Za-z0-9]+\z/ }
+  validates :name,
+            presence: true,
+            format: {
+              with: /\A[A-Za-z0-9]+\z/
+            },
+            length: {
+              minimum: 2,
+              maximum: 100
+            }
 
   validates :expiry,
             comparison: {

--- a/app/models/batch.rb
+++ b/app/models/batch.rb
@@ -42,7 +42,15 @@ class Batch < ApplicationRecord
   scope :not_expired,
         -> { where.not(expiry: nil).where("expiry > ?", Time.current) }
 
-  validates :name, presence: true, format: { with: /\A[A-Za-z0-9]+\z/ }
+  validates :name,
+            presence: true,
+            format: {
+              with: /\A[A-Za-z0-9]+\z/
+            },
+            length: {
+              minimum: 2,
+              maximum: 100
+            }
 
   validates :expiry,
             uniqueness: {

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -54,6 +54,8 @@ class GillickAssessment < ApplicationRecord
               in: [true, false]
             }
 
+  validates :notes, length: { maximum: 1000 }
+
   def gillick_competent?
     knows_consequences && knows_delivery && knows_disease &&
       knows_side_effects && knows_vaccination

--- a/app/models/pre_screening.rb
+++ b/app/models/pre_screening.rb
@@ -46,4 +46,6 @@ class PreScreening < ApplicationRecord
   has_one :patient, through: :patient_session
 
   encrypts :notes
+
+  validates :notes, length: { maximum: 1000 }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
             name:
               blank: Enter a batch
               invalid: Enter a batch with only letters and numbers
+              too_short: Enter a batch that is more than %{count} characters long
+              too_long: Enter a batch that is less than %{count} characters long
         draft_class_import:
           attributes:
             session_id:
@@ -335,6 +337,8 @@ en:
               inclusion: Choose whether the child knows how the injection will be given
             knows_side_effects:
               inclusion: Choose whether the child knows which side effects they might experience
+            notes:
+              too_long: Enter notes that are less than %{count} characters long
         immunisation_import:
           attributes:
             csv:
@@ -361,6 +365,10 @@ en:
             nhs_number:
               invalid: Enter a valid NHS number
               taken: NHS number is already assigned to a different patient
+        pre_screening:
+          attributes:
+            notes:
+              too_long: Enter notes that are less than %{count} characters long
         programme:
           attributes:
             type:

--- a/spec/forms/batch_form_spec.rb
+++ b/spec/forms/batch_form_spec.rb
@@ -4,7 +4,9 @@ describe BatchForm do
   subject(:form) { described_class.new }
 
   describe "validations" do
+    it { should validate_length_of(:name).is_at_least(2).is_at_most(100) }
     it { should validate_presence_of(:name) }
+
     it { should validate_presence_of(:expiry) }
 
     it do

--- a/spec/models/batch_spec.rb
+++ b/spec/models/batch_spec.rb
@@ -49,6 +49,7 @@ describe Batch do
     it { should be_valid }
 
     it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_least(2).is_at_most(100) }
 
     it do
       expect(batch).to validate_uniqueness_of(:expiry).scoped_to(

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -39,6 +39,10 @@
 #
 
 describe Consent do
+  describe "validations" do
+    it { should validate_length_of(:notes).is_at_most(1000) }
+  end
+
   describe "when consent given by parent or guardian, all health questions are no" do
     it "does not require triage" do
       response = build(:consent, :given)

--- a/spec/models/gillick_assessment_spec.rb
+++ b/spec/models/gillick_assessment_spec.rb
@@ -38,7 +38,9 @@ describe GillickAssessment do
     it { should allow_values(true, false).for(:knows_disease) }
     it { should allow_values(true, false).for(:knows_side_effects) }
     it { should allow_values(true, false).for(:knows_vaccination) }
+
     it { should_not validate_presence_of(:notes) }
+    it { should validate_length_of(:notes).is_at_most(1000) }
   end
 
   describe "#gillick_competent?" do

--- a/spec/models/pre_screening_spec.rb
+++ b/spec/models/pre_screening_spec.rb
@@ -43,6 +43,8 @@ describe PreScreening do
     it { should allow_values(true, false).for(:not_already_had) }
     it { should allow_values(true, false).for(:not_pregnant) }
     it { should allow_values(true, false).for(:not_taking_medication) }
+
     it { should_not validate_presence_of(:notes) }
+    it { should validate_length_of(:notes).is_at_most(1000) }
   end
 end


### PR DESCRIPTION
This adds a number of length validations to fields where the user inputs a value directly. I looked over the models and found only a few places where we were missing appropriate length validation.

This will be followed up with a PR which adds similar validations to the import process, as currently we don't validate the length of any of the fields coming from an import.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-955)