### PR TITLE
Allow changing consent response from child to parent

### DIFF
--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -141,11 +141,13 @@ class DraftConsent
     @new_or_existing_contact = value
 
     if value == "new"
+      self.route = nil
       self.parent = nil
     elsif value == "patient"
       self.route = "self_consent"
       self.parent = nil
     else
+      self.route = nil
       self.parent =
         patient.parents.find_by(id: value) ||
           Parent.where(consents: patient.consents.where(programme:)).find_by(


### PR DESCRIPTION
When changing the consent response from a child, currently this doesn't reset the "route" from self-consent, meaning that the consent continues to show as part of the self-consent journey even if the consent has been changed to be from a parent.