### PR TITLE
Triage from vaccination history requires consent

### DIFF
--- a/spec/features/triage_partially_vaccinated_spec.rb
+++ b/spec/features/triage_partially_vaccinated_spec.rb
@@ -15,8 +15,10 @@ describe "Triage" do
 
     when_i_go_the_session
     then_i_see_one_patient_needing_consent
+    and_i_see_no_patients_needing_triage
 
-    when_the_parent_gives_consent
+    when_i_go_the_session
+    and_the_parent_gives_consent
     and_i_click_on_triage
     then_i_see_one_patient_needing_triage
     and_i_click_on_the_patient
@@ -67,7 +69,7 @@ describe "Triage" do
   end
 
   def when_i_go_the_session
-    click_on "Sessions"
+    click_on "Sessions", match: :first
     click_on "Scheduled"
     click_on @session.location.name
   end
@@ -89,12 +91,21 @@ describe "Triage" do
     click_on "Update results"
 
     expect(page).to have_content("Showing 1 to 1 of 1 children")
-
-    click_on @session.location.name
   end
 
-  def when_the_parent_gives_consent
-    Patient.first.consent_status(programme: @programme).given!
+  def and_i_see_no_patients_needing_triage
+    click_on "Triage"
+
+    choose "Needs triage"
+    click_on "Update results"
+
+    expect(page).to have_content("No children matching search criteria found")
+  end
+
+  def and_the_parent_gives_consent
+    create(:consent, :given, patient: Patient.first, programme: @programme)
+    StatusUpdater.call(patient: @patient)
+
     page.refresh
   end
 

--- a/spec/models/patient/triage_status_spec.rb
+++ b/spec/models/patient/triage_status_spec.rb
@@ -57,6 +57,28 @@ describe Patient::TriageStatus do
       it { should be(:required) }
     end
 
+    context "with a historical vaccination that needs triage" do
+      let(:programme) { create(:programme, :td_ipv) }
+
+      before do
+        create(:vaccination_record, patient:, programme:, dose_sequence: 1)
+      end
+
+      it { should be(:not_required) }
+
+      context "when consent is given" do
+        before { create(:consent, :given, patient:, programme:) }
+
+        it { should be(:required) }
+      end
+
+      context "when consent is refused" do
+        before { create(:consent, :refused, patient:, programme:) }
+
+        it { should be(:not_required) }
+      end
+    end
+
     context "with a safe to vaccinate triage" do
       before { create(:triage, :ready_to_vaccinate, patient:, programme:) }
 


### PR DESCRIPTION
This fixes a bug where for a patient to be triaged based on their vaccination history, they should receive have received consent.

This is logic that we used to have (https://github.com/nhsuk/manage-vaccinations-in-schools/blob/a3c88d2900b11ae7aea67d6655046ef4a6d2233d/app/models/patient/triage_outcome.rb#L94) but was inadvertently removed in version 2.1.2 with the performance improvements that stored the patient statuses in the database.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1162)