### PR TITLE
Raise if relations on draft models don't exist

### DIFF
--- a/app/models/draft_class_import.rb
+++ b/app/models/draft_class_import.rb
@@ -24,10 +24,9 @@ class DraftClassImport
   end
 
   def session
-    SessionPolicy::Scope
-      .new(@current_user, Session)
-      .resolve
-      .find_by(id: session_id)
+    return nil if session_id.nil?
+
+    SessionPolicy::Scope.new(@current_user, Session).resolve.find(session_id)
   end
 
   def session=(value)

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -202,10 +202,12 @@ class DraftConsent
   end
 
   def patient_session
+    return nil if patient_session_id.nil?
+
     PatientSessionPolicy::Scope
       .new(@current_user, PatientSession)
       .resolve
-      .find_by(id: patient_session_id)
+      .find(patient_session_id)
   end
 
   def patient_session=(value)
@@ -228,7 +230,9 @@ class DraftConsent
   end
 
   def recorded_by
-    User.find_by(id: recorded_by_user_id)
+    return nil if recorded_by_user_id.nil?
+
+    User.find(recorded_by_user_id)
   end
 
   def recorded_by=(value)
@@ -236,10 +240,12 @@ class DraftConsent
   end
 
   def programme
+    return nil if programme_id.nil?
+
     ProgrammePolicy::Scope
       .new(@current_user, Programme)
       .resolve
-      .find_by(id: programme_id)
+      .find(programme_id)
   end
 
   def programme=(value)

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -107,7 +107,9 @@ class DraftVaccinationRecord
   alias_method :administered, :administered?
 
   def batch
-    BatchPolicy::Scope.new(@current_user, Batch).resolve.find_by(id: batch_id)
+    return nil if batch_id.nil?
+
+    BatchPolicy::Scope.new(@current_user, Batch).resolve.find(batch_id)
   end
 
   def batch=(value)
@@ -115,7 +117,9 @@ class DraftVaccinationRecord
   end
 
   def patient
-    Patient.find_by(id: patient_id)
+    return nil if patient_id.nil?
+
+    Patient.find(patient_id)
   end
 
   def patient=(value)
@@ -125,7 +129,9 @@ class DraftVaccinationRecord
   delegate :location, to: :session, allow_nil: true
 
   def performed_by_user
-    User.find_by(id: performed_by_user_id)
+    return nil if performed_by_user_id.nil?
+
+    User.find(performed_by_user_id)
   end
 
   def performed_by_user=(value)
@@ -133,10 +139,12 @@ class DraftVaccinationRecord
   end
 
   def programme
+    return nil if programme_id.nil?
+
     ProgrammePolicy::Scope
       .new(@current_user, Programme)
       .resolve
-      .find_by(id: programme_id)
+      .find(programme_id)
   end
 
   def programme=(value)
@@ -144,10 +152,9 @@ class DraftVaccinationRecord
   end
 
   def session
-    SessionPolicy::Scope
-      .new(@current_user, Session)
-      .resolve
-      .find_by(id: session_id)
+    return nil if session_id.nil?
+
+    SessionPolicy::Scope.new(@current_user, Session).resolve.find(session_id)
   end
 
   def session=(value)
@@ -155,10 +162,12 @@ class DraftVaccinationRecord
   end
 
   def vaccination_record
+    return nil if editing_id.nil?
+
     VaccinationRecordPolicy::Scope
       .new(@current_user, VaccinationRecord)
       .resolve
-      .find_by(id: editing_id)
+      .find(editing_id)
   end
 
   def vaccination_record=(value)

--- a/spec/models/draft_consent_spec.rb
+++ b/spec/models/draft_consent_spec.rb
@@ -13,7 +13,7 @@ describe DraftConsent do
   let(:current_user) { organisation.users.first }
 
   let(:programme) { create(:programme, :hpv) }
-  let(:session) { create(:session, programmes: [programme]) }
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
 
   let(:patient_session) { create(:patient_session, session:) }
 

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -13,7 +13,7 @@ describe DraftVaccinationRecord do
   let(:current_user) { organisation.users.first }
 
   let(:programme) { create(:programme, :hpv) }
-  let(:session) { create(:session, programmes: [programme]) }
+  let(:session) { create(:session, organisation:, programmes: [programme]) }
   let(:patient) { create(:patient, session:) }
   let(:vaccine) { programme.vaccines.first }
   let(:batch) { create(:batch, organisation:, vaccine:) }


### PR DESCRIPTION
This ensures that the behaviour of the draft model relationships mostly follow the same behaviour as a real model stored in the database. This has no effect on functionality, but it does mean that errors are easier to understand as instead of getting an error about a value being `nil`, instead a error will be raised about a query that failed to return any object.