### PR TITLE
Persist filters, per user, per view, per browser session

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -98,7 +98,7 @@ class AppSearchComponent < ViewComponent::Base
           <% if show_buttons_in_details? %>
             <div class="app-button-group">
               <%= f.govuk_submit "Update results", secondary: true, class: "app-button--small" %>
-              <%= govuk_button_link_to "Clear filters", @url, secondary: true, class: "app-button--small" %>
+              <%= govuk_button_link_to "Clear filters", clear_filters_path, class: "app-button--small app-button--secondary" %>
             </div>
           <% end %>
         <% end %>
@@ -106,7 +106,7 @@ class AppSearchComponent < ViewComponent::Base
         <% unless show_buttons_in_details? %>
           <div class="app-button-group">
             <%= f.govuk_submit "Update results", secondary: true, class: "app-button--small" %>
-            <%= govuk_button_link_to "Clear filters", @url, secondary: true, class: "app-button--small" %>
+            <%= govuk_button_link_to "Clear filters", clear_filters_path, class: "app-button--small app-button--secondary" %>
           </div>
         <% end %>
       <% end %>
@@ -158,5 +158,9 @@ class AppSearchComponent < ViewComponent::Base
         register_statuses.any? || session_statuses.any? ||
         triage_statuses.any? || year_groups.any?
     )
+  end
+
+  def clear_filters_path
+    "#{@url}?search_form[clear_filters]=true"
   end
 end

--- a/app/controllers/concerns/search_form_concern.rb
+++ b/app/controllers/concerns/search_form_concern.rb
@@ -6,7 +6,8 @@ module SearchFormConcern
   def set_search_form
     @form =
       SearchForm.new(
-        params.fetch(:search_form, {}).permit(
+        **params.fetch(:search_form, {}).permit(
+          :clear_filters,
           :consent_status,
           :date_of_birth_day,
           :date_of_birth_month,
@@ -18,7 +19,9 @@ module SearchFormConcern
           :session_status,
           :triage_status,
           year_groups: []
-        )
+        ),
+        session: session,
+        request_path: request.path
       )
   end
 end

--- a/spec/features/filter_state_persistence_spec.rb
+++ b/spec/features/filter_state_persistence_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+describe "Filter state persistence" do
+  scenario "filters maintain state across navigation" do
+    given_i_am_signed_in
+
+    when_i_visit_the_consent_page
+    and_i_apply_consent_filters
+    then_the_consent_filters_are_applied
+
+    when_i_navigate_to_another_page
+    and_i_return_to_the_consent_page
+    then_the_consent_filters_are_still_applied
+
+    when_i_clear_the_consent_filters
+    then_i_should_see_no_applied_filters
+
+    when_i_visit_the_triage_page
+    and_i_apply_triage_filters
+    then_the_triage_filters_are_applied
+
+    when_i_navigate_to_another_page
+    and_i_return_to_the_triage_page
+    then_the_triage_filters_are_still_applied
+
+    when_i_visit_the_consent_page
+    then_i_should_see_no_applied_filters
+  end
+
+  def given_i_am_signed_in
+    @programme = create(:programme, :hpv)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [@programme])
+    @session =
+      create(:session, organisation: @organisation, programmes: [@programme])
+
+    sign_in @organisation.users.first
+  end
+
+  def when_i_visit_the_consent_page
+    visit session_consent_path(@session)
+  end
+
+  def and_i_apply_consent_filters
+    choose "Consent given"
+    click_on "Update results"
+  end
+
+  def then_the_consent_filters_are_applied
+    expect(page).to have_checked_field("Consent given")
+  end
+
+  def then_the_consent_filters_are_still_applied
+    expect(page).to have_checked_field("Consent given")
+  end
+
+  def when_i_clear_the_consent_filters
+    click_on "Clear filters"
+  end
+
+  def when_i_navigate_to_another_page
+    visit root_path
+  end
+
+  def and_i_return_to_the_consent_page
+    visit session_consent_path(@session)
+  end
+
+  def when_i_visit_the_triage_page
+    visit session_triage_path(@session)
+  end
+
+  def and_i_apply_triage_filters
+    choose "Safe to vaccinate"
+    click_on "Update results"
+  end
+
+  def then_the_triage_filters_are_applied
+    expect(page).to have_checked_field("Safe to vaccinate")
+  end
+
+  def and_i_return_to_the_triage_page
+    visit session_triage_path(@session)
+  end
+
+  def then_the_triage_filters_are_still_applied
+    expect(page).to have_checked_field("Safe to vaccinate")
+  end
+
+  def when_i_clear_the_triage_filters
+    click_on "Clear filters"
+  end
+
+  def then_i_should_see_no_applied_filters
+    expect(page).to have_checked_field("Any")
+  end
+end


### PR DESCRIPTION
User feedback suggested that filters maintain state because they often filter patients, move away from the page, and then come back having to apply the same filters again.

This update will ensure each page with filters maintains its own unique state. This state can only be cleared with the "Clear filters" button on the form.

**Test Guidance:**

1. Visit the various pages with filters
2. Apply filters to each of those pages
3. Visit other pages and come back to the filtered page
4. The filters previously set should still be there even though there's no URL params
5. Click the "Clear filters" button to reset the filters (it should only apply to that particular page)
