### PR TITLE
Fix check for running deployments script

### DIFF
--- a/terraform/scripts/check-for-running-deployments.sh
+++ b/terraform/scripts/check-for-running-deployments.sh
@@ -15,8 +15,8 @@ echo "Deployment Group Name: $APPLICATION_GROUP"
 
 running_deployment=$(aws deploy list-deployments --application-name $APPLICATION_NAME \
     --deployment-group-name $APPLICATION_GROUP --include-only-statuses InProgress \
-    --query 'deployments[0]' --output text) || { echo "No running deployment found for ${environment}"; exit 0; }
-if [ "$running_deployment" != "None" ]; then
+    --query 'deployments[]' --output text) || { echo "No running deployment found for ${environment}"; exit 0; }
+if [ -n "$running_deployment" ]; then
   echo "A mavis deployment for ${environment} is currently running: $running_deployment"
   echo "Aborting infrastructure deployment"
   exit 1


### PR DESCRIPTION
- Strange behaviour caused output to be None\nNone in some cases and simply None in others. Refactoring to not get null as query output fixes the issue