### PR TITLE
Upgrade DB engine version to 14.15

### DIFF
--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -37,7 +37,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
   cluster_identifier          = var.resource_name.db_cluster
   engine                      = "aurora-postgresql"
   engine_mode                 = "provisioned"
-  engine_version              = "14.9"
+  engine_version              = "14.15"
   database_name               = "manage_vaccinations"
   master_username             = "postgres"
   manage_master_user_password = var.db_secret_arn == null


### PR DESCRIPTION
* Minor DB version upgrades happen automatically during the weekly DB maintenance window. On 5 May, a new minor version upgrade from 14.9 to 14.15 has become available and will be applied during the next maintenance window.
* On preview, this has already been done. It will happen without any downtime
* This PR only updates the terraform config to match the current DB state