### PR TITLE
Add ability to remove parent relationships

### DIFF
--- a/app/components/app_child_summary_component.rb
+++ b/app/components/app_child_summary_component.rb
@@ -1,16 +1,19 @@
 # frozen_string_literal: true
 
 class AppChildSummaryComponent < ViewComponent::Base
-  def initialize(child, show_parents: false, change_links: {})
+  def initialize(child, show_parents: false, change_links: {}, remove_links: {})
     super
 
     @child = child
     @show_parents = show_parents
     @change_links = change_links
+    @remove_links = remove_links
   end
 
   def call
-    govuk_summary_list(actions: @change_links.present?) do |summary_list|
+    govuk_summary_list(
+      actions: @change_links.present? || @remove_links.present?
+    ) do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "NHS number" }
         row.with_value { format_nhs_number }
@@ -76,6 +79,16 @@ class AppChildSummaryComponent < ViewComponent::Base
             row.with_key { parent_relationship.ordinal_label.upcase_first }
             row.with_value do
               helpers.format_parent_with_relationship(parent_relationship)
+            end
+            if (
+                 href =
+                   @remove_links.dig(:parent, parent_relationship.parent_id)
+               )
+              row.with_action(
+                text: "Remove",
+                href:,
+                visually_hidden_text: parent_relationship.ordinal_label
+              )
             end
           end
         end

--- a/app/components/app_child_summary_component.rb
+++ b/app/components/app_child_summary_component.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class AppChildSummaryComponent < ViewComponent::Base
-  def initialize(child, change_links: {})
+  def initialize(child, show_parents: false, change_links: {})
     super
 
     @child = child
+    @show_parents = show_parents
     @change_links = change_links
   end
 
@@ -67,6 +68,16 @@ class AppChildSummaryComponent < ViewComponent::Base
         summary_list.with_row do |row|
           row.with_key { "GP surgery" }
           row.with_value { gp_practice.name }
+        end
+      end
+      if @show_parents && !@child.restricted?
+        @child.parent_relationships.each do |parent_relationship|
+          summary_list.with_row do |row|
+            row.with_key { parent_relationship.ordinal_label.upcase_first }
+            row.with_value do
+              helpers.format_parent_with_relationship(parent_relationship)
+            end
+          end
         end
       end
     end

--- a/app/components/app_parent_card_component.rb
+++ b/app/components/app_parent_card_component.rb
@@ -11,11 +11,7 @@ class AppParentCardComponent < ViewComponent::Base
   def call
     render AppCardComponent.new do |card|
       card.with_heading { "Parent or guardian" }
-      render AppParentSummaryComponent.new(
-               parent_relationship:,
-               change_links:,
-               show_name_and_relationship: true
-             )
+      render AppParentSummaryComponent.new(parent_relationship:, change_links:)
     end
   end
 

--- a/app/components/app_parent_summary_component.rb
+++ b/app/components/app_parent_summary_component.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 class AppParentSummaryComponent < ViewComponent::Base
-  def initialize(
-    parent_relationship:,
-    change_links: {},
-    show_name_and_relationship: false
-  )
+  def initialize(parent_relationship:, change_links: {})
     super
 
     @parent_relationship = parent_relationship
@@ -13,42 +9,34 @@ class AppParentSummaryComponent < ViewComponent::Base
     @patient = parent_relationship.patient
 
     @change_links = change_links
-
-    @show_name_and_relationship = show_name_and_relationship
   end
 
   def call
     govuk_summary_list do |summary_list|
-      if @show_name_and_relationship
-        summary_list.with_row do |row|
-          row.with_key { "Name" }
+      summary_list.with_row do |row|
+        row.with_key { "Name" }
 
-          if @parent.full_name.present?
-            row.with_value { @parent.full_name }
-            if (href = @change_links[:name])
-              row.with_action(
-                text: "Change",
-                href:,
-                visually_hidden_text: "name"
-              )
-            end
-          elsif (href = @change_links[:name])
-            row.with_value { govuk_link_to("Add name", href) }
-          else
-            row.with_value { "Not provided" }
+        if @parent.full_name.present?
+          row.with_value { @parent.full_name }
+          if (href = @change_links[:name])
+            row.with_action(text: "Change", href:, visually_hidden_text: "name")
           end
+        elsif (href = @change_links[:name])
+          row.with_value { govuk_link_to("Add name", href) }
+        else
+          row.with_value { "Not provided" }
         end
+      end
 
