### PR TITLE
Ensure patients who don't need triage are hidden

### DIFF
--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -10,7 +10,7 @@ class Sessions::TriageController < ApplicationController
   layout "full"
 
   def show
-    @statuses = Patient::TriageStatus.statuses.keys - [:not_required]
+    @statuses = Patient::TriageStatus.statuses.keys - %w[not_required]
     @programmes = @session.programmes
 
     scope =


### PR DESCRIPTION
When viewing the "Triage" tab of a session, patients who don't need triage should not be shown in this list. This was always the intention behind the design and this commit fixes a bug which meant that it wasn't working as expected.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1141)