### PR TITLE
Set batch name length limit to 100 when importing

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -491,11 +491,8 @@ class ImmunisationImportRow
           )
         elsif batch_name.blank?
           errors.add(batch_name.header, "Enter a batch number.")
-        elsif batch_name.to_s.length > MAX_FIELD_LENGTH
-          errors.add(
-            batch_name.header,
-            "is greater than #{MAX_FIELD_LENGTH} characters long"
-          )
+        elsif batch_name.to_s.length > 100
+          errors.add(batch_name.header, "is greater than 100 characters long")
         end
       end
     elsif batch_name.present?

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -655,7 +655,7 @@ describe ImmunisationImportRow do
         expect(immunisation_import_row).to be_invalid
 
         expect(immunisation_import_row.errors["BATCH_NUMBER"]).to include(
-          "is greater than 300 characters long"
+          "is greater than 100 characters long"
         )
         expect(immunisation_import_row.errors["CLINIC_NAME"]).to include(
           "is greater than 300 characters long"


### PR DESCRIPTION
The batch name length limit in the model itself is 100, so we need to ensure that the batch length while importing matches this.