-        summary_list.with_row do |row|
-          row.with_key { "Relationship" }
-          row.with_value { @parent_relationship.label }
-          if (href = @change_links[:relationship])
-            row.with_action(
-              text: "Change",
-              href:,
-              visually_hidden_text: "relationship"
-            )
-          end
+      summary_list.with_row do |row|
+        row.with_key { "Relationship" }
+        row.with_value { @parent_relationship.label }
+        if (href = @change_links[:relationship])
+          row.with_action(
+            text: "Change",
+            href:,
+            visually_hidden_text: "relationship"
+          )
         end
       end
 

--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -23,20 +23,21 @@ class AppPatientCardComponent < ViewComponent::Base
         ) %>
       <% end %>
 
-      <%= render AppChildSummaryComponent.new(patient, show_parents: true, change_links:) %>
+      <%= render AppChildSummaryComponent.new(patient, show_parents: true, change_links:, remove_links:) %>
 
       <%= content %>
     <% end %>
   ERB
 
-  def initialize(patient, change_links: {})
+  def initialize(patient, change_links: {}, remove_links: {})
     super
 
     @patient = patient
     @change_links = change_links
+    @remove_links = remove_links
   end
 
   private
 
-  attr_reader :patient, :change_links
+  attr_reader :patient, :change_links, :remove_links
 end

--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -23,31 +23,20 @@ class AppPatientCardComponent < ViewComponent::Base
         ) %>
       <% end %>
 
-      <%= render AppChildSummaryComponent.new(patient) %>
-
-      <% unless patient.restricted? %>
-        <% parent_relationships.each do |parent_relationship| %>
-          <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
-            <%= parent_relationship.label_with_parent %>
-          </h3>
-
-          <%= render AppParentSummaryComponent.new(parent_relationship:) %>
-        <% end %>
-      <% end %>
+      <%= render AppChildSummaryComponent.new(patient, show_parents: true, change_links:) %>
 
       <%= content %>
     <% end %>
   ERB
 
-  def initialize(patient)
+  def initialize(patient, change_links: {})
     super
 
     @patient = patient
+    @change_links = change_links
   end
 
   private
 
-  attr_reader :patient
-
-  delegate :parent_relationships, to: :patient
+  attr_reader :patient, :change_links
 end

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -320,24 +320,14 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   def dose_number
     return nil if @vaccine&.seasonal?
 
-    return "Unknown" if @vaccination_record.dose_sequence.nil?
+    dose_sequence = @vaccination_record.dose_sequence
 
-    numbers_to_words = {
-      1 => "First",
-      2 => "Second",
-      3 => "Third",
-      4 => "Fourth",
-      5 => "Fifth",
-      6 => "Sixth",
-      7 => "Seventh",
-      8 => "Eighth",
-      9 => "Ninth"
-    }.freeze
-
-    if @vaccination_record.dose_sequence <= 9
-      numbers_to_words[@vaccination_record.dose_sequence]
+    if dose_sequence.nil?
+      "Unknown"
+    elsif dose_sequence <= 10
+      I18n.t(dose_sequence, scope: :ordinal_number).upcase_first
     else
-      @vaccination_record.dose_sequence.ordinalize
+      dose_sequence.ordinalize
     end
   end
 

--- a/app/controllers/parent_relationships_controller.rb
+++ b/app/controllers/parent_relationships_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ParentRelationshipsController < ApplicationController
+  before_action :set_patient
+  before_action :set_parent_relationship
+  before_action :set_parent
+
+  def confirm_destroy = render :destroy
+
+  def destroy
+    @parent_relationship.destroy!
+
+    redirect_to edit_patient_path(@patient),
+                flash: {
+                  success: "Parent relationship removed"
+                }
+  end
+
+  private
+
+  def set_patient
+    @patient = policy_scope(Patient).find(params[:patient_id])
+  end
+
+  def set_parent_relationship
+    @parent_relationship =
+      @patient
+        .parent_relationships
+        .includes(:parent)
+        .find_by!(parent_id: params[:id])
+  end
+
+  def set_parent
+    @parent = @parent_relationship.parent
+  end
+end

--- a/app/models/parent_relationship.rb
+++ b/app/models/parent_relationship.rb
@@ -56,4 +56,16 @@ class ParentRelationship < ApplicationRecord
   def label_with_parent
     unknown? ? parent.label : "#{parent.label} (#{label})"
   end
