### PR TITLE
Fix code owners team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nhsuk/vaccine-digital-service

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @nhsuk/future-vaccinations


### PR DESCRIPTION
This fixes the specified code owners team to use the correct one which contains the Mavis developers.