### PR TITLE
Rename `data-qa` to `data-testid`

### DIFF
--- a/app/components/app_import_errors_component.rb
+++ b/app/components/app_import_errors_component.rb
@@ -10,9 +10,9 @@ class AppImportErrorsComponent < ViewComponent::Base
 
         <%= content %>
 
-        <div data-qa="import-errors">
+        <div data-testid="import-errors">
           <% @errors.each do |error| %>
-            <h3 class="nhsuk-heading-s" data-qa="import-errors__heading">
+            <h3 class="nhsuk-heading-s" data-testid="import-errors__heading">
               <% if error.attribute == :csv %>
                 CSV
               <% else %>
@@ -20,8 +20,7 @@ class AppImportErrorsComponent < ViewComponent::Base
               <% end %>
             </h3>
 
-            <ul class="nhsuk-list nhsuk-list--bullet"
-                data-qa="import-errors__list">
+            <ul class="nhsuk-list nhsuk-list--bullet" data-testid="import-errors__list">
               <% if error.type.is_a?(Array) %>
                 <% error.type.each do |type| %>
                   <li><%= sanitize type %></li>

--- a/app/views/parent_interface/consent_forms/edit/confirm_school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/confirm_school.html.erb
@@ -6,7 +6,7 @@
 
 <%= govuk_inset_text classes: "nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-4" do %>
   <p>
-    <span class="nhsuk-heading-m nhsuk-u-margin-bottom-0" data-qa="school-name">
+    <span class="nhsuk-heading-m nhsuk-u-margin-bottom-0" data-testid="school-name">
       <%= @consent_form.location.name %>
     </span>
     <%= format_address_single_line(@consent_form.location) %>


### PR DESCRIPTION
`data-testid` is the default attribute that Playwright looks for, so by using this we avoid needing additional configuration in the testing repo.

Related to https://github.com/NHSDigital/manage-vaccinations-in-schools-testing/pull/242.