### PR TITLE
TimelineRecords UI

### DIFF
--- a/app/components/app_timeline_component.rb
+++ b/app/components/app_timeline_component.rb
@@ -6,27 +6,37 @@ class AppTimelineComponent < ViewComponent::Base
       <% @items.each do |item| %>
         <% next if item.blank? %>
 
-        <li class="app-timeline__item <%= 'app-timeline__item--past' if item[:is_past_item] %>">
-          <% if item[:active] || item[:is_past_item] %>
-            <svg class="app-timeline__badge" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
-              <circle cx="14" cy="14" r="13" fill="#005EB8"/>
-            </svg>
-          <% else %>
-            <svg class="app-timeline__badge app-timeline__badge--small" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
-              <circle cx="7" cy="7" r="6" fill="white" stroke="#AEB7BD" stroke-width="2"/>
-            </svg>
-          <% end %>
-
-          <div class="app-timeline__content">
-            <h3 class="app-timeline__header <%= 'nhsuk-u-font-weight-bold' if item[:active] %>">
-              <%= item[:heading_text].html_safe %>
+        <% if item[:type] == :section_header %>
+          <li>
+            <h3 class="nhsuk-u-margin-top-2">
+              <%= content_tag(:strong, item[:date]) %>
             </h3>
-
-            <% if item[:description].present? %>
-              <p class="app-timeline__description"><%= item[:description].html_safe %></p>
+          </li>
+        <% else %>
+          <li class="app-timeline__item <%= 'app-timeline__item--past' if item[:is_past_item] %>">
+            <% if item[:active] || item[:is_past_item] %>
+              <svg class="app-timeline__badge" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">
+                <circle cx="14" cy="14" r="13" fill="#005EB8"/>
+              </svg>
+            <% else %>
+              <svg class="app-timeline__badge app-timeline__badge--small" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+                <circle cx="7" cy="7" r="6" fill="white" stroke="#AEB7BD" stroke-width="2"/>
+              </svg>
             <% end %>
-          </div>
-        </li>
+
+            <div class="app-timeline__content">
+              <h3 class="app-timeline__header <%= 'nhsuk-u-font-weight-bold' if item[:active] %>">
+                <%= format_heading(item).html_safe %>
+              </h3>
+
+              <% if item[:description].present? || item[:details].present? %>
+                <div class="app-timeline__description">
+                  <%= format_description(item).html_safe %>
+                </div>
+              <% end %>
+            </div>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   ERB
@@ -37,5 +47,80 @@ class AppTimelineComponent < ViewComponent::Base
 
   def render?
     @items.present?
+  end
+
+  private
+
+  EVENT_COLOUR_MAPPING = {
+    "CohortImport" => "blue",
+    "ClassImport" => "purple",
+    "PatientSession" => "green",
+    "Consent" => "yellow",
+    "Triage" => "red",
+    "VaccinationRecord" => "grey",
+    "SchoolMove" => "orange",
+    "SchoolMoveLogEntry" => "pink"
+  }.freeze
+
+  def format_heading(item)
+    if item[:type] && item[:created_at]
+      time = format_time(item[:created_at])
+      event_tag =
+        govuk_tag(
+          text: item[:event_type],
+          colour: tag_colour(item[:event_type])
+        )
+      "#{event_tag} at #{time}"
+    elsif item[:heading_text]
+      item[:heading_text]
+    end
+  end
+
+  def format_description(item)
+    if item[:details].present?
+      formatted_details = format_event_details(item[:details])
+      id_info =
+        item[:id] ? "<p class=\"timeline__byline\">id: #{item[:id]}</p>" : ""
+      "#{id_info}#{formatted_details}"
+    elsif item[:description].present?
+      item[:description]
+    end
+  end
+
+  def format_time(date_time)
+    date_time.strftime("%H:%M:%S")
+  end
+
+  def format_event_details(details)
+    return "" if details.blank?
+
+    if details.is_a?(Hash)
+      formatted =
+        details.map do |key, value|
+          if value.is_a?(Hash)
+            nested =
+              value.map do |sub_key, sub_value|
+                nested_value =
+                  sub_value.is_a?(String) ? sub_value : sub_value.inspect
+                "<div style='margin-left: 1em;'><strong>#{sub_key}:</strong> #{nested_value}</div>"
+              end
+            "<div><strong>#{key}:</strong>#{nested.join}</div>"
+          else
+            "<div><strong>#{key}:</strong> #{value}</div>"
+          end
+        end
+      formatted.join
+    else
+      details.to_s
+    end
+  end
+
+  def tag_colour(type)
+    return "light-blue" if type.end_with?("-Audit")
+    EVENT_COLOUR_MAPPING.fetch(type, "grey")
+  end
+
+  def govuk_tag(text:, colour:)
+    helpers.govuk_tag(text: text, colour: colour)
   end
 end

--- a/app/components/app_timeline_filter_component.html.erb
+++ b/app/components/app_timeline_filter_component.html.erb
@@ -158,6 +158,15 @@
                                          "data-turbo-permanent": "true" %>
             <% end %>
             <% end %>
+
+            <div class="nhsuk-u-margin-bottom-4">
+            <%= f.govuk_check_box :show_pii, true,
+                                  label: { text: "Show PII" },
+                                  checked: @show_pii,
+                                  "data-autosubmit-target": "field",
+                                  "data-action": "autosubmit#submit",
+                                  "data-turbo-permanent": "true" %>
+            </div>
             
             <%= helpers.govuk_button_link_to "Reset filters",
                                              @reset_url,

