### PR TITLE
Remove brakeman from pre-commit and fail on changed files

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,4 +5,4 @@ awscli      2.13.31
 terraform   1.10.5
 tflint      0.55.1
 pkl         0.28.1
-hk          0.8.5
+hk          1.0.0

--- a/hk.pkl
+++ b/hk.pkl
@@ -35,13 +35,29 @@ local linters = new Mapping<String, Group> {
                 }
         }
     }
+    local steps_with_staged_fixes = (linters["all"].steps) {
+        for (key, value in linters["all"].steps) {
+            [key] = (value) {
+                stage = List("*")
+            }
+        }
+    }
+    ["pre-commit"] = new Group {
+        steps = steps_with_staged_fixes.toMap().remove("brakeman").toMapping()
+    }
 }
 
 hooks {
     ["pre-commit"] {
         fix = true
         stash = "patch-file"
-        steps = linters["all"].steps
+        steps = new Mapping<String, Step | Group> {
+            ["pre-commit"] = linters["pre-commit"]
+            ["check_staged"] = new Step {
+                check = "if git diff --staged --quiet; then echo 'No staged files aborting commit'; exit 1; fi"
+                exclusive = true
+            }
+        }
     }
     ["fix"] {
         fix = true

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,35 +1,39 @@
-amends "package://github.com/jdx/hk/releases/download/v0.8.5/hk@0.8.5#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v0.8.5/hk@0.8.5#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Builtins.pkl"
 
-local linters = new Mapping<String, Step> {
-    ["brakeman"] {
-        check = "bin/brakeman --quiet --no-summary --no-pager"
-    }
+local linters = new Mapping<String, Group> {
+    ["all"] = new Group {
+        steps = new Mapping<String, Step> {
+                ["prettier"] = new Step {
+                    check = "bin/prettier --check --ignore-unknown {{ files }}"
+                    fix = "bin/prettier --write --list-different --ignore-unknown {{ files }}"
+                }
 
-    ["prettier"] {
-        check = "bin/prettier --check --ignore-unknown {{ files }}"
-        fix = "bin/prettier --write --list-different --ignore-unknown {{ files }}"
-    }
+                ["rubocop"] = new Step {
+                    glob = List("**/*.rb")
+                    check = "bin/rubocop {{ files }}"
+                    fix = "bin/rubocop --fix {{ files }}"
+                }
 
-    ["rubocop"] {
-        glob = List("**/*.rb")
-        check = "bin/rubocop {{ files }}"
-        fix = "bin/rubocop --fix {{ files }}"
-    }
+                ["rufo"] = new Step {
+                    glob = List("**/*.erb")
+                    exclude = List("**/layouts/*")
+                    check = "bin/rufo --check {{ files }}"
+                    fix = "bin/rufo {{ files }}"
+                }
 
-    ["rufo"] {
-        glob = List("**/*.erb")
-        exclude = List("**/layouts/*")
-        check = "bin/rufo --check {{ files }}"
-        fix = "bin/rufo {{ files }}"
-    }
+                ["terraform"] = (Builtins.terraform) {
+                }
 
-    ["terraform"] = Builtins.terraform
-
-    ["tf_lint"] {
-        glob = List("**/*.tf")
-        check = "tflint --chdir=terraform --recursive"
-        fix = "tflint --chdir=terraform --recursive --fix"
+                ["tf_lint"] = new Step {
+                    glob = List("**/*.tf")
+                    check = "tflint --chdir=terraform --recursive"
+                    fix = "tflint --chdir=terraform --recursive --fix"
+                }
+                ["brakeman"] = new Step {
+                    check = "bin/brakeman --quiet --no-summary --no-pager"
+                }
+        }
     }
 }
 
@@ -37,13 +41,13 @@ hooks {
     ["pre-commit"] {
         fix = true
         stash = "patch-file"
-        steps = linters
+        steps = linters["all"].steps
     }
     ["fix"] {
         fix = true
-        steps = linters
+        steps = linters["all"].steps
     }
     ["check"] {
-        steps = linters
+        steps = linters["all"].steps
     }
 }


### PR DESCRIPTION
- Adding a custom check to ensure we do not initiate commit when running linters in fix mode
- Removing brakeman as it runs on all files and takes too long as a pre-commit step