### PR TITLE
Don't set session when recording already had vaccinations

### DIFF
--- a/app/controllers/patient_sessions/programmes_controller.rb
+++ b/app/controllers/patient_sessions/programmes_controller.rb
@@ -24,7 +24,7 @@ class PatientSessions::ProgrammesController < PatientSessions::BaseController
       performed_by_user_id: current_user.id,
       programme: @programme,
       session: @session,
-      location_name: @session.clinic? ? "Unknown" : nil,
+      location_name: "Unknown",
       performed_ods_code: current_user.selected_organisation.ods_code
     )
 

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -183,7 +183,18 @@ class DraftVaccinationRecord
   private
 
   def writable_attribute_names
-    super + %w[vaccine_id]
+    attributes = super + %w[vaccine_id]
+
+    # We don't store the session if there's no appropriate date.
+    # This is to handle when marking a patient as already having
+    # had the vaccine outside the normal vaccination journey,
+    # which is only allowed when there isn't a date today.
+
+    if session && !session.dates.include?(performed_at.to_date)
+      attributes.delete("session_id")
+    end
+
+    attributes
   end
 
   def reset_unused_fields

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -10,8 +10,9 @@ class VaccinationRecordPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.is_nurse? && record.session_id.present? &&
-      record.performed_ods_code == user.selected_organisation.ods_code
+    user.is_nurse? &&
+      record.performed_ods_code == user.selected_organisation.ods_code &&
+      (record.session_id.present? || record.already_had?)
   end
 
   def update?


### PR DESCRIPTION
The session of a vaccination record is used to determine the location where the vaccination took place. When recording an "already had" vaccination, we don't know where the vaccination took place so it doesn't make sense to store a location