### PR TITLE
Store dose sizes on vaccination records

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -81,8 +81,12 @@ class DraftVaccinationRecordsController < ApplicationController
   end
 
   def handle_outcome
-    # If not administered we can skip the remaining steps as they're not relevant.
-    jump_to("confirm") unless @draft_vaccination_record.administered?
+    if @draft_vaccination_record.administered?
+      @draft_vaccination_record.full_dose = true
+    else
+      # If not administered we can skip the remaining steps as they're not relevant.
+      jump_to("confirm")
+    end
   end
 
   def handle_batch

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -60,6 +60,7 @@ class VaccinateForm
 
     draft_vaccination_record.batch_id = todays_batch&.id
     draft_vaccination_record.dose_sequence = dose_sequence
+    draft_vaccination_record.full_dose = true
     draft_vaccination_record.patient_id = patient_session.patient_id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user

--- a/app/models/concerns/has_dose_volume.rb
+++ b/app/models/concerns/has_dose_volume.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module HasDoseVolume
+  extend ActiveSupport::Concern
+
+  def full_dose? = full_dose == true
+
+  def half_dose? = full_dose == false
+
+  def dose_volume_ml
+    return nil if vaccine.nil?
+
+    if full_dose?
+      vaccine.dose_volume_ml
+    elsif half_dose?
+      vaccine.dose_volume_ml * 0.5
+    end
+  end
+end

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -14,17 +14,18 @@ class DraftVaccinationRecord
   attribute :delivery_method, :string
   attribute :delivery_site, :string
   attribute :dose_sequence, :integer
+  attribute :full_dose, :boolean
   attribute :location_name, :string
   attribute :notes, :string
   attribute :outcome, :string
   attribute :patient_id, :integer
-  attribute :session_id, :integer
   attribute :performed_at, :datetime
   attribute :performed_by_family_name, :string
   attribute :performed_by_given_name, :string
   attribute :performed_by_user_id, :integer
   attribute :performed_ods_code, :string
   attribute :programme_id, :integer
+  attribute :session_id, :integer
 
   validates :performed_by_family_name,
             :performed_by_given_name,
@@ -86,6 +87,7 @@ class DraftVaccinationRecord
     validates :batch_id,
               :delivery_method,
               :delivery_site,
+              :full_dose,
               :performed_at,
               presence: true
   end

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -3,6 +3,7 @@
 class DraftVaccinationRecord
   include RequestSessionPersistable
   include EditableWrapper
+  include HasDoseVolume
   include VaccinationRecordPerformedByConcern
   include WizardStepConcern
 
@@ -111,12 +112,6 @@ class DraftVaccinationRecord
 
   def batch=(value)
     self.batch_id = value.id
-  end
-
-  def dose_volume_ml
-    # TODO: this will need to be revisited once it's possible to record half-doses
-    # e.g. for the flu programme where a child refuses the second half of the dose
-    vaccine.dose_volume_ml * 1 if vaccine.present?
   end
 
   def patient

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -98,6 +98,7 @@ class ImmunisationImportRow
 
     attributes = {
       dose_sequence: dose_sequence_value,
+      full_dose: true,
       location_name:,
       outcome:,
       patient:,

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -51,6 +51,7 @@
 #
 class VaccinationRecord < ApplicationRecord
   include Discard::Model
+  include HasDoseVolume
   include PendingChangesConcern
   include VaccinationRecordPerformedByConcern
 
@@ -168,12 +169,6 @@ class VaccinationRecord < ApplicationRecord
 
   def recorded_in_service?
     session_id != nil
-  end
-
-  def dose_volume_ml
-    # TODO: this will need to be revisited once it's possible to record half-doses
-    # e.g. for the flu programme where a child refuses the second half of the dose
-    vaccine.dose_volume_ml * 1 if vaccine.present?
   end
 
   def academic_year

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -10,6 +10,7 @@
 #  delivery_site            :integer
 #  discarded_at             :datetime
 #  dose_sequence            :integer
+#  full_dose                :boolean
 #  location_name            :string
 #  notes                    :text
 #  outcome                  :integer          not null

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -151,6 +151,8 @@ class VaccinationRecord < ApplicationRecord
               allow_nil: true
             }
 
+  validates :full_dose, inclusion: [true, false], if: :administered?
+
   validates :performed_at,
             comparison: {
               less_than_or_equal_to: -> { Time.current }

--- a/db/migrate/20250522140257_add_full_dose_to_vaccination_records.rb
+++ b/db/migrate/20250522140257_add_full_dose_to_vaccination_records.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddFullDoseToVaccinationRecords < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vaccination_records, :full_dose, :boolean
+
+    reversible do |dir|
+      dir.up { VaccinationRecord.administered.update_all(full_dose: true) }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_15_173205) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_22_140257) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -801,6 +801,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_15_173205) do
     t.bigint "session_id"
     t.string "performed_ods_code"
     t.bigint "vaccine_id"
