### PR TITLE
Make github policy matching check fail on missmatch

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -52,8 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-    outputs:
-      policy-mismatch: ${{ steps.compare-permissions.outputs.policy_mismatch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,13 +65,15 @@ jobs:
       - name: Compare permissions
         id: compare-permissions
         run: |
-          ../scripts/validate-github-actions-policy.sh arn:aws:iam::${{ env.aws_account_id }}:policy/DeployMavisResources ../resources/github_actions_policy.json
+          source ../scripts/validate-github-actions-policy.sh
+          validate_policies arn:aws:iam::${{ env.aws_account_id }}:policy/DeployMavisResources ../resources/github_actions_policy.json
+          exit $?
 
   update-permissions:
     name: Update permissions
     runs-on: ubuntu-latest
     needs: validate-permissions
-    if: (inputs.environment == 'production' || inputs.environment == 'preview') && needs.validate-permissions.outputs.policy-mismatch == 'true'
+    if: always() && (inputs.environment == 'production' || inputs.environment == 'preview') && needs.validate-permissions.result == 'failure'
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write
@@ -95,7 +95,13 @@ jobs:
     name: Terraform plan
     runs-on: ubuntu-latest
     needs: [validate-permissions, update-permissions]
-    if: always() && (needs.validate-permissions.outputs.policy-mismatch != 'true' || needs.update-permissions.result == 'success')
+    if: >
+      always() &&
+      (
+      (inputs.environment != 'production' && inputs.environment != 'preview') ||
+      needs.validate-permissions.result == 'success' ||
+      needs.update-permissions.result == 'success'
+      )
     permissions:
       id-token: write
     steps:

--- a/terraform/scripts/validate-github-actions-policy.sh
+++ b/terraform/scripts/validate-github-actions-policy.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
 
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <policy-arn> <policy-file>"
-    exit 1
-fi
+function validate_policies() {
+  if [ "$#" -ne 2 ]; then
+      echo "Usage: $0 <policy-arn> <policy-file>"
+      exit 1
+  fi
 
-POLICY_ARN=$1
-POLICY_FILE=$2
+  POLICY_ARN=$1
+  POLICY_FILE=$2
 
-VERSION_ID=$(aws iam get-policy --policy-arn "$POLICY_ARN" --query 'Policy.DefaultVersionId' --output text)
-aws iam get-policy-version --policy-arn "$POLICY_ARN" --version-id "$VERSION_ID" --query 'PolicyVersion.Document' --output json > deployed_policy.json
+  VERSION_ID=$(aws iam get-policy --policy-arn "$POLICY_ARN" --query 'Policy.DefaultVersionId' --output text)
+  aws iam get-policy-version --policy-arn "$POLICY_ARN" --version-id "$VERSION_ID" --query 'PolicyVersion.Document' --output json > deployed_policy.json
 
-jq -S . deployed_policy.json > deployed_policy_sorted.json
-jq -S . "$POLICY_FILE" > github_actions_policy_sorted.json
+  jq -S . deployed_policy.json > deployed_policy_sorted.json
+  jq -S . "$POLICY_FILE" > github_actions_policy_sorted.json
 
-POLICY_DIFF=$(diff --unified deployed_policy_sorted.json github_actions_policy_sorted.json)
-if [ -n "$POLICY_DIFF" ]; then
-  echo "Policy mismatch detected: $POLICY_DIFF"
-  echo "policy_mismatch=true" >> "$GITHUB_OUTPUT"
-else
-  echo "No policy mismatch detected"
-fi
+  POLICY_DIFF=$(diff --unified deployed_policy_sorted.json github_actions_policy_sorted.json)
+  if [ -n "$POLICY_DIFF" ]; then
+    echo "Policy mismatch detected: $POLICY_DIFF"
+    return 1
+  else
+    echo "No policy mismatch detected"
+    return 0
+  fi
+}


### PR DESCRIPTION
- Ensure relevant jobs run in relevant environments afterwards
- Use result of job instead of custom outputs for clarity