### PR TITLE
Don't show today's date in session reminder

### DIFF
--- a/app/components/app_programme_session_table_component.html.erb
+++ b/app/components/app_programme_session_table_component.html.erb
@@ -37,9 +37,9 @@
                   Last session completed <%= session.dates.max&.to_fs(:long) %>
                 <% else %>
                   <% if session.started? %>
-                    Next session starts <%= session.next_date.to_fs(:long) %>
+                    Next session starts <%= session.next_date(include_today: true).to_fs(:long) %>
                   <% else %>
-                    First session starts <%= session.next_date.to_fs(:long) %>
+                    First session starts <%= session.next_date(include_today: true).to_fs(:long) %>
                   <% end %>
 
                   <br />

--- a/app/controllers/sessions/invite_to_clinic_controller.rb
+++ b/app/controllers/sessions/invite_to_clinic_controller.rb
@@ -48,7 +48,7 @@ class Sessions::InviteToClinicController < ApplicationController
   end
 
   def set_invitations_to_send
-    session_date = @generic_clinic_session.next_date
+    session_date = @generic_clinic_session.next_date(include_today: true)
 
     @invitations_to_send =
       if @session.school?

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -8,7 +8,7 @@ class SendClinicInitialInvitationsJob < ApplicationJob
   def perform(session, school:, programmes:)
     raise InvalidLocation unless session.clinic?
 
-    session_date = session.next_date
+    session_date = session.next_date(include_today: true)
     raise NoSessionDates if session_date.nil?
 
     patient_sessions(

--- a/app/jobs/send_clinic_subsequent_invitations_job.rb
+++ b/app/jobs/send_clinic_subsequent_invitations_job.rb
@@ -8,7 +8,7 @@ class SendClinicSubsequentInvitationsJob < ApplicationJob
   def perform(session)
     raise InvalidLocation unless session.clinic?
 
-    session_date = session.next_date
+    session_date = session.next_date(include_today: true)
     raise NoSessionDates if session_date.nil?
 
     patient_sessions(session, session_date:).each do |patient_session|

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -138,19 +138,16 @@ class GovukNotifyPersonalisation
   end
 
   def next_session_date
-    session.next_date&.to_fs(:short_day_of_week)
+    session.next_date(include_today: false)&.to_fs(:short_day_of_week)
   end
 
   def next_session_dates
-    session
-      .today_or_future_dates
-      .map { _1.to_fs(:short_day_of_week) }
-      .to_sentence
+    session.future_dates.map { it.to_fs(:short_day_of_week) }.to_sentence
   end
 
   def next_session_dates_or
     session
-      .today_or_future_dates
+      .future_dates
       .map { _1.to_fs(:short_day_of_week) }
       .to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -163,15 +163,15 @@ class Session < ApplicationRecord
   end
 
   def today_or_future_dates
-    dates.select { _1.today? || _1.future? }
+    dates.select { it.today? || it.future? }
   end
 
   def future_dates
     dates.select(&:future?)
   end
 
-  def next_date
-    today_or_future_dates.first
+  def next_date(include_today:)
+    (include_today ? today_or_future_dates : future_dates).first
   end
 
   def can_change_notification_dates?
@@ -180,9 +180,10 @@ class Session < ApplicationRecord
 
   def can_send_clinic_invitations?
     if clinic?
-      next_date && !completed?
+      next_date(include_today: true) && !completed?
     else
-      completed? && organisation.generic_clinic_session.next_date
+      completed? &&
+        organisation.generic_clinic_session.next_date(include_today: true)
     end
   end
 

--- a/app/views/sessions/invite_to_clinic/edit.html.erb
+++ b/app/views/sessions/invite_to_clinic/edit.html.erb
@@ -29,7 +29,7 @@
   <% end %>
 <% end %>
 
-<p>The next clinic is on <%= @generic_clinic_session.next_date.to_fs(:long) %>.</p>
+<p>The next clinic is on <%= @generic_clinic_session.next_date(include_today: true).to_fs(:long) %>.</p>
 
 <% if @invitations_to_send == 0 %>
   <p><%= link_to "Return to session", session_path(@session) %></p>

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -77,6 +77,24 @@ describe GovukNotifyPersonalisation do
     )
   end
 
+  context "when the session is today" do
+    let(:session) do
+      create(
+        :session,
+        location:,
+        organisation:,
+        programmes:,
+        dates: [Date.current, Date.tomorrow]
+      )
+    end
+
+    it "doesn't show today's date" do
+      expect(to_h).to include(
+        next_session_date: Date.tomorrow.to_fs(:short_day_of_week)
+      )
+    end
+  end
+
   context "when patient is in Year 9" do
     let(:patient) do
       create(


### PR DESCRIPTION
This fixes the session reminder email to ensure that if there's a session date today and one tomorrow, we show tomorrow's date in the email and not today's date.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-944)