### PR TITLE
Ensure health questions reset after changing consent

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -460,7 +460,7 @@ class ConsentForm < ApplicationRecord
   def chosen_vaccines
     return [] if consent_refused?
 
-    if chosen_vaccine.present?
+    if consent_given_one? && chosen_vaccine.present?
       programmes.find_by(type: chosen_vaccine).vaccines.active
     else
       vaccines.active

--- a/spec/features/parental_consent_doubles_spec.rb
+++ b/spec/features/parental_consent_doubles_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
-  scenario "Doubles - consent given for both programmes" do
-    stub_pds_search_to_return_no_patients
+  before { stub_pds_search_to_return_no_patients }
 
-    given_a_menacwy_programme_is_underway
+  scenario "Doubles - consent given for both programmes" do
+    given_a_doubles_programme_is_underway
     when_i_go_to_the_consent_form
     then_i_see_the_consent_form
 
@@ -18,9 +18,7 @@ describe "Parental consent" do
   end
 
   scenario "Doubles - consent given for one programme" do
-    stub_pds_search_to_return_no_patients
-
-    given_a_menacwy_programme_is_underway
+    given_a_doubles_programme_is_underway
     when_i_go_to_the_consent_form
     then_i_see_the_consent_form
 
@@ -34,7 +32,28 @@ describe "Parental consent" do
     then_i_can_check_my_answers
   end
 
-  def given_a_menacwy_programme_is_underway
+  scenario "Doubles - change consent given from one programme to both" do
+    given_a_doubles_programme_is_underway
+    when_i_go_to_the_consent_form
+    then_i_see_the_consent_form
+
+    when_i_fill_in_my_details
+    then_i_see_the_consent_page
+
+    when_i_give_consent_to_one_programme
+    and_i_fill_in_my_address
+    and_i_answer_no_to_all_the_medical_questions(only_menacwy: true)
+    and_i_give_a_reason_for_refusal
+    then_i_can_check_my_answers
+
+    when_i_change_my_consent_response
+    and_i_give_consent_to_both_programmes
+    and_i_fill_in_my_address
+    and_i_answer_no_to_all_the_medical_questions(only_menacwy: false)
+    then_i_can_check_my_answers
+  end
+
+  def given_a_doubles_programme_is_underway
     @programme1 = create(:programme, :menacwy)
     @programme2 = create(:programme, :td_ipv)
     @organisation =
@@ -103,6 +122,9 @@ describe "Parental consent" do
     click_on "Continue"
   end
 
+  alias_method :and_i_give_consent_to_both_programmes,
+               :when_i_give_consent_to_both_programmes
+
   def and_i_fill_in_my_address
     expect(page).to have_content("Home address")
     fill_in "Address line 1", with: "1 Test Street"
@@ -157,6 +179,10 @@ describe "Parental consent" do
     expect(page).to have_content(
       "Child’s name#{@child.full_name(context: :parents)}"
     )
+  end
+
+  def when_i_change_my_consent_response
+    click_on "Change consent", match: :first
   end
 
   def then_i_see_the_consent_page


### PR DESCRIPTION
If a parent changes their mind while submitting consent for doubles where they change which programme they wish to consent for from only one to multiple, currently they are not asked any additional health questions for that programme.

This fixes that bug by ensuring that all the vaccines that the parent has consented for are used to generate the health questions.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-810)