### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export PATH="$OPENSSL_PATH/bin:$CMAKE_PREFIX_PATH/bin:$PATH"
 export LDFLAGS="-L$OPENSSL_PATH/lib $LDFLAGS"
 export CPPFLAGS="-I$OPENSSL_PATH/include $CPPFLAGS"
 export PKG_CONFIG_PATH="$CMAKE_PREFIX_PATH/lib/pkgconfig"
+export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion)"
 
 # Version manager
 brew install mise


### PR DESCRIPTION
See https://github.com/theory/pgenv/issues/93

Without adding the `MACOSX_DEPLOYMENT_TARGET` variable, Postgres fails to install using `mise` on macOS 15.4 and above.