### PR TITLE
Add `aria-label` to new batch buttons

### DIFF
--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -7,7 +7,10 @@
       <%= vaccine.manufacturer %>
     </p>
 
-    <%= govuk_button_link_to "Add a new batch", new_vaccine_batch_path(vaccine), secondary: true %>
+    <%= govuk_button_link_to "Add a new batch",
+                             new_vaccine_batch_path(vaccine),
+                             secondary: true,
+                             aria: { label: "Add a new #{vaccine.brand} batch" } %>
 
     <% if (batches = @batches_by_vaccine_id[vaccine.id]).present? %>
       <%= govuk_table do |table| %>

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -35,7 +35,7 @@ test("Accessibility", async ({ page }) => {
   await checkAccessibility(page);
 
   // Vaccine page
-  await page.getByRole("link", { name: "Gardasil 9" }).click();
+  await page.getByRole("link", { name: "Gardasil 9 (HPV)" }).click();
   await expect(page.locator("h1")).toContainText("Gardasil 9");
   await checkAccessibility(page);
 });


### PR DESCRIPTION
At the moment all these buttons have the same accessible name ("Add a new batch") meaning when using an accessibility tool it can be hard to know which button to press. This also helps us in the automated tests which use the accessible name.