### PR TITLE
Update location question for refused vaccinations

### DIFF
--- a/app/views/draft_vaccination_records/location.html.erb
+++ b/app/views/draft_vaccination_records/location.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% title = "Where was the #{@programme.name} vaccination given?" %>
+<% title = "Where was the #{@programme.name} vaccination offered?" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>


### PR DESCRIPTION
A recent [PR](#3581) addressed a missing location name error when a user records a vaccination with an outcome other than "administered", ("refused" for example).

However, QA discovered that the wording around the question "Where was the vaccination given?" didn't seem right as the vaccination wasn't given.

This word change makes the question more appropriate.