### PR TITLE
Include moves out in school moves export

### DIFF
--- a/app/lib/reports/school_moves_exporter.rb
+++ b/app/lib/reports/school_moves_exporter.rb
@@ -24,11 +24,15 @@ class Reports::SchoolMovesExporter
     DES_NUMBER
   ].freeze
 
-  def initialize(school_move_log_entries)
-    @school_move_log_entries = school_move_log_entries
+  def initialize(organisation:, start_date:, end_date:)
+    @organisation = organisation
+    @start_date = start_date
+    @end_date = end_date
   end
 
-  def call
+  def row_count = school_move_log_entries.count
+
+  def csv_data
     CSV.generate(headers: HEADERS, write_headers: true) do |csv|
       school_move_log_entries
         .includes(:patient, :school)
@@ -37,13 +41,36 @@ class Reports::SchoolMovesExporter
     end
   end
 
-  def self.call(...) = new(...).call
-
-  private_class_method :new
-
   private
 
-  attr_reader :school_move_log_entries
+  attr_reader :organisation, :start_date, :end_date
+
+  delegate :patients, to: :organisation
+
+  def school_move_log_entries
+    @school_move_log_entries ||=
+      begin
+        scope = SchoolMoveLogEntry.where(patient: patients)
+
+        if start_date.present?
+          scope =
+            scope.where(
+              "school_move_log_entries.created_at >= ?",
+              start_date.beginning_of_day
+            )
+        end
+
+        if end_date.present?
+          scope =
+            scope.where(
+              "school_move_log_entries.created_at <= ?",
+              end_date.end_of_day
+            )
+        end
+
+        scope
+      end
+  end
 
   def row(log_entry)
     patient = log_entry.patient

--- a/app/models/school_move_log_entry.rb
+++ b/app/models/school_move_log_entry.rb
@@ -4,13 +4,12 @@
 #
 # Table name: school_move_log_entries
 #
-#  id             :bigint           not null, primary key
-#  home_educated  :boolean
-#  move_to_school :boolean
-#  created_at     :datetime         not null
-#  patient_id     :bigint           not null
-#  school_id      :bigint
-#  user_id        :bigint
+#  id            :bigint           not null, primary key
+#  home_educated :boolean
+#  created_at    :datetime         not null
+#  patient_id    :bigint           not null
+#  school_id     :bigint
+#  user_id       :bigint
 #
 # Indexes
 #

--- a/app/views/school_moves/exports/confirm.html.erb
+++ b/app/views/school_moves/exports/confirm.html.erb
@@ -23,7 +23,7 @@
       
         summary_list.with_row do |row|
           row.with_key { "Records" }
-          row.with_value { @school_move_export.count.to_s }
+          row.with_value { @school_move_export.row_count.to_s }
         end
       end %>
 <% end %>

--- a/db/migrate/20250429140846_remove_move_to_school_from_school_move_log_entries.rb
+++ b/db/migrate/20250429140846_remove_move_to_school_from_school_move_log_entries.rb
@@ -1,0 +1,5 @@
+class RemoveMoveToSchoolFromSchoolMoveLogEntries < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :school_move_log_entries, :move_to_school, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_14_092500) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -659,7 +659,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_14_092500) do
     t.bigint "user_id"
     t.bigint "school_id"
     t.boolean "home_educated"
-    t.boolean "move_to_school"
     t.datetime "created_at", null: false
     t.index ["patient_id"], name: "index_school_move_log_entries_on_patient_id"
     t.index ["school_id"], name: "index_school_move_log_entries_on_school_id"

--- a/spec/factories/school_move_log_entries.rb
+++ b/spec/factories/school_move_log_entries.rb
@@ -4,13 +4,12 @@
 #
 # Table name: school_move_log_entries
 #
-#  id             :bigint           not null, primary key
-#  home_educated  :boolean
-#  move_to_school :boolean
-#  created_at     :datetime         not null
-#  patient_id     :bigint           not null
-#  school_id      :bigint
-#  user_id        :bigint
+#  id            :bigint           not null, primary key
+#  home_educated :boolean
+#  created_at    :datetime         not null
+#  patient_id    :bigint           not null
+#  school_id     :bigint
+#  user_id       :bigint
 #
 # Indexes
 #

--- a/spec/features/download_school_moves_spec.rb
+++ b/spec/features/download_school_moves_spec.rb
@@ -42,10 +42,15 @@ describe "Download school moves" do
   end
 
   def and_school_moves_exist
-    create(:school_move_log_entry, patient: @patients.first)
+    create(
+      :school_move_log_entry,
+      patient: @patients.first,
+      school: @session.location
+    )
     create(
       :school_move_log_entry,
       patient: @patients.second,
+      school: @session.location,
       created_at: Time.zone.local(2024, 6, 15) # Middle of the date range
     )
   end

--- a/spec/lib/reports/school_moves_exporter_spec.rb
+++ b/spec/lib/reports/school_moves_exporter_spec.rb
@@ -1,18 +1,53 @@
 # frozen_string_literal: true
 
 describe Reports::SchoolMovesExporter do
