### PR TITLE
Fix header navigation to be compatible with NHS.UK Frontend 9.4.x

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -9,11 +9,19 @@
 }
 
 .app-header__navigation-item--current {
-  box-shadow: inset 0 ($nhsuk-focus-width * -1) $nhsuk-border-color;
+  .nhsuk-header__navigation-link {
+    border-bottom-color: $nhsuk-border-color;
+  }
+
   .nhsuk-header__drop-down & {
     box-shadow: inset $nhsuk-focus-width 0 $nhsuk-link-color;
+
+    .nhsuk-header__navigation-link {
+      border-bottom-color: transparent;
+    }
   }
 }
+
 .app-header__navigation-item--with-count {
   .app-count {
     @include nhsuk-font(14, $line-height: 1);

--- a/app/assets/stylesheets/_overrides.scss
+++ b/app/assets/stylesheets/_overrides.scss
@@ -1,8 +1,8 @@
 // `$nhsuk-page-width` isn’t globally editable, so need to apply manually
 .app-signed-in {
   .nhsuk-width-container,
-  .nhsuk-header__navigation-list,
-  .nhsuk-header__container {
+  .nhsuk-header__container,
+  .nhsuk-navigation {
     max-width: $app-page-width;
 
     @include govuk-media-query($from: desktop) {


### PR DESCRIPTION
`nhsuk-frontend v9.4.x` changed the implementation of the header navigation to fix the behaviour around the overflow navigation menu, and using `padding` instead of `gap` to improve presentation on older devices. This conflicts with the specific changes we’ve made to the container width and current item indicator.

(`nhsuk-frontend v10.0.0` will change the header markup considerably, and provide a number of these features saving us from needing to implement them separately.)

### Before

![Before](https://github.com/user-attachments/assets/de9807ae-44da-4546-95bb-32279076ede9)

### After

![After](https://github.com/user-attachments/assets/cb5d76c5-078c-4ce7-8c5a-4201e242e5e3)
