### PR TITLE
Remove ? and _ from NHS number on import

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -432,7 +432,7 @@ class ImmunisationImportRow
   end
 
   def patient_nhs_number_value
-    patient_nhs_number&.to_s&.gsub(/\s/, "")
+    patient_nhs_number&.to_s&.gsub(/\s|\?|_/, "")
   end
 
   def reason_not_administered_value

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -161,7 +161,7 @@ class PatientImportRow
   def parent_2_phone = @data[:parent_2_phone]
 
   def nhs_number_value
-    nhs_number&.to_s&.gsub(/\s/, "")
+    nhs_number&.to_s&.gsub(/\s|\?|_/, "")
   end
 
   attr_reader :organisation, :year_groups

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -1846,6 +1846,16 @@ describe ImmunisationImportRow do
     it { should eq("Smith") }
   end
 
+  describe "#patient_nhs_number" do
+    subject { immunisation_import_row.patient_nhs_number&.to_s }
+
+    context "with an NHS_NUMBER field" do
+      let(:data) { { "NHS_NUMBER" => "546 142 4058" } }
+
+      it { should eq("546 142 4058") }
+    end
+  end
+
   describe "#school_name" do
     subject { immunisation_import_row.school_name&.to_s }
 


### PR DESCRIPTION
These characters maybe unintentionally introduced when copying an NHS number from our app into excel using an encoding that does not support zero-width-joiner characters. They should be removed again so that the NHS number can be properly parsed.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1215