### PR TITLE
Generate consent status from submitted at time

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -99,7 +99,7 @@ class AppActivityLogComponent < ViewComponent::Base
         {
           title:
             "Consent #{original_response} by #{consent.name} (#{consent.who_responded})",
-          at: consent.created_at,
+          at: consent.submitted_at,
           by: consent.recorded_by,
           programmes: programmes_for(consent)
         }

--- a/app/lib/consent_grouper.rb
+++ b/app/lib/consent_grouper.rb
@@ -15,7 +15,7 @@ class ConsentGrouper
         .reject(&:invalidated?)
         .select(&:response_provided?)
         .group_by(&:name)
-        .map { it.second.max_by(&:created_at) }
+        .map { it.second.max_by(&:submitted_at) }
     else
       consents
         .where(programme_id:)
@@ -23,7 +23,7 @@ class ConsentGrouper
         .response_provided
         .includes(:parent)
         .group_by(&:name)
-        .map { it.second.max_by(&:created_at) }
+        .map { it.second.max_by(&:submitted_at) }
     end
   end
 

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -12,6 +12,7 @@
 #  reason_for_refusal  :integer
 #  response            :integer          not null
 #  route               :integer          not null
+#  submitted_at        :datetime         not null
 #  withdrawn_at        :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -278,6 +278,10 @@ class ConsentForm < ApplicationRecord
     ].compact
   end
 
+  def recorded?
+    recorded_at != nil
+  end
+
   def each_health_answer
     return if health_answers.empty?
     return to_enum(:each_health_answer) unless block_given?

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -250,6 +250,7 @@ class DraftConsent
     super(consent)
 
     consent.parent = parent
+    consent.submitted_at ||= Time.current
 
     if triage_allowed? && response_given?
       triage.notes = triage_notes || ""

--- a/db/migrate/20250515173205_add_submitted_at_to_consents.rb
+++ b/db/migrate/20250515173205_add_submitted_at_to_consents.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddSubmittedAtToConsents < ActiveRecord::Migration[8.0]
+  def up
+    add_column :consents, :submitted_at, :datetime
+
+    Consent
+      .includes(:consent_form)
+      .find_each do |consent|
+        submitted_at = consent.consent_form&.recorded_at || consent.created_at
+        consent.update_column(:submitted_at, submitted_at)
+      end
+
+    change_column_null :consents, :submitted_at, false
+  end
+
+  def down
+    remove_column :consents, :submitted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_15_173205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -237,6 +237,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_140846) do
     t.datetime "withdrawn_at"
     t.datetime "invalidated_at"
     t.boolean "notify_parents"
+    t.datetime "submitted_at", null: false
     t.index ["organisation_id"], name: "index_consents_on_organisation_id"
     t.index ["parent_id"], name: "index_consents_on_parent_id"
     t.index ["patient_id"], name: "index_consents_on_patient_id"

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -63,7 +63,7 @@ describe AppActivityLogComponent do
         programme: programmes.first,
         patient:,
         parent: mum,
-        created_at: Time.zone.parse("2024-05-30 12:00"),
+        submitted_at: Time.zone.parse("2024-05-30 12:00"),
         recorded_by: user
       )
       create(
@@ -72,7 +72,7 @@ describe AppActivityLogComponent do
         programme: programmes.first,
         patient:,
         parent: dad,
-        created_at: Time.zone.parse("2024-05-30 13:00")
+        submitted_at: Time.zone.parse("2024-05-30 13:00")
       )
 
       create(
@@ -251,7 +251,7 @@ describe AppActivityLogComponent do
         :self_consent,
         programme: programmes.first,
         patient:,
-        created_at: Time.zone.parse("2024-05-30 12:00")
+        submitted_at: Time.zone.parse("2024-05-30 12:00")
       )
     end
 
@@ -308,7 +308,7 @@ describe AppActivityLogComponent do
         programme: programmes.first,
         patient:,
         parent: mum,
-        created_at: Time.zone.local(2024, 5, 30, 12),
+        submitted_at: Time.zone.local(2024, 5, 30, 12),
         withdrawn_at: Time.zone.local(2024, 6, 30, 12)
       )
     end
@@ -333,7 +333,7 @@ describe AppActivityLogComponent do
         programme: programmes.first,
         patient:,
         parent: mum,
-        created_at: Time.zone.local(2024, 5, 30, 12),
+        submitted_at: Time.zone.local(2024, 5, 30, 12),
         invalidated_at: Time.zone.local(2024, 6, 30, 12)
       )
     end

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -72,7 +72,7 @@ FactoryBot.define do
       end
     end
 
