### PR TITLE
Use checkboxes instead of radios for consent status filter

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -21,10 +21,9 @@ class AppSearchComponent < ViewComponent::Base
         </div>
 
         <% if consent_statuses.any? %>
-          <%= f.govuk_radio_buttons_fieldset :consent_status, legend: { text: "Consent status", size: "s" } do %>
-            <%= f.govuk_radio_button :consent_status, "", label: { text: "Any" } %>
+          <%= f.govuk_check_boxes_fieldset :consent_statuses, legend: { text: "Consent status", size: "s" } do %>
             <% consent_statuses.each do |status| %>
-              <%= f.govuk_radio_button :consent_status, status, label: { text: t(status, scope: %i[status consent label]) } %>
+              <%= f.govuk_check_box :consent_statuses, status, label: { text: t(status, scope: %i[status consent label]) } %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/controllers/concerns/search_form_concern.rb
+++ b/app/controllers/concerns/search_form_concern.rb
@@ -7,7 +7,6 @@ module SearchFormConcern
     @form =
       SearchForm.new(
         params.fetch(:search_form, {}).permit(
-          :consent_status,
           :date_of_birth_day,
           :date_of_birth_month,
           :date_of_birth_year,
@@ -17,6 +16,7 @@ module SearchFormConcern
           :register_status,
           :session_status,
           :triage_status,
+          consent_statuses: [],
           year_groups: []
         )
       )

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -5,7 +5,7 @@ class SearchForm
   include ActiveModel::Attributes
   include ActiveRecord::AttributeAssignment
 
-  attribute :consent_status, :string
+  attribute :consent_statuses, array: true
   attribute :date_of_birth_day, :integer
   attribute :date_of_birth_month, :integer
   attribute :date_of_birth_year, :integer
@@ -16,6 +16,10 @@ class SearchForm
   attribute :session_status, :string
   attribute :triage_status, :string
   attribute :year_groups, array: true
+
+  def consent_statuses=(values)
+    super(values&.compact_blank || [])
+  end
 
   def year_groups=(values)
     super(values&.compact_blank&.map(&:to_i)&.compact || [])
@@ -40,8 +44,8 @@ class SearchForm
 
     scope = scope.search_by_nhs_number(nil) if missing_nhs_number.present?
 
-    if (status = consent_status).present?
-      scope = scope.has_consent_status(status, programme:)
+    if (statuses = consent_statuses).present?
+      scope = scope.has_consent_status(statuses, programme:)
     end
 
     if (status = programme_status&.to_sym).present?

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -161,7 +161,7 @@ describe "End-to-end journey" do
 
   def when_i_look_at_children_that_need_consent_responses
     click_link "Consent"
-    choose "No response"
+    check "No response"
     click_on "Update results"
   end
 

--- a/spec/features/invalidate_consent_spec.rb
+++ b/spec/features/invalidate_consent_spec.rb
@@ -78,7 +78,7 @@ describe "Invalidate consent" do
 
   def when_i_go_to_the_patient
     visit session_consent_path(@session)
-    choose "Consent given"
+    check "Consent given"
     click_on "Update results"
     click_link @patient.full_name
   end

--- a/spec/features/parental_consent_inexact_auto_match_spec.rb
+++ b/spec/features/parental_consent_inexact_auto_match_spec.rb
@@ -106,7 +106,7 @@ describe "Parental consent given with an inexact automatic match" do
   def then_they_see_that_the_child_has_consent
     expect(page).to have_content("Consent given")
 
-    choose "Consent given"
+    check "Consent given"
     click_on "Update results"
 
     expect(page).to have_content(@child.full_name)

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -140,7 +140,7 @@ describe "Parental consent" do
 
   def then_they_see_that_the_child_has_consent_refused
     expect(page).to have_content("Consent refused")
-    choose "Consent refused"
+    check "Consent refused"
     click_on "Update results"
     expect(page).to have_content(@child.full_name)
   end

--- a/spec/features/parental_consent_school_session_completed_spec.rb
+++ b/spec/features/parental_consent_school_session_completed_spec.rb
@@ -64,7 +64,7 @@ describe "Parental consent" do
   def then_there_should_be_no_consent_for_my_child
     expect(page).to have_content("No response")
 
-    choose "No response"
+    check "No response"
     click_on "Update results"
 
     expect(page).to have_content(@child.full_name)

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -59,7 +59,7 @@ describe "Parental consent" do
   def then_there_should_be_no_consent_for_my_child
     expect(page).to have_content("No response")
 
-    choose "No response"
+    check "No response"
     click_on "Update results"
 
     expect(page).to have_content(@child.full_name)
@@ -156,7 +156,7 @@ describe "Parental consent" do
 
   def then_they_see_that_the_child_has_consent
     expect(page).to have_content("Consent given")
-    choose "Consent given"
+    check "Consent given"
     click_on "Update results"
     expect(page).to have_content(@child.full_name)
   end

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -55,7 +55,7 @@ describe "Self-consent" do
     click_on @school.name
     click_on "Consent"
 
-    choose "No response"
+    check "No response"
     click_on "Update results"
 
     expect(page).to have_content("Showing 1 to 1 of 1 children")

--- a/spec/features/td_ipv_already_had_spec.rb
+++ b/spec/features/td_ipv_already_had_spec.rb
@@ -144,7 +144,7 @@ describe "Td/IPV" do
   def then_i_see_one_patient_needing_consent
     click_on "Consent"
 
