### PR TITLE
Improve workflow for adding back into cohort

### DIFF
--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -32,7 +32,8 @@ class PatientImport < ApplicationRecord
     @school_moves_to_save ||= Set.new
 
     if (school_move = row.to_school_move(patient))
-      if patient.school.nil? && !patient.home_educated
+      if (patient.school.nil? && !patient.home_educated) ||
+           patient.organisation.nil?
         @school_moves_to_confirm.add(school_move)
       else
         @school_moves_to_save.add(school_move)


### PR DESCRIPTION
This change auto-confirms a school move when processing a cohort or class upload for a patient with a nil organisation. The generated school move is immediately confirmed—replicating the behavior of importing a new patient—so the confirmed move isn’t returned for further processing by the user. 