### PR TITLE
Policy version sync

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -39,6 +39,8 @@ env:
   aws_role: ${{ inputs.environment == 'production'
     && 'arn:aws:iam::820242920762:role/GithubDeployMavisAndInfrastructure'
     || 'arn:aws:iam::393416225559:role/GithubDeployMavisAndInfrastructure' }}
+  aws_account_id: ${{ inputs.environment == 'production'
+    && '820242920762' || '393416225559' }}
 
 defaults:
   run:
@@ -60,6 +62,10 @@ jobs:
         with:
           role-to-assume: ${{ env.aws_role }}
           aws-region: eu-west-2
+      - name: Update IAM policy
+        run: |
+          set -e
+          ./../scripts/update-github-actions-policy.sh arn:aws:iam::${{ env.aws_role }}:policy/DeployMavisResources ../resources/github_actions_policy.json
       - name: Set image tag
         run: |
           IMAGE_TAG="${{ inputs.image_tag || github.sha }}"

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -47,9 +47,34 @@ defaults:
     working-directory: terraform/app
 
 jobs:
-  plan:
-    name: Terraform plan
+  validate-permissions:
+    name: Validate permissions
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    outputs:
+      policy-mismatch: ${{ steps.compare-permissions.outputs.policy_mismatch }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.image_tag || github.sha }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
+      - name: Compare permissions
+        id: compare-permissions
+        run: |
+          ../scripts/validate-github-actions-policy.sh arn:aws:iam::${{ env.aws_account_id }}:policy/DeployMavisResources ../resources/github_actions_policy.json
+
+  update-permissions:
+    name: Update permissions
+    runs-on: ubuntu-latest
+    needs: validate-permissions
+    if: inputs.environment == 'production' && needs.validate-permissions.outputs.policy-mismatch == 'true'
+    environment: ${{ inputs.environment }}
     permissions:
       id-token: write
     steps:
@@ -64,8 +89,25 @@ jobs:
           aws-region: eu-west-2
       - name: Update IAM policy
         run: |
-          set -e
-          ./../scripts/update-github-actions-policy.sh arn:aws:iam::${{ env.aws_role }}:policy/DeployMavisResources ../resources/github_actions_policy.json
+          ../scripts/update-github-actions-policy.sh arn:aws:iam::${{ env.aws_account_id }}:policy/DeployMavisResources ../resources/github_actions_policy.json
+
+  plan:
+    name: Terraform plan
+    runs-on: ubuntu-latest
+    needs: [validate-permissions, update-permissions]
+    if: always() && (needs.validate-permissions.outputs.policy-mismatch != 'true' || needs.update-permissions.result == 'success')
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.image_tag || github.sha }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
       - name: Set image tag
         run: |
           IMAGE_TAG="${{ inputs.image_tag || github.sha }}"

--- a/terraform/scripts/update-github-actions-policy.sh
+++ b/terraform/scripts/update-github-actions-policy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <policy-arn> <policy-file>"
+    exit 1
+fi
+
+POLICY_ARN=$1
+POLICY_FILE=$2
+
+# Get existing policy versions
+EXISTING_VERSIONS=$(aws iam list-policy-versions --policy-arn "$POLICY_ARN" --query 'Versions[].VersionId' --output text)
+
+# If there are 5 or more versions, delete the oldest one
+if [ "$(echo "$EXISTING_VERSIONS" | wc -w)" -ge 5 ]; then
+    OLDEST_VERSION=$(echo "$EXISTING_VERSIONS" | awk '{print $NF}')
+    echo "Deleting oldest version: $OLDEST_VERSION"
+    aws iam delete-policy-version --policy-arn "$POLICY_ARN" --version-id "$OLDEST_VERSION"
+else
+    echo "No need to delete any policy versions."
+fi
+
+# Create a new version of the policy
+aws iam create-policy-version --policy-arn "$POLICY_ARN" --policy-document "file://$POLICY_FILE" --set-as-default

--- a/terraform/scripts/update-github-actions-policy.sh
+++ b/terraform/scripts/update-github-actions-policy.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <policy-arn> <policy-file>"
     exit 1

--- a/terraform/scripts/validate-github-actions-policy.sh
+++ b/terraform/scripts/validate-github-actions-policy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <policy-arn> <policy-file>"
+    exit 1
+fi
+
+POLICY_ARN=$1
+POLICY_FILE=$2
+
+VERSION_ID=$(aws iam get-policy --policy-arn "$POLICY_ARN" --query 'Policy.DefaultVersionId' --output text)
+aws iam get-policy-version --policy-arn "$POLICY_ARN" --version-id "$VERSION_ID" --query 'PolicyVersion.Document' --output json > deployed_policy.json
+
+jq -S . deployed_policy.json > deployed_policy_sorted.json
+jq -S . "$POLICY_FILE" > github_actions_policy_sorted.json
+
+POLICY_DIFF=$(diff --unified deployed_policy_sorted.json github_actions_policy_sorted.json)
+if [ -n "$POLICY_DIFF" ]; then
+  echo "Policy mismatch detected: $POLICY_DIFF"
+  echo "policy_mismatch=true" >> "$GITHUB_OUTPUT"
+else
+  echo "No policy mismatch detected"
+fi


### PR DESCRIPTION
This change updates the IAM permissions used by the Github Actions role before every production deployment. 
This way, the source of truth for the IAM permissions is always the the file `terraform/resources/github_actions_policy.json`

The workflow will first check the file for differences to the currently deployed policy. If there is a mismatch, the workflow will wait for approval before updating the policy.

The workflow will proceed with the terraform plan/apply commands only if the policy has been updated successfully or if no differences have been detected. This reduces the risk of partial terraform deployments that fail due to missing permissions.
