### PR TITLE
Fix team phone formatting for Notify

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -2,6 +2,7 @@
 
 class GovukNotifyPersonalisation
   include Rails.application.routes.url_helpers
+  include PhoneHelper
 
   def initialize(
     consent: nil,
@@ -58,8 +59,6 @@ class GovukNotifyPersonalisation
       team_email:,
       team_name:,
       team_phone:,
-      team_phone_instructions_present:,
-      team_phone_instructions:,
       today_or_date_of_vaccination:,
       vaccination:
     }.compact
@@ -244,15 +243,7 @@ class GovukNotifyPersonalisation
   end
 
   def team_phone
-    (team || organisation).phone
-  end
-
-  def team_phone_instructions_present
-    team_phone_instructions.present? ? "yes" : "no"
-  end
-
-  def team_phone_instructions
-    (team || organisation).phone_instructions
+    format_phone_with_instructions(team || organisation)
   end
 
   def today_or_date_of_vaccination

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -69,9 +69,7 @@ describe GovukNotifyPersonalisation do
         subsequent_session_dates_offered_message: "",
         team_email: "organisation@example.com",
         team_name: "Organisation",
-        team_phone: "01234 567890",
-        team_phone_instructions_present: "yes",
-        team_phone_instructions: "option 1",
+        team_phone: "01234 567890 (option 1)",
         vaccination: "HPV vaccination"
       }
     )


### PR DESCRIPTION
Updated team phone method to include instructions in brackets, as required due to Notify template limitations on using variables inside conditionals. The team_phone in Notify now will always have instructions (if present) next to the phone number.