### PR TITLE
Add phone instructions for organisations and teams

### DIFF
--- a/app/helpers/phone_helper.rb
+++ b/app/helpers/phone_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PhoneHelper
+  def format_phone_with_instructions(entity)
+    return entity.phone if entity.phone_instructions.blank?
+
+    "#{entity.phone} (#{entity.phone_instructions})"
+  end
+end

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -58,6 +58,8 @@ class GovukNotifyPersonalisation
       team_email:,
       team_name:,
       team_phone:,
+      team_phone_instructions_present:,
+      team_phone_instructions:,
       today_or_date_of_vaccination:,
       vaccination:
     }.compact
@@ -243,6 +245,14 @@ class GovukNotifyPersonalisation
 
   def team_phone
     (team || organisation).phone
+  end
+
+  def team_phone_instructions_present
+    team_phone_instructions.present? ? "yes" : "no"
+  end
+
+  def team_phone_instructions
+    (team || organisation).phone_instructions
   end
 
   def today_or_date_of_vaccination

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -13,6 +13,7 @@
 #  name                          :text             not null
 #  ods_code                      :string           not null
 #  phone                         :string
+#  phone_instructions            :string
 #  privacy_notice_url            :string           not null
 #  privacy_policy_url            :string           not null
 #  created_at                    :datetime         not null
@@ -68,7 +69,9 @@ class Organisation < ApplicationRecord
   end
 
   def generic_team
-    teams.create_with(email:, phone:).find_or_create_by!(name:)
+    teams.create_with(email:, phone:, phone_instructions:).find_or_create_by!(
+      name:
+    )
   end
 
   def generic_clinic

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -4,14 +4,15 @@
 #
 # Table name: teams
 #
-#  id              :bigint           not null, primary key
-#  email           :string           not null
-#  name            :string           not null
-#  phone           :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organisation_id :bigint           not null
-#  reply_to_id     :uuid
+#  id                 :bigint           not null, primary key
+#  email              :string           not null
+#  name               :string           not null
+#  phone              :string           not null
+#  phone_instructions :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organisation_id    :bigint           not null
+#  reply_to_id        :uuid
 #
 # Indexes
 #

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -14,7 +14,7 @@
       
         summary_list.with_row do |row|
           row.with_key { "Phone number" }
-          row.with_value { @organisation.phone }
+          row.with_value { format_phone_with_instructions(@organisation) }
         end
       end %>
 <% end %>

--- a/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
@@ -14,5 +14,5 @@
 
 <p>
   If you have any questions, please contact the local health organisation by calling
-  <%= @team.phone %>, or email <%= mail_to @team.email %>.
+  <%= format_phone_with_instructions(@team) %>, or email <%= mail_to @team.email %>.
 </p>

--- a/db/migrate/20250429081203_add_phone_instructions_to_organisations_and_teams.rb
+++ b/db/migrate/20250429081203_add_phone_instructions_to_organisations_and_teams.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddPhoneInstructionsToOrganisationsAndTeams < ActiveRecord::Migration[8.0]
+  def change
+    add_column :organisations, :phone_instructions, :string
+    add_column :teams, :phone_instructions, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -509,6 +509,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
     t.integer "days_before_invitations", default: 21, null: false
     t.string "careplus_venue_code", null: false
     t.string "privacy_notice_url", null: false
+    t.string "phone_instructions"
     t.index ["name"], name: "index_organisations_on_name", unique: true
     t.index ["ods_code"], name: "index_organisations_on_ods_code", unique: true
   end
@@ -735,6 +736,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "reply_to_id"
+    t.string "phone_instructions"
     t.index ["organisation_id", "name"], name: "index_teams_on_organisation_id_and_name", unique: true
   end
 

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -13,6 +13,7 @@
 #  name                          :text             not null
 #  ods_code                      :string           not null
 #  phone                         :string
+#  phone_instructions            :string
 #  privacy_notice_url            :string           not null
 #  privacy_policy_url            :string           not null
 #  created_at                    :datetime         not null

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -4,14 +4,15 @@
 #
 # Table name: teams
 #
-#  id              :bigint           not null, primary key
-#  email           :string           not null
-#  name            :string           not null
-#  phone           :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organisation_id :bigint           not null
-#  reply_to_id     :uuid
+#  id                 :bigint           not null, primary key
+#  email              :string           not null
+#  name               :string           not null
+#  phone              :string           not null
+#  phone_instructions :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organisation_id    :bigint           not null
+#  reply_to_id        :uuid
 #
 # Indexes
 #

