### PR TITLE
Deduplicate health answers with followups

### DIFF
--- a/app/lib/health_answers_deduplicator.rb
+++ b/app/lib/health_answers_deduplicator.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class HealthAnswersDeduplicator
+  def initialize(vaccines:)
+    @vaccines = vaccines
+  end
+
+  def call
+    @health_answers = []
+
+    vaccines.each { |vaccine| add_unique_health_answers(vaccine) }
+
+    re_map_question_indexes
+    fill_in_next_question_gaps
+
+    @health_answers
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :vaccines
+
+  def add_unique_health_answers(vaccine)
+    vaccine_health_answers = vaccine.health_questions.to_health_answers
+
+    vaccine_health_answers.each do |health_answer|
+      existing_index = existing_question_index(health_answer.question)
+
+      # This doesn't work very well if the question already exists but is
+      # otherwise different, for example if the followup question is
+      # different. We don't have instances of this currently.
+
+      next unless existing_index.nil?
+
+      health_answer.id = @health_answers.length
+
+      # We store the questions here and re-map them to indexes later when we
+      # know what all the questions will be.
+
+      if (index = health_answer.next_question).present?
+        health_answer.next_question =
+          vaccine_health_answers.find { it.id == index }.question
+      end
+
+      if (index = health_answer.follow_up_question).present?
+        health_answer.follow_up_question =
+          vaccine_health_answers.find { it.id == index }.question
+      end
+
+      @health_answers << health_answer
+    end
+  end
+
+  def existing_question_index(question)
+    @health_answers.index { it.question == question }
+  end
+
+  def re_map_question_indexes
+    @health_answers.each do |health_answer|
+      if (question = health_answer.next_question)
+        health_answer.next_question = existing_question_index(question)
+      end
+
+      if (question = health_answer.follow_up_question)
+        health_answer.follow_up_question = existing_question_index(question)
+      end
+    end
+  end
+
+  def fill_in_next_question_gaps
+    @health_answers.each_with_index do |health_answer, index|
+      if health_answer.next_question.nil? && index < @health_answers.length - 1
+        health_answer.next_question = index + 1
+      end
+    end
+  end
+end

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -28,11 +28,10 @@ RSpec.feature "Parental consent change answers" do
     when_i_change_my_answer_to_yes_for_the_asthma_question
     then_i_see_the_first_follow_up_question
 
-    # TODO: Follow up questions currently don't work.
-    # when_i_answer_yes_to_the_follow_up_question_and_continue
-    # then_i_see_the_second_follow_up_question
+    when_i_answer_yes_to_the_follow_up_question_and_continue
+    then_i_see_the_second_follow_up_question
 
-    # when_i_answer_yes_to_the_second_follow_up_question_and_continue
+    when_i_answer_yes_to_the_second_follow_up_question_and_continue
     then_i_see_the_consent_form_confirmation_page
     and_i_see_the_answer_i_changed_is_yes
 
@@ -148,7 +147,7 @@ RSpec.feature "Parental consent change answers" do
     # BUG: The page should be the consent confirm page, but because we
     # encountered a validation error, the skip_to_confirm flag gets lost and we
     # end up on the next page in the wizard.
-    12.times { click_button "Continue" }
+    10.times { click_button "Continue" }
   end
 
   def when_i_change_my_parental_relationship_to_dad
@@ -209,9 +208,8 @@ RSpec.feature "Parental consent change answers" do
   def and_i_see_the_answer_i_changed_is_yes
     expect(page).to have_content("Yes – He has had asthma since he was 2")
 
-    # TODO: Follow up questions currently don't work.
-    # expect(page).to have_content("Yes – Follow up details")
-    # expect(page).to have_content("Yes – Even more follow up details")
+    expect(page).to have_content("Yes – Follow up details")
+    expect(page).to have_content("Yes – Even more follow up details")
   end
 
   def when_i_click_back

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -2,8 +2,6 @@
 
 describe "Parental consent" do
   scenario "Flu programme" do
-    skip "We don't handle flu yet and health answers with follow up questions doesn't work."
-
     given_a_flu_programme_is_underway
     when_i_go_to_the_consent_form
     then_i_see_the_consent_form

