### PR TITLE
Allow editing parent contact details

### DIFF
--- a/app/controllers/parent_relationships_controller.rb
+++ b/app/controllers/parent_relationships_controller.rb
@@ -6,6 +6,7 @@ class ParentRelationshipsController < ApplicationController
   before_action :set_parent
 
   def edit
+    @parent.contact_method_type = "any" if @parent.contact_method_type.nil?
   end
 
   def update
@@ -50,7 +51,17 @@ class ParentRelationshipsController < ApplicationController
       parent_relationship: [
         :type,
         :other_name,
-        { parent_attributes: %i[id full_name email phone] }
+        {
+          parent_attributes: %i[
+            id
+            full_name
+            email
+            phone
+            phone_receive_updates
+            contact_method_other_details
+            contact_method_type
+          ]
+        }
       ]
     )
   end

--- a/app/views/parent_relationships/edit.html.erb
+++ b/app/views/parent_relationships/edit.html.erb
@@ -27,6 +27,27 @@
   <%= f.fields_for :parent do |parent_f| %>
     <%= parent_f.govuk_text_field :email, label: { text: "Email address" } %>
     <%= parent_f.govuk_text_field :phone, label: { text: "Phone number" } %>
+
+    <%= parent_f.govuk_check_boxes_fieldset :phone_receive_updates, multiple: false, legend: nil do %>
+      <%= parent_f.govuk_check_box :phone_receive_updates, 1, 0, multiple: false, link_errors: true, label: { text: "Get updates by text message" } %>
+    <% end %>
+
+    <%= parent_f.govuk_radio_buttons_fieldset :contact_method_type,
+                                              legend: { text: "Does the parent have any specific needs?", size: "s" } do %>
+      <%= parent_f.govuk_radio_button :contact_method_type, "text",
+                                      label: { text: "They can only receive text messages" },
+                                      link_errors: true %>
+      <%= parent_f.govuk_radio_button :contact_method_type, "voice",
+                                      label: { text: "They can only receive voice calls" } %>
+      <%= parent_f.govuk_radio_button :contact_method_type, "other",
+                                      label: { text: "Other" } do %>
+        <%= parent_f.govuk_text_area :contact_method_other_details,
+                                     label: { text: "Give details" } %>
+      <% end %>
+      <%= parent_f.govuk_radio_divider %>
+      <%= parent_f.govuk_radio_button :contact_method_type, "any",
+                                      label: { text: "They do not have specific needs" } %>
+    <% end %>
   <% end %>
 
   <%= f.govuk_submit "Continue" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,7 +357,7 @@ en:
             contact_method_type:
               inclusion: Choose a contact method
             contact_method_other_details:
-              blank: Enter details about how to contact you
+              blank: Enter details about how to contact the parent
               too_long: Enter details that are less than 300 characters long
             email:
               blank: Enter an email address

--- a/spec/features/edit_parent_spec.rb
+++ b/spec/features/edit_parent_spec.rb
@@ -86,7 +86,7 @@ describe "Edit parent" do
   end
 
   def and_i_change_the_relationship_of_the_parent_to_other
-    choose "Other"
+    choose "Other", match: :first
     fill_in "Relationship to the child", with: "Someone"
     click_on "Continue"
   end
@@ -98,11 +98,18 @@ describe "Edit parent" do
   def when_i_change_the_contact_details_of_the_parent
     fill_in "Email address", with: "selina@meyer.com"
     fill_in "Phone number", with: "07700 900 000"
+    check "Get updates by text message"
+    choose "They can only receive text messages"
     click_on "Continue"
   end
 
   def then_i_see_the_new_contact_details_of_the_parent
     expect(page).to have_content("selina@meyer.com")
     expect(page).to have_content("07700 900000")
+
+    # Communication preferences aren't shown in the UI
+    parent = Parent.last
+    expect(parent.phone_receive_updates).to be(true)
+    expect(parent.contact_method_type).to eq("text")
   end
 end


### PR DESCRIPTION
This amends the ability to edit parent contact details to also allow editing the communication preferences of the parent, which are captured as part of the consent form but weren't shown on this page.

[Jira issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-275)

## Screenshot

<img width="542" alt="Screenshot 2025-06-04 at 11 14 41" src="https://github.com/user-attachments/assets/2886802a-1609-42fa-a727-468ce35e9241" />
