### PR TITLE
Optimize data replication pipeline

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -46,6 +46,7 @@ concurrency:
 
 jobs:
   prepare:
+    if: ${{ inputs.action == 'Recreate' }}
     name: Prepare data replica
     runs-on: ubuntu-latest
     permissions:
@@ -162,7 +163,6 @@ jobs:
           terraform apply ${{ runner.temp }}/tfplan_destroy
 
   plan:
-    if: ${{ inputs.action == 'Recreate' }}
     name: Terraform plan
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
- There is no reason to run prepare stage if we will not run plan stage
- Since prepare stage is not needed for destroy simply move conditional check to prepare step and skip if not needed