### PR TITLE
Ensure vaccine is set when saving a vaccination record

### DIFF
--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -170,9 +170,15 @@ class DraftVaccinationRecord
 
   delegate :vaccine, to: :batch, allow_nil: true
 
+  delegate :id, to: :vaccine, prefix: true, allow_nil: true
+
   def vaccine_id_changed? = batch_id_changed?
 
   private
+
+  def writable_attribute_names
+    super + %w[vaccine_id]
+  end
 
   def reset_unused_fields
     unless administered?

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -64,6 +64,22 @@ describe DraftVaccinationRecord do
     end
   end
 
+  describe "#write_to!" do
+    subject(:write_to!) do
+      draft_vaccination_record.write_to!(vaccination_record)
+    end
+
+    let(:attributes) { valid_administered_attributes }
+
+    let(:vaccination_record) { VaccinationRecord.new }
+
+    it "sets the vaccine" do
+      expect { write_to! }.to change(vaccination_record, :vaccine).to(
+        batch.vaccine
+      )
+    end
+  end
+
   describe "#reset_unused_fields" do
     subject(:save!) { draft_vaccination_record.save! }
 


### PR DESCRIPTION
This fixes a regression that was introduced in 2073e01c1d6db2277cf677c5d4f9d00262c34469 where the vaccine isn't being set on vaccination records when recorded in the service itself. I've fixed the regression and then introduced a test to ensure this doesn't break again in the future.