### PR TITLE
Update terraform version

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Get db secret arn
         id: get-db-secret-arn
         working-directory: terraform/app
@@ -116,7 +116,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Terraform Plan
         run: |
           set -e
@@ -148,7 +148,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -185,7 +185,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Terraform Plan
         id: plan
         run: |
@@ -223,7 +223,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Apply the changes
         run: |
           set -e

--- a/.github/workflows/deploy-application.yml
+++ b/.github/workflows/deploy-application.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Get terraform output
         id: terraform-output
         working-directory: terraform/app

--- a/.github/workflows/deploy-backup-infrastructure.yml
+++ b/.github/workflows/deploy-backup-infrastructure.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Terraform Plan
         id: plan
         env:
@@ -87,7 +87,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Apply the changes
         env:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.BACKUP_MODULES_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Install AWS CLI
         run: sudo snap install --classic aws-cli
       - name: Check if any deployments are running
@@ -178,7 +178,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Apply the changes
         run: |
           set -e

--- a/.github/workflows/destroy-infrastructure.yml
+++ b/.github/workflows/destroy-infrastructure.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - name: Ensure DB cluster can be deleted
         run: |
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.10.5
+          terraform_version: 1.11.4
       - run: terraform init -backend=false
       - run: terraform validate

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ nodejs      22.15.0
 postgres    17.2
 ruby        3.4.3
 awscli      2.13.31
-terraform   1.10.5
+terraform   1.11.4
 tflint      0.55.1
 pkl         0.28.1
 hk          1.0.0

--- a/terraform/account/main.tf
+++ b/terraform/account/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/app/main.tf
+++ b/terraform/app/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/app/modules/dns/main.tf
+++ b/terraform/app/modules/dns/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/app/modules/ecs_service/main.tf
+++ b/terraform/app/modules/ecs_service/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/app/modules/vpc_endpoint/main.tf
+++ b/terraform/app/modules/vpc_endpoint/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/backup/destination-bootstrap/main.tf
+++ b/terraform/backup/destination-bootstrap/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   backend "local" {}
   required_providers {
     aws = {

--- a/terraform/backup/destination/main.tf
+++ b/terraform/backup/destination/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/backup/source/main.tf
+++ b/terraform/backup/source/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   backend "local" {}
   required_providers {
     aws = {

--- a/terraform/data_replication/main.tf
+++ b/terraform/data_replication/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.10.5"
+  required_version = "~> 1.11.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
* Version 1.11 supports write-only attributes which is needed for the DB migration resources