### PR TITLE
Query full subset of year groups

### DIFF
--- a/app/controllers/api/locations_controller.rb
+++ b/app/controllers/api/locations_controller.rb
@@ -14,7 +14,7 @@ class API::LocationsController < ActionController::API
 
     if (year_groups = params[:year_groups]).present?
       @locations =
-        @locations.where("year_groups && ARRAY[?]::integer[]", year_groups)
+        @locations.where("ARRAY[?]::integer[] <@ year_groups", year_groups)
     end
 
     if (

--- a/spec/requests/api/locations_spec.rb
+++ b/spec/requests/api/locations_spec.rb
@@ -72,6 +72,22 @@ describe "/api/locations" do
 
         expect(locations).to eq([primary_school.as_json])
       end
+
+      context "with multiple year groups" do
+        before { create(:school, year_groups: [8, 9]) }
+
+        let!(:secondary_school) { create(:school, year_groups: [8, 9, 10]) }
+
+        it "includes locations with all those year groups" do
+          get "/api/locations", params: { year_groups: [8, 9, 10] }
+
+          expect(response).to have_http_status(:ok)
+
+          locations = JSON.parse(response.body)
+
+          expect(locations).to eq([secondary_school.as_json])
+        end
+      end
     end
 
     context "when filtering by attached to organisation" do


### PR DESCRIPTION
When filtering locations by year groups, we want to only return locations that have all the year groups requested. The idea is that if the tests are going to be running for HPV and Doubles, we want to find schools that administeres years 8, 9, 10, and 11, not just a subset of those.