### PR TITLE
Normalise spaces during import

### DIFF
--- a/app/lib/csv_parser.rb
+++ b/app/lib/csv_parser.rb
@@ -107,13 +107,13 @@ class CSVParser
       row = info.line
       header = unconverted_headers[info.index]
 
-      Field.new(value&.tr("\u00A0", " ")&.strip.presence, column, row, header)
+      Field.new(value&.normalise_whitespace, column, row, header)
     end
   end
 
   def header_converters
     proc do |value|
-      value.downcase.tr("-", "_").tr(" ", "_").tr("\u00A0", " ").strip.to_sym
+      value.downcase.normalise_whitespace.tr("-", "_").tr(" ", "_").to_sym
     end
   end
 end

--- a/lib/core_ext/string/normalise_whitespace.rb
+++ b/lib/core_ext/string/normalise_whitespace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class String
+  def normalise_whitespace
+    result = self
+
+    # \u200D is a zero-width joiner (ZWJ) which is used in the frontend to display the NHS number
+    result = result.tr("\u200D", "")
+
+    # \u00A0 is a non-breaking space
+    result = result.tr("\u00A0", " ")
+
+    result.strip.gsub(/\s+/, " ").presence
+  end
+end

--- a/spec/lib/core_ext/string_normalise_whitespace_spec.rb
+++ b/spec/lib/core_ext/string_normalise_whitespace_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe String do
+  describe "#normalise_whitespace" do
+    it "removes leading and trailing whitespace" do
+      expect("  hello  ".normalise_whitespace).to eq("hello")
+    end
+
+    it "replaces multiple spaces with a single space" do
+      expect("hello  world".normalise_whitespace).to eq("hello world")
+    end
+
+    it "handles tabs and newlines" do
+      expect("hello\t\nworld".normalise_whitespace).to eq("hello world")
+    end
+
+    it "returns nil if string is empty after normalization" do
+      expect("   ".normalise_whitespace).to be_nil
+    end
+
+    it "returns nil if string is empty" do
+      expect("".normalise_whitespace).to be_nil
+    end
+
+    context "with UTF-8 encoded strings" do
+      it "removes zero-width joiners (ZWJ)" do
+        string_with_zwj = "1234\u200D567890"
+        expect(string_with_zwj.normalise_whitespace).to eq("1234567890")
+      end
+
+      it "converts non-breaking spaces to regular spaces" do
+        string_with_nbsp = "hello\u00A0world"
+        expect(string_with_nbsp.normalise_whitespace).to eq("hello world")
+      end
+
+      it "handles strings with multiple Unicode characters" do
+        complex_string = "  hello\u200D \u00A0 world\u200D  "
+        expect(complex_string.normalise_whitespace).to eq("hello world")
+      end
+    end
+
+    context "with non-UTF-8 encoded strings" do
+      it "does not apply Unicode-specific transformations" do
+        ascii_string = "hello world".encode(Encoding::ASCII)
+        expect(ascii_string.normalise_whitespace).to eq("hello world")
+      end
+    end
+  end
+end

--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -22,13 +22,13 @@ describe CSVParser do
     expect(row[:another_header].header).to eq("Another-Header")
   end
 
-  context "with a non-breaking space" do
-    let(:data) { "header\u00A0\nvalue\u00A0" }
+  context "with un-normalised whitespace" do
+    let(:data) { "  header\u200D \u00A0 \n clean \u200D \t value\u00A0 " }
 
     it "removes the characters" do
       row = table.first
 
-      expect(row[:header].value).to eq("value")
+      expect(row[:header].value).to eq("clean value")
     end
   end
 end


### PR DESCRIPTION
During an import, all string fields now have their whitespace normalised before any other processing occurs. This includes the headers

[MAV-1080](https://nhsd-jira.digital.nhs.uk/browse/MAV-1080)