-    submitted_at { Time.current }
+    submitted_at { consent_form&.recorded_at || Time.current }
 
     traits_for_enum :response
 

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -72,6 +72,8 @@ FactoryBot.define do
       end
     end
 
+    submitted_at { Time.current }
+
     traits_for_enum :response
 
     trait :given_verbally do

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -12,6 +12,7 @@
 #  reason_for_refusal  :integer
 #  response            :integer          not null
 #  route               :integer          not null
+#  submitted_at        :datetime         not null
 #  withdrawn_at        :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/jobs/consent_form_matching_job_spec.rb
+++ b/spec/jobs/consent_form_matching_job_spec.rb
@@ -7,6 +7,7 @@ describe ConsentFormMatchingJob do
   let(:consent_form) do
     create(
       :consent_form,
+      :recorded,
       session:,
       given_name: "John",
       family_name: "Smith",
@@ -70,6 +71,7 @@ describe ConsentFormMatchingJob do
       let(:consent_form) do
         create(
           :consent_form,
+          :recorded,
           session:,
           given_name: "john",
           family_name: "SMITH",

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -12,6 +12,7 @@
 #  reason_for_refusal  :integer
 #  response            :integer          not null
 #  route               :integer          not null
+#  submitted_at        :datetime         not null
 #  withdrawn_at        :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -78,30 +78,11 @@ describe Consent do
   describe "#responded_at" do
     subject(:responded_at) { consent.responded_at }
 
-    context "with a consent form" do
-      let(:consent) do
-        build(
-          :consent,
-          created_at: Time.current,
-          consent_form:
-            build(:consent_form, recorded_at: Time.zone.local(2024, 12, 20, 12))
-        )
-      end
-
-      it { should eq(Time.zone.local(2024, 12, 20, 12)) }
+    let(:consent) do
+      build(:consent, submitted_at: Time.zone.local(2024, 12, 20, 12))
     end
 
-    context "without a consent form" do
-      let(:consent) do
-        build(
-          :consent,
-          created_at: Time.zone.local(2024, 12, 20, 12),
-          consent_form: nil
-        )
-      end
-
-      it { should eq(Time.zone.local(2024, 12, 20, 12)) }
-    end
+    it { should eq(Time.zone.local(2024, 12, 20, 12)) }
   end
 
   describe "#from_consent_form!" do

--- a/spec/models/draft_consent_spec.rb
+++ b/spec/models/draft_consent_spec.rb
@@ -53,6 +53,23 @@ describe DraftConsent do
     end
   end
 
+  describe "#write_to" do
+    subject(:write_to) { draft_consent.write_to!(consent, triage:) }
+
+    let(:consent) { Consent.new }
+    let(:triage) { Triage.new }
+
+    let(:attributes) { valid_given_attributes }
+
+    it "sets the submitted at to today" do
+      freeze_time do
+        expect { write_to }.to change(consent, :submitted_at).from(nil).to(
+          Time.current
+        )
+      end
+    end
+  end
+
   describe "#reset_unused_fields" do
     subject(:save!) { draft_consent.save! }
 

--- a/spec/models/patient/consent_status_spec.rb
+++ b/spec/models/patient/consent_status_spec.rb
@@ -102,6 +102,29 @@ describe Patient::ConsentStatus do
       it { should be(:given) }
     end
 
+    context "with a refused and given consent from the same parent at different times" do
+      before do
+        create(
+          :consent,
+          :refused,
+          patient:,
+          programme:,
+          created_at: 1.day.ago,
+          submitted_at: 2.days.ago
+        )
+        create(
+          :consent,
+          :given,
+          patient:,
+          programme:,
+          created_at: 2.days.ago,
+          submitted_at: 1.day.ago
+        )
+      end
+
+      it { should be(:given) }
+    end
+
     context "with self-consent" do
       before { create(:consent, :self_consent, :given, patient:, programme:) }
 


### PR DESCRIPTION
This changes how we determine the most recent consent response from the `created_at` to the `submitted_at`. In most cases these values will be the same, but it's possible for a consent to be matched with a patient manually which can occur some period of time after the consent was submitted.

In particular, it's possible to manually match multiple consents in a different order to when they were submitted, which can lead to bugs where the patient is given the wrong consent status.

This has been implemented by storing a `submitted_at` column on consent responses, which has been done to ensure we don't hit performance issues when filtering or ordering consents where we need to fetch the related consent form.

This is a version of https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3558 which will be merged in to `main` to make sure it's in the 2.2.2 release.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1196)