### PR TITLE
Hide "Contains gelatine" reason when not valid

### DIFF
--- a/app/components/app_consent_refused_table_component.html.erb
+++ b/app/components/app_consent_refused_table_component.html.erb
@@ -10,7 +10,7 @@
     <% end %>
 
     <% table.with_body do |body| %>
-      <% Consent.reason_for_refusals.keys.each do |reason_for_refusal| %>
+      <% reasons_for_refusal.each do |reason_for_refusal| %>
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <%= VaccinationRecord.human_enum_name(:reason_for_refusal, reason_for_refusal) %>

--- a/app/components/app_consent_refused_table_component.rb
+++ b/app/components/app_consent_refused_table_component.rb
@@ -1,18 +1,31 @@
 # frozen_string_literal: true
 
 class AppConsentRefusedTableComponent < ViewComponent::Base
-  def initialize(consents)
+  def initialize(consents, vaccine_may_contain_gelatine:)
     super
 
     @grouped_by_reason_for_refusal =
       consents.response_refused.group(:reason_for_refusal).count
     @total_count = @grouped_by_reason_for_refusal.values.sum
+    @vaccine_may_contain_gelatine = vaccine_may_contain_gelatine
   end
 
-  def percentage_for(reason_for_refusal)
-    return 0 if @total_count.zero?
+  private
 
-    @grouped_by_reason_for_refusal.fetch(reason_for_refusal, 0) /
-      @total_count.to_f * 100.0
+  attr_reader :grouped_by_reason_for_refusal,
+              :total_count,
+              :vaccine_may_contain_gelatine
+
+  def percentage_for(reason_for_refusal)
+    return 0 if total_count.zero?
+
+    grouped_by_reason_for_refusal.fetch(reason_for_refusal, 0) /
+      total_count.to_f * 100.0
+  end
+
+  def reasons_for_refusal
+    reasons = Consent.reason_for_refusals.keys
+    reasons -= %w[contains_gelatine] unless vaccine_may_contain_gelatine
+    reasons
   end
 end

--- a/app/models/concerns/gelatine_vaccines_concern.rb
+++ b/app/models/concerns/gelatine_vaccines_concern.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module GelatineVaccinesConcern
+  extend ActiveSupport::Concern
+
+  def vaccine_may_contain_gelatine?
+    vaccines.any?(&:contains_gelatine?)
+  end
+end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -63,6 +63,7 @@ class ConsentForm < ApplicationRecord
   include AgeConcern
   include Archivable
   include FullNameConcern
+  include GelatineVaccinesConcern
   include HasHealthAnswers
   include WizardStepConcern
 
@@ -307,19 +308,6 @@ class ConsentForm < ApplicationRecord
 
   def any_health_answers_truthy?
     health_answers.any? { _1.response == "yes" }
-  end
-
-  def gelatine_content_status_in_vaccines
-    # we don't YET track the vaccine type that the user is agreeing to in the consent form,
-    # so we have to check all vaccines
-    # there might not be a true or false answer if there are multiple vaccines in the programme
-    # (e.g. flu nasal and flu injection)
-    possible_answers = vaccines.map(&:contains_gelatine?)
-    if possible_answers.uniq.length == 1
-      possible_answers.first
-    else
-      :maybe
-    end
   end
 
   def reason_notes_must_be_provided?

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -14,6 +14,8 @@
 #  index_programmes_on_type  (type) UNIQUE
 #
 class Programme < ApplicationRecord
+  include GelatineVaccinesConcern
+
   self.inheritance_column = nil
 
   audited

--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -12,7 +12,7 @@
 
   <%= f.govuk_radio_buttons_fieldset(:reason,
                                      legend: { size: "l", text: title, tag: "h1" }) do %>
-    <% if @consent_form.gelatine_content_status_in_vaccines.in? [true, :maybe] %>
+    <% if @consent_form.vaccine_may_contain_gelatine? %>
       <%= f.govuk_radio_button :reason, "contains_gelatine",
                                label: { text: "Vaccine contains gelatine from pigs" },
                                link_errors: true %>

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -14,4 +14,8 @@
 <%= govuk_button_to "Download vaccination report", programme_vaccination_reports_path(@programme), secondary: true, class: "nhsuk-u-margin-bottom-5" %>
 
 <%= render AppProgrammeStatsComponent.new(programme: @programme) %>
-<%= render AppConsentRefusedTableComponent.new(@consents) %>
+
+<%= render AppConsentRefusedTableComponent.new(
+      @consents,
+      vaccine_may_contain_gelatine: @programme.vaccine_may_contain_gelatine?,
+    ) %>

--- a/spec/components/app_consent_refused_table_component_spec.rb
+++ b/spec/components/app_consent_refused_table_component_spec.rb
@@ -3,7 +3,12 @@
 describe AppConsentRefusedTableComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(Consent.all) }
+  let(:component) do
+    described_class.new(consents, vaccine_may_contain_gelatine:)
+  end
+
+  let(:consents) { Consent.all }
+  let(:vaccine_may_contain_gelatine) { true }
 
   let(:programme) { create(:programme) }
 
