### PR TITLE
Fix school consent reminders cron job 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,6 +102,17 @@ Rails.application.configure do
       class: "EnqueueClinicSessionInvitationsJob",
       description: "Send school clinic invitation emails to parents"
     },
+    invalidate_self_consents: {
+      cron: "every day at 2am",
+      class: "InvalidateSelfConsentsJob",
+      description:
+        "Invalidate all self-consents and associated triage for the previous day"
+    },
+    remove_import_csv: {
+      cron: "every day at 1am",
+      class: "RemoveImportCSVJob",
+      description: "Remove CSV data from old cohort and immunisation imports"
+    },
     school_consent_requests: {
       cron: "every day at 4pm",
       class: "EnqueueSchoolConsentRequestsJob",
@@ -114,21 +125,10 @@ Rails.application.configure do
       description:
         "Send school consent reminder emails to parents for each session"
     },
-    invalidate_self_consents: {
-      cron: "every day at 2am",
-      class: "InvalidateSelfConsentsJob",
-      description:
-        "Invalidate all self-consents and associated triage for the previous day"
-    },
     school_session_reminders: {
       cron: "every day at 9am",
       class: "SendSchoolSessionRemindersJob",
       description: "Send school session reminder emails to parents"
-    },
-    remove_import_csv: {
-      cron: "every day at 1am",
-      class: "RemoveImportCSVJob",
-      description: "Remove CSV data from old cohort and immunisation imports"
     },
     status_updater: {
       cron: "every day at 3am",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -108,9 +108,9 @@ Rails.application.configure do
       description:
         "Send school consent request emails to parents for each session"
     },
-    consent_reminder: {
-      cron: "every day at 9am",
-      class: "SendSchoolConsentReminderJob",
+    school_consent_reminders: {
+      cron: "every day at 4pm",
+      class: "EnqueueSchoolConsentRemindersJob",
       description:
         "Send school consent reminder emails to parents for each session"
     },


### PR DESCRIPTION
This was referring the wrong job class and the wrong time, resulting in no consent reminders being sent out. This fixes a regression that was added in 3ce129ae53521ed61d25af1da8b02396e3ae2255.

Good Job doesn't current report an error if the cron jobs are misconfigured, this is tracked here: https://github.com/bensheldon/good_job/issues/1261