### PR TITLE
Use inputs.git-sha to checkout out code for build

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -65,6 +65,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-sha || github.sha }}
+      - name: Write build SHA
+        run: git rev-parse HEAD > public/sha
       - name: Build Docker image
         run: docker build -t "mavis:latest" .
       - name: Save Docker image

--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-sha || github.sha }}
       - name: Build Docker image
         run: docker build -t "mavis:latest" .
       - name: Save Docker image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,7 +88,7 @@ jobs:
   deploy-application:
     permissions:
       id-token: write
-    needs: deploy-infrastructure
+    needs: [deploy-infrastructure, determine-git-sha]
     uses: ./.github/workflows/deploy-application.yml
     with:
       environment: ${{ inputs.environment }}


### PR DESCRIPTION
Otherwise we always build from using the workflow ref, but tag using the
deploy sha.