### PR TITLE
Fix bucket name for terraform state

### DIFF
--- a/terraform/backup/source/env/development-backend.hcl
+++ b/terraform/backup/source/env/development-backend.hcl
@@ -1,1 +1,2 @@
+bucket         = "nhse-mavis-terraform-state"
 key            = "terraform-backup-dev.tfstate"

--- a/terraform/backup/source/env/production-backend.hcl
+++ b/terraform/backup/source/env/production-backend.hcl
@@ -1,1 +1,2 @@
-key = "terraform-backup-prod.tfstate"
+bucket         = "nhse-mavis-terraform-state-production"
+key            = "terraform-backup-prod.tfstate"

--- a/terraform/backup/source/main.tf
+++ b/terraform/backup/source/main.tf
@@ -8,7 +8,6 @@ terraform {
   }
 
   backend "s3" {
-    bucket         = "nhse-mavis-terraform-state"
     region         = "eu-west-2"
     dynamodb_table = "mavis-terraform-state-lock"
     encrypt        = true


### PR DESCRIPTION
* This bucket stores the terraform state of the AWS backup module. The name of the production bucket was wrong