### PR TITLE
Add notes to patients

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -38,6 +38,13 @@ class AppActivityLogComponent < ViewComponent::Base
     @gillick_assessments =
       (patient || patient_session).gillick_assessments.includes(:performed_by)
 
+    @notes =
+      (patient || patient_session).notes.includes(
+        :created_by,
+        :patient,
+        session: :programmes
+      )
+
     @notify_log_entries = @patient.notify_log_entries.includes(:sent_by)
 
     @pre_screenings =
@@ -59,6 +66,7 @@ class AppActivityLogComponent < ViewComponent::Base
               :patient_sessions,
               :consents,
               :gillick_assessments,
+              :notes,
               :notify_log_entries,
               :pre_screenings,
               :session_attendances,
@@ -74,6 +82,7 @@ class AppActivityLogComponent < ViewComponent::Base
       attendance_events,
       consent_events,
       gillick_assessment_events,
+      note_events,
       notify_events,
       pre_screening_events,
       session_events,
@@ -152,6 +161,18 @@ class AppActivityLogComponent < ViewComponent::Base
         at: gillick_assessment.created_at,
         by: gillick_assessment.performed_by,
         programmes: programmes_for(gillick_assessment)
+      }
+    end
+  end
+
+  def note_events
+    notes.map do |note|
+      {
+        title: "Note",
+        body: note.body,
+        at: note.created_at,
+        by: note.created_by,
+        programmes: programmes_for(note)
       }
     end
   end

--- a/app/components/app_create_note_component.rb
+++ b/app/components/app_create_note_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AppCreateNoteComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <%= render AppDetailsComponent.new(summary: "Add a note", open:, expander: true) do %>
+      <%= form_with model: note, url:, builder: do |f| %>
+        <% content_for(:before_content) { f.govuk_error_summary } %>
+
+        <%= f.govuk_text_area :body, label: { text: "Note" } %>
+        <%= f.govuk_submit "Save note", class: "nhsuk-u-margin-bottom-0" %>
+      <% end %>
+    <% end %>
+  ERB
+
+  def initialize(note, open: false)
+    super
+
+    @note = note
+    @open = open
+  end
+
+  private
+
+  attr_reader :note, :open
+
+  delegate :patient, :session, to: :note
+
+  def url = session_patient_activity_path(session, patient)
+
+  def builder = GOVUKDesignSystemFormBuilder::FormBuilder
+end

--- a/app/components/app_log_event_component.rb
+++ b/app/components/app_log_event_component.rb
@@ -6,9 +6,11 @@ class AppLogEventComponent < ViewComponent::Base
       <div class="nhsuk-card"><div class="nhsuk-card__content">
     <% end %>
 
-    <h3 class="<% if card %>nhsuk-card__heading <% end %>nhsuk-heading-s">
-      <%= invalidated ? tag.s(title) : title %>
-    </h3>
+    <% if title.present? %>
+      <h3 class="<% if card %>nhsuk-card__heading <% end %>nhsuk-heading-s">
+        <%= invalidated ? tag.s(title) : title %>
+      </h3>
+    <% end %>
 
     <% if body.present? %>
       <blockquote><p>
