### PR TITLE
Deadline passed

### DIFF
--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -4,8 +4,6 @@ module ParentInterface
   class ConsentFormsController < ConsentForms::BaseController
     include ConsentFormMailerConcern
 
-    prepend_before_action :set_session_and_programmes,
-                          only: %i[start create deadline_passed]
     skip_before_action :set_consent_form, only: %i[start create deadline_passed]
     skip_before_action :authenticate_consent_form_user!,
                        only: %i[start create deadline_passed]
@@ -63,14 +61,6 @@ module ParentInterface
 
     private
 
-    def set_session_and_programmes
-      @session = Session.find_by!(slug: params[:session_slug])
-      @organisation = @session.organisation
-      @programmes =
-        @session.programmes.where(type: params[:programme_types].split("-"))
-      @team = @session.team
-    end
-
     def clear_session_edit_variables
       session.delete(:follow_up_changes_start_page)
     end
@@ -78,7 +68,7 @@ module ParentInterface
     def check_if_past_deadline
       return if @session.open_for_consent?
       redirect_to action: :deadline_passed,
-                  programme_types: params[:programme_types],
+                  programme_types: @programmes.map(&:type).join("-"),
                   session_slug: @session.slug
     end
   end

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -77,7 +77,9 @@ module ParentInterface
 
     def check_if_past_deadline
       return if @session.open_for_consent?
-      redirect_to action: :deadline_passed
+      redirect_to action: :deadline_passed,
+                  programme_types: params[:programme_types],
+                  session_slug: @session.slug
     end
   end
 end

--- a/spec/features/parental_consent_closed_spec.rb
+++ b/spec/features/parental_consent_closed_spec.rb
@@ -7,6 +7,15 @@ describe "Parental consent closed" do
     then_i_see_that_consent_is_closed
   end
 
+  scenario "Before parent submits the consent" do
+    given_an_hpv_programme_is_starting_soon
+    when_i_go_through_the_consent_journey
+    then_i_see_the_confirmation_page
+
+    when_i_wait_a_long_time_before_submitting
+    then_i_see_that_consent_is_closed
+  end
+
   def given_an_hpv_programme_is_underway_with_a_backfilled_session
     @programme = create(:programme, :hpv)
     @organisation =
@@ -23,8 +32,82 @@ describe "Parental consent closed" do
       )
   end
 
+  def given_an_hpv_programme_is_starting_soon
+    @programme = create(:programme, :hpv)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [@programme])
+    location = create(:school, name: "Pilot School", team: create(:team))
+    @session =
+      create(
+        :session,
+        :scheduled,
+        organisation: @organisation,
+        programmes: [@programme],
+        location:,
+        date: Date.tomorrow
+      )
+    @child = create(:patient, :consent_no_response, session: @session)
+  end
+
   def when_i_go_to_the_consent_form
     visit start_parent_interface_consent_forms_path(@session, @programme)
+  end
+
+  def when_i_go_through_the_consent_journey
+    visit start_parent_interface_consent_forms_path(@session, @programme)
+
+    click_on "Start now"
+
+    expect(page).to have_content("What is your child’s name?")
+    fill_in "First name", with: @child.given_name
+    fill_in "Last name", with: @child.family_name
+    choose "No" # Do they use a different name in school?
+    click_on "Continue"
+
+    expect(page).to have_content("What is your child’s date of birth?")
+    fill_in "Day", with: @child.date_of_birth.day
+    fill_in "Month", with: @child.date_of_birth.month
+    fill_in "Year", with: @child.date_of_birth.year
+    click_on "Continue"
+
+    choose "Yes, they go to this school"
+    click_on "Continue"
+
+    expect(page).to have_content("About you")
+    fill_in "Full name", with: "Jane #{@child.family_name}"
+    choose "Mum" # Your relationship to the child
+    fill_in "Email address", with: "jane@example.com"
+    fill_in "Phone number", with: "07123456789"
+    check "Tick this box if you’d like to get updates by text message"
+    click_on "Continue"
+
+    expect(page).to have_content("Phone contact method")
+    choose "I do not have specific needs"
+    click_on "Continue"
+
+    expect(page).to have_content("Do you agree")
+    choose "Yes, I agree"
+    click_on "Continue"
+
+    expect(page).to have_content("Home address")
+    fill_in "Address line 1", with: "1 Test Street"
+    fill_in "Address line 2 (optional)", with: "2nd Floor"
+    fill_in "Town or city", with: "Testville"
+    fill_in "Postcode", with: "TE1 1ST"
+    click_on "Continue"
+
+    until page.has_content?("Check and confirm")
+      choose "No"
+      click_on "Continue"
+    end
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_content("Check and confirm")
+  end
+
+  def when_i_wait_a_long_time_before_submitting
+    travel_to(1.day.from_now) { click_on "Confirm" }
   end
 
   def then_i_see_that_consent_is_closed


### PR DESCRIPTION
There is an edge case where parents giving consent would get an error page if they begin the consent journey before the deadline has passed, but only finish it after. Instead of getting the helpful "the deadline has passed, please contact the SAIS team", they got the generic 500 error page.

This fixes that and adds a test.

https://good-machine.sentry.io/issues/6428092252/
https://nhsd-jira.digital.nhs.uk/browse/MAV-1123