--- a/spec/lib/health_answers_deduplicator_spec.rb
+++ b/spec/lib/health_answers_deduplicator_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+describe HealthAnswersDeduplicator do
+  subject(:health_answers) { described_class.call(vaccines:) }
+
+  let(:vaccines) { Vaccine.where(programme: programmes) }
+
+  context "with doubles programmes" do
+    let(:programmes) do
+      [create(:programme, :menacwy), create(:programme, :td_ipv)]
+    end
+
+    it "generates the correct health answers" do
+      expect(health_answers.count).to eq(6)
+
+      expect(health_answers[0].question).to eq(
+        "Does your child have a bleeding disorder or another medical condition they receive treatment for?"
+      )
+      expect(health_answers[0].next_question).to eq(1)
+      expect(health_answers[0].follow_up_question).to be_nil
+
+      expect(health_answers[1].question).to eq(
+        "Does your child have any severe allergies?"
+      )
+      expect(health_answers[1].next_question).to eq(2)
+      expect(health_answers[1].follow_up_question).to be_nil
+
+      expect(health_answers[2].question).to eq(
+        "Has your child ever had a severe reaction to any medicines, including vaccines?"
+      )
+      expect(health_answers[2].next_question).to eq(3)
+      expect(health_answers[2].follow_up_question).to be_nil
+
+      expect(health_answers[3].question).to eq(
+        "Does your child need extra support during vaccination sessions?"
+      )
+      expect(health_answers[3].next_question).to eq(4)
+      expect(health_answers[3].follow_up_question).to be_nil
+
+      expect(health_answers[4].question).to eq(
+        "Has your child had a meningitis (MenACWY) vaccination in the last 5 years?"
+      )
+      expect(health_answers[4].next_question).to eq(5)
+      expect(health_answers[4].follow_up_question).to be_nil
+
+      expect(health_answers[5].question).to eq(
+        "Has your child had a tetanus, diphtheria and polio vaccination in the last 5 years?"
+      )
+      expect(health_answers[5].next_question).to be_nil
+      expect(health_answers[5].follow_up_question).to be_nil
+    end
+  end
+
+  context "with a Flu programme" do
+    let(:programmes) { [create(:programme, :flu_all_vaccines)] }
+
+    it "generates the correct health answers" do
+      expect(health_answers.count).to eq(10)
+
+      expect(health_answers[0].question).to eq(
+        "Has your child been diagnosed with asthma?"
+      )
+      expect(health_answers[0].next_question).to eq(3)
+      expect(health_answers[0].follow_up_question).to eq(1)
+
+      expect(health_answers[1].question).to eq(
+        "Have they taken oral steroids in the last 2 weeks?"
+      )
+      expect(health_answers[1].next_question).to eq(2)
+      expect(health_answers[1].follow_up_question).to be_nil
+
+      expect(health_answers[2].question).to eq(
+        "Have they been admitted to intensive care for their asthma?"
+      )
+      expect(health_answers[2].next_question).to eq(3)
+      expect(health_answers[2].follow_up_question).to be_nil
+
+      expect(health_answers[3].question).to eq(
+        "Has your child had a flu vaccination in the last 5 months?"
+      )
+      expect(health_answers[3].next_question).to eq(4)
+      expect(health_answers[3].follow_up_question).to be_nil
+
+      expect(health_answers[4].question).to eq(
+        "Does your child have a disease or treatment that severely affects their immune system?"
+      )
+      expect(health_answers[4].next_question).to eq(5)
+      expect(health_answers[4].follow_up_question).to be_nil
+
+      expect(health_answers[5].question).to eq(
+        "Is anyone in your household currently having treatment that severely affects their immune system?"
+      )
+      expect(health_answers[5].next_question).to eq(6)
+      expect(health_answers[5].follow_up_question).to be_nil
+
+      expect(health_answers[6].question).to eq(
+        "Has your child ever been admitted to intensive care due to an allergic reaction to egg?"
+      )
+      expect(health_answers[6].next_question).to eq(7)
+      expect(health_answers[6].follow_up_question).to be_nil
+
+      expect(health_answers[7].question).to eq(
+        "Does your child have any allergies to medication?"
+      )
+      expect(health_answers[7].next_question).to eq(8)
+      expect(health_answers[7].follow_up_question).to be_nil
+
+      expect(health_answers[8].question).to eq(
+        "Has your child ever had a reaction to previous vaccinations?"
+      )
+      expect(health_answers[8].next_question).to eq(9)
+      expect(health_answers[8].follow_up_question).to be_nil
+
+      expect(health_answers[9].question).to eq(
+        "Does you child take regular aspirin?"
+      )
+      expect(health_answers[9].next_question).to be_nil
+      expect(health_answers[9].follow_up_question).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This updates the deduplication logic introduced to support health answers across multiple vaccines to also support health answers with followup questions, which so far aren't in use but will be used for Flu.

I've introduced a new class `HealthAnswersDeduplicator` which handles this logic and then re-instated the tests we had for Flu which are currently to show that it's working as expected.

I think there are likely some scenarios where the deduplicator doesn't work correctly, most likely if there are questions with the same title but different followups, however we don't know of any where that is the case currently.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1176)