### PR TITLE
Enable autoscaling on all environments

### DIFF
--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -24,4 +24,6 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "preview.mavistesting.com"
 }
 
-appspec_bucket = "nhse-mavis-appspec-bucket-preview"
+appspec_bucket       = "nhse-mavis-appspec-bucket-preview"
+minimum_web_replicas = 2
+maximum_web_replicas = 4

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -28,4 +28,6 @@ backup_retention_period   = 7
 ssl_policy                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 access_logs_bucket        = "nhse-mavis-access-logs-production"
 max_aurora_capacity_units = 16
+minimum_web_replicas      = 2
+maximum_web_replicas      = 4
 container_insights        = "enhanced"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -19,4 +19,6 @@ http_hosts = {
   MAVIS__HOST                        = "test.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "test.mavistesting.com"
 }
-appspec_bucket = "nhse-mavis-appspec-bucket-test"
+appspec_bucket       = "nhse-mavis-appspec-bucket-test"
+minimum_web_replicas = 2
+maximum_web_replicas = 4

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -26,4 +26,6 @@ http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "training.give-or-refuse-consent-for-vaccinations.nhs.uk"
 }
-appspec_bucket = "nhse-mavis-appspec-bucket-training"
+appspec_bucket       = "nhse-mavis-appspec-bucket-training"
+minimum_web_replicas = 2
+maximum_web_replicas = 4


### PR DESCRIPTION
This change has passed performance testing on QA and Test environments. As the configuration already exists in production this change only enables the feature.