+
+  def ordinal_label
+    index = patient.parent_relationships.find_index(self)
+
+    if index.nil?
+      "parent or guardian"
+    elsif index <= 10
+      "#{I18n.t(index + 1, scope: :ordinal_number)} parent or guardian"
+    else
+      "#{index.ordinalize} parent or guardian"
+    end
+  end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -67,7 +67,7 @@ class Patient < ApplicationRecord
   has_many :consent_statuses
   has_many :consents
   has_many :notify_log_entries
-  has_many :parent_relationships
+  has_many :parent_relationships, -> { order(:created_at) }
   has_many :patient_sessions
   has_many :school_move_log_entries
   has_many :school_moves

--- a/app/views/parent_relationships/destroy.html.erb
+++ b/app/views/parent_relationships/destroy.html.erb
@@ -1,0 +1,32 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(edit_patient_path(@patient), name: "patient") %>
+<% end %>
+
+<% page_title = "Are you sure you want to remove the relationship between #{@parent_relationship.label_with_parent} and #{@patient.full_name(context: :parents)}?" %>
+
+<%= h1 page_title do %>
+  <span class="nhsuk-caption-l">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<% if @patient.consents.not_invalidated.exists?(parent: @parent) %>
+  <div class="nhsuk-inset-text">
+    <span class="nhsuk-u-visually-hidden">Information: </span>
+    <p><%= @parent.label %> has submitted the following consent responses for this child:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @patient.consents.includes(:programme).not_invalidated.where(parent: @parent).find_each do |consent| %>
+        <li><%= consent.human_enum_name(:response).upcase_first %> (<%= consent.created_at.to_date.to_fs(:long) %> for <%= consent.programme.name %>)</li>
+      <% end %>
+    </ul>
+    <p>You should review these before continuing.</p>
+  </div>
+<% end %>
+
+<%= form_with url: patient_parent_relationship_path, method: :delete do |f| %>
+  <div class="app-button-group">
+    <%= f.govuk_submit "Yes, remove this relationship", warning: true %>
+    <%= govuk_link_to "No, return to child record", edit_patient_path(@patient) %>
+  </div>
+<% end %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -9,11 +9,8 @@
   <%= page_title %>
 <% end %>
 
-<% change_links = { nhs_number: edit_nhs_number_patient_path(@patient) } %>
-
-<%= render AppCardComponent.new do |card| %>
-  <% card.with_heading { "Record details" } %>
-  <%= render AppChildSummaryComponent.new(@patient, change_links:) %>
-<% end %>
+<%= render AppPatientCardComponent.new(@patient, change_links: {
+                                                   nhs_number: edit_nhs_number_patient_path(@patient),
+                                                 }) %>
 
 <%= govuk_button_link_to "Continue", patient_path(@patient) %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -9,8 +9,16 @@
   <%= page_title %>
 <% end %>
 
-<%= render AppPatientCardComponent.new(@patient, change_links: {
-                                                   nhs_number: edit_nhs_number_patient_path(@patient),
-                                                 }) %>
+<% change_links = {
+     nhs_number: edit_nhs_number_patient_path(@patient),
+   } %>
+
+<% remove_links = {
+     parent: @patient.parent_relationships.each_with_object({}) do |parent_relationship, memo|
+       memo[parent_relationship.parent_id] = destroy_patient_parent_relationship_path(@patient, parent_relationship.parent_id)
+     end,
+   } %>
+
+<%= render AppPatientCardComponent.new(@patient, change_links:, remove_links:) %>
 
 <%= govuk_button_link_to "Continue", patient_path(@patient) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -573,17 +573,18 @@ en:
     info: Information
     success: Success
     warning: Warning
-  number:
-    "0": zero
-    "1": one
-    "2": two
-    "3": three
-    "4": four
-    "5": five
-    "6": six
-    "7": seven
-    "8": eight
-    "9": nine
+  ordinal_number:
+    "0": zeroth
+    "1": first
+    "2": second
+    "3": third
+    "4": fourth
+    "5": fifth
+    "6": sixth
+    "7": seventh
+    "8": eighth
+    "9": ninth
+    "10": tenth
   page_titles:
     accessibility_statement: Accessibility statement
   patients:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,10 @@ Rails.application.routes.draw do
   resources :patients, only: %i[index show edit update] do
     post "", action: :index, on: :collection
 
+    resources :parent_relationships, path: "parents", only: %i[destroy] do
+      get "destroy", action: :confirm_destroy, on: :member, as: "destroy"
+    end
+
     member do
       get "log"
 

