### PR TITLE
Stop requesting triage for already vaccinated patients

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -121,8 +121,6 @@ class DraftVaccinationRecordsController < ApplicationController
 
     send_vaccination_confirmation(@vaccination_record) if should_notify_parents
 
-    @vaccination_record.triage_patient_as_do_not_vaccinate!
-
     # In case the user navigates back to try and edit the newly created
     # vaccination record.
     @draft_vaccination_record.update!(editing_id: @vaccination_record.id)

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -175,33 +175,6 @@ class VaccinationRecord < ApplicationRecord
     performed_at.to_date.academic_year
   end
 
-  def triage_patient_as_do_not_vaccinate!
-    return unless already_had?
-
-    # If an "already had" vaccination record is created, and the patient needs
-    # triage, we should record a "do not vaccinate" triage to make sure the
-    # patient isn't double vaccinated.
-
-    patient = Patient.includes(:triage_statuses).find(patient_id)
-    triage_status = patient.triage_status(programme:)
-
-    return unless triage_status.required? || triage_status.delay_vaccination?
-
-    triage_notes =
-      "Recorded as already vaccinated on #{Date.current.to_fs(:long)}"
-    triage_notes += ": #{notes}" if notes.present?
-
-    patient.triages.create!(
-      programme:,
-      organisation:,
-      status: :do_not_vaccinate,
-      performed_by: performed_by_user,
-      notes: triage_notes
-    )
-
-    StatusUpdater.call(patient:)
-  end
-
   private
 
   def requires_location_name?

--- a/spec/features/td_ipv_already_had_spec.rb
+++ b/spec/features/td_ipv_already_had_spec.rb
@@ -46,7 +46,7 @@ describe "Td/IPV" do
     when_i_record_the_patient_as_already_vaccinated
     then_i_see_the_patient_is_already_vaccinated
     and_i_click_on_triage
-    then_i_see_the_patient_should_not_be_vaccinated
+    then_i_see_the_patient_doesnt_need_triage
   end
 
   scenario "can't record as already vaccinated as an admin" do
@@ -201,10 +201,10 @@ describe "Td/IPV" do
     click_on "Triage"
   end
 
-  def then_i_see_the_patient_should_not_be_vaccinated
-    choose "Do not vaccinate"
+  def then_i_see_the_patient_doesnt_need_triage
+    choose "Any"
     click_on "Update results"
 
-    expect(page).to have_content(@patient.full_name)
+    expect(page).not_to have_content(@patient.full_name)
   end
 end

--- a/spec/models/patient/triage_status_spec.rb
+++ b/spec/models/patient/triage_status_spec.rb
@@ -24,7 +24,7 @@ describe Patient::TriageStatus do
     build(:patient_triage_status, patient:, programme:)
   end
 
-  let(:patient) { create(:patient) }
+  let(:patient) { create(:patient, year_group: 9) }
   let(:programme) { create(:programme) }
 
   it { should belong_to(:patient) }
@@ -109,6 +109,45 @@ describe Patient::TriageStatus do
       end
 
       it { should be(:not_required) }
+    end
+
+    context "when the patient is already vaccinated" do
+      shared_examples "a vaccinated patient with any triage status" do
+        before do
+          create(:triage, triage_trait, patient:, programme:) if triage_trait
+        end
+
+        it { should be(:not_required) }
+      end
+
+      before do
+        create(:vaccination_record, patient:, programme:)
+        create(:patient_vaccination_status, :vaccinated, patient:, programme:)
+      end
+
+      context "with a safe to vaccinate triage" do
+        it_behaves_like "a vaccinated patient with any triage status" do
+          let(:triage_trait) { :ready_to_vaccinate }
+        end
+      end
+
+      context "with a do not vaccinate triage" do
+        it_behaves_like "a vaccinated patient with any triage status" do
+          let(:triage_trait) { :do_not_vaccinate }
+        end
+      end
+
+      context "with a needs follow up triage" do
+        it_behaves_like "a vaccinated patient with any triage status" do
+          let(:triage_trait) { :needs_follow_up }
+        end
+      end
+
+      context "with a delay vaccination triage" do
+        it_behaves_like "a vaccinated patient with any triage status" do
+          let(:triage_trait) { :delay_vaccination }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If a patient has already been vaccinated, then they don't need another vaccination. This means that they don't need to be triaged.

Previously, Mavis would've requested triage for this patient. Now it won't.

[MAV-1089](https://nhsd-jira.digital.nhs.uk/browse/MAV-1089)