### PR TITLE
Reduce spacing between header navigation items above tablet breakpoint

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -8,6 +8,20 @@
   }
 }
 
+.app-header {
+  .nhsuk-header__navigation-item {
+    @include mq($from: tablet) {
+      padding: 0 12px;
+    }
+  }
+
+  .nhsuk-header__drop-down .nhsuk-header__navigation-item {
+    @include mq($from: tablet) {
+      padding: 0;
+    }
+  }
+}
+
 .app-header__navigation-item--current {
   .nhsuk-header__navigation-link {
     border-bottom-color: $nhsuk-border-color;


### PR DESCRIPTION
`nhsuk-frontend` v9.4 increased this space to 16px which, when accumulated across all navigation items, moves the last item beyond the container on desktop. We’ll override this value to 12px to resolve this issue in the short term.