### PR TITLE
Ensure "Other" delivery site can be chosen

### DIFF
--- a/app/helpers/vaccinations_helper.rb
+++ b/app/helpers/vaccinations_helper.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module VaccinationsHelper
-  def vaccination_delivery_methods_for(vaccine)
-    vaccine.available_delivery_methods.map do |m|
-      [m, VaccinationRecord.human_enum_name("delivery_methods", m)]
+  def available_delivery_methods_for(object)
+    object.available_delivery_methods.map do
+      [it, VaccinationRecord.human_enum_name("delivery_methods", it)]
     end
   end
 
-  def vaccination_delivery_sites_for(vaccine)
-    vaccine.available_delivery_sites.map do |s|
-      [s, VaccinationRecord.human_enum_name("delivery_sites", s)]
+  def available_delivery_sites_for(object)
+    object.available_delivery_sites.map do
+      [it, VaccinationRecord.human_enum_name("delivery_sites", it)]
     end
   end
 end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -71,6 +71,14 @@ class Programme < ApplicationRecord
     year_groups.map(&:to_birth_academic_year)
   end
 
+  def available_delivery_methods
+    vaccines.flat_map(&:available_delivery_methods).uniq
+  end
+
+  def available_delivery_sites
+    vaccines.flat_map(&:available_delivery_sites).uniq
+  end
+
   def common_delivery_sites
     if hpv? || menacwy? || td_ipv?
       %w[left_arm_upper_position right_arm_upper_position]

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -15,13 +15,13 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_collection_radio_buttons :delivery_method,
-                                       vaccination_delivery_methods_for(@draft_vaccination_record.vaccine),
+                                       available_delivery_methods_for(@draft_vaccination_record.programme),
                                        :first,
                                        :second,
                                        legend: { text: "Method" } %>
 
   <%= f.govuk_collection_radio_buttons :delivery_site,
-                                       vaccination_delivery_sites_for(@draft_vaccination_record.vaccine),
+                                       available_delivery_sites_for(@draft_vaccination_record.programme),
                                        :first,
                                        :second,
                                        legend: { text: "Site" } %>

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -3,11 +3,14 @@
 describe "HPV vaccination" do
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
-  scenario "Administered" do
+  scenario "Administered with common delivery site" do
     given_i_am_signed_in
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    and_i_record_that_the_patient_has_been_vaccinated
+    and_i_fill_in_pre_screening_questions
+    and_i_record_that_the_patient_has_been_vaccinated(
+      "Left arm (upper position)"
+    )
     and_i_see_only_not_expired_batches
     and_i_select_the_batch
     then_i_see_the_confirmation_page
@@ -53,6 +56,20 @@ describe "HPV vaccination" do
     and_a_text_is_sent_to_the_parent_confirming_the_vaccination
   end
 
+  scenario "Administered with other delivery site" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_fill_in_pre_screening_questions
+    and_i_record_that_the_patient_has_been_vaccinated("Other")
+    and_i_select_the_delivery
+    and_i_select_the_batch
+    then_i_see_the_confirmation_page
+
+    when_i_confirm_the_details
+    then_i_see_a_success_message
+  end
+
   def given_i_am_signed_in
     programme = create(:programme, :hpv_all_vaccines)
     organisation =
@@ -92,16 +109,16 @@ describe "HPV vaccination" do
     click_link @patient.full_name
   end
 
-  def and_i_record_that_the_patient_has_been_vaccinated
-    # pre-screening
+  def and_i_fill_in_pre_screening_questions
     check "know what the vaccination is for, and are happy to have it"
     check "have not already had the vaccination"
     check "are feeling well"
     check "have no allergies which would prevent vaccination"
+  end
 
-    # vaccination
+  def and_i_record_that_the_patient_has_been_vaccinated(where)
     choose "Yes"
-    choose "Left arm (upper position)"
+    choose where
     click_button "Continue"
   end
 


### PR DESCRIPTION
This fixes a regression that was added in 2073e01c1d6db2277cf677c5d4f9d00262c34469 where the "Other" delivery site no longer works as it requires the vaccine to be present, but we don't have a vaccine at that point. Instead we can allow the user to select a delivery site across all the vaccines.

I suspect this will need to be revisited for Flu where we have nasal spray and injection vaccines and the vaccine that the nurse selects needs to match the approriate delivery site.