### PR TITLE
Add basic API endpoints to be used in testing

### DIFF
--- a/app/controllers/api/locations_controller.rb
+++ b/app/controllers/api/locations_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class API::LocationsController < ActionController::API
+  def index
+    @locations = Location.order(:name)
+
+    if (type = params[:type]).present?
+      @locations = @locations.where(type:)
+    end
+
+    if (status = params[:status]).present?
+      @locations = @locations.where(status: status)
+    end
+
+    if (year_groups = params[:year_groups]).present?
+      @locations =
+        @locations.where("year_groups && ARRAY[?]::integer[]", year_groups)
+    end
+
+    if (
+         is_attached_to_organisation = params[:is_attached_to_organisation]
+       ).present?
+      @locations =
+        if ActiveModel::Type::Boolean.new.cast(is_attached_to_organisation)
+          @locations.where.not(team_id: nil)
+        else
+          @locations.where(team_id: nil)
+        end
+    end
+
+    render json: @locations
+  end
+end

--- a/app/controllers/api/onboard_controller.rb
+++ b/app/controllers/api/onboard_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class API::OnboardController < ActionController::API
+  def create
+    onboarding = Onboarding.new(params.to_unsafe_h)
+
+    if onboarding.invalid?
+      render json: onboarding.errors, status: :unprocessable_entity
+    else
+      onboarding.save!
+      render status: :created
+    end
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -95,6 +95,12 @@ class Location < ApplicationRecord
     "#{gias_local_authority_code}#{gias_establishment_number}" if school?
   end
 
+  def as_json
+    super.except("created_at", "updated_at", "team_id").merge(
+      "is_attached_to_organisation" => !team_id.nil?
+    )
+  end
+
   private
 
   def organisation_ods_code

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
   unless Rails.env.production?
     namespace :api do
       resources :locations, only: %i[index]
+      post "/onboard", to: "onboard#create"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,12 @@ Rails.application.routes.draw do
     end
   end
 
+  unless Rails.env.production?
+    namespace :api do
+      resources :locations, only: %i[index]
+    end
+  end
+
   resources :class_imports, path: "class-imports", except: %i[index destroy]
 
   resources :cohort_imports, path: "cohort-imports", except: %i[index destroy]

--- a/docs/api.md
+++ b/docs/api.md
@@ -30,3 +30,9 @@ Gets locations held by the service.
 - `url`
 - `urn`
 - `year_groups`
