### PR TITLE
Add locations to vaccination records separate from session

### DIFF
--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -33,6 +33,7 @@ class PatientSessionsController < ApplicationController
       performed_by_user_id: current_user.id,
       programme: @programme,
       session: @session,
+      location: @session.location,
       location_name: @session.clinic? ? "Unknown" : nil,
       performed_ods_code: current_user.selected_organisation.ods_code
     )

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -33,8 +33,8 @@ class PatientSessionsController < ApplicationController
       performed_by_user_id: current_user.id,
       programme: @programme,
       session: @session,
-      location: @session.location,
-      location_name: @session.clinic? ? "Unknown" : nil,
+      location: nil,
+      location_name: "Unknown",
       performed_ods_code: current_user.selected_organisation.ods_code
     )
 

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -59,6 +59,7 @@ class VaccinateForm
 
     draft_vaccination_record.batch_id = todays_batch&.id
     draft_vaccination_record.dose_sequence = dose_sequence
+    draft_vaccination_record.location_id = patient_session.session.location_id
     draft_vaccination_record.patient_id = patient_session.patient_id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -96,6 +96,7 @@ class Reports::ProgrammeVaccinationsExporter
           :batch,
           :location,
           :performed_by_user,
+          :session,
           :vaccine,
           patient: %i[consent_statuses gp_practice school]
         )

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -141,7 +141,7 @@ class Reports::SystmOneExporter
 
   # TODO: Needs support for community and generic clinics.
   def practice_code(vaccination_record)
-    location = vaccination_record.session.location
+    location = vaccination_record.location
 
     location.school? ? location.urn : location.ods_code
   end

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -14,17 +14,18 @@ class DraftVaccinationRecord
   attribute :delivery_method, :string
   attribute :delivery_site, :string
   attribute :dose_sequence, :integer
+  attribute :location_id, :integer
   attribute :location_name, :string
   attribute :notes, :string
   attribute :outcome, :string
   attribute :patient_id, :integer
-  attribute :session_id, :integer
   attribute :performed_at, :datetime
   attribute :performed_by_family_name, :string
   attribute :performed_by_given_name, :string
   attribute :performed_by_user_id, :integer
   attribute :performed_ods_code, :string
   attribute :programme_id, :integer
+  attribute :session_id, :integer
 
   validates :performed_by_family_name,
             :performed_by_given_name,
@@ -39,7 +40,7 @@ class DraftVaccinationRecord
       (:outcome if can_change_outcome?),
       (:delivery if administered?),
       (:batch if administered?),
-      (:location if location&.generic_clinic?),
+      (:location if session&.generic_clinic?),
       :confirm
     ].compact
   end
@@ -117,6 +118,17 @@ class DraftVaccinationRecord
     vaccine.dose_volume_ml * 1 if vaccine.present?
   end
 
+  def location
+    LocationPolicy::Scope
+      .new(@current_user, Location)
+      .resolve
+      .find_by(id: session_id)
+  end
+
+  def location=(value)
+    self.location_id = value&.id
+  end
+
   def patient
     Patient.find_by(id: patient_id)
   end
@@ -124,8 +136,6 @@ class DraftVaccinationRecord
   def patient=(value)
     self.patient_id = value.id
   end
-
-  delegate :location, to: :session, allow_nil: true
 
   def performed_by_user
     User.find_by(id: performed_by_user_id)

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -96,6 +96,7 @@ class ImmunisationImportRow
 
     attributes = {
       dose_sequence: dose_sequence_value,
+      location:,
       location_name:,
       outcome:,
       patient:,
@@ -217,6 +218,12 @@ class ImmunisationImportRow
   def vaccine_name = @data[:vaccine_given]
 
   private
+
+  def location
+    return nil if session&.generic_clinic?
+
+    session&.location
+  end
 
   def location_name
     return unless session.nil? || session.location.generic_clinic?

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -130,7 +130,7 @@ class Session < ApplicationRecord
 
   before_create :set_slug
 
-  delegate :clinic?, :school?, to: :location
+  delegate :clinic?, :generic_clinic?, :school?, to: :location
 
   def to_param
     slug

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -22,6 +22,7 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  batch_id                 :bigint
+#  location_id              :bigint
 #  patient_id               :bigint
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
@@ -32,6 +33,7 @@
 #
 #  index_vaccination_records_on_batch_id              (batch_id)
 #  index_vaccination_records_on_discarded_at          (discarded_at)
+#  index_vaccination_records_on_location_id           (location_id)
 #  index_vaccination_records_on_patient_id            (patient_id)
 #  index_vaccination_records_on_performed_by_user_id  (performed_by_user_id)
 #  index_vaccination_records_on_programme_id          (programme_id)
@@ -85,10 +87,10 @@ class VaccinationRecord < ApplicationRecord
   has_and_belongs_to_many :dps_exports
   has_and_belongs_to_many :immunisation_imports
 
+  belongs_to :location, optional: true
   belongs_to :patient
   belongs_to :session, optional: true
 
-  has_one :location, through: :session
   has_one :organisation, through: :session
   has_one :team, through: :session
 
@@ -207,7 +209,7 @@ class VaccinationRecord < ApplicationRecord
   private
 
   def requires_location_name?
-    session.nil? || location&.generic_clinic?
+    location.nil? || session&.generic_clinic?
   end
 
   delegate :maximum_dose_sequence, to: :programme

--- a/db/migrate/20250514170839_add_location_to_vaccination_records.rb
+++ b/db/migrate/20250514170839_add_location_to_vaccination_records.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddLocationToVaccinationRecords < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :vaccination_records, :location
+
+    reversible do |dir|
+      dir.up do
+        VaccinationRecord
+          .where.not(session_id: nil)
+          .eager_load(:session)
+          .find_each { it.update_column(:location_id, it.session.location_id) }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_14_170839) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -798,8 +798,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
     t.bigint "session_id"
     t.string "performed_ods_code"
     t.bigint "vaccine_id"
