### PR TITLE
Move `/dev/reset/:ods_code` endpoint

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class API::BaseController < ActionController::API
+  before_action :ensure_local_or_feature_enabled
+
+  private
+
+  def ensure_local_or_feature_enabled
+    render status: :forbidden unless Rails.env.local? || Flipper.enabled?(:api)
+  end
+end

--- a/app/controllers/api/locations_controller.rb
+++ b/app/controllers/api/locations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::LocationsController < ActionController::API
+class API::LocationsController < API::BaseController
   def index
     @locations = Location.order(:name)
 

--- a/app/controllers/api/onboard_controller.rb
+++ b/app/controllers/api/onboard_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::OnboardController < ActionController::API
+class API::OnboardController < API::BaseController
   def create
     onboarding = Onboarding.new(params.to_unsafe_h)
 

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -1,15 +1,13 @@
 # frozen_string_literal: true
 
-class Dev::ResetOrganisationController < ApplicationController
+class API::OrganisationsController < ActionController::API
   include ActionController::Live
-  include DevConcern
 
-  def call
+  def destroy
     response.headers["Content-Type"] = "text/event-stream"
     response.headers["Cache-Control"] = "no-cache"
 
-    organisation =
-      Organisation.find_by!(ods_code: params[:organisation_ods_code])
+    organisation = Organisation.find_by!(ods_code: params[:ods_code])
 
     @start_time = Time.zone.now
 

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class API::OrganisationsController < ActionController::API
+class API::OrganisationsController < API::BaseController
   include ActionController::Live
 
   def destroy

--- a/app/controllers/api/organisations_controller.rb
+++ b/app/controllers/api/organisations_controller.rb
@@ -19,7 +19,6 @@ class API::OrganisationsController < API::BaseController
         sessions = Session.where(organisation:)
 
         log_destroy(ClassImport.where(session: sessions))
-        log_destroy(SessionDate.where(session: sessions))
 
         log_destroy(ConsentNotification.where(session: sessions))
         log_destroy(SessionNotification.where(session: sessions))
@@ -30,6 +29,7 @@ class API::OrganisationsController < API::BaseController
         log_destroy(PreScreening.where(patient_session: patient_sessions))
         patient_sessions.in_batches { log_destroy(it) }
 
+        log_destroy(SessionDate.where(session: sessions))
         log_destroy(sessions)
 
         patients = organisation.patients

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,3 +1,5 @@
+api: Basic API useful for automated testing.
+
 basic_auth: Require users to sign in with basic authentication before they
   can use the service.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,9 +60,6 @@ Rails.application.routes.draw do
   mount flipper_app, at: "/flipper"
 
   unless Rails.env.production?
-    get "/reset/:organisation_ods_code",
-        to: "dev/reset_organisation#call",
-        as: :reset_organisation
     get "/random-consent-form(/:slug)", to: "dev/random_consent_form#call"
   end
 
@@ -89,7 +86,8 @@ Rails.application.routes.draw do
 
   unless Rails.env.production?
     namespace :api do
-      resources :locations, only: %i[index]
+      resources :locations, only: :index
+      resources :organisations, only: :destroy, param: :ods_code
       post "/onboard", to: "onboard#create"
     end
   end

--- a/docs/api.md
+++ b/docs/api.md
@@ -36,3 +36,7 @@ Gets locations held by the service.
 ### Body
 
 See [onboarding documentation](onboarding.md).
+
+## `DELETE /organisations/:ods_code`
+
+Resets an organisation by deleting all associated records.

--- a/spec/controllers/api/organisations_controller_spec.rb
+++ b/spec/controllers/api/organisations_controller_spec.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-describe Dev::ResetOrganisationController do
-  before { Flipper.enable(:dev_tools) }
-  after { Flipper.disable(:dev_tools) }
-
-  describe "GET" do
+describe API::OrganisationsController do
+  describe "DELETE" do
     let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
 
     let(:organisation) { create(:organisation, ods_code: "R1L", programmes:) }
@@ -61,7 +58,7 @@ describe Dev::ResetOrganisationController do
     end
 
     it "deletes associated data" do
-      expect { get :call, params: { organisation_ods_code: "r1l" } }.to(
+      expect { delete :destroy, params: { ods_code: "r1l" } }.to(
         change(CohortImport, :count)
           .by(-1)
           .and(change(ImmunisationImport, :count).by(-1))

--- a/spec/controllers/api/organisations_controller_spec.rb
+++ b/spec/controllers/api/organisations_controller_spec.rb
@@ -60,6 +60,12 @@ describe API::OrganisationsController do
       create(:school_move, :to_school, patient: Patient.first)
 
       create(:session_date, session: Session.first)
+
+      create(
+        :pre_screening,
+        :allows_vaccination,
+        patient_session: PatientSession.first
+      )
     end
 
     it "deletes associated data" do

--- a/spec/controllers/api/organisations_controller_spec.rb
+++ b/spec/controllers/api/organisations_controller_spec.rb
@@ -58,6 +58,8 @@ describe API::OrganisationsController do
       end
 
       create(:school_move, :to_school, patient: Patient.first)
+
+      create(:session_date, session: Session.first)
     end
 
     it "deletes associated data" do
@@ -70,6 +72,7 @@ describe API::OrganisationsController do
           .and(change(Patient, :count).by(-3))
           .and(change(PatientSession, :count).by(-3))
           .and(change(VaccinationRecord, :count).by(-11))
+          .and(change(SessionDate, :count).by(-1))
       )
     end
   end

--- a/spec/controllers/api/organisations_controller_spec.rb
+++ b/spec/controllers/api/organisations_controller_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe API::OrganisationsController do
+  before { Flipper.enable(:api) }
+  after { Flipper.disable(:api) }
+
   describe "DELETE" do
     let(:programmes) { [create(:programme, :hpv_all_vaccines)] }
 

--- a/spec/requests/api/locations_spec.rb
+++ b/spec/requests/api/locations_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "/api/locations" do
+  before { Flipper.enable(:api) }
+  after { Flipper.disable(:api) }
+
   let(:team) { create(:team) }
 
   let!(:community_clinic) do

--- a/spec/requests/api/onboard_spec.rb
+++ b/spec/requests/api/onboard_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe "/api/onboard" do
+  before { Flipper.enable(:api) }
+  after { Flipper.disable(:api) }
+
   let(:config) { YAML.safe_load(file_fixture(filename).read) }
 
   describe "POST" do


### PR DESCRIPTION
This moves it to the new API that's mostly used for testing at the moment, under `DELETE /api/organisations/:ods_code`.

I've also put the API behind a feature flag ensuring that it's only enabled in environments where we want it enabled (specifically QA and possibly test). The routes for the API are already not set when in a production environment, but this allows us to turn off the API functionality in preview and training.