--- a/app/components/app_timeline_filter_component.html.erb
+++ b/app/components/app_timeline_filter_component.html.erb
@@ -1,0 +1,172 @@
+<%= render AppCardComponent.new(filters: true) do |card| %>
+    <% card.with_heading { "Customise timeline" } %>
+    <%= form_with url: @url,
+                  method: :get,
+                  data: { module: "autosubmit",
+                          turbo: "true",
+                          turbo_action: "replace" },
+                  builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_fieldset legend: { text: "Events to display:", size: "s" } do %>
+            <% event_options.keys.each do |value| %>
+                <%= f.govuk_check_boxes_fieldset :event_names, legend: { hidden: true } do %>
+                    <%= f.govuk_check_box :event_names,
+                                          value,
+                                          label: { text: value.to_s.humanize },
+                                          checked: value.to_s.in?(params[:event_names] || event_options.keys.map(&:to_s)),
+                                          "data-autosubmit-target": "field",
+                                          "data-action": "autosubmit#submit",
+                                          "data-turbo-permanent": "true" %>
+                    
+                    <% available_fields = timeline_fields[value.to_sym] || [] %>
+                    <% if available_fields.any? && value.to_s.in?(params[:event_names]) %>
+                        <div class="nhsuk-checkboxes__conditional nhsuk-u-margin-bottom-2">
+                            <% available_fields.each do |field| %>
+                                <%= f.govuk_check_box "detail_config[#{value}]",
+                                                      field,
+                                                      small: true,
+                                                      label: { text: field },
+                                                      checked: field.to_s.in?(params.dig("detail_config", value) || []),
+                                                      "data-autosubmit-target": "field",
+                                                      "data-action": "autosubmit#submit",
+                                                      "data-turbo-permanent": "true" %>
+                            <% end %>
+                        </div>
+                    <% end %>
+                <% end %>
+            <% end %>
+
+            <%= f.govuk_check_boxes_fieldset :audit_config, legend: { hidden: true } do %>
+                <%= f.govuk_check_box :event_names, "audits",
+                                      label: { text: "Audits" },
+                                      checked: "audits".in?(params[:event_names]),
+                                      "data-autosubmit-target": "field",
+                                      "data-action": "autosubmit#submit",
+                                      "data-turbo-permanent": "true" %>
+                <% if "audits".in?(params[:event_names]) %>
+                    <div class="nhsuk-checkboxes__conditional nhsuk-u-margin-bottom-2">
+                        <%= f.govuk_check_box "audit_config[include_associated_audits]", true, false,
+                                              multiple: false,
+                                              label: { text: "include associated audits" },
+                                              checked: params.dig(:audit_config, :include_associated_audits) == "true",
+                                              "data-autosubmit-target": "field",
+                                              "data-action": "autosubmit#submit",
+                                              "data-turbo-permanent": "true" %>
+
+                        <%= f.govuk_check_box "audit_config[include_filtered_audit_changes]", true, false,
+                                              multiple: false,
+                                              label: { text: "include filtered audit changes" },
+                                              checked: params.dig(:audit_config, :include_filtered_audit_changes) == "true",
+                                              "data-autosubmit-target": "field",
+                                              "data-action": "autosubmit#submit",
+                                              "data-turbo-permanent": "true" %>
+                    </div>
+                <% end %>
+            <% end %>
+
+            <%= f.govuk_check_box :event_names, "org_cohort_imports",
+                                  label: { text: "Cohort Imports for Team #{@teams.join(",")} excluding patient" },
+                                  checked: "org_cohort_imports".in?(params[:event_names]),
+                                  "data-autosubmit-target": "field",
+                                  "data-action": "autosubmit#submit",
+                                  "data-turbo-permanent": "true" %>
+
+            <% (@additional_class_imports).each do |location_id, import_ids| %>
+                <%= f.govuk_check_box :event_names, "add_class_imports_#{location_id}",
+                                      label: { text: "Class Imports for Location-#{location_id} excluding Patient" },
+                                      checked: "add_class_imports_#{location_id}".in?(params[:event_names]),
+                                      "data-autosubmit-target": "field",
+                                      "data-action": "autosubmit#submit",
+                                      "data-turbo-permanent": "true" %>
+            <% end %>
+
+            
+            <%= f.govuk_radio_buttons_fieldset :compare_option, legend: { text: "Compare with another patient:", size: "s" } do %>
+            <%= f.govuk_radio_button :compare_option,
+                                     nil,
+                                     label: { text: "Do not compare" },
+                                     checked: params[:compare_option].blank?,
+                                     "data-autosubmit-target": "field",
+                                     "data-action": "autosubmit#submit",
+                                     "data-turbo-permanent": "true" %>
+            
+            <% if class_imports.present? %>
+                <%= f.govuk_radio_button :compare_option,
+                                         "class_import",
+                                         label: { text: "From a Class Import" },
+                                         checked: params[:compare_option] == "class_import",
+                                         "data-autosubmit-target": "field",
+                                         "data-action": "autosubmit#submit",
+                                         "data-turbo-permanent": "true" do %>
+                <% class_imports.each do |import| %>
+                    <%= f.govuk_radio_button :compare_option_class_import,
+                                             import,
+                                             label: { text: "ClassImport-#{import}" },
+                                             checked: params[:compare_option_class_import].to_s == import.to_s,
+                                             "data-autosubmit-target": "field",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+                <% end %>
+                <% end %>
+            <% end %>
+            
+            <% if cohort_imports.present? %>
+                <%= f.govuk_radio_button :compare_option,
+                                         "cohort_import",
+                                         label: { text: "From a Cohort Import" },
+                                         checked: params[:compare_option] == "cohort_import",
+                                         "data-autosubmit-target": "field",
+                                         "data-action": "autosubmit#submit",
+                                         "data-turbo-permanent": "true" do %>
+                <% cohort_imports.each do |import| %>
+                    <%= f.govuk_radio_button :compare_option_cohort_import,
+                                             import,
+                                             label: { text: "CohortImport-#{import}" },
+                                             checked: params[:compare_option_cohort_import].to_s == import.to_s,
+                                             "data-autosubmit-target": "field",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+                <% end %>
+                <% end %>
+            <% end %>
+            
+            <% if sessions.present? %>
+                <%= f.govuk_radio_button :compare_option,
+                                         "session",
+                                         label: { text: "In a Session" },
+                                         checked: params[:compare_option] == "session" do %>
+                <% sessions.each do |session| %>
+                    <%= f.govuk_radio_button :compare_option_session,
+                                             session,
+                                             label: { text: "Session-#{session}" },
+                                             checked: params[:compare_option_session].to_s == session.to_s && params[:compare_option] == "session",
+                                             "data-autosubmit-target": "field",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+                <% end %>
+                <% end %>
+            <% end %>
+            
+            <%= f.govuk_radio_button :compare_option,
+                                     "manual_entry",
+                                     label: { text: "With a specific Patient ID" },
+                                     checked: params[:compare_option] == "manual_entry" do %>
+                <%= f.govuk_number_field :manual_patient_id,
+                                         label: { hidden: true },
+                                         width: 10,
+                                         "data-autosubmit-target": "field",
+                                         "data-action": "autosubmit#submit",
+                                         "data-turbo-permanent": "true" %>
+            <% end %>
+            <% end %>
+            
+            <%= helpers.govuk_button_link_to "Reset filters",
+                                             @reset_url,
+                                             class: "govuk-button govuk-button--secondary nhsuk-u-display-block app-button--small",
+                                             secondary: true,
+                                             "data-autosubmit-target": "reset",
+                                             "data-action": "autosubmit#submit",
+                                             "data-turbo-permanent": "true" %>
+            <%= f.govuk_submit "Filter" %>
+        <% end %>
+    <% end %>
+<% end %>

--- a/app/components/app_timeline_filter_component.rb
+++ b/app/components/app_timeline_filter_component.rb
@@ -11,7 +11,8 @@ class AppTimelineFilterComponent < ViewComponent::Base
     class_imports:,
     cohort_imports:,
     sessions:,
-    reset_url:
+    reset_url:,
+    show_pii:
   )
     @url = url
     @patient = patient
@@ -23,6 +24,7 @@ class AppTimelineFilterComponent < ViewComponent::Base
     @cohort_imports = cohort_imports
     @sessions = sessions
     @reset_url = reset_url
+    @show_pii = show_pii
   end
 
   attr_reader :url,
@@ -33,5 +35,6 @@ class AppTimelineFilterComponent < ViewComponent::Base
               :class_imports,
               :cohort_imports,
               :sessions,
-              :reset_url
+              :reset_url,
+              :show_pii
 end

--- a/app/components/app_timeline_filter_component.rb
+++ b/app/components/app_timeline_filter_component.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AppTimelineFilterComponent < ViewComponent::Base
+  def initialize(
+    url:,
+    patient:,
+    teams:,
+    event_options:,
+    timeline_fields:,
+    additional_class_imports:,
+    class_imports:,
+    cohort_imports:,
+    sessions:,
+    reset_url:
+  )
+    @url = url
+    @patient = patient
+    @teams = teams.map(&:id)
+    @event_options = event_options
+    @timeline_fields = timeline_fields
+    @additional_class_imports = additional_class_imports
+    @class_imports = class_imports
+    @cohort_imports = cohort_imports
+    @sessions = sessions
+    @reset_url = reset_url
+  end
+
+  attr_reader :url,
+              :patient,
+              :event_options,
+              :timeline_fields,
+              :additional_class_imports,
+              :class_imports,
+              :cohort_imports,
+              :sessions,
+              :reset_url
+end

