### PR TITLE
Fix long batch name

### DIFF
--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -27,7 +27,9 @@
           <% batches.each do |batch| %>
             <% body.with_row do |row| %>
               <% row.with_cell(text: batch.name) do %>
-                <%= batch.name %>
+                <span class="nhsuk-u-text-break-word">
+                  <%= batch.name %>
+                </span>
                 <% if batch.id == @todays_batch_id_by_programme[vaccine.programme] %>
                   <br>
                   <span class="nhsuk-caption-m">


### PR DESCRIPTION
This PR fixes MAV-1240

Currently long batch names cause the table to look weird. This was not really an issue as we do not have batch names over length 6 on prod. Regardless, a ticket was opened and so here is a fix.

Using the css-style, batch names are now allowed to wrap inside of the name, allowing the table with to remain limited.