### PR TITLE
Accept import capitalisation differences during import

### DIFF
--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -332,6 +332,21 @@ describe ClassImport do
       end
     end
 
+    context "with an existing parent matching the name but a different case" do
+      let!(:existing_parent) do
+        create(:parent, full_name: "JOHN smith", email: "john@example.com")
+      end
+
+      it "doesn't create an additional parent" do
+        expect { process! }.to change(Parent, :count).by(4)
+      end
+
+      it "changes the parent's name to the incoming version" do
+        process!
+        expect(existing_parent.reload.full_name).to eq("John Smith")
+      end
+    end
+
     context "with an existing patient in a different school" do
       let(:patient) do
         create(

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -295,7 +295,7 @@ describe CohortImport do
     end
 
     context "with an existing patient matching the name but a different case" do
-      before do
+      let!(:existing_patient) do
         create(
           :patient,
           given_name: "JIMMY",
@@ -308,6 +308,37 @@ describe CohortImport do
 
       it "doesn't create an additional patient" do
         expect { process! }.to change(Patient, :count).by(2)
+      end
+
+      it "doesn't stage the changes to the names" do
+        process!
+        expect(existing_patient.reload.pending_changes).not_to have_key(
+          "given_name"
+        )
+        expect(existing_patient.reload.pending_changes).not_to have_key(
+          "family_name"
+        )
+      end
+
+      it "automatically accepts the incoming case differences" do
+        process!
+        expect(existing_patient.reload.given_name).to eq("Jimmy")
+        expect(existing_patient.reload.family_name).to eq("Smith")
+      end
+    end
+
+    context "with an existing parent matching the name but a different case" do
+      let!(:existing_parent) do
+        create(:parent, full_name: "JOHN smith", email: "john@example.com")
+      end
+
+      it "doesn't create an additional parent" do
+        expect { process! }.to change(Parent, :count).by(2)
+      end
+
+      it "changes the parent's name to the incoming version" do
+        process!
+        expect(existing_parent.reload.full_name).to eq("John Smith")
       end
     end
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1521,6 +1521,33 @@ describe ImmunisationImportRow do
         end
       end
 
+      context "with an existing matching patient but mismatching capitalisation, without NHS number" do
+        let(:data) do
+          valid_data.except("NHS_NUMBER").merge(
+            {
+              "PERSON_FORENAME" => "RON",
+              "PERSON_SURNAME" => "WEASLEY",
+              "PERSON_POSTCODE" => "sw1a 1aa"
+            }
+          )
+        end
+
+        let!(:existing_patient) do
+          create(
+            :patient,
+            given_name: "Ron",
+            family_name: "Weasley",
+            date_of_birth: Date.parse(date_of_birth),
+            address_postcode:,
+            nhs_number: "9990000018"
+          )
+        end
+
+        it "still matches to a patient" do
+          expect(patient).to eq(existing_patient)
+        end
+      end
+
       describe "#address_postcode" do
         subject { patient.address_postcode }
 


### PR DESCRIPTION
Names which only differ by capitalisation (eg "SMITH" vs "Smith") currently require a manual review. This has caused many (100s) manual reviews per import for C&W. This is made even more confusing by the fact that Mavis capitalises all surnames in the front end, so the "change" looked identical to the users.

This should probably be automated, accepting the incoming capitalisation.

[MAV-1084](https://nhsd-jira.digital.nhs.uk/browse/MAV-1084)