### PR TITLE
Revert "Don't validate when marking patient as invalid"

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -348,7 +348,7 @@ class Patient < ApplicationRecord
   def invalidate!
     return if invalidated?
 
-    update_column(:invalidated_at, Time.current)
+    update!(invalidated_at: Time.current)
   end
 
   def dup_for_pending_changes

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -466,19 +466,6 @@ describe Patient do
         )
       end
     end
-
-    context "with an invalid NHS number" do
-      let(:patient) { create(:patient, nhs_number: nil) }
-
-      before do
-        patient.nhs_number = "1234567890"
-        patient.save!(validate: false)
-      end
-
-      it "doesn't raise an error" do
-        expect { invalidate! }.not_to raise_error
-      end
-    end
   end
 
   describe "#stage_changes" do


### PR DESCRIPTION
Reverts nhsuk/manage-vaccinations-in-schools#3529

Once all patients in production have been updated to ensure they have valid NHS numbers we can merge this in.