### PR TITLE
Allow programme vaccination types without dose sequence

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -614,7 +614,8 @@ class ImmunisationImportRow
 
     field = dose_sequence.presence || combined_vaccination_and_dose_sequence
 
-    if field.present?
+    if dose_sequence.present? ||
+         parsed_vaccination_description_string&.dig(:dose_sequence).present?
       if offline_recording? && default_dose_sequence.nil?
         errors.add(
           field.header,

--- a/spec/fixtures/immunisation_import/systm_one.csv
+++ b/spec/fixtures/immunisation_import/systm_one.csv
@@ -1,3 +1,4 @@
 Date of birth,NHS number,Vaccination area code,Vaccination batch number,Vaccination reason,Vaccination type,First name,Postcode,Sex,Surname,Event date,Event location type,Event time,Organisation ID,School,School code,Patient Count
 20100912,7420180008,,123013325,,Cervarix 1,Chyna,LE3 2DA,Female,Pickle,20240514,School,,,Eton College,110158,
 20100913,,,123013325,,HPV,Renie,LE1 2DA,Female,Parrish,20240514,School,,,Eton College,110158,
+20100914,4146825652,,"",,MenACWY,Caden,LE1 2DA,Male,Attwater,20240514,School,,,Eton College,110158,

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -99,7 +99,9 @@ describe ImmunisationImport do
     end
 
     context "with a SystmOne file" do
-      let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
+      let(:programmes) do
+        [create(:programme, :hpv_all_vaccines), create(:programme, :menacwy)]
+      end
       let(:file) { "systm_one.csv" }
 
       it "is invalid" do
@@ -240,7 +242,9 @@ describe ImmunisationImport do
     end
 
     context "with a SystmOne file format" do
-      let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
+      let(:programmes) do
+        [create(:programme, :hpv_all_vaccines), create(:programme, :menacwy)]
+      end
       let(:file) { "systm_one.csv" }
 
       before { Flipper.enable(:systm_one_import) }
@@ -250,8 +254,8 @@ describe ImmunisationImport do
         # stree-ignore
         expect { process! }
           .to change(immunisation_import, :processed_at).from(nil)
-          .and change(immunisation_import.vaccination_records, :count).by(2)
-          .and change(immunisation_import.patients, :count).by(2)
+          .and change(immunisation_import.vaccination_records, :count).by(3)
+          .and change(immunisation_import.patients, :count).by(3)
           .and change(immunisation_import.batches, :count).by(1)
           .and not_change(immunisation_import.patient_sessions, :count)
 


### PR DESCRIPTION
Dose sequence is optional for some vaccination types, notably MenACWY and Td/IPV. In the SystmOne file format, the programme is determined from the `Vaccination type` column.

This column contains is a single value containing a combination of the programme, vaccine and dose sequence. Therefore we can't check for the existence of this value to validate the dose sequence, instead we need to check for the presence of the dose sequence component of this value.

[Jira issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1046)