### PR TITLE
Create configuration for data replication

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -1,0 +1,186 @@
+name: Data replication pipeline
+run-name: ${{ inputs.action }} data replication resources for ${{ inputs.environment }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        type: choice
+        options:
+          - training
+          - production
+          - test
+          - qa
+          - sandbox-alpha
+          - sandbox-beta
+      image_tag:
+        description: Docker image tag to deploy
+        required: false
+        type: string
+      action:
+        description: Action to perform on data replication env
+        required: true
+        type: choice
+        options:
+          - Destroy
+          - Recreate
+        default: Recreate
+
+env:
+  aws_role: ${{ inputs.environment == 'production'
+    && 'arn:aws:iam::820242920762:role/GithubDeployDataReplicationInfrastructure'
+    || 'arn:aws:iam::393416225559:role/GithubDeployDataReplicationInfrastructure' }}
+
+defaults:
+  run:
+    working-directory: terraform/data_replication
+
+concurrency:
+  group: deploy-data-replica-${{ inputs.environment }}
+
+jobs:
+  prepare:
+    name: Prepare data replica
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
+      - name: get latest snapshot
+        id: get-latest-snapshot
+        run: |
+          set -e
+          SNAPSHOT_ARN=$(aws rds describe-db-cluster-snapshots \
+          --query 'DBClusterSnapshots[?contains(DBClusterSnapshotIdentifier, `${{ inputs.environment}}`)].[DBClusterSnapshotArn, SnapshotCreateTime]' \
+          --output text | sort -k2 -r | head -n 1 | cut -f1)
+          echo "SNAPSHOT_ARN=$SNAPSHOT_ARN" >> $GITHUB_OUTPUT
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+      - name: Get db secret arn
+        id: get-db-secret-arn
+        working-directory: terraform/app
+        run: |
+          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
+          DB_SECRET_ARN=$(terraform output --raw db_secret_arn)
+          echo "DB_SECRET_ARN=$DB_SECRET_ARN" >> $GITHUB_OUTPUT
+      - name: ECR login
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Get docker image digest
+        id: get-docker-image-digest
+        run: |
+          set -e
+          DOCKER_IMAGE="${{ steps.login-ecr.outputs.registry }}/mavis/webapp:${{ inputs.image_tag || github.sha }}"
+          docker pull "$DOCKER_IMAGE"
+          DOCKER_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "$DOCKER_IMAGE")
+          DIGEST="${DOCKER_DIGEST#*@}"
+          echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
+    outputs:
+      SNAPSHOT_ARN: ${{ steps.get-latest-snapshot.outputs.SNAPSHOT_ARN }}
+      DB_SECRET_ARN: ${{ steps.get-db-secret-arn.outputs.DB_SECRET_ARN }}
+      DOCKER_DIGEST: ${{ steps.get-docker-image-digest.outputs.DIGEST }}
+
+  destroy:
+    name: Destroy data replication infrastructure
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+      - name: Terraform Destroy
+        id: destroy
+        run: |
+          set -e
+          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
+          terraform destroy -var-file="env/${{ inputs.environment }}.tfvars" -var="image_digest=filler_value" \
+          -var="db_secret_arn=filler_value" -var="imported_snapshot=filler_value" -auto-approve
+
+  plan:
+    if: ${{ inputs.action == 'Recreate' }}
+    name: Terraform plan
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - destroy
+    env:
+      SNAPSHOT_ARN: ${{ needs.prepare.outputs.SNAPSHOT_ARN }}
+      DB_SECRET_ARN: ${{ needs.prepare.outputs.DB_SECRET_ARN }}
+      DOCKER_DIGEST: ${{ needs.prepare.outputs.DOCKER_DIGEST }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+      - name: Terraform Plan
+        id: plan
+        run: |
+          set -e
+          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
+          terraform plan -var="image_digest=${{ env.DOCKER_DIGEST }}" -var="db_secret_arn=${{ env.DB_SECRET_ARN }}" \
+          -var="imported_snapshot=${{ env.SNAPSHOT_ARN }}" -var-file="env/${{ inputs.environment }}.tfvars" \
+          -out ${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tfplan_infrastructure-${{ inputs.environment }}
+          path: ${{ runner.temp }}/tfplan
+
+  apply:
+    name: Terraform apply
+    runs-on: ubuntu-latest
+    needs: plan
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tfplan_infrastructure-${{ inputs.environment }}
+          path: ${{ runner.temp }}
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.10.5
+      - name: Apply the changes
+        run: |
+          set -e
+          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
+          terraform apply ${{ runner.temp }}/tfplan

--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -27,6 +27,10 @@ on:
           - Destroy
           - Recreate
         default: Recreate
+      db_snapshot_arn:
+        description: ARN of the DB snapshot to use (optional)
+        required: false
+        type: string
 
 env:
   aws_role: ${{ inputs.environment == 'production'
@@ -58,9 +62,15 @@ jobs:
         id: get-latest-snapshot
         run: |
           set -e
-          SNAPSHOT_ARN=$(aws rds describe-db-cluster-snapshots \
-          --query 'DBClusterSnapshots[?contains(DBClusterSnapshotIdentifier, `${{ inputs.environment}}`)].[DBClusterSnapshotArn, SnapshotCreateTime]' \
-          --output text | sort -k2 -r | head -n 1 | cut -f1)
+          if [ -z "${{ inputs.db_snapshot_arn }}" ]; then
+              echo "No snapshot ARN provided, fetching the latest snapshot"
+              SNAPSHOT_ARN=$(aws rds describe-db-cluster-snapshots \
+              --query 'DBClusterSnapshots[?contains(DBClusterSnapshotIdentifier, `${{ inputs.environment}}`)].[DBClusterSnapshotArn, SnapshotCreateTime]' \
+              --output text | sort -k2 -r | head -n 1 | cut -f1)
+          else
+              echo "Using provided snapshot ARN: ${{ inputs.db_snapshot_arn }}"
+              SNAPSHOT_ARN="${{ inputs.db_snapshot_arn }}"
+          fi
           echo "SNAPSHOT_ARN=$SNAPSHOT_ARN" >> $GITHUB_OUTPUT
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3

--- a/bin/docker-start
+++ b/bin/docker-start
@@ -8,7 +8,10 @@ if [ "$SERVER_TYPE" == "web" ]; then
 elif [ "$SERVER_TYPE" == "good-job" ]; then
   echo "Starting good-job server..."
   exec "$BIN_DIR"/good_job start
+elif [ "$SERVER_TYPE" == "none" ]; then
+  echo "No server started"
+  exec tail -f /dev/null  # Keep container running
 else
-  echo "SERVER_TYPE variable: '$SERVER_TYPE' unknown. Allowed values ['web','good-job']"
+  echo "SERVER_TYPE variable: '$SERVER_TYPE' unknown. Allowed values ['web','good-job', 'none']"
   exit 1
 fi

--- a/terraform/app/modules/ecs_service/autoscaling.tf
+++ b/terraform/app/modules/ecs_service/autoscaling.tf
@@ -10,7 +10,7 @@ resource "aws_appautoscaling_target" "this" {
 
 resource "aws_appautoscaling_policy" "this" {
   for_each           = local.autoscaling_enabled ? var.autoscaling_policies : {}
-  name               = "${var.server_type}-${each.key}-scaling-${var.environment}"
+  name               = "${local.server_type_name}-${each.key}-scaling-${var.environment}"
   policy_type        = "TargetTrackingScaling"
   resource_id        = aws_appautoscaling_target.this[0].resource_id
   scalable_dimension = aws_appautoscaling_target.this[0].scalable_dimension

--- a/terraform/app/modules/ecs_service/main.tf
+++ b/terraform/app/modules/ecs_service/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "aws_security_group" "this" {
-  name        = "${var.server_type}-service-${var.environment}"
+  name        = "${local.server_type_name}-service-${var.environment}"
   description = "Security Group for communication with ECS Service"
   vpc_id      = var.network_params.vpc_id
   lifecycle {
@@ -27,7 +27,7 @@ resource "aws_security_group_rule" "egress_all" {
 }
 
 resource "aws_ecs_service" "this" {
-  name                              = "${var.naming_prefix}${var.environment}-${var.server_type}"
+  name                              = "mavis-${var.environment}-${local.server_type_name}"
   cluster                           = var.cluster_id
   task_definition                   = aws_ecs_task_definition.this.arn
   desired_count                     = var.minimum_replica_count
@@ -70,7 +70,7 @@ resource "aws_ecs_service" "this" {
 }
 
 resource "aws_ecs_task_definition" "this" {
-  family                   = "${var.naming_prefix}${var.server_type}-task-definition-${var.environment}"
+  family                   = "mavis-${local.server_type_name}-task-definition-${var.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = var.task_config.cpu
@@ -95,7 +95,7 @@ resource "aws_ecs_task_definition" "this" {
         options = {
           awslogs-group         = var.task_config.log_group_name
           awslogs-region        = var.task_config.region
-          awslogs-stream-prefix = "${var.environment}-${var.server_type}-logs"
+          awslogs-stream-prefix = "${var.environment}-${local.server_type_name}-logs"
         }
       }
       healthCheck = {

--- a/terraform/app/modules/ecs_service/main.tf
+++ b/terraform/app/modules/ecs_service/main.tf
@@ -27,7 +27,7 @@ resource "aws_security_group_rule" "egress_all" {
 }
 
 resource "aws_ecs_service" "this" {
-  name                              = "mavis-${var.environment}-${var.server_type}"
+  name                              = "${var.naming_prefix}${var.environment}-${var.server_type}"
   cluster                           = var.cluster_id
   task_definition                   = aws_ecs_task_definition.this.arn
   desired_count                     = var.minimum_replica_count
@@ -70,7 +70,7 @@ resource "aws_ecs_service" "this" {
 }
 
 resource "aws_ecs_task_definition" "this" {
-  family                   = "mavis-${var.server_type}-task-definition-${var.environment}"
+  family                   = "${var.naming_prefix}${var.server_type}-task-definition-${var.environment}"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = var.task_config.cpu

--- a/terraform/app/modules/ecs_service/variables.tf
+++ b/terraform/app/modules/ecs_service/variables.tf
@@ -26,6 +26,13 @@ variable "maximum_replica_count" {
   }
 }
 
+variable "naming_prefix" {
+  type        = string
+  description = "Prefix to be used for naming the ECS service and task definition"
+  default     = "mavis-"
+  nullable    = false
+}
+
 variable "autoscaling_policies" {
   type = map(object({
     predefined_metric_type = string

--- a/terraform/app/modules/ecs_service/variables.tf
+++ b/terraform/app/modules/ecs_service/variables.tf
@@ -6,8 +6,15 @@ variable "environment" {
 
 variable "server_type" {
   type        = string
-  description = "Type of server to be deployed. This is set as an environment variable in the main container, and is used to determine how the application is launched"
+  description = "Type of server to be deployed. This is set as an environment variable in the main container, and is used to determine how the application is launched."
   nullable    = false
+}
+
+variable "server_type_name" {
+  type        = string
+  description = "Name of the server type to be deployed."
+  default     = null
+  nullable    = true
 }
 
 variable "minimum_replica_count" {
@@ -24,13 +31,6 @@ variable "maximum_replica_count" {
     condition     = var.maximum_replica_count >= var.minimum_replica_count
     error_message = "Maximum replica count must be greater than initial replica count when autoscaling policies are defined and null otherwise"
   }
-}
-
-variable "naming_prefix" {
-  type        = string
-  description = "Prefix to be used for naming the ECS service and task definition"
-  default     = "mavis-"
-  nullable    = false
 }
 
 variable "autoscaling_policies" {
@@ -116,4 +116,5 @@ variable "container_name" {
 
 locals {
   autoscaling_enabled = var.maximum_replica_count > var.minimum_replica_count
+  server_type_name    = var.server_type_name != null ? var.server_type_name : var.server_type
 }

--- a/terraform/data_replication/README.md
+++ b/terraform/data_replication/README.md
@@ -1,0 +1,32 @@
+# Data replication module
+
+## Overview
+
+This module can be used to verify data migration tasks on a copy of actual production data before running them on production.
+
+It creates
+
+- A replication of a given database based on a provided snapshot
+- A dedicated ECS service connected to the database
+
+## Setup
+
+This module is managed via a GitHub Actions workflow. To separate it from the rest of the infrastructure, the workflow uses a dedicated IAM role. To set up everything from scratch, manually create the role
+`GithubDeployDataReplicationInfrastructure` based on the policy template `github_data_replication_actions_policy.json` and the trust policy `github_role_<ENVIRONMENT>_trust_policy.json`.
+
+## Usage
+
+### Manage the database replication infrastructure
+
+To create the infrastructure, run the `data-replication-pipeline.yml` workflow and select the 'Recreate' option.
+This will destroy any existing replication infrastructure and create a new replicated database from the latest snapshot.
+
+To destroy the resources, run the `data-replication-pipeline.yml` with the 'Destroy' option.
+
+### Connect to the dedicated ECS task
+
+To connect to the dedicated ECS task, run
+
+```
+./script/shell.sh <ENV>-data-replication
+```

--- a/terraform/data_replication/ecs.tf
+++ b/terraform/data_replication/ecs.tf
@@ -1,0 +1,44 @@
+
+resource "aws_ecs_cluster" "cluster" {
+  name = local.name_prefix
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_log_group" {
+  name              = "${local.name_prefix}-ecs"
+  retention_in_days = 1
+  skip_destroy      = false
+}
+
+
+module "db_access_service" {
+  source                = "../app/modules/ecs_service"
+  cluster_id            = aws_ecs_cluster.cluster.id
+  cluster_name          = aws_ecs_cluster.cluster.name
+  environment           = var.environment
+  naming_prefix         = "mavis-data-replication-"
+  maximum_replica_count = 1
+  minimum_replica_count = 1
+  network_params = {
+    subnets = local.subnet_list
+    vpc_id  = aws_vpc.vpc.id
+  }
+  server_type = "good-job"
+  task_config = {
+    environment          = local.task_envs
+    secrets              = local.task_secrets
+    cpu                  = 1024
+    memory               = 2048
+    docker_image         = "${var.account_id}.dkr.ecr.eu-west-2.amazonaws.com/${var.docker_image}@${var.image_digest}"
+    execution_role_arn   = aws_iam_role.ecs_task_execution_role.arn
+    task_role_arn        = aws_iam_role.ecs_task_role.arn
+    log_group_name       = aws_cloudwatch_log_group.ecs_log_group.name
+    region               = var.region
+    health_check_command = ["CMD-SHELL", "curl -f http://localhost:4000 || exit 1"]
+  }
+  depends_on = [aws_rds_cluster_instance.instance]
+}

--- a/terraform/data_replication/ecs.tf
+++ b/terraform/data_replication/ecs.tf
@@ -10,7 +10,7 @@ resource "aws_ecs_cluster" "cluster" {
 
 resource "aws_cloudwatch_log_group" "ecs_log_group" {
   name              = "${local.name_prefix}-ecs"
-  retention_in_days = 1
+  retention_in_days = 14
   skip_destroy      = false
 }
 
@@ -20,14 +20,14 @@ module "db_access_service" {
   cluster_id            = aws_ecs_cluster.cluster.id
   cluster_name          = aws_ecs_cluster.cluster.name
   environment           = var.environment
-  naming_prefix         = "mavis-data-replication-"
   maximum_replica_count = 1
   minimum_replica_count = 1
   network_params = {
     subnets = local.subnet_list
     vpc_id  = aws_vpc.vpc.id
   }
-  server_type = "good-job"
+  server_type      = "none"
+  server_type_name = "data-replication"
   task_config = {
     environment          = local.task_envs
     secrets              = local.task_secrets
@@ -38,7 +38,7 @@ module "db_access_service" {
     task_role_arn        = aws_iam_role.ecs_task_role.arn
     log_group_name       = aws_cloudwatch_log_group.ecs_log_group.name
     region               = var.region
-    health_check_command = ["CMD-SHELL", "curl -f http://localhost:4000 || exit 1"]
+    health_check_command = ["CMD-SHELL", "echo 'alive' || exit 1"]
   }
   depends_on = [aws_rds_cluster_instance.instance]
 }

--- a/terraform/data_replication/env/production-backend.hcl
+++ b/terraform/data_replication/env/production-backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "nhse-mavis-terraform-state-production"
+key            = "terraform-data-replication-production.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/data_replication/env/production.tfvars
+++ b/terraform/data_replication/env/production.tfvars
@@ -1,0 +1,4 @@
+environment               = "production"
+rails_env                 = "production"
+rails_master_key_path     = "/copilot/mavis/production/secrets/RAILS_MASTER_KEY"
+max_aurora_capacity_units = 16

--- a/terraform/data_replication/env/qa-backend.hcl
+++ b/terraform/data_replication/env/qa-backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "nhse-mavis-terraform-state"
+key            = "terraform-data-replication-qa.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/data_replication/env/qa.tfvars
+++ b/terraform/data_replication/env/qa.tfvars
@@ -1,0 +1,2 @@
+environment           = "qa"
+rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"

--- a/terraform/data_replication/env/sandbox-alpha-backend.hcl
+++ b/terraform/data_replication/env/sandbox-alpha-backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "nhse-mavis-terraform-state"
+key            = "terraform-data-replication-sandbox-alpha.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/data_replication/env/sandbox-alpha.tfvars
+++ b/terraform/data_replication/env/sandbox-alpha.tfvars
@@ -1,0 +1,2 @@
+environment           = "sandbox-alpha"
+rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"

--- a/terraform/data_replication/env/sandbox-beta-backend.hcl
+++ b/terraform/data_replication/env/sandbox-beta-backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "nhse-mavis-terraform-state"
+key            = "terraform-data-replication-sandbox-beta.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/data_replication/env/sandbox-beta.tfvars
+++ b/terraform/data_replication/env/sandbox-beta.tfvars
@@ -1,0 +1,2 @@
+environment           = "sandbox-beta"
+rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"

--- a/terraform/data_replication/env/test-backend.hcl
+++ b/terraform/data_replication/env/test-backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "nhse-mavis-terraform-state"
+key            = "terraform-data-replication-test.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/data_replication/env/test.tfvars
+++ b/terraform/data_replication/env/test.tfvars
@@ -1,0 +1,3 @@
+environment           = "test"
+rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
+db_engine_version     = "16.8"

--- a/terraform/data_replication/env/test.tfvars
+++ b/terraform/data_replication/env/test.tfvars
@@ -1,3 +1,2 @@
 environment           = "test"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
-db_engine_version     = "16.8"

--- a/terraform/data_replication/env/training-backend.hcl
+++ b/terraform/data_replication/env/training-backend.hcl
@@ -1,0 +1,4 @@
+bucket         = "nhse-mavis-terraform-state"
+key            = "terraform-data-replication-training.tfstate"
+region         = "eu-west-2"
+dynamodb_table = "mavis-terraform-state-lock"

--- a/terraform/data_replication/env/training.tfvars
+++ b/terraform/data_replication/env/training.tfvars
@@ -1,0 +1,2 @@
+environment           = "training"
+rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"

--- a/terraform/data_replication/iam.tf
+++ b/terraform/data_replication/iam.tf
@@ -1,0 +1,66 @@
+data "aws_iam_policy_document" "ecs_permissions" {
+  statement {
+    sid     = "railsKeySid"
+    actions = ["ssm:GetParameters"]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter${var.rails_master_key_path}"
+    ]
+    effect = "Allow"
+  }
+  statement {
+    sid     = "dbSecretSid"
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = [
+      var.db_secret_arn
+    ]
+    effect = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "shell_access" {
+  statement {
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+    resources = ["*"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_policy" "ecs_permissions" {
+  name   = "${local.name_prefix}-ecs-permissions"
+  policy = data.aws_iam_policy_document.ecs_permissions.json
+}
+
+resource "aws_iam_policy" "shell_access_policy" {
+  name   = "${local.name_prefix}-ecs-shell-access"
+  policy = data.aws_iam_policy_document.shell_access.json
+}
+
+resource "aws_iam_role" "ecs_task_execution_role" {
+  name               = "${local.name_prefix}-ecsTaskExecutionRole"
+  assume_role_policy = templatefile("../app/templates/iam_assume_role.json.tpl", { service_name = "ecs-tasks.amazonaws.com" })
+}
+
+resource "aws_iam_role" "ecs_task_role" {
+  name               = "${local.name_prefix}-ecsTaskRole"
+  assume_role_policy = templatefile("../app/templates/iam_assume_role.json.tpl", { service_name = "ecs-tasks.amazonaws.com" })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_permissinos" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.ecs_permissions.arn
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_ecr_and_log_permissions" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_fargate" {
+  role       = aws_iam_role.ecs_task_role.name
+  policy_arn = aws_iam_policy.shell_access_policy.arn
+}

--- a/terraform/data_replication/main.tf
+++ b/terraform/data_replication/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.10.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.95"
+    }
+  }
+
+  backend "s3" {
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  default_tags {
+    tags = {
+      Environment = local.name_prefix
+    }
+  }
+}

--- a/terraform/data_replication/network.tf
+++ b/terraform/data_replication/network.tf
@@ -1,0 +1,65 @@
+resource "aws_vpc" "vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_subnet" "subnet_a" {
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "${var.region}a"
+}
+
+resource "aws_subnet" "subnet_b" {
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = "${var.region}b"
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(local.subnet_list)
+  route_table_id = aws_route_table.private.id
+  subnet_id      = local.subnet_list[count.index]
+}
+
+locals {
+  vpc_endpoints = tomap(
+    {
+      ecr_api        = "com.amazonaws.${var.region}.ecr.api"
+      ecr_docker     = "com.amazonaws.${var.region}.ecr.dkr"
+      secretsmanager = "com.amazonaws.${var.region}.secretsmanager"
+      cloudwatch     = "com.amazonaws.${var.region}.logs"
+      ssm            = "com.amazonaws.${var.region}.ssm"
+      ssmmessages    = "com.amazonaws.${var.region}.ssmmessages"
+      rds            = "com.amazonaws.${var.region}.rds"
+    }
+  )
+}
+
+module "vpc_endpoints" {
+  for_each              = local.vpc_endpoints
+  source                = "../app/modules/vpc_endpoint"
+  service_name          = each.value
+  vpc_id                = aws_vpc.vpc.id
+  subnet_ids            = local.subnet_list
+  ingress_ports         = [443]
+  source_security_group = module.db_access_service.security_group_id
+
+  tags = {
+    Name = "${local.name_prefix}-${each.key}-endpoint"
+  }
+}
+
+resource "aws_vpc_endpoint" "s3_gateway" {
+  vpc_id            = aws_vpc.vpc.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+  tags = {
+    Name = "${local.name_prefix}-s3-gw-endpoint"
+  }
+}

--- a/terraform/data_replication/rds.tf
+++ b/terraform/data_replication/rds.tf
@@ -1,0 +1,47 @@
+resource "aws_db_subnet_group" "dbsg" {
+  name       = "${local.name_prefix}-subnet-group"
+  subnet_ids = [aws_subnet.subnet_a.id, aws_subnet.subnet_b.id]
+}
+
+resource "aws_security_group" "rds" {
+  vpc_id = aws_vpc.vpc.id
+}
+
+resource "aws_security_group_rule" "rds_inbound" {
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.rds.id
+  source_security_group_id = module.db_access_service.security_group_id
+}
+
+resource "aws_rds_cluster" "cluster" {
+  cluster_identifier     = "${local.name_prefix}-rds"
+  engine                 = "aurora-postgresql"
+  engine_mode            = "provisioned"
+  database_name          = "manage_vaccinations"
+  master_username        = "postgres"
+  snapshot_identifier    = var.imported_snapshot
+  db_subnet_group_name   = aws_db_subnet_group.dbsg.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  storage_encrypted      = true
+  skip_final_snapshot    = true
+  deletion_protection    = false
+  engine_version         = var.db_engine_version
+
+  serverlessv2_scaling_configuration {
+    max_capacity = var.max_aurora_capacity_units
+    min_capacity = 0.5
+  }
+}
+
+resource "aws_rds_cluster_instance" "instance" {
+  cluster_identifier   = aws_rds_cluster.cluster.id
+  identifier           = "${local.name_prefix}-rds-instance"
+  instance_class       = "db.serverless"
+  engine               = aws_rds_cluster.cluster.engine
+  engine_version       = aws_rds_cluster.cluster.engine_version
+  db_subnet_group_name = aws_db_subnet_group.dbsg.name
+  promotion_tier       = 1
+}

--- a/terraform/data_replication/variables.tf
+++ b/terraform/data_replication/variables.tf
@@ -20,7 +20,7 @@ variable "region" {
 
 variable "db_engine_version" {
   type        = string
-  default     = "14"
+  default     = "16.8"
   description = "The version of the database engine to use."
   nullable    = false
 }

--- a/terraform/data_replication/variables.tf
+++ b/terraform/data_replication/variables.tf
@@ -1,0 +1,127 @@
+variable "environment" {
+  type        = string
+  description = "String literal for the environment"
+  nullable    = false
+
+  validation {
+    condition = contains([
+      "sandbox-alpha", "sandbox-beta", "qa", "test", "training", "preview", "production"
+    ], var.environment)
+    error_message = "Valid values for environment: sandbox-alpha, sandbox-beta, qa, test, training, preview, production."
+  }
+}
+
+variable "region" {
+  type        = string
+  default     = "eu-west-2"
+  description = "AWS region"
+  nullable    = false
+}
+
+variable "db_engine_version" {
+  type        = string
+  default     = "14"
+  description = "The version of the database engine to use."
+  nullable    = false
+}
+
+variable "imported_snapshot" {
+  type        = string
+  description = "ARN of snapshot to create DB cluster from. This is the basis for replicating the existing DB."
+  nullable    = false
+}
+
+variable "max_aurora_capacity_units" {
+  type        = number
+  default     = 8
+  description = "Maximum amount of allowed ACU capacity for Aurora Serverless v2"
+}
+
+variable "db_secret_arn" {
+  type        = string
+  description = "The ARN of the secret that stores the credentials for the database from which the snapshot originates."
+  nullable    = false
+}
+
+variable "account_id" {
+  type        = string
+  default     = "393416225559"
+  description = "ID of aws account. Defaults to non-prod account."
+  nullable    = false
+}
+
+variable "docker_image" {
+  type        = string
+  default     = "mavis/webapp"
+  description = "The docker image name for the essential container in the task definition"
+  nullable    = false
+}
+
+variable "image_digest" {
+  type        = string
+  description = "The docker image digest for the essential container in the task definition."
+  nullable    = false
+}
+
+variable "rails_env" {
+  type        = string
+  default     = "staging"
+  description = "The rails environment configuration to use for the mavis application"
+  nullable    = false
+  validation {
+    condition     = contains(["staging", "production"], var.rails_env)
+    error_message = "Incorrect rails environment, allowed values are: {staging, production}"
+  }
+}
+
+variable "rails_master_key_path" {
+  type        = string
+  default     = "/mavis/staging/credentials/RAILS_MASTER_KEY"
+  description = "The path of the System Manager Parameter Store secure string for the rails master key."
+  nullable    = false
+}
+
+locals {
+  name_prefix = "mavis-${var.environment}-data-replication"
+  subnet_list = [aws_subnet.subnet_a.id, aws_subnet.subnet_b.id]
+  task_envs = [
+    {
+      name  = "DB_HOST"
+      value = aws_rds_cluster.cluster.endpoint
+    },
+    {
+      name  = "DB_NAME"
+      value = aws_rds_cluster.cluster.database_name
+    },
+    {
+      name  = "RAILS_ENV"
+      value = var.rails_env
+    },
+    {
+      name  = "SENTRY_ENVIRONMENT"
+      value = var.environment
+    },
+    {
+      name  = "MAVIS__CIS2__ENABLED"
+      value = "false"
+    },
+    {
+      name  = "MAVIS__SPLUNK__ENABLED"
+      value = "false"
+    },
+    {
+      name  = "MAVIS__PDS__ENQUEUE_BULK_UPDATES"
+      value = "false"
+    }
+  ]
+  task_secrets = [
+    {
+      name      = "DB_CREDENTIALS"
+      valueFrom = var.db_secret_arn
+    },
+    {
+      name      = "RAILS_MASTER_KEY"
+      valueFrom = var.rails_master_key_path
+    }
+  ]
+}

--- a/terraform/resources/github_data_replication_actions_policy.json
+++ b/terraform/resources/github_data_replication_actions_policy.json
@@ -1,0 +1,50 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Deny",
+      "Action": ["*"],
+      "Resource": "*",
+      "Condition": {
+        "ArnEquals": {
+          "ec2:Vpc": [
+            "arn:aws:ec2:eu-west-1:393416225559:vpc/vpc-029e1475034ab2fed",
+            "arn:aws:ec2:eu-west-1:393416225559:vpc/vpc-087d03fc1f439f7fd",
+            "arn:aws:ec2:eu-west-1:393416225559:vpc/vpc-0016fa51fbdfbf86e",
+            "arn:aws:ec2:eu-west-1:393416225559:vpc/vpc-038fc6883f3d93661",
+            "arn:aws:ec2:eu-west-1:820242920762:vpc/vpc-0abccf7c5d1538d12"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Deny",
+      "Action": ["*"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/Environment": [
+            "training",
+            "qa",
+            "test",
+            "preview",
+            "sandbox-alpha",
+            "sandbox-beta",
+            "production"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcEndpoints",
+        "ec2:CreateVpcEndpoint",
+        "ec2:ModifyVpcEndpoint",
+        "ec2:DeleteVpcEndpoints",
+        "rds:RestoreDBClusterFromSnapshot"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
- This produces a replicate DB with a single ECS task connected
- Useful for testing migrations/sql/etc on a production data without actually modifying the production system
- The replicate system is completely ignorant of source db/service
- The replicate DB will be spawned from a snapshot which is passed as a variable
- Some modification was done to the ecs module to ensure that task definitions are distinct