### PR TITLE
Remove unnecessary update! call in PendingChangesConcern

### DIFF
--- a/app/models/concerns/pending_changes_concern.rb
+++ b/app/models/concerns/pending_changes_concern.rb
@@ -13,7 +13,7 @@ module PendingChangesConcern
       end
 
     if new_pending_changes.any?
-      update!(pending_changes: pending_changes.merge(new_pending_changes))
+      self.pending_changes = pending_changes.merge(new_pending_changes)
     end
   end
 

--- a/spec/models/concerns/pending_changes_concern_spec.rb
+++ b/spec/models/concerns/pending_changes_concern_spec.rb
@@ -34,12 +34,6 @@ describe PendingChangesConcern do
       expect(model.pending_changes).to eq({ "family_name" => "Smith" })
     end
 
-    it "updates the pending_changes attribute" do
-      expect { model.stage_changes(given_name: "Jane") }.to change {
-        model.reload.pending_changes
-      }.from({}).to({ "given_name" => "Jane" })
-    end
-
     it "does not update other attributes directly" do
       model.stage_changes(given_name: "Jane", family_name: "Smith")
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -509,12 +509,6 @@ describe Patient do
       expect(patient.pending_changes).to eq({ "family_name" => "Smith" })
     end
 
-    it "updates the pending_changes attribute" do
-      expect { patient.stage_changes(given_name: "Jane") }.to change {
-        patient.reload.pending_changes
-      }.from({}).to({ "given_name" => "Jane" })
-    end
-
     it "does not update other attributes directly" do
       patient.stage_changes(given_name: "Jane", family_name: "Smith")
 


### PR DESCRIPTION
Since records using this mixin will be bulk imported later in the process, using `update!` would trigger an immediate database write, validation checks, and callbacks for each record, negatively impacting performance without providing any benefit.