### PR TITLE
Automatically accept preferred names

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -57,6 +57,19 @@ class PatientImportRow
         %w[male female not_specified]
       )
 
+      auto_accept_attribute(
+        existing_patient,
+        attributes,
+        :preferred_given_name,
+        :present?
+      )
+      auto_accept_attribute(
+        existing_patient,
+        attributes,
+        :preferred_family_name,
+        :present?
+      )
+
       if address_postcode.present? &&
            address_postcode.to_postcode != existing_patient.address_postcode
         attributes.merge!(

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -49,11 +49,13 @@ class PatientImportRow
         existing_patient.registration = attributes.delete(:registration)
       end
 
-      if attributes[:gender_code].in?(%w[male female not_specified]) &&
-           !existing_patient.gender_code.in?(%w[male female not_specified]) &&
-           attributes[:gender_code] != existing_patient.gender_code
-        existing_patient.gender_code = attributes.delete(:gender_code)
-      end
+      auto_accept_attribute(
+        existing_patient,
+        attributes,
+        :gender_code,
+        :in?,
+        %w[male female not_specified]
+      )
 
       if address_postcode.present? &&
            address_postcode.to_postcode != existing_patient.address_postcode
@@ -206,6 +208,22 @@ class PatientImportRow
   attr_reader :organisation, :year_groups
 
   private
+
+  def auto_accept_attribute(
+    existing_patient,
+    attributes,
+    attribute_name,
+    condition_function,
+    *condition_params
+  )
+    if attributes[attribute_name].send(condition_function, *condition_params) &&
+         !existing_patient[attribute_name].send(
+           condition_function,
+           *condition_params
+         )
+      existing_patient[attribute_name] = attributes.delete(attribute_name)
+    end
+  end
 
   def auto_overwrite_address?(existing_patient)
     existing_patient.address_postcode == address_postcode&.to_postcode &&

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -304,6 +304,81 @@ describe ClassImportRow do
       end
     end
 
+    context "with an existing patient without preferred names" do
+      let(:data) do
+        valid_data.merge(
+          "CHILD_PREFERRED_FIRST_NAME" => "Jim",
+          "CHILD_PREFERRED_LAST_NAME" => "Smithy"
+        )
+      end
+
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          given_name: "Jimmy",
+          date_of_birth: Date.new(2010, 1, 1)
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "saves the incoming preferred names" do
+        expect(patient).to have_attributes(
+          preferred_given_name: "Jim",
+          preferred_family_name: "Smithy"
+        )
+      end
+
+      it "doesn't stage the preferred names differences" do
+        expect(patient.pending_changes).to be_empty
+      end
+    end
+
+    context "with an existing patient already with preferred names" do
+      let(:data) do
+        valid_data.merge(
+          "CHILD_PREFERRED_FIRST_NAME" => "Jim",
+          "CHILD_PREFERRED_LAST_NAME" => "Smithy"
+        )
+      end
+
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          given_name: "Jimmy",
+          preferred_given_name: "Jimothy",
+          preferred_family_name: "Smithers",
+          nhs_number: "9990000018",
+          address_line_1: "10 Downing Street",
+          address_line_2: "",
+          address_town: "London",
+          birth_academic_year: 2009,
+          date_of_birth: Date.new(2010, 1, 1),
+          registration: "8AB"
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "does not save the incoming gender" do
+        expect(patient).to have_attributes(
+          preferred_given_name: "Jimothy",
+          preferred_family_name: "Smithers"
+        )
+      end
+
+      it "does stage the gender differences" do
+        expect(patient.pending_changes).to include(
+          "preferred_given_name" => "Jim",
+          "preferred_family_name" => "Smithy"
+        )
+      end
+    end
+
     context "with an existing patient without address" do
       let(:data) do
         valid_data.merge(

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -27,11 +27,11 @@ describe CohortImportRow do
       "CHILD_ADDRESS_LINE_2" => "",
       "CHILD_TOWN" => "London",
       "CHILD_POSTCODE" => "SW1A 1AA",
+      "CHILD_FIRST_NAME" => "Jimmy",
+      "CHILD_LAST_NAME" => "Smith",
       "CHILD_PREFERRED_GIVEN_NAME" => "Jim",
       "CHILD_DATE_OF_BIRTH" => "2010-01-01",
-      "CHILD_FIRST_NAME" => "Jimmy",
       "CHILD_GENDER" => "Male",
-      "CHILD_LAST_NAME" => "Smith",
       "CHILD_NHS_NUMBER" => "9990000018",
       "CHILD_REGISTRATION" => "8AB",
       "CHILD_SCHOOL_URN" => school_urn

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -29,7 +29,8 @@ describe CohortImportRow do
       "CHILD_POSTCODE" => "SW1A 1AA",
       "CHILD_FIRST_NAME" => "Jimmy",
       "CHILD_LAST_NAME" => "Smith",
-      "CHILD_PREFERRED_GIVEN_NAME" => "Jim",
+      "CHILD_PREFERRED_FIRST_NAME" => "Jim",
+      "CHILD_PREFERRED_LAST_NAME" => "Smithy",
       "CHILD_DATE_OF_BIRTH" => "2010-01-01",
       "CHILD_GENDER" => "Male",
       "CHILD_NHS_NUMBER" => "9990000018",
@@ -288,6 +289,74 @@ describe CohortImportRow do
 
       it "does stage the gender differences" do
         expect(patient.pending_changes).to include("gender_code" => "male")
+      end
+    end
+
+    context "with an existing patient without preferred names" do
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "male",
+          given_name: "Jimmy",
+          nhs_number: "9990000018",
+          address_line_1: "10 Downing Street",
+          address_line_2: "",
+          address_town: "London",
+          birth_academic_year: 2009,
+          date_of_birth: Date.new(2010, 1, 1),
+          registration: "8AB"
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "saves the incoming preferred names" do
+        expect(patient).to have_attributes(
+          preferred_given_name: "Jim",
+          preferred_family_name: "Smithy"
+        )
+      end
+
+      it "doesn't stage the preferred names differences" do
+        expect(patient.pending_changes).to be_empty
+      end
+    end
+
+    context "with an existing patient already with preferred names" do
+      let!(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          given_name: "Jimmy",
+          family_name: "Smith",
+          preferred_given_name: "Jimothy",
+          preferred_family_name: "Smithers",
+          nhs_number: "9990000018",
+          address_line_1: "10 Downing Street",
+          address_line_2: "",
+          address_town: "London",
+          birth_academic_year: 2009,
+          date_of_birth: Date.new(2010, 1, 1),
+          registration: "8AB"
+        )
+      end
+
+      it { should eq(existing_patient) }
+
+      it "does not save the incoming gender" do
+        expect(patient).to have_attributes(
+          preferred_given_name: "Jimothy",
+          preferred_family_name: "Smithers"
+        )
+      end
+
+      it "does stage the gender differences" do
+        expect(patient.pending_changes).to include(
+          "preferred_given_name" => "Jim",
+          "preferred_family_name" => "Smithy"
+        )
       end
     end
 


### PR DESCRIPTION
If a patient has either `preferred_given_name` or `preferred_family_name` set to `nil` in Mavis, but a name (eg "Benny") is uploaded for a matching record (in either a class upload, or cohort upload), this is now automatically accepted, rather than prompting the user to review.

[MAV-1100](https://nhsd-jira.digital.nhs.uk/browse/MAV-1100)