### PR TITLE
Bulk import consents in generator

### DIFF
--- a/lib/generate/consents.rb
+++ b/lib/generate/consents.rb
@@ -65,7 +65,7 @@ module Generate
         .take(count)
         .tap do
           if it.size < count
-            raise "Not enough patients without consent and with parents to generate consents"
+            raise "Only #{it.size} patients without consent in #{programme.type} programme"
           end
         end
     end

--- a/lib/generate/consents.rb
+++ b/lib/generate/consents.rb
@@ -115,7 +115,7 @@ module Generate
               )
           )
         end
-      Consent.import(consents, recursive: true)
+      Consent.import!(consents, recursive: true)
     end
 
     def validate_programme_and_session(programme, session)

--- a/lib/generate/consents.rb
+++ b/lib/generate/consents.rb
@@ -20,13 +20,16 @@ module Generate
       @refused = refused
       @given = given
       @given_needs_triage = given_needs_triage
+      @updated_patients = []
+      @updated_sessions = Set.new
     end
 
     def call
       create_consent_with_response(:refused, @refused)
       create_consent_with_response(:given, @given)
       create_consent_given_needs_triage(@given_needs_triage)
-      StatusUpdater.call(patient: patients)
+
+      StatusUpdater.call(patient: @updated_patients, session: @updated_sessions)
     end
 
     def self.call(...) = new(...).call
@@ -85,6 +88,9 @@ module Generate
         available_patient_sessions.map do |patient, session|
           school = session.location.school? ? session.location : patient.school
 
+          @updated_patients << patient
+          @updated_sessions << session
+
           FactoryBot.build(
             :consent,
             patient:,
@@ -110,6 +116,9 @@ module Generate
       consents =
         available_patient_sessions.map do |patient, session|
           school = session.location.school? ? session.location : patient.school
+
+          @updated_patients << patient
+          @updated_sessions << session
 
           FactoryBot.build(
             :consent,

--- a/lib/generate/consents.rb
+++ b/lib/generate/consents.rb
@@ -103,6 +103,7 @@ module Generate
             *traits,
             patient:,
             programme:,
+            organisation:,
             consent_form:
               FactoryBot.build(
                 :consent_form,

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -44,6 +44,9 @@ module Generate
           )
         end
 
+        location_name =
+          patient_session.location.name if patient_session.session.clinic?
+
         vaccination_records << FactoryBot.build(
           :vaccination_record,
           :administered,
@@ -51,10 +54,10 @@ module Generate
           programme:,
           organisation:,
           performed_by:,
-          session:,
+          session: patient_session.session,
           vaccine:,
           batch:,
-          location_name: patient_session.location.name
+          location_name:
         )
       end
 

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -49,6 +49,7 @@ module Generate
           :administered,
           patient: patient_session.patient,
           programme:,
+          organisation:,
           performed_by:,
           session:,
           vaccine:,

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -26,6 +26,9 @@ module Generate
     private
 
     def create_vaccinations
+      session_attendances = []
+      vaccination_records = []
+
       random_patient_sessions.each do |patient_session|
         patient_session_id = patient_session.id
         session_date_ids = patient_session.session.session_dates.pluck(:id)
@@ -34,10 +37,14 @@ module Generate
                  patient_session_id:,
                  session_date_id: session_date_ids
                )
-          FactoryBot.create(:session_attendance, :present, patient_session:)
+          session_attendances << FactoryBot.build(
+            :session_attendance,
+            :present,
+            patient_session:
+          )
         end
 
-        FactoryBot.create(
+        vaccination_records << FactoryBot.build(
           :vaccination_record,
           :administered,
           patient: patient_session.patient,
@@ -50,7 +57,10 @@ module Generate
         )
       end
 
-      StatusUpdater.call(patient: patient_sessions.map(&:patient))
+      SessionAttendance.import(session_attendances)
+      VaccinationRecord.import(vaccination_records)
+
+      StatusUpdater.call(patient: vaccination_records.map(&:patient))
     end
 
     def random_patient_sessions

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -61,8 +61,8 @@ module Generate
         )
       end
 
-      SessionAttendance.import(session_attendances)
-      VaccinationRecord.import(vaccination_records)
+      SessionAttendance.import!(session_attendances)
+      VaccinationRecord.import!(vaccination_records)
 
       StatusUpdater.call(patient: vaccination_records.map(&:patient))
     end

--- a/spec/lib/generate/vaccination_records_spec.rb
+++ b/spec/lib/generate/vaccination_records_spec.rb
@@ -25,6 +25,16 @@ describe Generate::VaccinationRecords do
       expect(VaccinationRecord.administered.count).to eq 1
     end
 
+    describe "with a session" do
+      it "creates a vaccination record for the session" do
+        user
+        patient
+
+        described_class.call(organisation:, session:, administered: 1)
+        expect(session.reload.vaccination_records.administered.count).to eq 1
+      end
+    end
+
     context "no patients without vaccinations" do
       it "raises an error" do
         expect {


### PR DESCRIPTION
Changes consents and vaccination records generators to use bulk inserts for faster processing.

Includes other optimisations such as only updating statuses for patients that have had a consent or a vaccination record generated.

An example, creating 3000 consents including consent forms.

```
[5] pry(main)> Benchmark.bm { it.report { Generate::Consents.call(organisation: org, programme: hpv, given: 1000, refused: 1000, given_needs_triage: 1000) } }
       user     system      total        real
  22.676558   8.623392  31.299950 ( 35.757822)
```