+    t.boolean "full_dose"
     t.index ["batch_id"], name: "index_vaccination_records_on_batch_id"
     t.index ["discarded_at"], name: "index_vaccination_records_on_discarded_at"
     t.index ["patient_id"], name: "index_vaccination_records_on_patient_id"

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -10,6 +10,7 @@
 #  delivery_site            :integer
 #  discarded_at             :datetime
 #  dose_sequence            :integer
+#  full_dose                :boolean
 #  location_name            :string
 #  notes                    :text
 #  outcome                  :integer          not null

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -94,6 +94,8 @@ FactoryBot.define do
     performed_at { Time.current }
 
     dose_sequence { programme.vaccinated_dose_sequence }
+    full_dose { true }
+
     uuid { SecureRandom.uuid }
 
     location_name { "Unknown" if session.nil? }

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -106,12 +106,17 @@ FactoryBot.define do
       outcome { "not_well" }
       vaccine { nil }
       dose_sequence { nil }
+      full_dose { nil }
     end
 
     trait :performed_by_not_user do
       performed_by { nil }
       performed_by_given_name { Faker::Name.first_name }
       performed_by_family_name { Faker::Name.last_name }
+    end
+
+    trait :half_dose do
+      full_dose { false }
     end
 
     trait :discarded do

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -25,6 +25,7 @@ describe DraftVaccinationRecord do
       delivery_method: "intramuscular",
       delivery_site: "left_arm_upper_position",
       dose_sequence: 1,
+      full_dose: true,
       notes: "Some notes.",
       outcome: "administered",
       patient_id: patient.id,

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -111,12 +111,16 @@ describe DraftVaccinationRecord do
   end
 
   describe "#dose_volume_ml" do
+    subject { draft_vaccination_record.dose_volume_ml }
+
     let(:attributes) { valid_administered_attributes }
 
-    it "determines the dose volume in ml from the vaccine" do
-      expect(draft_vaccination_record.dose_volume_ml).to eq(
-        vaccine.dose_volume_ml
-      )
+    it { should eq(vaccine.dose_volume_ml) }
+
+    context "with a half dose" do
+      let(:attributes) { valid_administered_attributes.merge(full_dose: false) }
+
+      it { should eq(vaccine.dose_volume_ml * 0.5) }
     end
   end
 end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -54,6 +54,15 @@ describe VaccinationRecord do
   subject(:vaccination_record) { build(:vaccination_record) }
 
   describe "validations" do
+    context "when administered" do
+      it { should allow_values(true, false).for(:full_dose) }
+      it { should_not allow_values(nil).for(:full_dose) }
+    end
+
+    context "when not administered" do
+      it { should_not validate_presence_of(:full_dose) }
+    end
+
     context "for a school session" do
       subject(:vaccination_record) do
         build(:vaccination_record, programme:, session:)

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -10,6 +10,7 @@
 #  delivery_site            :integer
 #  discarded_at             :datetime
 #  dose_sequence            :integer
+#  full_dose                :boolean
 #  location_name            :string
 #  notes                    :text
 #  outcome                  :integer          not null

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -108,6 +108,38 @@ describe VaccinationRecord do
     end
   end
 
+  describe "#dose_volume_ml" do
+    subject { vaccination_record.dose_volume_ml }
+
+    let(:programme) { create(:programme) }
+
+    let(:vaccine) { build(:vaccine, programme:, dose_volume_ml: 10) }
+
+    context "when administered" do
+      let(:vaccination_record) do
+        build(:vaccination_record, programme:, vaccine:)
+      end
+
+      it { should eq(10) }
+    end
+
+    context "when not administered" do
+      let(:vaccination_record) do
+        build(:vaccination_record, :not_administered, programme:)
+      end
+
+      it { should be_nil }
+    end
+
+    context "with a half dose" do
+      let(:vaccination_record) do
+        build(:vaccination_record, :half_dose, programme:, vaccine:)
+      end
+
+      it { should eq(5) }
+    end
+  end
+
   describe "#performed_by" do
     subject(:performed_by) { vaccination_record.performed_by }
 


### PR DESCRIPTION
This is a small refactor in preparation for Flu where we need to record half dose vs full dose vaccination records. This has no user facing changes, but it adds the new column to the data model so it can be released sooner.