@@ -30,8 +32,8 @@ class AppLogEventComponent < ViewComponent::Base
   ERB
 
   def initialize(
-    title:,
-    at:,
+    title: nil,
+    at: nil,
     body: nil,
     by: nil,
     programmes: [],

--- a/app/controllers/patient_sessions/activities_controller.rb
+++ b/app/controllers/patient_sessions/activities_controller.rb
@@ -3,10 +3,30 @@
 class PatientSessions::ActivitiesController < PatientSessions::BaseController
   before_action :record_access_log_entry, only: :show
 
+  before_action :set_note
+
   def show
   end
 
+  def create
+    if @note.update(note_params)
+      redirect_to session_patient_activity_path(@session, @patient),
+                  flash: {
+                    success: "Note added"
+                  }
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
   private
+
+  def set_note
+    @note =
+      Note.new(created_by: current_user, patient: @patient, session: @session)
+  end
+
+  def note_params = params.expect(note: %i[body])
 
   def access_log_entry_action = "log"
 end

--- a/app/controllers/sessions/consent_controller.rb
+++ b/app/controllers/sessions/consent_controller.rb
@@ -17,7 +17,7 @@ class Sessions::ConsentController < ApplicationController
       @session
         .patient_sessions
         .includes_programmes
-        .includes(patient: :consent_statuses)
+        .includes(:latest_note, patient: :consent_statuses)
         .in_programmes(@programmes)
 
     patient_sessions = @form.apply(scope, programme: @programmes)

--- a/app/controllers/sessions/outcome_controller.rb
+++ b/app/controllers/sessions/outcome_controller.rb
@@ -17,7 +17,7 @@ class Sessions::OutcomeController < ApplicationController
       @session
         .patient_sessions
         .includes_programmes
-        .includes(:session_statuses)
+        .includes(:latest_note, :session_statuses)
         .in_programmes(@programmes)
 
     patient_sessions = @form.apply(scope, programme: @programmes)

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -19,6 +19,7 @@ class Sessions::RecordController < ApplicationController
       @session
         .patient_sessions
         .includes(
+          :latest_note,
           patient: %i[consent_statuses triage_statuses vaccination_statuses]
         )
         .in_programmes(@session.programmes)

--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -21,13 +21,13 @@ class Sessions::RegisterController < ApplicationController
         .patient_sessions
         .includes_programmes
         .includes(
+          :latest_note,
           :registration_status,
           patient: %i[consent_statuses triage_statuses vaccination_statuses]
         )
         .in_programmes(@session.programmes)
 
     patient_sessions = @form.apply(scope)
-
     @pagy, @patient_sessions = pagy(patient_sessions)
   end
 

--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -17,7 +17,7 @@ class Sessions::TriageController < ApplicationController
       @session
         .patient_sessions
         .includes_programmes
-        .includes(patient: :triage_statuses)
+        .includes(:latest_note, patient: :triage_statuses)
         .in_programmes(@programmes)
         .has_triage_status(@statuses, programme: @programmes)
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -29,7 +29,15 @@ class Note < ApplicationRecord
   belongs_to :patient
   belongs_to :session
 
-  has_many :programmes, through: :session
+  has_one :organisation, through: :session
 
   validates :body, presence: true, length: { maximum: 1000 }
+
+  def programmes
+    session.programmes.select { it.year_groups.include?(year_group) }
+  end
+
+  private
+
+  def year_group = patient.year_group(now: created_at.to_date)
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id                 :bigint           not null, primary key
+#  body               :text             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  created_by_user_id :bigint           not null
+#  patient_id         :bigint           not null
+#  session_id         :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_created_by_user_id  (created_by_user_id)
+#  index_notes_on_patient_id          (patient_id)
+#  index_notes_on_session_id          (session_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_user_id => users.id)
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
+class Note < ApplicationRecord
+  belongs_to :created_by, class_name: "User", foreign_key: :created_by_user_id
+  belongs_to :patient
+  belongs_to :session
+
+  has_many :programmes, through: :session
+
+  validates :body, presence: true, length: { maximum: 1000 }
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -62,6 +62,7 @@ class Patient < ApplicationRecord
   has_many :consent_notifications
   has_many :consent_statuses
   has_many :consents
+  has_many :notes
   has_many :notify_log_entries
   has_many :parent_relationships, -> { order(:created_at) }
   has_many :patient_sessions

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -260,8 +260,10 @@ class Patient < ApplicationRecord
     results
   end
 
-  def year_group
-    birth_academic_year.to_year_group
+  def year_group(now: nil)
+    birth_academic_year.to_year_group(
+      academic_year: (now || Date.current).academic_year
+    )
   end
 
   def year_group_changed?

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -40,6 +40,11 @@ class PatientSession < ApplicationRecord
 
   has_many :notes, -> { where(session_id: it.session_id) }, through: :patient
 
+  has_one :latest_note,
+          -> { where(session_id: it.session_id).order(created_at: :desc) },
+          through: :patient,
+          source: :notes
+
   has_many :session_notifications,
            -> { where(session_id: it.session_id) },
            through: :patient

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -38,12 +38,14 @@ class PatientSession < ApplicationRecord
   has_one :organisation, through: :session
   has_many :session_attendances, dependent: :destroy
 
+  has_many :notes, -> { where(session_id: it.session_id) }, through: :patient
+
   has_many :session_notifications,
-           -> { where(session_id: _1.session_id) },
+           -> { where(session_id: it.session_id) },
            through: :patient
 
   has_many :vaccination_records,
-           -> { where(session_id: _1.session_id) },
+           -> { where(session_id: it.session_id) },
            through: :patient
 
   has_and_belongs_to_many :immunisation_imports

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -32,6 +32,7 @@ class Session < ApplicationRecord
   belongs_to :location
 
   has_many :consent_notifications
+  has_many :notes
   has_many :patient_sessions
   has_many :session_dates, -> { order(:value) }
   has_many :session_notifications

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -59,7 +59,7 @@
     
       nav.with_item(
         href: session_patient_activity_path(@session, @patient, return_to: params[:return_to]),
-        text: "Activity log",
+        text: "Session activity and notes",
         selected: request.path.ends_with?("/activity"),
       )
     end %>

--- a/app/views/patient_sessions/activities/show.html.erb
+++ b/app/views/patient_sessions/activities/show.html.erb
@@ -1,3 +1,5 @@
 <%= render "patient_sessions/header" %>
 
+<%= render AppCreateNoteComponent.new(@note, open: action_name == "create") %>
+
 <%= render AppActivityLogComponent.new(patient_session: @patient_session) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -331,6 +331,11 @@ en:
               blank: Choose a file
               empty: Choose a CSV file with at least one record
               invalid: Choose a CSV file in the correct format
+        note:
+          attributes:
+            body:
+              blank: Enter a note
+              too_long: Enter a note that is less than %{count} characters long
         offline_password:
           attributes:
             password:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,7 +276,7 @@ Rails.application.routes.draw do
               as: :patient,
               only: [],
               module: :patient_sessions do
-      resource :activity, only: :show
+      resource :activity, only: %i[show create]
       resource :session_attendance, path: "attendance", only: %i[edit update]
 
       resources :programmes, path: "", param: :type, only: :show do

--- a/db/migrate/20250604122111_create_notes.rb
+++ b/db/migrate/20250604122111_create_notes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateNotes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :notes do |t|
+      t.references :created_by_user,
+                   null: false,
+                   foreign_key: {
+                     to_table: :users
+                   }
+      t.references :patient, null: false, foreign_key: true
+      t.references :session, null: false, foreign_key: true
+
+      t.text :body, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -463,6 +463,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_09_112437) do
     t.index ["urn"], name: "index_locations_on_urn", unique: true
   end
 