--- a/spec/fixtures/files/onboarding/valid.yaml
+++ b/spec/fixtures/files/onboarding/valid.yaml
@@ -2,6 +2,7 @@ organisation:
   name: NHS Trust
   email: example@trust.nhs.uk
   phone: 07700 900815
+  phone_instructions: option 1, followed by option 3
   ods_code: EXAMPLE
   careplus_venue_code: EXAMPLE
   privacy_notice_url: https://example.com/privacy-notice
@@ -14,6 +15,7 @@ teams:
     name: Team 1
     email: team-1@trust.nhs.uk
     phone: 07700 900816
+    phone_instructions: option 9
     reply_to_id: 24af66c3-d6bd-4b9f-8067-3844f49e08d0
   team_2:
     name: Team 2

--- a/spec/helpers/phone_helper_spec.rb
+++ b/spec/helpers/phone_helper_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe PhoneHelper do
+  describe "#format_phone_with_instructions" do
+    subject(:formatted_phone) { helper.format_phone_with_instructions(entity) }
+
+    context "when phone instructions are present" do
+      let(:entity) do
+        create(
+          :organisation,
+          name: "Organisation",
+          email: "organisation@example.com",
+          phone: "01234 567890",
+          phone_instructions: "option 1"
+        )
+      end
+
+      it { should eq("01234 567890 (option 1)") }
+    end
+
+    context "when phone instructions are blank" do
+      let(:entity) do
+        create(
+          :organisation,
+          name: "Organisation",
+          email: "organisation@example.com",
+          phone: "01234 567890",
+          phone_instructions: nil
+        )
+      end
+
+      it { should eq("01234 567890") }
+    end
+
+    context "when phone instructions are an empty string" do
+      let(:entity) do
+        create(
+          :organisation,
+          name: "Organisation",
+          email: "organisation@example.com",
+          phone: "01234 567890",
+          phone_instructions: ""
+        )
+      end
+
+      it { should eq("01234 567890") }
+    end
+  end
+end

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -19,6 +19,7 @@ describe GovukNotifyPersonalisation do
       name: "Organisation",
       email: "organisation@example.com",
       phone: "01234 567890",
+      phone_instructions: "option 1",
       programmes:
     )
   end
@@ -69,6 +70,8 @@ describe GovukNotifyPersonalisation do
         team_email: "organisation@example.com",
         team_name: "Organisation",
         team_phone: "01234 567890",
+        team_phone_instructions_present: "yes",
+        team_phone_instructions: "option 1",
         vaccination: "HPV vaccination"
       }
     )

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -27,12 +27,16 @@ describe Onboarding do
       expect(organisation.name).to eq("NHS Trust")
       expect(organisation.email).to eq("example@trust.nhs.uk")
       expect(organisation.phone).to eq("07700 900815")
+      expect(organisation.phone_instructions).to eq(
+        "option 1, followed by option 3"
+      )
       expect(organisation.careplus_venue_code).to eq("EXAMPLE")
       expect(organisation.programmes).to contain_exactly(programme)
 
       team1 = organisation.teams.includes(:schools).find_by!(name: "Team 1")
       expect(team1.email).to eq("team-1@trust.nhs.uk")
       expect(team1.phone).to eq("07700 900816")
+      expect(team1.phone_instructions).to eq("option 9")
       expect(team1.reply_to_id).to eq("24af66c3-d6bd-4b9f-8067-3844f49e08d0")
 
       team2 = organisation.teams.includes(:schools).find_by!(name: "Team 2")

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -13,6 +13,7 @@
 #  name                          :text             not null
 #  ods_code                      :string           not null
 #  phone                         :string
+#  phone_instructions            :string
 #  privacy_notice_url            :string           not null
 #  privacy_policy_url            :string           not null
 #  created_at                    :datetime         not null

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,14 +4,15 @@
 #
 # Table name: teams
 #
-#  id              :bigint           not null, primary key
-#  email           :string           not null
-#  name            :string           not null
-#  phone           :string           not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  organisation_id :bigint           not null
-#  reply_to_id     :uuid
+#  id                 :bigint           not null, primary key
+#  email              :string           not null
+#  name               :string           not null
+#  phone              :string           not null
+#  phone_instructions :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  organisation_id    :bigint           not null
+#  reply_to_id        :uuid
 #
 # Indexes
 #


### PR DESCRIPTION
Some organisations may need to provide additional guidance when sharing phone numbers (like menu options), and this change allows that information to be stored and consistently displayed throughout the application.

Added a phone_instructions string field to both organisation and team models, with corresponding database migrations. The instructions now appear in brackets next to phone numbers in all user-facing views and are included in the Notify personalisation for emails and text communications.

The onboarding process also supports importing these instructions.