### PR TITLE
Send vaccination record confirmations earlier

### DIFF
--- a/app/jobs/send_vaccination_confirmations_job.rb
+++ b/app/jobs/send_vaccination_confirmations_job.rb
@@ -20,10 +20,10 @@ class SendVaccinationConfirmationsJob < ApplicationJob
       .where("created_at >= ?", since)
       .where(confirmation_sent_at: nil)
       .recorded_in_service
-      .select { _1.academic_year == academic_year }
-      .each do |vaccation_record|
-        send_vaccination_confirmation(vaccation_record)
-        vaccation_record.update!(confirmation_sent_at: Time.current)
+      .select { it.academic_year == academic_year }
+      .each do |vaccination_record|
+        send_vaccination_confirmation(vaccination_record)
+        vaccination_record.update!(confirmation_sent_at: Time.current)
       end
   end
 end

--- a/config/cron_jobs.rb
+++ b/config/cron_jobs.rb
@@ -65,7 +65,7 @@ CRON_JOBS = {
     description: "Keep patient details up to date with PDS."
   },
   vaccination_confirmations: {
-    cron: "every day at 7pm",
+    cron: "every day at 13:00 and 16:00 and 19:00",
     class: "SendVaccinationConfirmationsJob",
     description: "Send vaccination confirmation emails to parents"
   }


### PR DESCRIPTION
This updates the schedule for the vaccination record confirmations to send them earlier in the day closer to when schools typically finish. This has been requested by one of our SAIS organisations.

The vaccination record confirmations will now be sent at 3pm.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1105)