--- a/app/controllers/inspect/timeline/patients_controller.rb
+++ b/app/controllers/inspect/timeline/patients_controller.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+class Inspect::Timeline::PatientsController < ApplicationController
+  skip_after_action :verify_policy_scoped
+  skip_before_action :authenticate_user!
+  before_action :set_patient
+
+  layout "full"
+
+  DEFAULT_EVENT_NAMES = %w[
+    consents
+    school_moves
+    school_move_log_entries
+    audits
+    sessions
+    triages
+    vaccination_records
+    class_imports
+    cohort_imports
+  ].freeze
+
+  def show
+    params.reverse_merge!(event_names: DEFAULT_EVENT_NAMES)
+    params[:audit_config] ||= {}
+
+    event_names = params[:event_names]
+    compare_option = params[:compare_option] || nil
+
+    if params[:detail_config].blank?
+      default_details = TimelineRecords::DEFAULT_DETAILS_CONFIG
+      new_params = params.to_unsafe_h.merge("detail_config" => default_details)
+      redirect_to inspect_timeline_patient_path(new_params) and return
+    end
+
+    audit_config = {
+      include_associated_audits:
+        params[:audit_config][:include_associated_audits],
+      include_filtered_audit_changes:
+        params[:audit_config][:include_filtered_audit_changes]
+    }
+
+    @patient_timeline =
+      TimelineRecords.new(
+        @patient,
+        detail_config: build_details_config,
+        audit_config: audit_config
+      ).load_timeline_events(event_names)
+
+    @no_events_message = true if @patient_timeline.empty?
+
+    @compare_patient = sample_patient(params[:compare_option]) if compare_option
+
+    if @compare_patient == :invalid_patient
+      @invalid_patient_id = true
+    elsif @compare_patient
+      @compare_patient_timeline =
+        TimelineRecords.new(
+          @compare_patient,
+          detail_config: build_details_config,
+          audit_config: audit_config
+        ).load_timeline_events(event_names)
+
+      @no_events_compare_message = true if @compare_patient_timeline.empty?
+    end
+  end
+
+  private
+
+  def set_patient
+    @patient = Patient.find(params[:id])
+    timeline = TimelineRecords.new(@patient)
+    @patient_events = timeline.patient_events(@patient)
+    @additional_events = timeline.additional_events(@patient)
+  end
+
+  # TODO: Fix so that a new comparison patient isn't sampled every time
+  #       a filter option is changed and the page is reloaded.
+  def sample_patient(compare_option)
+    case compare_option
+    when "class_import"
+      class_import = params[:compare_option_class_import]
+      class_import.patients.where.not(id: @patient.id).sample
+    when "cohort_import"
+      cohort_import = params[:compare_option_cohort_import]
+      cohort_import.patients.where.not(id: @patient.id).sample
+    when "session"
+      session = Session.find(params[:compare_option_session])
+      session.patients.where.not(id: @patient.id).sample
+    when "manual_entry"
+      begin
+        Patient.find(params[:manual_patient_id])
+      rescue ActiveRecord::RecordNotFound
+        :invalid_patient
+      end
+    else
+      raise ArgumentError,
+            "Invalid patient comparison option: #{compare_option}"
+    end
+  end
+
+  def build_details_config
+    details_params = params[:detail_config] || {}
+    details_params = details_params.to_unsafe_h unless details_params.is_a?(
+      Hash
+    )
+
+    details_params.each_with_object({}) do |(event_type, fields), hash|
+      selected_fields = Array(fields).reject(&:blank?).map(&:to_sym)
+      hash[event_type.to_sym] = selected_fields
+    end
+  end
+end

--- a/app/controllers/inspect/timeline/patients_controller.rb
+++ b/app/controllers/inspect/timeline/patients_controller.rb
@@ -76,6 +76,8 @@ class Inspect::Timeline::PatientsController < ApplicationController
   # TODO: Fix so that a new comparison patient isn't sampled every time
   #       a filter option is changed and the page is reloaded.
   def sample_patient(compare_option)
+    return nil if compare_option.blank? || compare_option == "on"
+
     case compare_option
     when "class_import"
       class_import = params[:compare_option_class_import]

--- a/app/controllers/inspect/timeline/patients_controller.rb
+++ b/app/controllers/inspect/timeline/patients_controller.rb
@@ -7,6 +7,8 @@ class Inspect::Timeline::PatientsController < ApplicationController
 
   layout "full"
 
+  SHOW_PII = false
+
   DEFAULT_EVENT_NAMES = %w[
     consents
     school_moves
@@ -20,6 +22,8 @@ class Inspect::Timeline::PatientsController < ApplicationController
   ].freeze
 
   def show
+    @show_pii = params[:show_pii] || SHOW_PII
+
     params.reverse_merge!(event_names: DEFAULT_EVENT_NAMES)
     params[:audit_config] ||= {}
 
@@ -43,7 +47,8 @@ class Inspect::Timeline::PatientsController < ApplicationController
       TimelineRecords.new(
         @patient,
         detail_config: build_details_config,
-        audit_config: audit_config
+        audit_config: audit_config,
+        show_pii: @show_pii
       ).load_timeline_events(event_names)
 
     @no_events_message = true if @patient_timeline.empty?
@@ -95,8 +100,10 @@ class Inspect::Timeline::PatientsController < ApplicationController
         :invalid_patient
       end
     else
-      raise ArgumentError,
-            "Invalid patient comparison option: #{compare_option}"
+      raise ArgumentError, <<~MESSAGE
+      Invalid patient comparison option: #{compare_option}.
+      Supported options are: class_import, cohort_import, session, manual_entry
+    MESSAGE
     end
   end
 

--- a/app/views/inspect/timeline/patients/show.html.erb
+++ b/app/views/inspect/timeline/patients/show.html.erb
@@ -1,0 +1,78 @@
+<%= h1 page_title: @patient.initials do %>
+  <%= "Inspect Patient #{@patient.id}" %>
+<% end %>
+
+<code>
+  <%= "Patient.find(#{@patient.id})" %>
+</code>
+
+<% if params[:event_names].include?("audits") && @patient_timeline %>
+  <%= govuk_inset_text do %>
+    <p class="nhsuk-body">
+      Only audited changes that do not involve PII are included
+    </p>
+  <% end %>
+<% end %>
+
+<div class="nhsuk-grid-row nhsuk-u-margin-top-4">
+  
+  <div class="nhsuk-grid-column-one-third app-grid-column--sticky">
+      <%= render AppTimelineFilterComponent.new(
+            url: inspect_timeline_patient_path,
+            patient: @patient,
+            teams: @patient.teams,
+            event_options: TimelineRecords::DEFAULT_DETAILS_CONFIG,
+            timeline_fields: TimelineRecords::AVAILABLE_DETAILS_CONFIG,
+            class_imports: @patient_events[:class_imports],
+            cohort_imports: @patient_events[:cohort_imports],
+            sessions: @patient_events[:sessions],
+            additional_class_imports: @additional_events[:class_imports],
+            reset_url: inspect_timeline_patient_path(
+              event_names: Inspect::Timeline::PatientsController::DEFAULT_EVENT_NAMES,
+              detail_config: TimelineRecords::DEFAULT_DETAILS_CONFIG,
+              compare_option: nil,
+            ),
+          ) %>
+  </div>
+
+  <div class="nhsuk-grid-column-two-thirds">
+    <% if @no_events_message %>
+      <%= render AppWarningCalloutComponent.new(
+            heading: "No events found",
+            description: "Patient-#{@patient.id} doesn't have the following events recorded: " +
+                         "#{params[:event_names].map(&:humanize).join(", ")}".html_safe,
+          ) %>
+    <% else %>
+        <% if @compare_patient_timeline || @invalid_patient_id || @no_events_compare_message %>
+          <div class="nhsuk-grid-column-one-half">
+            <h2 class="nhsuk-heading-m">Patient <%= @patient.id %></h2>
+            <%= render AppTimelineComponent.new(@patient_timeline) %>
+          </div>
+
+          <% if @invalid_patient_id %>
+            <div class="nhsuk-grid-column-one-half">
+              <%= render AppWarningCalloutComponent.new(
+                    heading: "Invalid patient ID",
+                    description: "Patient-#{params[:manual_patient_id]} doesn't exist",
+                  ) %>
+            </div>
+          <% elsif @no_events_compare_message %>
+            <div class="nhsuk-grid-column-one-half">
+              <%= render AppWarningCalloutComponent.new(
+                    heading: "No events found for comparison patient",
+                    description: "Patient-#{@compare_patient.id} doesn't have the following events recorded: " +
+                                 "#{params[:event_names].map(&:humanize).join(", ")}".html_safe,
+                  ) %>
+            </div>
+          <% elsif @compare_patient_timeline %>
+            <h2 class="nhsuk-heading-m">Patient <%= @compare_patient.id %></h2>
+              <div class="nhsuk-grid-column-one-half">
+                <%= render AppTimelineComponent.new(@compare_patient_timeline) %>
+              </div>
+          <% end %>
+        <% else %>
+          <%= render AppTimelineComponent.new(@patient_timeline) %>
+        <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/inspect/timeline/patients/show.html.erb
+++ b/app/views/inspect/timeline/patients/show.html.erb
@@ -6,7 +6,7 @@
   <%= "Patient.find(#{@patient.id})" %>
 </code>
 