-  subject(:csv) { described_class.call(SchoolMoveLogEntry.all) }
+  subject(:exporter) do
+    described_class.new(organisation:, start_date:, end_date:)
+  end
 
-  let(:rows) { CSV.parse(csv, headers: true) }
+  let(:organisation) { create(:organisation) }
+  let(:start_date) { nil }
+  let(:end_date) { nil }
 
-  describe "#call" do
+  describe "#row_count" do
+    subject { exporter.row_count }
+
+    let(:one_day_ago) { 1.day.ago }
+    let(:three_days_ago) { 3.days.ago }
+
+    before do
+      3.times do
+        patient = create(:patient, organisation:)
+        create(:school_move_log_entry, patient:, created_at: one_day_ago)
+      end
+
+      2.times do
+        patient = create(:patient, organisation:)
+        create(:school_move_log_entry, patient:, created_at: three_days_ago)
+      end
+    end
+
+    it { should eq(5) }
+
+    context "when date range is specified" do
+      let(:start_date) { one_day_ago }
+
+      it { should eq(3) }
+    end
+  end
+
+  describe "#csv_data" do
+    subject(:csv_data) { exporter.csv_data }
+
+    let(:rows) { CSV.parse(csv_data, headers: true) }
+
     context "with a standard school move" do
       let(:old_school) { create(:school, :secondary) }
       let(:new_school) { create(:school, :secondary) }
 
       before do
-        patient = create(:patient, school: old_school)
-        create(:school_move_log_entry, patient: patient, school: new_school)
+        patient = create(:patient, school: old_school, organisation:)
+        create(:school_move_log_entry, patient:, school: new_school)
       end
 
       it "returns a CSV with the school moves data" do
@@ -45,8 +80,8 @@ describe Reports::SchoolMovesExporter do
 
     context "when moving to home education" do
       before do
-        patient = create(:patient, :home_educated)
-        create(:school_move_log_entry, :home_educated, patient: patient)
+        patient = create(:patient, :home_educated, organisation:)
+        create(:school_move_log_entry, :home_educated, patient:)
       end
 
       it "returns '999999' as the URN" do
@@ -56,8 +91,8 @@ describe Reports::SchoolMovesExporter do
 
     context "when moving to an unknown school" do
       before do
-        patient = create(:patient, school: nil)
-        create(:school_move_log_entry, :unknown_school, patient: patient)
+        patient = create(:patient, school: nil, organisation:)
+        create(:school_move_log_entry, :unknown_school, patient:)
       end
 
       it "returns '888888' as the URN" do

--- a/spec/models/school_move_export_spec.rb
+++ b/spec/models/school_move_export_spec.rb
@@ -21,44 +21,6 @@ describe SchoolMoveExport do
     end
   end
 
-  describe "#count" do
-    let(:one_day_ago) { 1.day.ago }
-    let(:three_days_ago) { 3.days.ago }
-
-    before do
-      3.times do
-        patient = create(:patient, organisation: organisation)
-        create(:school_move_log_entry, patient:, created_at: one_day_ago)
-      end
-
-      2.times do
-        patient = create(:patient, organisation: organisation)
-        create(:school_move_log_entry, patient:, created_at: three_days_ago)
-      end
-    end
-
-    it "returns the count of school moves" do
-      expect(school_move_export.count).to eq(5)
-    end
-
-    context "when date range is specified" do
-      before do
-        school_move_export.assign_attributes(
-          {
-            "date_from(3i)" => one_day_ago.day.to_s,
-            "date_from(2i)" => one_day_ago.month.to_s,
-            "date_from(1i)" => one_day_ago.year.to_s,
-            "wizard_step" => :dates
-          }
-        )
-      end
-
-      it "returns the count of school moves within the date range" do
-        expect(school_move_export.count).to eq(3)
-      end
-    end
-  end
-
   describe "dates formatted" do
     let(:date) { Date.new(2023, 1, 1) }
 

--- a/spec/models/school_move_log_entry_spec.rb
+++ b/spec/models/school_move_log_entry_spec.rb
@@ -4,13 +4,12 @@
 #
 # Table name: school_move_log_entries
 #
-#  id             :bigint           not null, primary key
-#  home_educated  :boolean
-#  move_to_school :boolean
-#  created_at     :datetime         not null
-#  patient_id     :bigint           not null
-#  school_id      :bigint
-#  user_id        :bigint
+#  id            :bigint           not null, primary key
+#  home_educated :boolean
+#  created_at    :datetime         not null
+#  patient_id    :bigint           not null
+#  school_id     :bigint
+#  user_id       :bigint
 #
 # Indexes
 #


### PR DESCRIPTION
This updates the school moves export functionality to include patients who used to be within the remit of the organisation but have since moved outside of the organisation.

We don't currently have a good way of getting a list of patients who used to be in an organisation at a particular period of time, but we can look at the school move log entries for patients who are no longer in the organisation but was at some point moved to a school that was in the organisation.

I think in the future we might want to improve this by having an explicit way of tracking which school a patient went to a particular point in time, but I think this relates to potential future work on cohorting so we can handle it then.

[Jira issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1060)