-    choose "No response"
+    check "No response"
     click_on "Update results"
 
     expect(page).to have_content("Showing 1 to 1 of 1 children")

--- a/spec/features/triage_partially_vaccinated_spec.rb
+++ b/spec/features/triage_partially_vaccinated_spec.rb
@@ -85,7 +85,7 @@ describe "Triage" do
   def then_i_see_one_patient_needing_consent
     click_on "Consent"
 
-    choose "No response"
+    check "No response"
     click_on "Update results"
 
     expect(page).to have_content("Showing 1 to 1 of 1 children")

--- a/spec/features/triage_then_parental_consent_refused_spec.rb
+++ b/spec/features/triage_then_parental_consent_refused_spec.rb
@@ -128,7 +128,7 @@ describe "Triage" do
 
   def and_i_go_to_the_patient_with_conflicting_consent
     visit session_consent_path(@session)
-    choose "Conflicting consent"
+    check "Conflicting consent"
     click_on "Update results"
 
     click_on @patient.full_name

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -52,7 +52,7 @@ feature "Verbal consent" do
     end
     click_on "Pilot School"
     click_on "Consent"
-    choose "Consent refused"
+    check "Consent refused"
     click_on "Update results"
     click_on @child.full_name
     click_on "Get consent"
@@ -99,7 +99,7 @@ feature "Verbal consent" do
   end
 
   def and_the_child_is_shown_as_having_consent_given
-    choose "Consent given"
+    check "Consent given"
     click_on "Update results"
 
     expect(page).to have_content(@child.full_name)

--- a/spec/features/withdraw_consent_spec.rb
+++ b/spec/features/withdraw_consent_spec.rb
@@ -89,7 +89,7 @@ describe "Withdraw consent" do
 
   def when_i_go_to_the_patient
     visit session_consent_path(@session)
-    choose "Consent given"
+    check "Consent given"
     click_on "Update results"
     click_link @patient.full_name
   end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -3,7 +3,7 @@
 describe SearchForm do
   subject(:form) do
     described_class.new(
-      consent_status:,
+      consent_statuses:,
       date_of_birth_day:,
       date_of_birth_month:,
       date_of_birth_year:,
@@ -17,7 +17,7 @@ describe SearchForm do
     )
   end
 
-  let(:consent_status) { nil }
+  let(:consent_statuses) { nil }
   let(:date_of_birth_day) { Date.current.day }
   let(:date_of_birth_month) { Date.current.month }
   let(:date_of_birth_year) { Date.current.year }
@@ -37,7 +37,7 @@ describe SearchForm do
     end
 
     context "filtering on date of birth" do
-      let(:consent_status) { nil }
+      let(:consent_statuses) { nil }
       let(:date_of_birth_day) { nil }
       let(:date_of_birth_month) { nil }
       let(:date_of_birth_year) { nil }
@@ -87,7 +87,7 @@ describe SearchForm do
     end
 
     context "filtering on programme status" do
-      let(:consent_status) { nil }
+      let(:consent_statuses) { nil }
       let(:date_of_birth_day) { nil }
       let(:date_of_birth_month) { nil }
       let(:date_of_birth_year) { nil }
@@ -116,7 +116,7 @@ describe SearchForm do
     end
 
     context "filtering on consent status" do
-      let(:consent_status) { "given" }
+      let(:consent_statuses) { %w[given refused] }
       let(:date_of_birth_day) { nil }
       let(:date_of_birth_month) { nil }
       let(:date_of_birth_year) { nil }
@@ -130,18 +130,25 @@ describe SearchForm do
       let(:programme) { create(:programme) }
 
       it "filters on consent status" do
-        patient_session =
+        patient_session_given =
           create(
             :patient_session,
             :consent_given_triage_not_needed,
             programmes: [programme]
           )
-        expect(form.apply(scope, programme:)).to include(patient_session)
+
+        patient_session_refused =
+          create(:patient_session, :consent_refused, programmes: [programme])
+
+        expect(form.apply(scope, programme:)).to contain_exactly(
+          patient_session_given,
+          patient_session_refused
+        )
       end
     end
 
     context "filtering on session status" do
-      let(:consent_status) { nil }
+      let(:consent_statuses) { nil }
       let(:date_of_birth_day) { nil }
       let(:date_of_birth_month) { nil }
       let(:date_of_birth_year) { nil }
@@ -163,7 +170,7 @@ describe SearchForm do
     end
 
     context "filtering on register status" do
-      let(:consent_status) { nil }
+      let(:consent_statuses) { nil }
       let(:date_of_birth_day) { nil }
       let(:date_of_birth_month) { nil }
       let(:date_of_birth_year) { nil }
@@ -182,7 +189,7 @@ describe SearchForm do
     end
 
     context "filtering on triage status" do
-      let(:consent_status) { nil }
+      let(:consent_statuses) { nil }
       let(:date_of_birth_day) { nil }
       let(:date_of_birth_month) { nil }
       let(:date_of_birth_year) { nil }


### PR DESCRIPTION
There are a few filters for consent status that could in some scenarios be roughly equivalent (or require follow-up regardless of the specific status), for example ‘No response’ and ‘Conflicting consent’ might both warrant the parent needing to be phoned.

Right now it’s only possible to select one consent status at a time. If we change it from radios to checkboxes, then we give teams more flexibility in how they whittle down lists of children with varying consent statuses.

## Screenshot

<img width="353" alt="Screenshot 2025-05-07 at 17 53 25" src="https://github.com/user-attachments/assets/3221645c-c221-4d73-b01d-882e44a6bede" />