-<% if params[:event_names].include?("audits") && @patient_timeline %>
+<% if params[:event_names].include?("audits") && @patient_timeline && !@show_pii %>
   <%= govuk_inset_text do %>
     <p class="nhsuk-body">
       Only audited changes that do not involve PII are included
@@ -16,13 +16,13 @@
 
 <div class="nhsuk-grid-row nhsuk-u-margin-top-4">
   
-  <div class="nhsuk-grid-column-one-third app-grid-column--sticky">
+  <div class="nhsuk-grid-column-one-half app-grid-column--sticky">
       <%= render AppTimelineFilterComponent.new(
             url: inspect_timeline_patient_path,
             patient: @patient,
             teams: @patient.teams,
             event_options: TimelineRecords::DEFAULT_DETAILS_CONFIG,
-            timeline_fields: TimelineRecords::AVAILABLE_DETAILS_CONFIG,
+            timeline_fields: @show_pii ? TimelineRecords::AVAILABLE_DETAILS_CONFIG_WITH_PII : TimelineRecords::AVAILABLE_DETAILS_CONFIG,
             class_imports: @patient_events[:class_imports],
             cohort_imports: @patient_events[:cohort_imports],
             sessions: @patient_events[:sessions],
@@ -31,11 +31,13 @@
               event_names: Inspect::Timeline::PatientsController::DEFAULT_EVENT_NAMES,
               detail_config: TimelineRecords::DEFAULT_DETAILS_CONFIG,
               compare_option: nil,
+              show_pii: false,
             ),
+            show_pii: @show_pii,
           ) %>
   </div>
 
-  <div class="nhsuk-grid-column-two-thirds">
+  <div class="nhsuk-grid-column-one-half">
     <% if @no_events_message %>
       <%= render AppWarningCalloutComponent.new(
             heading: "No events found",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,4 +345,13 @@ Rails.application.routes.draw do
   end
 
   get "/oidc/jwks", to: "jwks#jwks"
+
+  constraints -> { Rails.env.local? } do
+    namespace :inspect do
+      get "graph/:object_type/:object_id", to: "graphs#show"
+      namespace :timeline do
+        resources :patients, only: [:show]
+      end
+    end
+  end
 end

--- a/lib/timeline_records.rb
+++ b/lib/timeline_records.rb
@@ -2,103 +2,84 @@
 
 class TimelineRecords
   DEFAULT_DETAILS_CONFIG = {
-    consents: %i[response route],
-    sessions: %i[],
-    session_attendances: %i[],
-    triages: %i[status performed_by_user_id],
-    vaccination_records: %i[outcome session_id],
-    cohort_imports: %i[],
+    changesets: %i[import_id import_type],
     class_imports: %i[],
-    parents: %i[],
+    cohort_imports: %i[],
+    consents: %i[response route],
     gillick_assessments: %i[],
     parent_relationships: %i[],
+    parents: %i[],
+    pds_search_results: %i[],
+    school_move_log_entries: %i[school_id user_id],
     school_moves: %i[school_id source],
-    school_move_log_entries: %i[school_id user_id]
+    sessions: %i[location_id],
+    teams: %i[name],
+    triages: %i[performed_by_user_id status],
+    vaccination_records: %i[outcome session_id]
   }.freeze
 
   AVAILABLE_DETAILS_CONFIG = {
-    consents: %i[response route updated_at withdrawn_at invalidated_at],
-    sessions: %i[slug academic_year],
-    session_attendances: %i[attending updated_at],
-    triages: %i[status updated_at invalidated_at performed_by_user_id],
-    vaccination_records: %i[
-      outcome
-      performed_at
-      updated_at
-      discarded_at
-      uuid
-      session_id
-    ],
-    cohort_imports: %i[
-      csv_filename
-      processed_at
-      status
-      rows_count
-      new_record_count
-      exact_duplicate_record_count
-      changed_record_count
-    ],
+    changesets: %i[import_id import_type],
     class_imports: %i[
-      csv_filename
-      processed_at
-      status
-      rows_count
-      new_record_count
-      exact_duplicate_record_count
       changed_record_count
+      csv_filename
+      exact_duplicate_record_count
+      new_record_count
+      processed_at
+      rows_count
+      status
       year_groups
     ],
-    parents: %i[],
+    cohort_imports: %i[
+      changed_record_count
+      csv_filename
+      exact_duplicate_record_count
+      new_record_count
+      processed_at
+      rows_count
+      status
+    ],
+    consents: %i[invalidated_at response route updated_at withdrawn_at],
     gillick_assessments: %i[],
     parent_relationships: %i[],
+    parents: %i[],
+    pds_search_results: %i[step],
+    school_move_log_entries: %i[school_id user_id],
     school_moves: %i[school_id source],
-    school_move_log_entries: %i[school_id user_id]
-  }.freeze
-
-  AVAILABLE_DETAILS_CONFIG_WITH_PII = {
-    consents: %i[response route updated_at withdrawn_at invalidated_at],
-    sessions: %i[slug academic_year],
-    session_attendances: %i[attending updated_at],
-    triages: %i[status updated_at invalidated_at performed_by_user_id],
+    sessions: %i[academic_year location_id slug],
+    teams: %i[name],
+    triages: %i[invalidated_at performed_by_user_id status updated_at],
     vaccination_records: %i[
+      discarded_at
+      nhs_immunisations_api_synced_at
       outcome
       performed_at
-      updated_at
-      discarded_at
-      uuid
+      protocol
       session_id
-    ],
-    cohort_imports: %i[
-      csv_filename
-      processed_at
-      status
-      rows_count
-      new_record_count
-      exact_duplicate_record_count
-      changed_record_count
-    ],
-    class_imports: %i[
-      csv_filename
-      processed_at
-      status
-      rows_count
-      new_record_count
-      exact_duplicate_record_count
-      changed_record_count
-      year_groups
-    ],
-    parents: %i[full_name email phone],
+      source
+      updated_at
+      uuid
+    ]
+  }.freeze
+
+  AVAILABLE_DETAILS_CONFIG_PII = {
+    changesets: %i[pds_nhs_number uploaded_nhs_number],
     gillick_assessments: %i[
-      knows_vaccination
-      knows_disease
       knows_consequences
       knows_delivery
+      knows_disease
       knows_side_effects
+      knows_vaccination
     ],
-    parent_relationships: %i[type other_name],
-    school_moves: %i[school_id source],
-    school_move_log_entries: %i[school_id user_id]
+    parent_relationships: %i[other_name type],
+    parents: %i[email full_name phone],
+    pds_search_results: %i[nhs_number]
   }.freeze
