### PR TITLE
Fix "Check if Rails tests need to run" job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,8 @@ jobs:
         id: check-rails-relevant-changes
         run: |
           if [ ${{ github.event_name }} == "pull_request" ]; then
-            git fetch origin ${{ github.event.pull_request.head.ref }} || echo "Fetch failed, running all tests"; exit 0
+            git fetch origin ${{ github.event.pull_request.head.ref }} || echo "Fetch failed, running all tests"; \
+            echo "RUN_RAILS_TESTS=false" > $GITHUB_OUTPUT; exit 0
             RELEVANT_DIRS=$(git diff ${{ github.event.pull_request.base.sha }} origin/${{ github.event.pull_request.head.ref }}  --name-only)
             if [ -z "$(echo "$RELEVANT_DIRS" | egrep -v "^(.github|adr|aws|docs|storage|terraform|tests|tests-examples)/")" ]; then
               echo "No relevant changes detected, skipping rails tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "pull_request" ]; then
             git fetch origin ${{ github.event.pull_request.head.ref }} || echo "Fetch failed, running all tests"; \
-            echo "RUN_RAILS_TESTS=false" > $GITHUB_OUTPUT; exit 0
+            echo "RUN_RAILS_TESTS=true" > $GITHUB_OUTPUT; exit 0
             RELEVANT_DIRS=$(git diff ${{ github.event.pull_request.base.sha }} origin/${{ github.event.pull_request.head.ref }}  --name-only)
             if [ -z "$(echo "$RELEVANT_DIRS" | egrep -v "^(.github|adr|aws|docs|storage|terraform|tests|tests-examples)/")" ]; then
               echo "No relevant changes detected, skipping rails tests"


### PR DESCRIPTION
This cherry-picks a couple of PRs from the 2.2.1 branch which fixes a couple of issues with the job which checks whether to run the Rails tests, to ensure the Rails tests run.