### PR TITLE
Enable PDS lookups from data-replication stack

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -31,6 +31,10 @@ on:
         description: ARN of the DB snapshot to use (optional)
         required: false
         type: string
+      egress_cidr:
+        description: CIDR block to allow egress traffic (optional)
+        required: false
+        type: string
 
 env:
   aws_role: ${{ inputs.environment == 'production'
@@ -193,6 +197,7 @@ jobs:
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
           terraform plan -var="image_digest=${{ env.DOCKER_DIGEST }}" -var="db_secret_arn=${{ env.DB_SECRET_ARN }}" \
           -var="imported_snapshot=${{ env.SNAPSHOT_ARN }}" -var-file="env/${{ inputs.environment }}.tfvars" \
+          -var="allowed_egress_cidr_block=${{ inputs.egress_cidr }}" \
           -out ${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -32,9 +32,10 @@ on:
         required: false
         type: string
       egress_cidr:
-        description: CIDR block to allow egress traffic (optional)
-        required: false
+        description: CIDR blocks to allow egress traffic.
         type: string
+        required: true
+        default: "[]"
 
 env:
   aws_role: ${{ inputs.environment == 'production'
@@ -197,7 +198,7 @@ jobs:
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
           terraform plan -var="image_digest=${{ env.DOCKER_DIGEST }}" -var="db_secret_arn=${{ env.DB_SECRET_ARN }}" \
           -var="imported_snapshot=${{ env.SNAPSHOT_ARN }}" -var-file="env/${{ inputs.environment }}.tfvars" \
-          -var="allowed_egress_cidr_block=${{ inputs.egress_cidr }}" \
+          -var="allowed_egress_cidr_blocks=${{ fromJSON(inputs.egress_cidr) }}" \
           -out ${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -198,7 +198,7 @@ jobs:
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
           terraform plan -var="image_digest=${{ env.DOCKER_DIGEST }}" -var="db_secret_arn=${{ env.DB_SECRET_ARN }}" \
           -var="imported_snapshot=${{ env.SNAPSHOT_ARN }}" -var-file="env/${{ inputs.environment }}.tfvars" \
-          -var="allowed_egress_cidr_blocks=${{ fromJSON(inputs.egress_cidr) }}" \
+          -var='allowed_egress_cidr_blocks=${{ inputs.egress_cidr }}' \
           -out ${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/terraform/data_replication/network.tf
+++ b/terraform/data_replication/network.tf
@@ -39,7 +39,7 @@ resource "aws_subnet" "public_subnet" {
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
-  count  = var.allowed_egress_cidr_block == null ? 0 : 1
+  count  = min(length(var.allowed_egress_cidr_blocks), 1)
   vpc_id = aws_vpc.vpc.id
   tags = {
     Name = "data-replication-igw-${var.environment}"
@@ -52,7 +52,7 @@ resource "aws_eip" "nat_ip" {
 }
 
 resource "aws_nat_gateway" "nat_gateway" {
-  count             = var.allowed_egress_cidr_block == null ? 0 : 1
+  count             = min(length(var.allowed_egress_cidr_blocks), 1)
   subnet_id         = aws_subnet.public_subnet.id
   allocation_id     = aws_eip.nat_ip.id
   connectivity_type = "public"
@@ -63,16 +63,16 @@ resource "aws_nat_gateway" "nat_gateway" {
 }
 
 resource "aws_route" "private_to_public" {
-  count                  = var.allowed_egress_cidr_block == null ? 0 : 1
+  count                  = length(var.allowed_egress_cidr_blocks)
   route_table_id         = aws_route_table.private.id
-  destination_cidr_block = var.allowed_egress_cidr_block
+  destination_cidr_block = var.allowed_egress_cidr_blocks[count.index]
   nat_gateway_id         = aws_nat_gateway.nat_gateway[0].id
 }
 
 resource "aws_route" "public_to_igw" {
-  count                  = var.allowed_egress_cidr_block == null ? 0 : 1
+  count                  = length(var.allowed_egress_cidr_blocks)
   route_table_id         = aws_route_table.public.id
-  destination_cidr_block = var.allowed_egress_cidr_block
+  destination_cidr_block = var.allowed_egress_cidr_blocks[count.index]
   gateway_id             = aws_internet_gateway.internet_gateway[0].id
 }
 

--- a/terraform/data_replication/network.tf
+++ b/terraform/data_replication/network.tf
@@ -39,6 +39,7 @@ resource "aws_subnet" "public_subnet" {
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
+  count  = var.allowed_egress_cidr_block == null ? 0 : 1
   vpc_id = aws_vpc.vpc.id
   tags = {
     Name = "data-replication-igw-${var.environment}"
@@ -51,6 +52,7 @@ resource "aws_eip" "nat_ip" {
 }
 
 resource "aws_nat_gateway" "nat_gateway" {
+  count             = var.allowed_egress_cidr_block == null ? 0 : 1
   subnet_id         = aws_subnet.public_subnet.id
   allocation_id     = aws_eip.nat_ip.id
   connectivity_type = "public"
@@ -61,15 +63,17 @@ resource "aws_nat_gateway" "nat_gateway" {
 }
 
 resource "aws_route" "private_to_public" {
+  count                  = var.allowed_egress_cidr_block == null ? 0 : 1
   route_table_id         = aws_route_table.private.id
   destination_cidr_block = var.allowed_egress_cidr_block
-  nat_gateway_id         = aws_nat_gateway.nat_gateway.id
+  nat_gateway_id         = aws_nat_gateway.nat_gateway[0].id
 }
 
 resource "aws_route" "public_to_igw" {
+  count                  = var.allowed_egress_cidr_block == null ? 0 : 1
   route_table_id         = aws_route_table.public.id
   destination_cidr_block = var.allowed_egress_cidr_block
-  gateway_id             = aws_internet_gateway.internet_gateway.id
+  gateway_id             = aws_internet_gateway.internet_gateway[0].id
 }
 
 resource "aws_route_table" "public" {

--- a/terraform/data_replication/network.tf
+++ b/terraform/data_replication/network.tf
@@ -39,7 +39,7 @@ resource "aws_subnet" "public_subnet" {
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
-  count  = min(length(var.allowed_egress_cidr_blocks), 1)
+  count  = local.shared_egress_infrastructure_count
   vpc_id = aws_vpc.vpc.id
   tags = {
     Name = "data-replication-igw-${var.environment}"
@@ -47,14 +47,15 @@ resource "aws_internet_gateway" "internet_gateway" {
 }
 
 resource "aws_eip" "nat_ip" {
+  count      = local.shared_egress_infrastructure_count
   domain     = "vpc"
   depends_on = [aws_internet_gateway.internet_gateway]
 }
 
 resource "aws_nat_gateway" "nat_gateway" {
-  count             = min(length(var.allowed_egress_cidr_blocks), 1)
+  count             = local.shared_egress_infrastructure_count
   subnet_id         = aws_subnet.public_subnet.id
-  allocation_id     = aws_eip.nat_ip.id
+  allocation_id     = aws_eip.nat_ip[0].id
   connectivity_type = "public"
   depends_on        = [aws_internet_gateway.internet_gateway]
   tags = {

--- a/terraform/data_replication/variables.tf
+++ b/terraform/data_replication/variables.tf
@@ -82,8 +82,10 @@ variable "rails_master_key_path" {
 }
 
 locals {
-  name_prefix = "mavis-${var.environment}-data-replication"
-  subnet_list = [aws_subnet.subnet_a.id, aws_subnet.subnet_b.id]
+  name_prefix                        = "mavis-${var.environment}-data-replication"
+  subnet_list                        = [aws_subnet.subnet_a.id, aws_subnet.subnet_b.id]
+  shared_egress_infrastructure_count = min(length(var.allowed_egress_cidr_blocks), 1)
+
   task_envs = [
     {
       name  = "DB_HOST"

--- a/terraform/data_replication/variables.tf
+++ b/terraform/data_replication/variables.tf
@@ -129,6 +129,5 @@ locals {
 variable "allowed_egress_cidr_block" {
   type        = string
   description = "CIDR block for the allowed outbound traffic from the data replication service."
-  nullable    = false
-  default     = "35.234.138.138/32"
+  default     = null
 }

--- a/terraform/data_replication/variables.tf
+++ b/terraform/data_replication/variables.tf
@@ -125,3 +125,10 @@ locals {
     }
   ]
 }
+
+variable "allowed_egress_cidr_block" {
+  type        = string
+  description = "CIDR block for the allowed outbound traffic from the data replication service."
+  nullable    = false
+  default     = "35.234.138.138/32"
+}

--- a/terraform/data_replication/variables.tf
+++ b/terraform/data_replication/variables.tf
@@ -126,8 +126,8 @@ locals {
   ]
 }
 
-variable "allowed_egress_cidr_block" {
-  type        = string
-  description = "CIDR block for the allowed outbound traffic from the data replication service."
-  default     = null
+variable "allowed_egress_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks for the allowed outbound traffic from the data replication service."
+  default     = []
 }


### PR DESCRIPTION
* This PR adds the necessary infrastructure for outgoing connections from the data-replication service. Only requests to the NHS API IP address are routed through to the internet.