### PR TITLE
Redirect users back to the patient after triage

### DIFF
--- a/app/controllers/patient_sessions/triages_controller.rb
+++ b/app/controllers/patient_sessions/triages_controller.rb
@@ -41,14 +41,7 @@ class PatientSessions::TriagesController < PatientSessions::BaseController
         .call(@patient.reload.consents, programme: @programme)
         .each { send_triage_confirmation(@patient_session, it) }
 
-      flash[:success] = {
-        heading: "Triage outcome updated for",
-        heading_link_text: @patient.full_name,
-        heading_link_href:
-          session_patient_programme_path(@session, @patient, @programme)
-      }
-
-      redirect_to redirect_path
+      redirect_to redirect_path, flash: { success: "Triage outcome updated" }
     else
       render "patient_sessions/programmes/show",
              layout: "full",
@@ -63,12 +56,11 @@ class PatientSessions::TriagesController < PatientSessions::BaseController
   end
 
   def redirect_path
-    if session[:current_section] == "vaccinations"
-      session_record_path(@session)
-    elsif session[:current_section] == "consents"
-      session_consent_path(@session)
-    else # if current_section is triage or anything else
-      session_triage_path(@session)
-    end
+    session_patient_programme_path(
+      @session,
+      @patient,
+      @programme,
+      return_to: "triage"
+    )
   end
 end

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -66,10 +66,7 @@ describe "Triage" do
   end
 
   def then_i_see_an_alert_saying_the_record_was_saved
-    expect(page).to have_alert(
-      "Success",
-      text: "Triage outcome updated for #{@patient.full_name}"
-    )
+    expect(page).to have_alert("Success", text: "Triage outcome updated")
   end
 
   def and_a_vaccination_at_clinic_email_is_sent_to_the_parent
@@ -78,6 +75,7 @@ describe "Triage" do
   end
 
   def when_i_filter_by_delay_vaccination
+    click_on "Triage"
     choose "Delay vaccination"
     click_on "Update results"
   end

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -17,19 +17,14 @@ describe "Triage" do
     then_i_see_a_validation_error
 
     when_i_record_that_they_need_triage
-    then_i_see_the_triage_page
+    then_i_see_the_triage_options
     and_needs_triage_emails_are_sent_to_both_parents
 
-    when_i_go_to_the_patient
-    and_i_do_not_vaccinate
-    then_i_see_the_triage_page
+    when_i_do_not_vaccinate
     and_vaccination_wont_happen_emails_are_sent_to_both_parents
 
-    when_i_go_to_the_patient
-    then_i_see_the_update_triage_link
-
     when_i_record_that_they_are_safe_to_vaccinate
-    then_i_see_the_triage_page
+    then_i_see_the_update_triage_link
     and_vaccination_will_happen_emails_are_sent_to_both_parents
   end
 
@@ -99,6 +94,10 @@ describe "Triage" do
     click_link @patient_triage_needed.full_name, match: :first
   end
 
+  def then_i_see_the_triage_options
+    expect(page).to have_selector :heading, "Is it safe to vaccinate"
+  end
+
   def when_i_record_that_they_need_triage
     choose "No, keep in triage"
     click_button "Save triage"
@@ -110,17 +109,9 @@ describe "Triage" do
     click_button "Save triage"
   end
 
-  def and_i_do_not_vaccinate
+  def when_i_do_not_vaccinate
     choose "No, do not vaccinate"
     click_button "Save triage"
-  end
-
-  def then_i_see_the_triage_page
-    expect(page).to have_content("Triage outcome")
-  end
-
-  def then_i_see_the_triage_options
-    expect(page).to have_selector :heading, "Is it safe to vaccinate"
   end
 
   def when_i_save_the_triage_without_choosing_an_option

--- a/spec/features/triage_then_parental_consent_refused_spec.rb
+++ b/spec/features/triage_then_parental_consent_refused_spec.rb
@@ -57,7 +57,6 @@ describe "Triage" do
   end
 
   def then_i_see_the_patient_is_ready
-    click_on @patient.full_name, match: :first
     expect(page).to have_content("Safe to vaccinate")
   end
 


### PR DESCRIPTION
While we don’t currently have the ability to provide a triage outcome for multiple programmes at a time, we require users to create a triage outcome multiple times.

This becomes even trickier because currently we return the user to the session Triage list after a adding a triage outcome; they then need to find the patient again, and then click on the other programme tab and add their second triage outcome.

We can make this process a little easier by returning the user to the page they came from (i.e. the patient session page), instead of taking them to the session Triage list view.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1129)