--- a/spec/components/app_parent_summary_component_spec.rb
+++ b/spec/components/app_parent_summary_component_spec.rb
@@ -11,23 +11,11 @@ describe AppParentSummaryComponent do
     create(:parent_relationship, :father, parent:, patient:)
   end
 
-  it { should_not have_content("Name") }
-  it { should_not have_content("Relationship") }
+  it { should have_content("Name") }
+  it { should have_content("John Smith") }
 
-  context "when showing name and relationship" do
-    let(:component) do
-      described_class.new(
-        parent_relationship:,
-        show_name_and_relationship: true
-      )
-    end
-
-    it { should have_content("Name") }
-    it { should have_content("John Smith") }
-
-    it { should have_content("Relationship") }
-    it { should have_content("Dad") }
-  end
+  it { should have_content("Relationship") }
+  it { should have_content("Dad") }
 
   context "with an email address" do
     let(:parent) { create(:parent, email: "test@example.com") }
@@ -81,13 +69,7 @@ describe AppParentSummaryComponent do
   it { should_not have_content("Change") }
 
   context "with change links" do
-    let(:component) do
-      described_class.new(
-        parent_relationship:,
-        change_links:,
-        show_name_and_relationship: true
-      )
-    end
+    let(:component) { described_class.new(parent_relationship:, change_links:) }
 
     let(:change_links) do
       {

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -236,7 +236,7 @@ describe "Manage children" do
   def then_i_see_the_edit_child_record_page
     expect(page).to have_title("Edit child record")
     expect(page).to have_content("SMITH, John")
-    expect(page).to have_content("Record details")
+    expect(page).to have_content("Change")
   end
 
   def when_i_click_on_change_nhs_number

--- a/spec/features/parent_relationships_spec.rb
+++ b/spec/features/parent_relationships_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+describe "Parent relationships" do
+  before { given_a_patient_with_a_parent_exists }
+
+  scenario "User removes a parent relationship from a patient" do
+    when_i_visit_the_patient_page
+    and_i_click_on_edit_child_record
+    and_i_click_on_remove_parent
+    then_i_see_the_delete_parent_relationship_page
+
+    when_i_go_back_to_the_patient
+    then_i_see_the_edit_child_record_page
+
+    when_i_click_on_remove_parent
+    and_i_delete_the_parent_relationship
+    then_i_see_the_edit_child_record_page
+    and_i_see_a_deletion_confirmation_message
+  end
+
+  def given_a_patient_with_a_parent_exists
+    organisation = create(:organisation)
+    @nurse = create(:nurse, organisation:)
+
+    @patient = create(:patient, organisation:)
+
+    @parent = create(:parent)
+
+    create(:parent_relationship, patient: @patient, parent: @parent)
+  end
+
+  def when_i_visit_the_patient_page
+    sign_in @nurse
+    visit patient_path(@patient)
+  end
+
+  def and_i_click_on_edit_child_record
+    click_on "Edit child record"
+  end
+
+  def and_i_click_on_remove_parent
+    click_on "Remove first parent or guardian"
+  end
+
+  alias_method :when_i_click_on_remove_parent, :and_i_click_on_remove_parent
+
+  def then_i_see_the_delete_parent_relationship_page
+    expect(page).to have_content(
+      "Are you sure you want to remove the relationship"
+    )
+  end
+
+  def when_i_go_back_to_the_patient
+    click_on "No, return to child record"
+  end
+
+  def then_i_see_the_edit_child_record_page
+    expect(page).to have_content("Edit child record")
+  end
+
+  def and_i_delete_the_parent_relationship
+    click_on "Yes, remove this relationship"
+  end
+
+  def and_i_see_a_deletion_confirmation_message
+    expect(page).to have_content("Parent relationship removed")
+  end
+end


### PR DESCRIPTION
This adds a new page which allows the anyone to remove a parent relationship from a patient while retaining any consents submitted against this patient by the parent.

This is based on the latest designs in the prototype.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1088)

## Screenshots

<img width="783" alt="Screenshot 2025-05-01 at 16 16 31" src="https://github.com/user-attachments/assets/9913a531-8e99-499e-b39d-bafb3d925cb9" />
<img width="728" alt="Screenshot 2025-05-01 at 16 16 35" src="https://github.com/user-attachments/assets/772f5b5b-b56b-401e-ac60-3b86fe57c374" />
<img width="1152" alt="Screenshot 2025-05-01 at 16 16 39" src="https://github.com/user-attachments/assets/1c895fa6-56b4-4f85-9044-27bc9c5bc90a" />

