### PR TITLE
Normalise whitespace in NHS number

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -186,7 +186,10 @@ class Patient < ApplicationRecord
 
   encrypts :address_line_1, :address_line_2, :address_town
 
-  normalizes :nhs_number, with: -> { _1.blank? ? nil : _1.gsub(/\s/, "") }
+  normalizes :nhs_number,
+             with: -> do
+               it.blank? ? nil : it.normalise_whitespace.gsub(/\s/, "")
+             end
 
   before_destroy :destroy_childless_parents
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -157,6 +157,20 @@ describe Patient do
     end
   end
 
+  describe "normalizations" do
+    let(:patient) { described_class.new }
+
+    it do
+      expect(patient).to normalize(:nhs_number).from(
+        "012\u200D345\u200D6789"
+      ).to("0123456789")
+    end
+
+    it { should normalize(:nhs_number).from(" 0123456789 ").to("0123456789") }
+
+    it { should normalize(:address_postcode).from(" SW111AA ").to("SW11 1AA") }
+  end
+
   describe "#vaccination_records" do
     subject(:vaccination_records) { patient.vaccination_records }
 
@@ -172,9 +186,6 @@ describe Patient do
     it { should include(kept_vaccination_record) }
     it { should_not include(discarded_vaccination_record) }
   end
-
-  it { should normalize(:nhs_number).from(" 0123456789 ").to("0123456789") }
-  it { should normalize(:address_postcode).from(" SW111AA ").to("SW11 1AA") }
 
   describe "#match_existing" do
     subject(:match_existing) do


### PR DESCRIPTION
When editing the NHS number of a patient we should normalise the whitespace on the NHS number to ensure that it's accepted and is valid. We do this already for spaces, but not for special unicode whitespace characters.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-504)