### PR TITLE
Remove report_gillick_notify_parents feature flag

### DIFF
--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -56,35 +56,27 @@ class Reports::ProgrammeVaccinationsExporter
       GILLICK_ASSESSMENT_DATE
       GILLICK_ASSESSED_BY
       GILLICK_ASSESSMENT_NOTES
-    ] +
-      (
-        if Flipper.enabled?(:report_gillick_notify_parents)
-          %w[GILLICK_NOTIFY_PARENTS]
-        else
-          []
-        end
-      ) +
-      %w[
-        VACCINATED
-        DATE_OF_VACCINATION
-        TIME_OF_VACCINATION
-        PROGRAMME_NAME
-        VACCINE_GIVEN
-        PERFORMING_PROFESSIONAL_EMAIL
-        PERFORMING_PROFESSIONAL_FORENAME
-        PERFORMING_PROFESSIONAL_SURNAME
-        BATCH_NUMBER
-        BATCH_EXPIRY_DATE
-        ANATOMICAL_SITE
-        ROUTE_OF_VACCINATION
-        DOSE_SEQUENCE
-        REASON_NOT_VACCINATED
-        LOCAL_PATIENT_ID
-        SNOMED_PROCEDURE_CODE
-        REASON_FOR_INCLUSION
-        RECORD_CREATED
-        RECORD_UPDATED
-      ]
+      GILLICK_NOTIFY_PARENTS
+      VACCINATED
+      DATE_OF_VACCINATION
+      TIME_OF_VACCINATION
+      PROGRAMME_NAME
+      VACCINE_GIVEN
+      PERFORMING_PROFESSIONAL_EMAIL
+      PERFORMING_PROFESSIONAL_FORENAME
+      PERFORMING_PROFESSIONAL_SURNAME
+      BATCH_NUMBER
+      BATCH_EXPIRY_DATE
+      ANATOMICAL_SITE
+      ROUTE_OF_VACCINATION
+      DOSE_SEQUENCE
+      REASON_NOT_VACCINATED
+      LOCAL_PATIENT_ID
+      SNOMED_PROCEDURE_CODE
+      REASON_FOR_INCLUSION
+      RECORD_CREATED
+      RECORD_UPDATED
+    ]
   end
 
   def vaccination_records
@@ -212,36 +204,28 @@ class Reports::ProgrammeVaccinationsExporter
       gillick_status(gillick_assessment:),
       gillick_assessment&.created_at&.to_date&.iso8601 || "",
       gillick_assessment&.performed_by&.full_name || "",
-      gillick_assessment&.notes || ""
-    ] +
-      (
-        if Flipper.enabled?(:report_gillick_notify_parents)
-          [gillick_notify_parents(patient:, gillick_assessment:)]
-        else
-          []
-        end
-      ) +
-      [
-        vaccinated(vaccination_record:),
-        vaccination_record.performed_at.to_date.iso8601,
-        vaccination_record.performed_at.strftime("%H:%M:%S"),
-        programme.name,
-        vaccination_record.vaccine&.nivs_name || "",
-        vaccination_record.performed_by_user&.email || "",
-        vaccination_record.performed_by&.given_name || "",
-        vaccination_record.performed_by&.family_name || "",
-        vaccination_record.batch&.name || "",
-        vaccination_record.batch&.expiry&.iso8601 || "",
-        anatomical_site(vaccination_record:),
-        route_of_vaccination(vaccination_record:),
-        dose_sequence(vaccination_record:),
-        reason_not_vaccinated(vaccination_record:),
-        patient.id,
-        programme.snomed_procedure_code,
-        reason_for_inclusion(vaccination_record:),
-        record_created_at(vaccination_record:),
-        record_updated_at(vaccination_record:)
-      ]
+      gillick_assessment&.notes || "",
+      gillick_notify_parents(patient:, gillick_assessment:),
+      vaccinated(vaccination_record:),
+      vaccination_record.performed_at.to_date.iso8601,
+      vaccination_record.performed_at.strftime("%H:%M:%S"),
+      programme.name,
+      vaccination_record.vaccine&.nivs_name || "",
+      vaccination_record.performed_by_user&.email || "",
+      vaccination_record.performed_by&.given_name || "",
+      vaccination_record.performed_by&.family_name || "",
+      vaccination_record.batch&.name || "",
+      vaccination_record.batch&.expiry&.iso8601 || "",
+      anatomical_site(vaccination_record:),
+      route_of_vaccination(vaccination_record:),
+      dose_sequence(vaccination_record:),
+      reason_not_vaccinated(vaccination_record:),
+      patient.id,
+      programme.snomed_procedure_code,
+      reason_for_inclusion(vaccination_record:),
+      record_created_at(vaccination_record:),
+      record_updated_at(vaccination_record:)
+    ]
   end
 
   def nhs_number_status_code(patient:)

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -6,6 +6,3 @@ dev_tools: Developer tools useful for testing and debugging.
 mesh_jobs: Export vaccination records to MESH automatically.
 
 offline_working: Prototype support for using Mavis offline.
-
-report_gillick_notify_parents: Include whether patients would like their
-  parents to be informed of vaccinations in the reporting.

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -57,6 +57,7 @@ describe Reports::ProgrammeVaccinationsExporter do
             GILLICK_ASSESSMENT_DATE
             GILLICK_ASSESSED_BY
             GILLICK_ASSESSMENT_NOTES
+            GILLICK_NOTIFY_PARENTS
             VACCINATED
             DATE_OF_VACCINATION
             TIME_OF_VACCINATION
@@ -78,13 +79,6 @@ describe Reports::ProgrammeVaccinationsExporter do
             RECORD_UPDATED
           ]
         )
-      end
-
-      context "when Gillick notify parents is enabled" do
-        before { Flipper.enable(:report_gillick_notify_parents) }
-        after { Flipper.disable(:report_gillick_notify_parents) }
-
-        it { should include("GILLICK_NOTIFY_PARENTS") }
       end
     end
 
@@ -139,6 +133,7 @@ describe Reports::ProgrammeVaccinationsExporter do
                 "GILLICK_ASSESSED_BY" => "",
                 "GILLICK_ASSESSMENT_DATE" => "",
                 "GILLICK_ASSESSMENT_NOTES" => "",
+                "GILLICK_NOTIFY_PARENTS" => "",
                 "GILLICK_STATUS" => "",
                 "GP_NAME" => "",
                 "GP_ORGANISATION_CODE" => "",
@@ -290,6 +285,7 @@ describe Reports::ProgrammeVaccinationsExporter do
                 "GILLICK_ASSESSED_BY" => "",
                 "GILLICK_ASSESSMENT_DATE" => "",
                 "GILLICK_ASSESSMENT_NOTES" => "",
+                "GILLICK_NOTIFY_PARENTS" => "",
                 "GILLICK_STATUS" => "",
                 "GP_NAME" => "",
                 "GP_ORGANISATION_CODE" => "",
@@ -455,11 +451,7 @@ describe Reports::ProgrammeVaccinationsExporter do
             performed_by:,
             created_at:
           )
-
-          Flipper.enable(:report_gillick_notify_parents)
         end
-
-        after { Flipper.disable(:report_gillick_notify_parents) }
 
         it "includes the information" do
           expect(rows.first.to_hash).to include(


### PR DESCRIPTION
This feature went live in 2.2.1 and therefore we can safely remove the feature flag and simplify the code.