### PR TITLE
Small validation improvements to SystmOne import

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -297,15 +297,17 @@ class ImmunisationImportRow
       end
   end
 
+  def vaccine_nivs_name
+    parsed_vaccination_description_string&.dig(:vaccine_name) ||
+      vaccine_name&.to_s
+  end
+
   def vaccine
     @vaccine ||=
-      begin
-        nivs_name =
-          parsed_vaccination_description_string&.dig(:vaccine_name) ||
-            vaccine_name&.to_s
-
-        organisation.vaccines.includes(:programme).find_by(nivs_name:)
-      end
+      organisation
+        .vaccines
+        .includes(:programme)
+        .find_by(nivs_name: vaccine_nivs_name)
   end
 
   def batch
@@ -956,7 +958,7 @@ class ImmunisationImportRow
           "is not given in the #{programme.name} programme"
         )
       end
-    elsif field.present?
+    elsif vaccine_nivs_name.present?
       errors.add(field.header, "This vaccine is not available in this session.")
     end
   end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -333,10 +333,7 @@ class ImmunisationImportRow
         end
   end
 
-  delegate :default_dose_sequence,
-           :maximum_dose_sequence,
-           to: :programme,
-           allow_nil: true
+  delegate :default_dose_sequence, :maximum_dose_sequence, to: :programme
 
   def offline_recording? = session_id.present?
 
@@ -613,6 +610,8 @@ class ImmunisationImportRow
   end
 
   def validate_dose_sequence
+    return if programme.nil?
+
     field = dose_sequence.presence || combined_vaccination_and_dose_sequence
 
     if field.present?

--- a/spec/fixtures/immunisation_import/systm_one.csv
+++ b/spec/fixtures/immunisation_import/systm_one.csv
@@ -1,2 +1,3 @@
 Date of birth,NHS number,Vaccination area code,Vaccination batch number,Vaccination reason,Vaccination type,First name,Postcode,Sex,Surname,Event date,Event location type,Event time,Organisation ID,School,School code,Patient Count
 20100912,7420180008,,123013325,,Cervarix 1,Chyna,LE3 2DA,Female,Pickle,20240514,School,,,Eton College,110158,
+20100913,,,123013325,,HPV,Renie,LE1 2DA,Female,Parrish,20240514,School,,,Eton College,110158,

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -182,6 +182,12 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "without a vaccine" do
+      let(:data) { valid_data.except("VACCINE_GIVEN") }
+
+      it { should be_valid }
+    end
+
     context "with an invalid reason not vaccinated" do
       let(:data) do
         { "VACCINATED" => "N", "REASON_NOT_VACCINATED" => "unknown" }
@@ -833,6 +839,18 @@ describe ImmunisationImportRow do
         expect(vaccination_record.performed_at).to eq(
           Time.new(2024, 1, 1, 10, 30, 0, "+00:00")
         )
+      end
+    end
+
+    context "without a vaccine" do
+      let(:data) { valid_data.except("VACCINE_GIVEN") }
+
+      it "doesn't set a vaccine" do
+        expect(vaccination_record.vaccine).to be_nil
+      end
+
+      it "does set a programme" do
+        expect(vaccination_record.programme).not_to be_nil
       end
     end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1041,6 +1041,26 @@ describe ImmunisationImportRow do
         it { expect(immunisation_import_row).to be_invalid }
       end
 
+      context "with an invalid value and no programme" do
+        let(:programmes) { [create(:programme, :hpv)] }
+
+        let(:data) do
+          valid_data.merge(
+            "PROGRAMME" => "Unknown",
+            "VACCINE_GIVEN" => "Unknown",
+            "DOSE_SEQUENCE" => "abc"
+          )
+        end
+
+        it "has errors about the programme but not the dose sequence" do
+          expect(immunisation_import_row).to be_invalid
+          expect(immunisation_import_row.errors["PROGRAMME"]).to eq(
+            ["This programme is not available in this session."]
+          )
+          expect(immunisation_import_row.errors["DOSE_SEQUENCE"]).to be_empty
+        end
+      end
+
       context "with a valid value" do
         let(:programmes) { [create(:programme, :hpv)] }
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -250,8 +250,8 @@ describe ImmunisationImport do
         # stree-ignore
         expect { process! }
           .to change(immunisation_import, :processed_at).from(nil)
-          .and change(immunisation_import.vaccination_records, :count).by(1)
-          .and change(immunisation_import.patients, :count).by(1)
+          .and change(immunisation_import.vaccination_records, :count).by(2)
+          .and change(immunisation_import.patients, :count).by(2)
           .and change(immunisation_import.batches, :count).by(1)
           .and not_change(immunisation_import.patient_sessions, :count)
 


### PR DESCRIPTION
This makes a number of small fixes to the SystmOne import to ensure users can upload files without vaccines and to hide dose sequence validation if a programme isn't present.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1046)