+
+## `POST /onboard`
+
+### Body
+
+See [onboarding documentation](onboarding.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,32 @@
+# API
+
+In non-production environments an API is available under the base path `/api`.
+
+## `GET /locations`
+
+Gets locations held by the service.
+
+### Parameters
+
+- `is_attached_to_organisation` - one of `true` or `false`
+- `status` - one of `open`, `closed` or `unknown`
+- `type` - one of `school`, `generic_clinic`, `community_clinic` or `gp_practice`
+- `year_groups[]` - an array of year groups which are administered at the location
+
+### Response
+
+- `address_line_1`
+- `address_line_2`
+- `address_postcode`
+- `address_town`
+- `gias_establishment_number`
+- `gias_local_authority_code`
+- `id`
+- `is_attached_to_organisation`
+- `name`
+- `ods_code`
+- `status`
+- `type`
+- `url`
+- `urn`
+- `year_groups`

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -159,4 +159,38 @@ describe Location do
       it { should eq("123456") }
     end
   end
+
+  describe "#as_json" do
+    subject(:as_json) { location.as_json }
+
+    let(:location) { create(:community_clinic) }
+
+    it do
+      expect(as_json).to eq(
+        {
+          "address_line_1" => location.address_line_1,
+          "address_line_2" => location.address_line_2,
+          "address_postcode" => location.address_postcode,
+          "address_town" => location.address_town,
+          "gias_establishment_number" => nil,
+          "gias_local_authority_code" => nil,
+          "id" => location.id,
+          "is_attached_to_organisation" => true,
+          "name" => location.name,
+          "ods_code" => location.ods_code,
+          "status" => "unknown",
+          "type" => "community_clinic",
+          "url" => location.url,
+          "urn" => nil,
+          "year_groups" => []
+        }
+      )
+    end
+
+    context "when the location is not attached to an organisation" do
+      let(:location) { create(:school, team: nil) }
+
+      it { should include("is_attached_to_organisation" => false) }
+    end
+  end
 end

--- a/spec/requests/api/locations_spec.rb
+++ b/spec/requests/api/locations_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+describe "/api/locations" do
+  let(:team) { create(:team) }
+
+  let!(:community_clinic) do
+    create(:community_clinic, :open, name: "Location A", team:)
+  end
+  let!(:generic_clinic) do
+    create(:generic_clinic, :closed, name: "Location B", team:)
+  end
+  let!(:gp_practice) do
+    create(:gp_practice, :closed, name: "Location C", team:)
+  end
+  let!(:primary_school) do
+    create(:school, :primary, :closed, name: "Location D", team: nil)
+  end
+  let!(:secondary_school) do
+    create(:school, :secondary, :closed, name: "Location E", team: nil)
+  end
+
+  describe "GET" do
+    it "includes all locations" do
+      get "/api/locations"
+
+      expect(response).to have_http_status(:ok)
+
+      locations = JSON.parse(response.body)
+
+      expect(locations).to eq(
+        [
+          community_clinic,
+          generic_clinic,
+          gp_practice,
+          primary_school,
+          secondary_school
+        ].map(&:as_json)
+      )
+    end
+
+    context "when filtering by status" do
+      it "includes only relevant locations" do
+        get "/api/locations", params: { status: "open" }
+
+        expect(response).to have_http_status(:ok)
+
+        locations = JSON.parse(response.body)
+
+        expect(locations).to eq([community_clinic.as_json])
+      end
+    end
+
+    context "when filtering by type" do
+      it "includes only relevant locations" do
+        get "/api/locations", params: { type: "gp_practice" }
+
+        expect(response).to have_http_status(:ok)
+
+        locations = JSON.parse(response.body)
+
+        expect(locations).to eq([gp_practice.as_json])
+      end
+    end
+
+    context "when filtering by year groups" do
+      it "includes only relevant locations" do
+        get "/api/locations", params: { year_groups: [1] }
+
+        expect(response).to have_http_status(:ok)
+
+        locations = JSON.parse(response.body)
+
+        expect(locations).to eq([primary_school.as_json])
+      end
+    end
+
+    context "when filtering by attached to organisation" do
+      it "includes only relevant locations" do
+        get "/api/locations", params: { is_attached_to_organisation: "false" }
+
+        expect(response).to have_http_status(:ok)
+
+        locations = JSON.parse(response.body)
+
+        expect(locations).to eq(
+          [primary_school, secondary_school].map(&:as_json)
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/onboard_spec.rb
+++ b/spec/requests/api/onboard_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+describe "/api/onboard" do
+  let(:config) { YAML.safe_load(file_fixture(filename).read) }
+
+  describe "POST" do
+    subject(:request) do
+      post "/api/onboard",
+           params: config.to_json,
+           headers: {
+             "Content-Type" => "application/json"
+           }
+    end
+
+    context "with a valid configuration file" do
+      let(:filename) { "onboarding/valid.yaml" }
+
+      before do
+        create(:programme, :hpv)
+        create(:school, :secondary, :open, urn: "123456")
+        create(:school, :secondary, :open, urn: "234567")
+        create(:school, :secondary, :open, urn: "345678")
+        create(:school, :secondary, :open, urn: "456789")
+      end
+
+      it "responds with created" do
+        request
+        expect(response).to have_http_status(:created)
+      end
+
+      it "creates the organisation" do
+        request
+        expect(Organisation.count).to eq(1)
+      end
+    end
+
+    context "with an invalid configuration file" do
+      let(:filename) { "onboarding/invalid.yaml" }
+
+      it "responds with an error" do
+        request
+
+        expect(response).to have_http_status(:unprocessable_entity)
+
+        errors = JSON.parse(response.body)
+
+        expect(errors).to eq(
+          {
+            "clinics" => ["can't be blank"],
+            "organisation.careplus_venue_code" => ["can't be blank"],
+            "organisation.name" => ["can't be blank"],
+            "organisation.ods_code" => ["can't be blank"],
+            "organisation.phone" => ["can't be blank", "is invalid"],
+            "organisation.privacy_notice_url" => ["can't be blank"],
+            "organisation.privacy_policy_url" => ["can't be blank"],
+            "programmes" => ["can't be blank"],
+            "school.0.location" => ["can't be blank"],
+            "school.0.status" => ["is not included in the list"],
+            "school.0.team" => ["can't be blank"],
+            "school.1.location" => ["can't be blank"],
+            "school.1.status" => ["is not included in the list"],
+            "school.1.team" => ["can't be blank"],
+            "school.2.location" => ["can't be blank"],
+            "school.2.status" => ["is not included in the list"],
+            "team.email" => ["can't be blank"],
+            "team.name" => ["can't be blank"]
+          }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds two new API endpoints which for now will be only used by the functional tests:

- `GET /api/locations` - Fetch locations that the service knows about.
- `POST /api/onboard` - Onboard a new organisation.

The idea behind this is to allow the tests to set up a fresh organisation each time they are run (by fetching a number of schools using the `/api/locations` endpoint and then using `/api/onboard` to create the organisation). By using a fresh organisation each time we avoid issues where multiple parallel test runs conflict with each other.