### PR TITLE
Ensure team email address is rendered on deadline passed page

### DIFF
--- a/app/views/parent_interface/consent_forms/deadline_passed.html.erb
+++ b/app/views/parent_interface/consent_forms/deadline_passed.html.erb
@@ -5,5 +5,5 @@
 <h2 class="nhsuk-heading-m">You can still book a clinic appointment</h2>
 
 <p class="govuk-body">
-  Contact <% govuk_link_to @team.email, "mailto:#{@team.email}" %> to book a clinic appointment.
+  Contact <%= link_to @team.email, "mailto:#{@team.email}" %> to book a clinic appointment.
 </p>

--- a/spec/features/parental_consent_closed_spec.rb
+++ b/spec/features/parental_consent_closed_spec.rb
@@ -20,8 +20,8 @@ describe "Parental consent closed" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location =
-      create(:school, name: "Pilot School", organisation: @organisation)
+    @team = create(:team, organisation: @organisation)
+    location = create(:school, name: "Pilot School", team: @team)
     @session =
       create(
         :session,
@@ -36,7 +36,8 @@ describe "Parental consent closed" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    location = create(:school, name: "Pilot School", team: create(:team))
+    @team = create(:team, organisation: @organisation)
+    location = create(:school, name: "Pilot School", team: @team)
     @session =
       create(
         :session,
@@ -112,5 +113,8 @@ describe "Parental consent closed" do
 
   def then_i_see_that_consent_is_closed
     expect(page).to have_content("The deadline for responding has passed")
+    expect(page).to have_content(
+      "Contact #{@team.email} to book a clinic appointment."
+    )
   end
 end


### PR DESCRIPTION
This fixes a bug where we were using `<%` and not `<%=` meaning that the email address that users should use to contact when seeing the deadline passed page wasn't being rendered correctly.

[Jira-Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1123)