+  create_table "notes", force: :cascade do |t|
+    t.bigint "created_by_user_id", null: false
+    t.bigint "patient_id", null: false
+    t.bigint "session_id", null: false
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_by_user_id"], name: "index_notes_on_created_by_user_id"
+    t.index ["patient_id"], name: "index_notes_on_patient_id"
+    t.index ["session_id"], name: "index_notes_on_session_id"
+  end
+
   create_table "notify_log_entries", force: :cascade do |t|
     t.integer "type", null: false
     t.uuid "template_id", null: false
@@ -880,6 +892,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_09_112437) do
   add_foreign_key "immunisation_imports_vaccination_records", "immunisation_imports"
   add_foreign_key "immunisation_imports_vaccination_records", "vaccination_records"
   add_foreign_key "locations", "teams"
+  add_foreign_key "notes", "patients"
+  add_foreign_key "notes", "sessions"
+  add_foreign_key "notes", "users", column: "created_by_user_id"
   add_foreign_key "notify_log_entries", "consent_forms"
   add_foreign_key "notify_log_entries", "parents", on_delete: :nullify
   add_foreign_key "notify_log_entries", "patients"

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -388,6 +388,29 @@ describe AppActivityLogComponent do
                      programme: "Td/IPV"
   end
 
+  describe "notes" do
+    let(:programmes) { [create(:programme, :hpv)] }
+    let(:session) { create(:session, programmes:) }
+
+    before do
+      create(
+        :note,
+        created_by: user,
+        patient:,
+        session:,
+        body: "A note.",
+        created_at: Time.zone.local(2025, 6, 1, 12)
+      )
+    end
+
+    include_examples "card",
+                     title: "Note",
+                     notes: "A note.",
+                     date: "1 June 2025 at 12:00pm",
+                     by: "JOY, Nurse",
+                     programme: "HPV"
+  end
+
   describe "pre-screenings" do
     let(:patient_session) { create(:patient_session, patient:, programmes:) }
 

