### PR TITLE
Fixing tf_lint stage of hk

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache --check-cache
       - uses: hashicorp/setup-terraform@v3
       - uses: terraform-linters/setup-tflint@v4
+      - run: tflint --chdir=terraform --init
       - uses: jdx/mise-action@v2
         with:
           install_args: hk pkl

--- a/hk.pkl
+++ b/hk.pkl
@@ -32,8 +32,8 @@ local linters = new Mapping<String, Group> {
 
             ["tf_lint"] = new Step {
                 glob = "*.tf"
-                check = "tflint --chdir=terraform --recursive"
-                fix = "tflint --chdir=terraform --recursive --fix"
+                check = "tflint --chdir=terraform --config=$(pwd)/terraform/.tflint.hcl --recursive"
+                fix = "tflint --chdir=terraform --config=$(pwd)/terraform/.tflint.hcl --recursive --fix"
             }
         }
     }


### PR DESCRIPTION
- Without specifying the configuration file it does not apply correct fixes
  - Pathing is relative to directory hk is running in, therefore with --recursive we must pass absolute paths