### PR TITLE
Add content for parent relationship type validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -299,7 +299,7 @@ en:
               inclusion: Choose a relationship
             parent_relationship_other_name:
               blank: Enter your relationship
-              too_long: Enter a relationship that are less than 300 characters long
+              too_long: Enter a relationship that is less than 300 characters long
             parental_responsibility:
               inclusion: You need parental responsibility to give consent
             preferred_family_name:
@@ -363,6 +363,14 @@ en:
               blank: Enter an email address
             phone:
               blank: Enter a phone number
+        parent_relationship:
+          attributes:
+            type:
+              blank: Choose a relationship
+              inclusion: Choose a relationship
+            other_name:
+              blank: Enter a relationship
+              too_long: Enter a relationship that is less than 300 characters long
         patient:
           attributes:
             nhs_number:


### PR DESCRIPTION
This adds missing validation error messages when editing parent relationships and not entering a value for the "Other" field. I've copied this content from the existing messaging we have in the consent journey for parents.

[Jira issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-275)