### PR TITLE
Fix validation of IAM policy

### DIFF
--- a/terraform/scripts/validate-github-actions-policy.sh
+++ b/terraform/scripts/validate-github-actions-policy.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 if [ "$#" -ne 2 ]; then
     echo "Usage: $0 <policy-arn> <policy-file>"
     exit 1


### PR DESCRIPTION
* If the policies are different, `diff` exits with exit code 1. The script should still continue in this case