+    t.bigint "location_id"
     t.index ["batch_id"], name: "index_vaccination_records_on_batch_id"
     t.index ["discarded_at"], name: "index_vaccination_records_on_discarded_at"
+    t.index ["location_id"], name: "index_vaccination_records_on_location_id"
     t.index ["patient_id"], name: "index_vaccination_records_on_patient_id"
     t.index ["performed_by_user_id"], name: "index_vaccination_records_on_performed_by_user_id"
     t.index ["programme_id"], name: "index_vaccination_records_on_programme_id"

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -114,7 +114,11 @@ describe AppOutcomeBannerComponent do
 
     context "when the vaccination is historical" do
       before do
-        vaccination_record.update!(session: nil, location_name: "Unknown")
+        vaccination_record.update!(
+          session: nil,
+          location: nil,
+          location_name: "Unknown"
+        )
       end
 
       it { should have_text("Vaccinated") }

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -22,6 +22,7 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  batch_id                 :bigint
+#  location_id              :bigint
 #  patient_id               :bigint
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
@@ -32,6 +33,7 @@
 #
 #  index_vaccination_records_on_batch_id              (batch_id)
 #  index_vaccination_records_on_discarded_at          (discarded_at)
+#  index_vaccination_records_on_location_id           (location_id)
 #  index_vaccination_records_on_patient_id            (patient_id)
 #  index_vaccination_records_on_performed_by_user_id  (performed_by_user_id)
 #  index_vaccination_records_on_programme_id          (programme_id)
@@ -95,6 +97,7 @@ FactoryBot.define do
     dose_sequence { programme.vaccinated_dose_sequence }
     uuid { SecureRandom.uuid }
 
+    location { session&.location }
     location_name { "Unknown" if session.nil? }
 
     trait :not_administered do

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -22,6 +22,7 @@
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  batch_id                 :bigint
+#  location_id              :bigint
 #  patient_id               :bigint
 #  performed_by_user_id     :bigint
 #  programme_id             :bigint           not null
@@ -32,6 +33,7 @@
 #
 #  index_vaccination_records_on_batch_id              (batch_id)
 #  index_vaccination_records_on_discarded_at          (discarded_at)
+#  index_vaccination_records_on_location_id           (location_id)
 #  index_vaccination_records_on_patient_id            (patient_id)
 #  index_vaccination_records_on_performed_by_user_id  (performed_by_user_id)
 #  index_vaccination_records_on_programme_id          (programme_id)


### PR DESCRIPTION
Currently the location of a vaccination record is determined from the session it was recorded in. In most cases, this will be the same, however there are scenarios where this is not the case:

- If the session is for the generic clinic, the location needs to be set to one of the community clinics.
- If a nurse is marking a patient as already having had the vaccine, this happens in a session, but the vaccination would have occurred elsewhere.

The first case is already handled by the `location_name` column which is a free-text field and can contain anything. This works, but is unstructured, ideally we'd like to move to a place where we can link these records with the locations in the database for the community clinic. This commit gets us closer to that point.

The second case is not handled currently. Instead, when recording a patient as having already had the vaccine, the location of the vaccination ends up being the session that the nurse happened to use to mark the patient as vaccinated already. In some cases this might be correct, but in most it won't be. This commit allows us to fix the second case, which will be done in a followup commit to this one.