### PR TITLE
Fix condition to run apply job

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -156,6 +156,7 @@ jobs:
     name: Terraform apply
     runs-on: ubuntu-latest
     needs: plan
+    if: always() && needs.plan.result == 'success'
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write


### PR DESCRIPTION
* With this condition, `apply` runs whenever the `plan` job finished successfully, regardless of whether the `update-permissions` job was skipped or not.