### PR TITLE
Use reading width for school moves introduction

### DIFF
--- a/app/views/school_moves/index.html.erb
+++ b/app/views/school_moves/index.html.erb
@@ -1,13 +1,10 @@
 <%= h1 "School moves", size: "xl" %>
 
-<div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-two-thirds">
-    <p>When imported records or a new consent response indicates that a child has changed
-      school, Mavis flags this as a school move.</p>
-    <p>You can then review the new information and confirm the school move or ignore it.</p>
+<div class="nhsuk-u-reading-width">
+  <p>When imported records or a new consent response indicates that a child has changed school, Mavis flags this as a school move.</p>
+  <p>You can then review the new information and confirm the school move or ignore it.</p>
 
-    <%= govuk_button_to "Download records", school_move_exports_path, class: "app-button--secondary nhsuk-u-margin-bottom-5" %>
-  </div>
+  <%= govuk_button_to "Download records", school_move_exports_path, class: "app-button--secondary nhsuk-u-margin-bottom-5" %>
 </div>
 
 <% if @school_moves.any? %>


### PR DESCRIPTION
This tweak changes the width of the container for the introduction text on the School moves page. This means the text wraps more sensibly at smaller viewport sizes – and also removes the runt ‘it.’ at the end of the sentence on desktop.

<img width="740" alt="Screenshot of School moves introduction text." src="https://github.com/user-attachments/assets/379ba3b7-4fd2-46a3-9012-ef0c5f8a9ad8" />
