### PR TITLE
Patch PR-tests to work with forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         id: check-rails-relevant-changes
         run: |
           if [ ${{ github.event_name }} == "pull_request" ]; then
-            git fetch origin ${{ github.event.pull_request.head.ref }}
+            git fetch origin ${{ github.event.pull_request.head.ref }} || echo "Fetch failed, running all tests"; exit 0
             RELEVANT_DIRS=$(git diff ${{ github.event.pull_request.base.sha }} origin/${{ github.event.pull_request.head.ref }}  --name-only)
             if [ -z "$(echo "$RELEVANT_DIRS" | egrep -v "^(.github|adr|aws|docs|storage|terraform|tests|tests-examples)/")" ]; then
               echo "No relevant changes detected, skipping rails tests"


### PR DESCRIPTION
The test fails when the PR is from fork
- Handle all edge cases by simply running when the reference cannot be found