### PR TITLE
Trim the timestamps being sent to Splunk

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -14,7 +14,9 @@ class MavisSplunkFormatter
   def call(log, logger)
     message = JSON.parse(logger.call(log, logger))
     message["time"] = message["time"].floor(6)
-    message["event"]["hosting_environment"] = HostingEnvironment.name
+    if defined?(HostingEnvironment)
+      message["event"]["hosting_environment"] = HostingEnvironment.name
+    end
     message.to_json
   end
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -13,6 +13,7 @@ end
 class MavisSplunkFormatter
   def call(log, logger)
     message = JSON.parse(logger.call(log, logger))
+    message["time"] = message["time"].floor(6)
     message["event"]["hosting_environment"] = HostingEnvironment.name
     message.to_json
   end


### PR DESCRIPTION
The time in the logs can be more precise than microseconds, i.e. more than 6 digits of precision, but this gets stringified into exponential/scientific notation and breaks Splunk. e.g. `1747143707.1161711` gets stringified as `1.7471437071161711e+9`.

Also, there are instances where messages can get logged during Rails boot, before `HostingEnvironment` can be auto-loaded.