@@ -43,4 +48,10 @@ describe AppConsentRefusedTableComponent do
   it { should have_content("Medical reasons\n\n            16.7%") }
   it { should have_content("Personal choice\n\n            16.7%") }
   it { should have_content("Other\n\n            16.7%") }
+
+  context "when no vaccine contains gelatine" do
+    let(:vaccine_may_contain_gelatine) { false }
+
+    it { should_not have_content("Contains gelatine") }
+  end
 end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -534,36 +534,31 @@ describe ConsentForm do
     end
   end
 
-  describe "#gelatine_content_status_in_vaccines" do
-    it "returns :maybe if the flu programme offers both injection and nasal vaccines" do
-      consent_form =
-        create(
-          :consent_form,
-          session: create(:session, programmes: [create(:programme, :flu)])
-        )
-      consent_form.strict_loading!(false)
-      expect(consent_form.gelatine_content_status_in_vaccines).to eq(:maybe)
+  describe "#vaccine_may_contain_gelatine?" do
+    subject { consent_form.vaccine_may_contain_gelatine? }
+
+    let(:consent_form) do
+      create(:consent_form, session: create(:session, programmes: [programme]))
     end
 
-    it "returns false if the flu programme only offers injection vaccines" do
-      consent_form =
-        create(
-          :consent_form,
-          session:
-            create(:session, programmes: [create(:programme, :flu_nasal_only)])
-        )
-      consent_form.strict_loading!(false)
-      expect(consent_form.gelatine_content_status_in_vaccines).to be(true)
+    before { consent_form.strict_loading!(false) }
+
+    context "if the flu programme offers both injection and nasal vaccines" do
+      let(:programme) { create(:programme, :flu) }
+
+      it { should be(true) }
     end
 
-    it "returns false for an HPV programme" do
-      consent_form =
-        create(
-          :consent_form,
-          session: create(:session, programmes: [create(:programme, :hpv)])
-        )
-      consent_form.strict_loading!(false)
-      expect(consent_form.gelatine_content_status_in_vaccines).to be(false)
+    context "if the flu programme only offers injection vaccines" do
+      let(:programme) { create(:programme, :flu_nasal_only) }
+
+      it { should be(true) }
+    end
+
+    context "for an HPV programme" do
+      let(:programme) { create(:programme, :hpv) }
+
+      it { should be(false) }
     end
   end
 

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -54,6 +54,34 @@ describe Programme do
     end
   end
 
+  describe "#vaccine_may_contain_gelatine?" do
+    subject { programme.vaccine_may_contain_gelatine? }
+
+    context "with a Flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should be(true) }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should be(false) }
+    end
+
+    context "with an MenACWY programme" do
+      let(:programme) { build(:programme, :menacwy) }
+
+      it { should be(false) }
+    end
+
+    context "with an Td/IPV programme" do
+      let(:programme) { build(:programme, :td_ipv) }
+
+      it { should be(false) }
+    end
+  end
+
   describe "#common_delivery_sites" do
     subject(:common_delivery_sites) { programme.common_delivery_sites }
 

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -36,19 +36,24 @@ describe Vaccine do
   end
 
   describe "#contains_gelatine?" do
-    it "returns true if the vaccine is a nasal flu vaccine" do
-      vaccine = build(:vaccine, :fluenz_tetra)
-      expect(vaccine.contains_gelatine?).to be true
+    subject { vaccine.contains_gelatine? }
+
+    context "with a nasal Flu vaccine" do
+      let(:vaccine) { build(:vaccine, :fluenz_tetra) }
+
+      it { should be(true) }
     end
 
-    it "returns false if the vaccine is an injected flu vaccine" do
-      vaccine = build(:vaccine, :quadrivalent_influenza)
-      expect(vaccine.contains_gelatine?).to be false
+    context "with an injected Flu vaccine" do
+      let(:vaccine) { build(:vaccine, :quadrivalent_influenza) }
+
+      it { should be(false) }
     end
 
-    it "returns false if the vaccine is not a flu vaccine" do
-      vaccine = build(:vaccine, :gardasil_9)
-      expect(vaccine.contains_gelatine?).to be false
+    context "with an HPV vaccine" do
+      let(:vaccine) { build(:vaccine, :gardasil_9) }
+
+      it { should be(false) }
     end
   end
 


### PR DESCRIPTION
Only for the Flu programme should this reason for refusal show in the list of reasons for refusal, as this is not a valid reason for the other programmes.

I've implemented this by passing in whether to show this option when using the component. We could be more dynamic and the component to check each consent to see if any of the programmes' vaccines may contain gelatine, but the performance hit on that (when we may have hundreds of thousands of responses) seemed not worth it.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-562)

## Screenshots

### Before

<img width="1145" alt="Screenshot 2025-05-12 at 14 57 43" src="https://github.com/user-attachments/assets/2131ed5d-25f7-4d69-9764-b845aec3fc10" />

### After

<img width="1149" alt="Screenshot 2025-05-12 at 14 57 22" src="https://github.com/user-attachments/assets/ae865d6f-eb08-4250-a804-546e539406da" />
