### PR TITLE
Ensure cron jobs reference valid classes

### DIFF
--- a/config/cron_jobs.rb
+++ b/config/cron_jobs.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+CRON_JOBS = {
+  clinic_session_invitations: {
+    cron: "every day at 9am",
+    class: "EnqueueClinicSessionInvitationsJob",
+    description: "Send school clinic invitation emails to parents"
+  },
+  invalidate_self_consents: {
+    cron: "every day at 2am",
+    class: "InvalidateSelfConsentsJob",
+    description:
+      "Invalidate all self-consents and associated triage for the previous day"
+  },
+  mesh_dps_export: {
+    cron: "every day at 2am",
+    class: "MESHDPSExportJob",
+    description: "Export DPS data via MESH"
+  },
+  mesh_track_dps_exports: {
+    cron: "every day at 3am",
+    class: "MESHTrackDPSExportsJob",
+    description: "Track the status of DPS exports"
+  },
+  mesh_validate_mailbox: {
+    cron: "every day at 1am",
+    class: "MESHValidateMailboxJob",
+    description: "Validate MESH mailbox"
+  },
+  remove_import_csv: {
+    cron: "every day at 1am",
+    class: "RemoveImportCSVJob",
+    description: "Remove CSV data from old cohort and immunisation imports"
+  },
+  school_consent_requests: {
+    cron: "every day at 4pm",
+    class: "EnqueueSchoolConsentRequestsJob",
+    description:
+      "Send school consent request emails to parents for each session"
+  },
+  school_consent_reminders: {
+    cron: "every day at 4pm",
+    class: "EnqueueSchoolConsentRemindersJob",
+    description:
+      "Send school consent reminder emails to parents for each session"
+  },
+  school_session_reminders: {
+    cron: "every day at 9am",
+    class: "SendSchoolSessionRemindersJob",
+    description: "Send school session reminder emails to parents"
+  },
+  status_updater: {
+    cron: "every day at 3am",
+    class: "StatusUpdaterJob",
+    description: "Updates the status of all patients"
+  },
+  trim_active_record_sessions: {
+    cron: "every day at 2am",
+    class: "TrimActiveRecordSessionsJob",
+    description: "Remove ActiveRecord sessions older than 30 days"
+  },
+  update_patients_from_pds: {
+    cron: "every day at 6:00 and 18:00",
+    class: "EnqueueUpdatePatientsFromPDSJob",
+    description: "Keep patient details up to date with PDS."
+  },
+  vaccination_confirmations: {
+    cron: "every day at 7pm",
+    class: "SendVaccinationConfirmationsJob",
+    description: "Send vaccination confirmation emails to parents"
+  }
+}

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,6 +2,8 @@
 
 require "active_support/core_ext/integer/time"
 
+require_relative "../cron_jobs"
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -96,59 +98,10 @@ Rails.application.configure do
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   config.good_job.enable_cron = true
-  config.good_job.cron = {
-    clinic_session_invitations: {
-      cron: "every day at 9am",
-      class: "EnqueueClinicSessionInvitationsJob",
-      description: "Send school clinic invitation emails to parents"
-    },
-    invalidate_self_consents: {
-      cron: "every day at 2am",
-      class: "InvalidateSelfConsentsJob",
-      description:
-        "Invalidate all self-consents and associated triage for the previous day"
-    },
-    remove_import_csv: {
-      cron: "every day at 1am",
-      class: "RemoveImportCSVJob",
-      description: "Remove CSV data from old cohort and immunisation imports"
-    },
-    school_consent_requests: {
-      cron: "every day at 4pm",
-      class: "EnqueueSchoolConsentRequestsJob",
-      description:
-        "Send school consent request emails to parents for each session"
-    },
-    school_consent_reminders: {
-      cron: "every day at 4pm",
-      class: "EnqueueSchoolConsentRemindersJob",
-      description:
-        "Send school consent reminder emails to parents for each session"
-    },
-    school_session_reminders: {
-      cron: "every day at 9am",
-      class: "SendSchoolSessionRemindersJob",
-      description: "Send school session reminder emails to parents"
-    },
-    status_updater: {
-      cron: "every day at 3am",
-      class: "StatusUpdaterJob",
-      description: "Updates the status of all patients"
-    },
-    trim_active_record_sessions: {
-      cron: "every day at 2am",
-      class: "TrimActiveRecordSessionsJob",
-      description: "Remove ActiveRecord sessions older than 30 days"
-    },
-    update_patients_from_pds: {
-      cron: "every day at 6:00 and 18:00",
-      class: "EnqueueUpdatePatientsFromPDSJob",
-      description: "Keep patient details up to date with PDS."
-    },
-    vaccination_confirmations: {
-      cron: "every day at 7pm",
-      class: "SendVaccinationConfirmationsJob",
-      description: "Send vaccination confirmation emails to parents"
-    }
-  }
+  config.good_job.cron =
+    CRON_JOBS.except(
+      :mesh_dps_export,
+      :mesh_track_dps_exports,
+      :mesh_validate_mailbox
+    )
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,23 +1,5 @@
 # frozen_string_literal: true
 
-require Rails.root.join("config/environments/production")
+require_relative "production"
 
-Rails.application.configure do
-  config.good_job.cron.merge!(
-    mesh_validate_mailbox: {
-      cron: "every day at 1am",
-      class: "MESHValidateMailboxJob",
-      description: "Validate MESH mailbox"
-    },
-    mesh_dps_export: {
-      cron: "every day at 2am",
-      class: "MESHDPSExportJob",
-      description: "Export DPS data via MESH"
-    },
-    mesh_track_dps_exports: {
-      cron: "every day at 3am",
-      class: "MESHTrackDPSExportsJob",
-      description: "Track the status of DPS exports"
-    }
-  )
-end
+Rails.application.configure { config.good_job.cron = CRON_JOBS }

--- a/spec/lib/cron_jobs_spec.rb
+++ b/spec/lib/cron_jobs_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require Rails.application.root.join("config/cron_jobs")
+
+describe "Cron jobs" do
+  CRON_JOBS.each do |key, config|
+    context "for #{key} job" do
+      it "references a valid class" do
+        expect(Object.const_defined?(config[:class])).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a test to ensure that the class names references in the cron job configuration are valid and refer to classes that exist.

We're adding this to catch any potential issues in the future where the cron jobs classes are invalid (as was fixed recently in https://github.com/nhsuk/manage-vaccinations-in-schools/commit/623a1e63809ed51e27028a369a526696947aec2c). This is necessary because Good Job itself doesn't check that the classes are valid and will fail silently.