+
+  AVAILABLE_DETAILS_CONFIG_WITH_PII =
+    AVAILABLE_DETAILS_CONFIG.merge(
+      AVAILABLE_DETAILS_CONFIG_PII
+    ) { |_, base_fields, pii_fields| (base_fields + pii_fields).uniq }
 
   DEFAULT_AUDITS_CONFIG = {
     include_associated_audits: true,
@@ -106,76 +87,58 @@ class TimelineRecords
   }.freeze
 
   ALLOWED_AUDITED_CHANGES = %i[
-    patient_id
-    session_id
-    location_id
-    programme_id
-    vaccine_id
-    organisation_id
-    team_id
-    school_id
-    gp_practice_id
-    uploaded_by_user_id
-    performed_by_user_id
-    user_id
-    parent_id
-    status
-    outcome
-    response
-    route
     date_of_death_recorded_at
-    restricted_at
-    invalidated_at
-    withdrawn_at
-    rows_count
-    year_groups
+    gp_practice_id
     home_educated
+    invalidated_at
+    location_id
+    organisation_id
+    outcome
+    parent_id
+    patient_id
+    performed_by_user_id
+    programme_id
+    registration_academic_year
+    response
+    restricted_at
+    rows_count
+    route
+    school_id
+    session_id
     source
+    status
+    team_id
+    uploaded_by_user_id
+    user_id
+    vaccine_id
+    withdrawn_at
+    year_groups
   ].freeze
 