--- a/spec/components/app_create_note_component_spec.rb
+++ b/spec/components/app_create_note_component_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe AppCreateNoteComponent do
+  subject(:rendered) { render_inline(component) }
+
+  let(:component) { described_class.new(note, open:) }
+
+  let(:note) { Note.new(patient:, session:) }
+  let(:open) { false }
+
+  let(:patient) { create(:patient) }
+  let(:session) { create(:session) }
+
+  it { should have_css(".nhsuk-details.nhsuk-expander") }
+  it { should have_css(".nhsuk-details__summary", text: "Add a note") }
+end

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AppPatientSessionSearchResultCardComponent do
-  subject { render_inline(component) }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) { described_class.new(patient_session, context:) }
 
@@ -28,6 +28,37 @@ describe AppPatientSessionSearchResultCardComponent do
   it { should have_link("SELDON, Hari", href:) }
   it { should have_text("Year 8") }
   it { should have_text("Consent status") }
+
+  context "when patient session has notes" do
+    let(:note) { create(:note, patient:, session:) }
+
+    it { should have_text(note.body) }
+    it { should_not have_link("Continue reading") }
+  end
+
+  context "when patient session has a long note" do
+    before { create(:note, patient:, session:, body: "a long note " * 50) }
+
+    it do
+      expect(rendered).to have_text(
+        "a long note a long note a long note a long note a long note a long note " \
+          "a long note a long note a long note a long note a long note a long note " \
+          "a long note a long note a long note a long note a long note a long note " \
+          "a long note a long note a long note a long note a long note a long note " \
+          "a long note a long note a long…"
+      )
+    end
+
+    it { should have_link("Continue reading") }
+  end
+
+  context "when patient has notes from a different session" do
+    let(:other_session) { create(:session, programmes: [programme]) }
+    let(:note) { create(:note, patient:, session: other_session) }
+
+    it { should_not have_text(note.body) }
+    it { should_not have_link("Continue reading") }
+  end
 
   context "when context is register" do
     let(:context) { :register }

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id                 :bigint           not null, primary key
+#  body               :text             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  created_by_user_id :bigint           not null
+#  patient_id         :bigint           not null
+#  session_id         :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_created_by_user_id  (created_by_user_id)
+#  index_notes_on_patient_id          (patient_id)
+#  index_notes_on_session_id          (session_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_user_id => users.id)
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
+FactoryBot.define do
+  factory :note do
+    created_by
+    patient
+    session { patient.sessions.first || association(:session) }
+
+    body { Faker::Lorem.sentence }
+  end
+end

--- a/spec/features/access_log_spec.rb
+++ b/spec/features/access_log_spec.rb
@@ -25,7 +25,7 @@ describe "Access log" do
   scenario "View patient's activity log in a session" do
     when_i_go_to_the_session
     and_i_go_to_a_patient
-    and_i_click_on_activity_log
+    and_i_click_on_session_activity_and_notes
     then_i_am_recorded_in_the_access_log_twice(controller: "patient_sessions")
   end
 
@@ -69,6 +69,10 @@ describe "Access log" do
 
   def and_i_click_on_activity_log
     click_on "Activity log"
+  end
+
+  def and_i_click_on_session_activity_and_notes
+    click_on "Session activity and notes"
   end
 
   def then_i_am_recorded_in_the_access_log(controller:)

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -230,7 +230,7 @@ describe "Delete vaccination record" do
   end
 
   def when_i_click_on_the_log
-    click_on "Activity log"
+    click_on "Session activity and notes"
   end
 
   def then_i_see_the_delete_vaccination

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -267,11 +267,11 @@ describe "End-to-end journey" do
   end
 
   def then_i_see_the_activity_log_link
-    expect(page).to have_link "Activity log"
+    expect(page).to have_link "Session activity and notes"
   end
 
   def when_i_go_to_the_activity_log
