### PR TITLE
Add rake task to transfer school data

### DIFF
--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -212,4 +212,30 @@ namespace :schools do
       year_groups: [8, 9, 10, 11]
     )
   end
+
+  desc "Transfer child records from one school to another."
+  task :move_patients, %i[old_urn new_urn] => :environment do |_task, args|
+    old_loc = Location.school.find_by(urn: args[:old_urn])
+    new_loc = Location.school.find_by(urn: args[:new_urn])
+
+    raise "Could not find one or both schools." if old_loc.nil? || new_loc.nil?
+
+    if !new_loc.team_id.nil? && new_loc.team_id != old_loc.team_id
+      raise "#{new_loc.urn} belongs to #{new_loc.team.name}. Could not complete transfer."
+    end
+    new_loc.update!(team: old_loc.team)
+
+    Session.where(location_id: old_loc.id).update_all(location_id: new_loc.id)
+    Patient.where(school_id: old_loc.id).update_all(school_id: new_loc.id)
+    ConsentForm.where(location_id: old_loc.id).update_all(
+      location_id: new_loc.id
+    )
+    ConsentForm.where(school_id: old_loc.id).update_all(school_id: new_loc.id)
+    SchoolMove.where(school_id: old_loc.id).update_all(school_id: new_loc.id)
+    Patient
+      .where(school_id: new_loc.id)
+      .find_each do |patient|
+        SchoolMoveLogEntry.create!(patient:, school: new_loc)
+      end
+  end
 end

--- a/spec/lib/tasks/schools_rake_spec.rb
+++ b/spec/lib/tasks/schools_rake_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+describe "schools:move_patients" do
+  subject(:invoke) do
+    Rake::Task["schools:move_patients"].invoke(source_urn, target_urn)
+  end
+
+  let(:organisation) { create(:organisation) }
+  let(:team) { create(:team, organisation:) }
+  let(:other_team) { create(:team, organisation:) }
+  let(:source_school) { create(:school, organisation: organisation, team:) }
+  let(:target_school) { create(:school, organisation: organisation) }
+  let(:programmes) { [create(:programme, :hpv)] }
+  let!(:patient) { create(:patient, school: source_school) }
+  let!(:session) { create(:session, location: source_school, programmes:) }
+  let!(:school_move) do
+    create(:school_move, patient: patient, school: source_school)
+  end
+  let!(:consent_form) do
+    create(
+      :consent_form,
+      school: source_school,
+      location: source_school,
+      session:
+    )
+  end
+  let(:other_org_school) { create(:school, team: other_team) }
+
+  let(:source_urn) { source_school.urn.to_s }
+  let(:target_urn) { target_school.urn.to_s }
+
+  after { Rake.application["schools:move_patients"].reenable }
+
+  it "transfers associated records from source to target school" do
+    expect { invoke }.to change { patient.reload.school }.from(
+      source_school
+    ).to(target_school).and change { consent_form.reload.school }.from(
+            source_school
+          ).to(target_school).and change { consent_form.reload.location }.from(
+                  source_school
+                ).to(target_school).and change { session.reload.location }.from(
+                        source_school
+                      ).to(target_school).and change {
+                              school_move.reload.school
+                            }.from(source_school).to(target_school)
+
+    expect(patient.school).to eq(target_school)
+    expect(consent_form.school).to eq(target_school)
+    expect(consent_form.location).to eq(target_school)
+    expect(session.location).to eq(target_school)
+    expect(school_move.school).to eq(target_school)
+  end
+
+  context "when source school ID is invalid" do
+    let(:source_urn) { "999999" }
+
+    it "raises an error" do
+      expect { invoke }.to raise_error(
+        RuntimeError,
+        /Could not find one or both schools./
+      )
+    end
+  end
+
+  context "when target school ID is invalid" do
+    let(:target_urn) { "999999" }
+
+    it "raises an error" do
+      expect { invoke }.to raise_error(
+        RuntimeError,
+        /Could not find one or both schools./
+      )
+    end
+  end
+end


### PR DESCRIPTION
Added a new rake task schools:roll_over that updates the location and school IDs for sessions, patients, and consent forms when rolling over a school to a new one, in the event the old one has been closed and reopened under a new name and URN for example. The task takes two arguments: old_urn and new_urn, which are the URNs of the old and new schools, respectively.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1229