### PR TITLE
Add ecs:UpdateCluster permission

### DIFF
--- a/terraform/resources/github_actions_policy.json
+++ b/terraform/resources/github_actions_policy.json
@@ -62,6 +62,7 @@
         "ecs:DeleteService",
         "ecs:DeregisterTaskDefinition",
         "ecs:RegisterTaskDefinition",
+        "ecs:UpdateCluster",
         "ecs:UpdateService",
         "elasticloadbalancing:CreateListener",
         "elasticloadbalancing:CreateLoadBalancer",


### PR DESCRIPTION
The workflows need this permission to be able to deploy changes to the autoscaling rules.

Example failure without the permission: https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/14773383019/job/41477398883