-    click_link "Activity log"
+    click_link "Session activity and notes"
   end
 
   def then_i_see_the_populated_activity_log

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -172,7 +172,7 @@ describe "Manage attendance" do
   end
 
   def when_i_go_to_the_activity_log
-    click_link "Activity log"
+    click_link "Session activity and notes"
   end
 
   def then_i_see_the_attendance_event

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -113,7 +113,7 @@ describe "Parental consent manual matching" do
   end
 
   def when_i_click_on_the_activity_log
-    click_on "Activity log"
+    click_on "Session activity and notes"
   end
 
   def then_i_see_the_consent_was_matched_manually

--- a/spec/features/parental_consent_send_request_spec.rb
+++ b/spec/features/parental_consent_send_request_spec.rb
@@ -77,7 +77,7 @@ describe "Parental consent" do
   end
 
   def and_an_activity_log_entry_is_visible_for_the_email
-    click_on "Activity log"
+    click_on "Session activity and notes"
     expect(page).to have_content(
       "Consent clinic request sent\n#{@parent.email}\n" \
         "HPV   1 January 2024 at 12:00am · USER, Test"
@@ -85,7 +85,7 @@ describe "Parental consent" do
   end
 
   def and_an_activity_log_entry_is_visible_for_the_text
-    click_on "Activity log"
+    click_on "Session activity and notes"
     expect(page).to have_content(
       "Consent clinic request sent\n#{@parent.phone}\n" \
         "HPV   1 January 2024 at 12:00am · USER, Test"

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -181,7 +181,7 @@ describe "Parental consent" do
 
     click_on "Back to #{@child.full_name}"
 
-    click_on "Activity log"
+    click_on "Session activity and notes"
     expect(page).to have_content("Consent given")
     expect(page).not_to have_content(
       "Consent response manually matched with child record"

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -151,7 +151,7 @@ describe "Self-consent" do
   end
 
   def and_the_activity_log_shows_the_gillick_non_competence
-    click_on "Activity log"
+    click_on "Session activity and notes"
     expect(page).to have_content(
       "Completed Gillick assessment as not Gillick competent"
     )
@@ -205,7 +205,7 @@ describe "Self-consent" do
   end
 
   def and_the_activity_log_shows_the_gillick_competence
-    click_on "Activity log"
+    click_on "Session activity and notes"
     expect(page).to have_content(
       "Updated Gillick assessment as Gillick competent"
     )

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: notes
+#
+#  id                 :bigint           not null, primary key
+#  body               :text             not null
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  created_by_user_id :bigint           not null
+#  patient_id         :bigint           not null
+#  session_id         :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_created_by_user_id  (created_by_user_id)
+#  index_notes_on_patient_id          (patient_id)
+#  index_notes_on_session_id          (session_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (created_by_user_id => users.id)
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (session_id => sessions.id)
+#
+describe Note do
+  subject(:note) { build(:note) }
+
+  describe "associations" do
+    it { should belong_to(:created_by).with_foreign_key("created_by_user_id") }
+    it { should belong_to(:patient) }
+    it { should belong_to(:session) }
+
+    it { should have_many(:programmes).through(:session) }
+  end
+
+  describe "validations" do
+    it { should be_valid }
+
+    it { should validate_presence_of(:body) }
+    it { should validate_length_of(:body).is_at_most(1000) }
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -32,7 +32,7 @@ describe Note do
     it { should belong_to(:patient) }
     it { should belong_to(:session) }
 
-    it { should have_many(:programmes).through(:session) }
+    it { should have_one(:organisation).through(:session) }
   end
 
   describe "validations" do
@@ -40,5 +40,22 @@ describe Note do
 
     it { should validate_presence_of(:body) }
     it { should validate_length_of(:body).is_at_most(1000) }
+  end
+
+  describe "#programmes" do
+    subject(:programmes) { note.programmes }
+
+    let(:note) { create(:note, patient:, session:) }
+
+    let(:patient) { create(:patient, year_group: 8) }
+    let(:hpv_programme) { create(:programme, :hpv) }
+    let(:menacwy_programme) { create(:programme, :menacwy) }
+    let(:session) do
+      create(:session, programmes: [hpv_programme, menacwy_programme])
+    end
+
+    it "onlies show programmes valid for the patient at the time" do
+      expect(programmes).to contain_exactly(hpv_programme)
+    end
   end
 end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -27,8 +27,18 @@ describe PatientSession do
   let(:programme) { create(:programme) }
   let(:session) { create(:session, programmes: [programme]) }
 
-  it { should have_many(:gillick_assessments) }
-  it { should have_many(:pre_screenings) }
+  describe "associations" do
+    it { should have_many(:gillick_assessments) }
+    it { should have_many(:pre_screenings) }
+
+    it do
+      expect(patient_session).to have_one(:latest_note)
+        .through(:patient)
+        .source(:notes)
+        .conditions(session_id: session.id)
+        .order(created_at: :desc)
+    end
+  end
 
   describe "#safe_to_destroy?" do
     subject(:safe_to_destroy?) { patient_session.safe_to_destroy? }

--- a/spec/requests/patient_sessions/activity_spec.rb
+++ b/spec/requests/patient_sessions/activity_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe "Patient sessions activity" do
+  let(:organisation) { create(:organisation) }
+  let(:session) { create(:session, organisation:) }
+  let(:patient) { create(:patient, session:) }
+  let(:nurse) { create(:nurse, organisation:) }
+
+  describe "creating notes" do
+    let(:path) { "/sessions/#{session.slug}/patients/#{patient.id}/activity" }
+
+    before { sign_in nurse }
+
+    it "renders the add note form" do
+      get path
+      expect(response.body).to include("Add a note")
+    end
+
+    it "creates a note and redirects to the activity log" do
+      post path, params: { note: { body: "My note" } }
+      expect(response).to redirect_to(path)
+
+      follow_redirect!
+      expect(response.body).to include("Note added")
+
+      note = Note.last
+      expect(note.patient).to eq(patient)
+      expect(note.session).to eq(session)
+      expect(note.created_by).to eq(nurse)
+      expect(note.body).to eq("My note")
+    end
+
+    it "validates the body is present" do
+      post path, params: { note: { body: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include("Enter a note")
+    end
+
+    it "validates the body isn't too long" do
+      post path, params: { note: { body: "a" * 2000 } }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to include(
+        "Enter a note that is less than 1000 characters long"
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -213,7 +213,9 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :request
   config.include CIS2AuthHelper, type: :feature
+  config.include CIS2AuthHelper, type: :request
   config.include PDSHelper, type: :feature
   config.include EmailExpectations, type: :feature
   config.include FactoryBot::Syntax::Methods

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -108,8 +108,10 @@ module CIS2AuthHelper
       workgroups:
     )
 
-    if page.driver.respond_to? :get
+    if try(:page)&.driver.respond_to?(:get)
       page.driver.get "/users/auth/cis2/callback"
+    elsif defined?(:get)
+      get "/users/auth/cis2/callback"
     else
       visit "/users/auth/cis2/callback"
     end


### PR DESCRIPTION
This adds the ability for users to attach general notes to patients in sessions. The notes are shown in the activity log and in the search results when displaying a list of patients in a session.

At the moment this has been built behind a feature flag (`notes`) so although it can be merged in without deploying the feature live yet.

## Screenshots

<img width="895" alt="Screenshot 2025-06-04 at 19 09 14" src="https://github.com/user-attachments/assets/29476c5b-5b71-4c9d-8baf-c1d1d444faf1" />
<img width="881" alt="Screenshot 2025-06-04 at 19 09 18" src="https://github.com/user-attachments/assets/2805f5db-73c1-4539-9d09-9c3b2f4e2aca" />
<img width="876" alt="Screenshot 2025-06-04 at 19 09 26" src="https://github.com/user-attachments/assets/ad231a3c-f9ef-401a-870c-a5dcf666326c" />
<img width="882" alt="Screenshot 2025-06-04 at 19 10 00" src="https://github.com/user-attachments/assets/2abdfbba-58af-49da-ae17-8ac23f22883b" />
<img width="887" alt="Screenshot 2025-06-04 at 19 18 38" src="https://github.com/user-attachments/assets/b33e18a9-a333-4510-b5d0-833415e03287" />
<img width="778" alt="Screenshot 2025-06-17 at 20 12 42" src="https://github.com/user-attachments/assets/ad482fef-9ad9-4ab2-96cd-26934165f25a" />
