### PR TITLE
Add a test to ensure CSV files are converted to UTF-8

### DIFF
--- a/spec/lib/csv_parser_spec.rb
+++ b/spec/lib/csv_parser_spec.rb
@@ -31,4 +31,15 @@ describe CSVParser do
       expect(row[:header].value).to eq("value")
     end
   end
+
+  context "with input data in Windows-1252 encoding" do
+    let(:data) { "header\nvalue with \x92 character".b }
+
+    it "detects the encoding and converts to UTF-8" do
+      row = table.first
+
+      expect(row[:header].value.encoding).to eq(Encoding::UTF_8)
+      expect(row[:header].value).to eq("value with ’ character")
+    end
+  end
 end


### PR DESCRIPTION
This adds a test to the `CSVParser` class to ensure that the input data is parsed in whatever encoding it is provided in and then converted to UTF-8 for manipulation and storage in the database.

Currently we're seeing an issue in production which will be fixed in 04ecafb8280bc4a406620a08a9f4df230ff3590d but hasn't been deployed yet. This adds a test to ensure that we don't introduced any regressions in future releases.