### PR TITLE
Upgrade DB version for QA and Test

### DIFF
--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -27,4 +27,4 @@ minimum_web_replicas = 2
 maximum_web_replicas = 4
 
 rds_engine_version     = "16.8"
-rds_maintenance_window = "thu:02:30-thu:03:00"
+rds_maintenance_window = "tue:02:30-tue:03:00"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -25,3 +25,6 @@ http_hosts = {
 appspec_bucket       = "nhse-mavis-appspec-bucket-qa"
 minimum_web_replicas = 2
 maximum_web_replicas = 4
+
+rds_engine_version     = "16.8"
+rds_maintenance_window = "thu:02:30-thu:03:00"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -20,3 +20,6 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "test.mavistesting.com"
 }
 appspec_bucket = "nhse-mavis-appspec-bucket-test"
+
+rds_engine_version     = "16.8"
+rds_maintenance_window = "thu:02:30-thu:03:00"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -22,4 +22,4 @@ http_hosts = {
 appspec_bucket = "nhse-mavis-appspec-bucket-test"
 
 rds_engine_version     = "16.8"
-rds_maintenance_window = "thu:02:30-thu:03:00"
+rds_maintenance_window = "tue:02:30-tue:03:00"

--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -34,19 +34,21 @@ resource "aws_db_subnet_group" "aurora_subnet_group" {
 }
 
 resource "aws_rds_cluster" "aurora_cluster" {
-  cluster_identifier          = var.resource_name.db_cluster
-  engine                      = "aurora-postgresql"
-  engine_mode                 = "provisioned"
-  engine_version              = "14.9"
-  database_name               = "manage_vaccinations"
-  master_username             = "postgres"
-  manage_master_user_password = var.db_secret_arn == null
-  storage_encrypted           = true
-  backup_retention_period     = var.backup_retention_period
-  skip_final_snapshot         = !local.is_production
-  db_subnet_group_name        = aws_db_subnet_group.aurora_subnet_group.name
-  vpc_security_group_ids      = [aws_security_group.rds_security_group.id]
-  deletion_protection         = true
+  cluster_identifier           = var.resource_name.db_cluster
+  engine                       = "aurora-postgresql"
+  engine_mode                  = "provisioned"
+  engine_version               = var.rds_engine_version
+  database_name                = "manage_vaccinations"
+  master_username              = "postgres"
+  manage_master_user_password  = var.db_secret_arn == null
+  storage_encrypted            = true
+  backup_retention_period      = var.backup_retention_period
+  skip_final_snapshot          = !local.is_production
+  db_subnet_group_name         = aws_db_subnet_group.aurora_subnet_group.name
+  vpc_security_group_ids       = [aws_security_group.rds_security_group.id]
+  deletion_protection          = true
+  allow_major_version_upgrade  = true
+  preferred_maintenance_window = var.rds_maintenance_window
 
   serverlessv2_scaling_configuration {
     max_capacity = var.max_aurora_capacity_units

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -229,7 +229,19 @@ variable "backup_retention_period" {
   description = "The number of days to retain backups for the RDS cluster."
 }
 
-########## ESC/Scaling Configuration ##########
+variable "rds_engine_version" {
+  type        = string
+  default     = "14.9"
+  description = "The version of the database engine to use for the RDS cluster."
+}
+
+variable "rds_maintenance_window" {
+  type        = string
+  default     = "sun:02:30-sun:03:00"
+  description = "The preferred maintenance window for the RDS cluster."
+}
+
+########## ECS/Scaling Configuration ##########
 
 variable "minimum_web_replicas" {
   type        = number


### PR DESCRIPTION
* Update QA and Test to use the latest available DB engine version, 16.8.
* The upgrade will be applied during the next maintenance window
* Also change maintenance window for sooner execution