### PR TITLE
Set QA RDS max ACUs to 16

### DIFF
--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -22,7 +22,8 @@ http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "qa.mavistesting.com"
 }
-appspec_bucket       = "nhse-mavis-appspec-bucket-qa"
-minimum_web_replicas = 2
-maximum_web_replicas = 4
-container_insights   = "enhanced"
+appspec_bucket            = "nhse-mavis-appspec-bucket-qa"
+minimum_web_replicas      = 2
+maximum_web_replicas      = 4
+max_aurora_capacity_units = 16
+container_insights        = "enhanced"


### PR DESCRIPTION
This brings qa in-line with production for performance tests.