-  ALLOWED_AUDITED_CHANGES_WITH_PII = %i[
-    full_name
-    email
-    phone
-    nhs_number
-    given_name
-    family_name
-    date_of_birth
+  ALLOWED_AUDITED_CHANGES_PII = %i[
     address_line_1
     address_line_2
-    address_town
     address_postcode
-    home_educated
-    updated_from_pds_at
-    restricted_at
+    address_town
+    birth_academic_year
+    date_of_birth
     date_of_death
+    email
+    family_name
+    full_name
+    gender_code
+    given_name
+    nhs_number
     pending_changes
-    patient_id
-    session_id
-    location_id
-    programme_id
-    vaccine_id
-    organisation_id
-    team_id
-    school_id
-    gp_practice_id
-    uploaded_by_user_id
-    performed_by_user_id
-    user_id
-    parent_id
-    status
-    outcome
-    response
-    route
-    date_of_death_recorded_at
-    restricted_at
-    invalidated_at
-    withdrawn_at
-    rows_count
-    year_groups
-    home_educated
-    source
+    phone
+    preferred_family_name
+    preferred_given_name
+    registration
+    updated_from_pds_at
   ].freeze
+
+  ALLOWED_AUDITED_CHANGES_WITH_PII =
+    (ALLOWED_AUDITED_CHANGES + ALLOWED_AUDITED_CHANGES_PII).uniq.freeze
 
   def initialize(patient, detail_config: {}, audit_config: {}, show_pii: false)
     @patient = patient

--- a/lib/timeline_records.rb
+++ b/lib/timeline_records.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+class TimelineRecords
+  DEFAULT_DETAILS_CONFIG = {
+    cohort_imports: [],
+    class_imports: [],
+    sessions: %i[],
+    school_moves: %i[school_id source],
+    school_move_log_entries: %i[school_id user_id],
+    consents: %i[response route],
+    triages: %i[status performed_by_user_id],
+    vaccination_records: %i[outcome session_id]
+  }.freeze
+
+  AVAILABLE_DETAILS_CONFIG = {
+    cohort_imports: %i[rows_count status uploaded_by_user_id],
+    class_imports: %i[rows_count year_groups uploaded_by_user_id location_id],
+    sessions: %i[],
+    school_moves: %i[source school_id home_educated],
+    school_move_log_entries: %i[user_id school_id home_educated],
+    consents: %i[
+      programme_id
+      response
+      route
+      parent_id
+      withdrawn_at
+      invalidated_at
+    ],
+    triages: %i[status performed_by_user_id programme_id invalidated_at],
+    vaccination_records: %i[
+      outcome
+      performed_by_user_id
+      programme_id
+      session_id
+      vaccine_id
+    ]
+  }.freeze
+
+  DEFAULT_AUDITS_CONFIG = {
+    include_associated_audits: true,
+    include_filtered_audit_changes: false
+  }.freeze
+
+  ALLOWED_AUDITED_CHANGES = %i[
+    patient_id
+    session_id
+    location_id
+    programme_id
+    vaccine_id
+    organisation_id
+    team_id
+    school_id
+    gp_practice_id
+    uploaded_by_user_id
+    performed_by_user_id
+    user_id
+    parent_id
+    status
+    outcome
+    response
+    route
+    date_of_death_recorded_at
+    restricted_at
+    invalidated_at
+    withdrawn_at
+    rows_count
+    year_groups
+    home_educated
+    source
+  ].freeze
+
+  def initialize(patient, detail_config: {}, audit_config: {})
+    @patient = patient
+    @patient_id = @patient.id
+    @patient_events = patient_events(@patient)
+    @additional_events = additional_events(@patient)
+    @detail_config = extract_detail_config(detail_config)
+    @events = []
+    @audit_config = audit_config
+  end
+
+  def render_timeline(*event_names, truncate_columns: false)
+    load_grouped_events(event_names)
+    format_timeline_console(truncate_columns)
+  end
+
+  def additional_events(patient)
+    patient_imports = patient_events(patient)[:class_imports]
+    patient_sessions = patient_events(patient)[:sessions]
+    patient_locations =
+      Location.joins(:sessions).where(sessions: { id: patient_sessions })
+    class_imports = ClassImport.where(location_id: patient_locations)
+    class_imports =
+      class_imports.where.not(id: patient_imports) if patient_imports.present?
+
+    {
+      class_imports:
+        class_imports
+          .group_by(&:location_id)
+          .transform_values { |imports| imports.map(&:id) },
+      cohort_imports:
+        patient
+          .teams
+          .flat_map(&:cohort_imports)
+          .map(&:id)
+          .reject { |id| patient_events(patient)[:cohort_imports].include?(id) }
+    }
+  end
+
+  def patient_events(patient)
+    {
+      class_imports: patient.class_imports.map(&:id),
+      cohort_imports: patient.cohort_imports.map(&:id),
+      sessions: patient.sessions.map(&:id)
+    }
+  end
+
+  def extract_detail_config(detail_config)
+    detail_config.deep_symbolize_keys
+  end
+
+  def details
+    @details ||= DEFAULT_DETAILS_CONFIG.merge(@detail_config)
+  end
+
+  def audits
+    @audits ||= DEFAULT_AUDITS_CONFIG.merge(@audit_config)
+  end
+
+  def load_events(event_names)
+    event_names.each do |event_name|
+      event_type = event_name.to_sym
+
+      if details.key?(event_type)
+        fields = details[event_type]
+        records = @patient.send(event_type)
+        records = Array(records)
+
+        records.each do |record|
+          event_details =
+            fields.each_with_object({}) do |field, hash|
+              field_value = record.send(field)
+              hash[field.to_s] = field_value.nil? ? "nil" : field_value
+            end
+          @events << {
+            event_type: record.class.name,
+            id: record.id,
+            details: event_details,
+            created_at: record.created_at
+          }
+        end
+      else
+        custom_event_handler(event_type)
+      end
+    end
+    @events.sort_by! { |event| event[:created_at] }.reverse!
+  end
+
+  def load_grouped_events(event_names)
+    load_events(event_names)
+    @grouped_events =
+      @events.group_by do |event|
+        event[:created_at].strftime(Date::DATE_FORMATS[:long])
+      end
+  end
+
+  private
+
+  def custom_event_handler(event_type)
+    case event_type
+    when :org_cohort_imports
+      @events += org_cohort_imports_events
+    when /^add_class_imports_\d+$/ # e.g. add_class_imports_123
+      location_id = event_type.to_s.split("_").last
+      @events += add_class_imports_events(location_id)
+    when :audits
+      @events += audits_events
+    else
+      puts "No handler for event type: #{event_type}"
+    end
+  end
+
+  def org_cohort_imports_events
+    CohortImport
+      .where(id: @additional_events[:cohort_imports])
+      .map do |cohort_import|
+        {
+          event_type: "CohortImport",
+          id: cohort_import.id,
+          details: "excluding patient",
+          created_at: cohort_import.created_at
+        }
+      end
+  end
+
+  def add_class_imports_events(location_id)
+    ClassImport
+      .where(id: @additional_events[:class_imports][location_id.to_i])
+      .map do |class_import|
+        {
+          event_type: "ClassImport",
+          id: class_import.id,
+          details: {
+            location_id: "#{class_import.location_id}, excluding patient"
+          },
+          created_at: class_import.created_at.to_time
+        }
+      end
+  end
+
+  def audits_events
+    audit_events =
+      (
+        if audits[:include_associated_audits]
+          @patient.own_and_associated_audits
+        else
+          @patient.audits
+        end
+      ).reject { it.audited_changes.keys == ["updated_from_pds_at"] }
+
+    audit_events.map do |audit|
+      filtered_changes =
+        audit
+          .audited_changes
+          .each_with_object({}) do |(key, value), hash|
+            if ALLOWED_AUDITED_CHANGES.include?(key.to_sym)
+              hash[key] = value
+            elsif audits[:include_filtered_audit_changes]
+              hash[key] = "[FILTERED]"
+            end
+          end
+
+      event_type = "#{audit.auditable_type}-Audit"
+
+      event_details = { action: audit.action }
+      event_details[
+        :audited_changes
+      ] = filtered_changes.deep_symbolize_keys unless filtered_changes.empty?
+      event_details[:auditable_id] = audit.auditable_id
+
+      {
+        event_type: event_type,
+        id: audit.id,
+        details: event_details,
+        created_at: audit.created_at
+      }
+    end
+  end
+
+  def format_timeline_console(truncate_columns)
+    event_type_width = 25
+    details_width = 50
+    header_format =
+      if truncate_columns
+        "%-12s %-10s %-#{event_type_width}s %-12s %-#{details_width}s"
+      else
+        "%-12s %-10s %-20s %-10s %-s"
+      end
+    puts sprintf(
+           header_format,
+           "DATE",
+           "TIME",
+           "EVENT_TYPE",
+           "EVENT-ID",
+           "DETAILS"
+         )
+    puts "-" * 115
+
+    @grouped_events.each do |date, events|
+      puts "=== #{date} ===\n" + "-" * 115
+      events.each do |event|
+        time = event[:created_at].strftime("%H:%M:%S")
+        event_type = event[:event_type].to_s
+        event_id = event[:id].to_s
+        details_string =
+          if event[:details].is_a?(Hash)
+            event[:details].map { |k, v| "#{k}: #{v}" }.join(", ")
+          else
+            event[:details].to_s
+          end
+        if truncate_columns
+          event_type = event_type.ljust(event_type_width)[0...event_type_width]
+          details = details_string.ljust(details_width)[0...details_width]
+        else
+          details = details_string
+        end
+        puts sprintf(header_format, "", time, event_type, event_id, details)
+      end
+    end
+    nil
+  end
+end

--- a/lib/timeline_records.rb
+++ b/lib/timeline_records.rb
@@ -164,7 +164,28 @@ class TimelineRecords
       end
   end
 
-  private
+  def load_timeline_events(event_names)
+    load_grouped_events(event_names)
+
+    formatted_items = []
+
+    @grouped_events.each do |date, events|
+      formatted_items << { type: :section_header, date: date }
+
+      events.each do |event|
+        formatted_items << {
+          type: :event,
+          event_type: event[:event_type],
+          id: event[:id],
+          details: event[:details],
+          created_at: event[:created_at],
+          active: false,
+          is_past_item: true
+        }
+      end
+    end
+    formatted_items
+  end
 
   def custom_event_handler(event_type)
     case event_type

--- a/spec/features/timeline_records_spec.rb
+++ b/spec/features/timeline_records_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe "TimelineRecords UI" do
+  before do
+    create(:session, id: 1)
+    create(:patient, id: 1, session: Session.first)
+  end
+
+  scenario "Endpoint doesn't exist in prod" do
+    given_i_am_in_production
+
+    when_i_visit_the_timeline_endpoint
+    then_i_should_see_a_404_error
+  end
+
+  scenario "Endpoint is rendered in test" do
+    given_i_am_in_test
+
+    when_i_visit_the_timeline_endpoint
+    then_i_should_see_the_page_rendered
+  end
+
+  def given_i_am_in_production
+    allow(Rails).to receive(:env).and_return("production".inquiry)
+  end
+
+  def given_i_am_in_test
+    # Already implicitly in test
+  end
+
+  def when_i_visit_the_timeline_endpoint
+    visit "/inspect/timeline/patients/1"
+  end
+
+  def then_i_should_see_a_404_error
+    expect(page.html).to include(
+      "If you entered a web address, check it is correct."
+    )
+  end
+
+  def then_i_should_see_the_page_rendered
+    expect(page.status_code).to eq(200)
+    expect(page.html).to include("Inspect Patient 1")
+  end
+end

--- a/spec/lib/timeline_records_spec.rb
+++ b/spec/lib/timeline_records_spec.rb
@@ -1,0 +1,573 @@
+# frozen_string_literal: true
+
+describe TimelineRecords do
+  subject(:timeline) do
+    described_class.new(patient, detail_config: detail_config)
+  end
+
+  let(:programme) { create(:programme, :hpv) }
+  let(:detail_config) { {} }
+  let(:team) { create(:team, programmes: [programme]) }
+  let(:session) { create(:session, team:, programmes: [programme]) }
+  let(:class_import) { create(:class_import, session:) }
+  let(:cohort_import) { create(:cohort_import, team:) }
+  let(:cohort_import_additional) { create(:cohort_import, team:) }
+  let(:class_import_additional) { create(:class_import, session:) }
+  let(:user) { create(:user) }
+  let(:patient) do
+    create(
+      :patient,
+      given_name: "Alex",
+      year_group: 8,
+      address_postcode: "SW1A 1AA",
+      class_imports: [class_import],
+      team:
+    )
+  end
+  let(:school_move) { create(:school_move, :to_school, patient:) }
+  let(:school_move_log_entry) { create(:school_move_log_entry, patient:) }
+  let(:triage) do
+    create(
+      :triage,
+      patient:,
+      programme:,
+      status: :ready_to_vaccinate,
+      performed_by: user
+    )
+  end
+  let(:consent) do
+    create(
+      :consent,
+      patient:,
+      response: :given,
+      programme:,
+      created_at: Date.new(2025, 1, 1)
+    )
+  end
+  let(:second_consent) do
+    create(
+      :consent,
+      patient:,
+      response: :given,
+      programme:,
+      created_at: Date.new(2025, 2, 1)
+    )
+  end
+  let(:third_consent) do
+    create(
+      :consent,
+      patient:,
+      response: :given,
+      programme:,
+      created_at: Date.new(2025, 3, 1)
+    )
+  end
+  let(:fourth_consent) do
+    create(
+      :consent,
+      patient:,
+      response: :given,
+      programme:,
+      created_at: Date.new(2025, 4, 1)
+    )
+  end
+  let(:consent_audit) do
+    consent.audits.create!(
+      audited_changes: {
+        response: %w[nil given]
+      },
+      associated_type: Patient,
+      associated_id: patient.id
+    )
+  end
+  let(:vaccination_record) do
+    create(
+      :vaccination_record,
+      patient:,
+      programme:,
+      session:,
+      created_at: Date.new(2025, 1, 1)
+    )
+  end
+  let(:second_vaccination_record) do
+    create(
+      :vaccination_record,
+      patient:,
+      programme:,
+      session:,
+      created_at: Date.new(2025, 2, 1)
+    )
+  end
+  let(:third_vaccination_record) do
+    create(
+      :vaccination_record,
+      patient:,
+      programme:,
+      session:,
+      created_at: Date.new(2025, 3, 1)
+    )
+  end
+  let(:fourth_vaccination_record) do
+    create(
+      :vaccination_record,
+      patient:,
+      programme:,
+      session:,
+      created_at: Date.new(2025, 4, 1)
+    )
+  end
+
+  describe "#load_events" do
+    before do
+      patient.triages << triage
+      patient.consents << consent
+      create(:patient_location, patient:, location: session.location, session:)
+      patient.school_moves << school_move
+      patient.school_move_log_entries << school_move_log_entry
+      patient.vaccination_records << vaccination_record
+      patient.cohort_imports << cohort_import
+    end
+
+    context "with default details configuration" do
+      it "loads consent events with default fields" do
+        timeline.send(:load_events, ["consents"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Consent"
+        expect(event[:details]).to eq(
+          { "response" => consent.response, "route" => consent.route }
+        )
+      end
+
+      it "loads triage events with default fields" do
+        timeline.send(:load_events, ["triages"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Triage"
+        expect(event[:details]).to eq(
+          { "status" => triage.status, "performed_by_user_id" => user.id }
+        )
+      end
+
+      it "loads cohort_import events with default fields" do
+        timeline.send(:load_events, ["cohort_imports"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "CohortImport"
+        expect(event[:details]).to eq({})
+      end
+
+      it "loads class_import events with default fields" do
+        timeline.send(:load_events, ["class_imports"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "ClassImport"
+        expect(event[:details]).to eq({})
+      end
+
+      it "loads school_move events with default fields" do
+        timeline.send(:load_events, ["school_moves"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "SchoolMove"
+        expect(event[:details]).to eq(
+          {
+            "school_id" => school_move.school_id,
+            "source" => school_move.source
+          }
+        )
+      end
+
+      it "loads school_move_log_entry events with default fields" do
+        timeline.send(:load_events, ["school_move_log_entries"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "SchoolMoveLogEntry"
+        expect(event[:details]).to eq(
+          {
+            "school_id" => school_move_log_entry.school_id,
+            "user_id" => school_move_log_entry.user_id
+          }
+        )
+      end
+
+      it "loads vaccination events with default fields" do
+        timeline.send(:load_events, ["vaccination_records"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "VaccinationRecord"
+        expect(event[:details]).to eq(
+          {
+            "outcome" => vaccination_record.outcome,
+            "session_id" => vaccination_record.session_id
+          }
+        )
+      end
+    end
+
+    context "with custom details configuration" do
+      let(:detail_config) { { consents: %i[route], triages: %i[status] } }
+
+      before do
+        patient.consents << consent
+        patient.triages << triage
+      end
+
+      it "loads consent events with custom fields" do
+        timeline.send(:load_events, ["consents"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Consent"
+        expect(event[:details]).to eq({ "route" => consent.route })
+      end
+
+      it "loads triage events with custom fields" do
+        timeline.send(:load_events, ["triages"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "Triage"
+        expect(event[:details]).to eq({ "status" => triage.status })
+      end
+    end
+
+    context "with custom event handler" do
+      before do
+        patient.cohort_imports = [cohort_import]
+        additional_events = {
+          class_imports: {
+            session.id => [class_import_additional.id]
+          },
+          cohort_imports: [cohort_import_additional.id]
+        }
+        timeline.instance_variable_set(:@additional_events, additional_events)
+      end
+
+      it "calls custom event handler for add_class_imports" do
+        timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "ClassImport"
+        expect(event[:id]).to eq class_import_additional.id
+        expect(event[:details]).to eq(
+          { location_id: "#{session.location.id}, excluding patient" }
+        )
+      end
+
+      it "calls custom event handler for org_cohort_imports" do
+        timeline.send(:load_events, ["org_cohort_imports"])
+        expect(timeline.instance_variable_get(:@events).size).to eq 1
+        event = timeline.instance_variable_get(:@events).first
+        expect(event[:event_type]).to eq "CohortImport"
+        expect(event[:id]).to eq cohort_import_additional.id
+        expect(event[:details]).to eq "excluding patient"
+      end
+    end
+  end
+
+  describe "#load_add_class_imports_events" do
+    before do
+      create(:patient_location, patient:, location: session.location, session:)
+      additional_events = {
+        class_imports: {
+          session.id => [class_import_additional.id]
+        }
+      }
+      timeline.instance_variable_set(:@additional_events, additional_events)
+    end
+
+    it "returns an array of events" do
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events).to be_an Array
+    end
+
+    it "includes the class import event" do
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events.size).to eq 1
+      event = events.first
+      expect(event[:event_type]).to eq "ClassImport"
+      expect(event[:id]).to eq class_import_additional.id
+      expect(event[:details]).to eq(
+        { location_id: "#{session.location.id}, excluding patient" }
+      )
+      expect(event[:created_at]).to eq class_import_additional.created_at
+    end
+
+    it "handles multiple additional class imports" do
+      another_additional_class_import =
+        create(:class_import, session:, created_at: 1.minute.from_now)
+      additional_events = {
+        class_imports: {
+          session.id => [
+            class_import_additional.id,
+            another_additional_class_import.id
+          ]
+        }
+      }
+      timeline.instance_variable_set(:@additional_events, additional_events)
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events.size).to eq 2
+      expect(events.map { |event| event[:id] }).to contain_exactly(
+        class_import_additional.id,
+        another_additional_class_import.id
+      )
+    end
+
+    it "handles no additional class imports" do
+      additional_events = { class_imports: { session.id => [] } }
+      timeline.instance_variable_set(:@additional_events, additional_events)
+      events = timeline.send(:load_events, ["add_class_imports_#{session.id}"])
+      expect(events).to be_empty
+    end
+
+    it "handles a nil session id" do
+      events = timeline.send(:load_events, ["add_class_imports_nil"])
+      expect(events).to be_empty
+    end
+  end
+
+  describe "#audits_events" do
+    before do
+      create(:patient_location, patient:, location: session.location, session:)
+    end
+
+    context "with default settings" do
+      let(:timeline) { described_class.new(patient) }
+
+      it "returns an array of events" do
+        patient.audits.create!(
+          audited_changes: {
+            team_id: [nil, 1],
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events).to be_an Array
+      end
+
+      it "includes the audit event" do
+        patient.audits.create!(
+          audited_changes: {
+            team_id: [nil, 1],
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 3 # create is the first audit, PatientSession-Audit is the second
+        event = events.first
+        expect(event[:event_type]).to eq "Patient-Audit"
+        expect(event[:details][:audited_changes][:team_id]).to eq([nil, 1])
+        expect(event[:created_at]).to eq patient.audits.second.created_at
+      end
+
+      it "does not include audited changes that are not allowed" do
+        patient.audits.create!(
+          audited_changes: {
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 3
+        expect(events.first[:event_type]).to eq "Patient-Audit"
+        expect(events.first[:details]).to eq(
+          { action: nil, auditable_id: patient.id }
+        )
+      end
+
+      it "includes associated audits by default" do
+        consent.audits << consent_audit
+        events = timeline.load_events(["audits"])
+        associated_event = events.find { |e| e[:id] == consent_audit.id }
+        expect(associated_event).to be_present
+        expect(associated_event[:event_type]).to eq "Consent-Audit"
+      end
+
+      it "excludes audits with only updated_from_pds_at changes" do
+        patient.audits.create!(
+          audited_changes: {
+            updated_from_pds_at: [nil, Time.current]
+          }
+        )
+        patient.audits.create!(audited_changes: { team_id: [nil, 1] })
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 3 # create is the first audit, PatientSession-Audit is the second
+        event = events.first
+        expect(event[:details][:audited_changes]).not_to have_key(
+          :updated_from_pds_at
+        )
+        expect(event[:details][:audited_changes][:team_id]).to eq([nil, 1])
+      end
+    end
+
+    context "with include_associated_audits: false" do
+      let(:timeline) do
+        described_class.new(
+          patient,
+          audit_config: {
+            include_associated_audits: false
+          }
+        )
+      end
+
+      it "does not include associated audits" do
+        consent.audits << consent_audit
+        events = timeline.load_events(["audits"])
+        associated_event = events.find { |e| e[:id] == consent_audit.id }
+        expect(associated_event).to be_nil
+      end
+
+      it "still includes patient audits" do
+        patient.audits.create!(audited_changes: { team_id: [nil, 1] })
+        events = timeline.load_events(["audits"])
+        expect(events.size).to eq 2
+        expect(events.first[:event_type]).to eq "Patient-Audit"
+      end
+    end
+
+    context "with include_filtered_audit_changes: true" do
+      let(:timeline) do
+        described_class.new(
+          patient,
+          audit_config: {
+            include_filtered_audit_changes: true
+          }
+        )
+      end
+
+      it "includes filtered changes with [FILTERED] value" do
+        patient.audits.create!(
+          audited_changes: {
+            given_name: %w[Alessia Alice]
+          }
+        )
+        events = timeline.load_events(["audits"])
+        expect(events.first[:details][:audited_changes][:given_name]).to eq(
+          "[FILTERED]"
+        )
+      end
+    end
+  end
+
+  describe "#additional_events" do
+    let(:cohort_imports_with_patient) do
+      create_list(:cohort_import, 2, team: session.team)
+    end
+    let(:cohort_imports_without_patient) do
+      create_list(:cohort_import, 1, team: session.team)
+    end
+
+    before do
+      class_import_additional.location_id = session.id
+      create(
+        :patient_location,
+        patient:,
+        location: session.location,
+        session: session
+      )
+      patient.class_imports = [class_import]
+      patient.cohort_imports = cohort_imports_with_patient
+      team.cohort_imports =
+        cohort_imports_with_patient + cohort_imports_without_patient
+    end
+
+    context "with class imports" do
+      it "returns a hash with class imports and cohort imports" do
+        result = timeline.additional_events(patient)
+        expect(result).to be_a(Hash)
+        expect(result.keys).to eq(%i[class_imports cohort_imports])
+      end
+
+      it "returns class imports that the patient is not in, for sessions that the patient is in" do
+        result = timeline.additional_events(patient)
+        expect(result[:class_imports]).to be_a(Hash)
+        expect(result[:class_imports].keys).to eq([session.location.id])
+        expect(result[:class_imports][session.location.id]).to eq(
+          [class_import_additional.id]
+        )
+      end
+    end
+
+    context "with cohort imports" do
+      it "returns cohort imports that the patient is not in, for teams that the patient is in" do
+        result = timeline.additional_events(patient)
+        expect(result[:cohort_imports]).to eq(
+          cohort_imports_without_patient.map(&:id)
+        )
+      end
+    end
+  end
+
+  describe "#patient_events" do
+    let(:class_imports) { create_list(:class_import, 3, session: session) }
+    let(:cohort_imports) { create_list(:cohort_import, 3, team: session.team) }
+
+    before do
+      patient.class_imports = class_imports
+      patient.cohort_imports = cohort_imports
+      create(
+        :patient_location,
+        patient:,
+        location: session.location,
+        session: session
+      )
+    end
+
+    context "with class imports" do
+      it "returns a hash with class imports, cohort imports, and sessions" do
+        result = timeline.patient_events(patient)
+        expect(result).to be_a(Hash)
+        expect(result.keys).to eq(%i[class_imports cohort_imports sessions])
+      end
+
+      it "returns an array of class import IDs" do
+        result = timeline.patient_events(patient)
+        expect(result[:class_imports]).to eq(class_imports.map(&:id))
+      end
+    end
+
+    context "with cohort imports" do
+      it "returns an array of cohort import IDs" do
+        result = timeline.patient_events(patient)
+        expect(result[:cohort_imports]).to eq(cohort_imports.map(&:id))
+      end
+    end
+  end
+
+  describe "#load_grouped_events" do
+    before do
+      [consent, second_consent, third_consent, fourth_consent].each do |c|
+        patient.consents << c
+      end
+      [
+        vaccination_record,
+        second_vaccination_record,
+        third_vaccination_record,
+        fourth_vaccination_record
+      ].each { |vr| patient.vaccination_records << vr }
+      create(
+        :patient_location,
+        patient:,
+        location: session.location,
+        session: session
+      )
+      timeline.send(:load_events, %w[consents triages])
+      timeline.send(:load_grouped_events, %w[consents triages])
+    end
+
+    it "groups events by date" do
+      grouped_events = timeline.instance_variable_get(:@grouped_events)
+      dates = grouped_events.keys
+      expect(grouped_events).to be_a(Hash)
+      expect(grouped_events.keys).to all(be_a(String))
+      expect(grouped_events.values).to all(be_an(Array))
+      expect(dates.uniq.size).to eq(dates.size)
+    end
+
+    it "orders events by date in descending order" do
+      grouped_events = timeline.instance_variable_get(:@grouped_events)
+      dates = grouped_events.keys
+      expect(dates).to eq(
+        ["1 April 2025", "1 March 2025", "1 February 2025", "1 January 2025"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
An endpoint which serves a UI used to view events related to a patient record.

This is a tool designed for use by the Ops Support people, to visualise the patient data without having to use the console.

The information that can be displayed for each 'event' is as follows: https://github.com/nhsuk/manage-vaccinations-in-schools/blob/730766c641fd414b9b1b721f684214adaa37b6b3/lib/timeline_records.rb#L21-L77

And the following audited changes are allowed: https://github.com/nhsuk/manage-vaccinations-in-schools/blob/730766c641fd414b9b1b721f684214adaa37b6b3/lib/timeline_records.rb#L89-L133

These details include PII, but there is a `show_pii` flag that can be turned off in the controller to remove any identifiable information from the above lists