### PR TITLE
Fix version number display in production

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -7,9 +7,6 @@ on:
       git-sha:
         description: The git commit sha to build the image from.
         type: string
-      git_ref_to_deploy:
-        required: false
-        type: string
 
 concurrency:
   group: build-and-push-image-${{ inputs.git-sha || github.sha }}
@@ -68,10 +65,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-sha || github.sha }}
-      - name: Write build metadata
-        run: |
-          git rev-parse HEAD > public/sha
-          echo "${{ inputs.git_ref_to_deploy || github.ref_name }}" > public/ref
+      - name: Write build SHA
+        run: git rev-parse HEAD > public/sha
       - name: Build Docker image
         run: docker build -t "mavis:latest" .
       - name: Save Docker image

--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -20,6 +20,10 @@ on:
         description: Docker image tag to deploy
         required: false
         type: string
+      git_ref_to_deploy:
+        required: true
+        type: string
+
   workflow_call:
     inputs:
       environment:
@@ -28,6 +32,9 @@ on:
         type: string
       image_tag:
         required: false
+        type: string
+      git_ref_to_deploy:
+        required: true
         type: string
 
 permissions: {}
@@ -141,12 +148,15 @@ jobs:
         run: sudo snap install --classic aws-cli
       - name: Check if any deployments are running
         run: ../scripts/check-for-running-deployments.sh ${{ inputs.environment }}
+      - name: Set Mavis app version
+        run: |
+          echo "APP_VERSION=${{ inputs.git_ref_to_deploy }}" >> $GITHUB_ENV
       - name: Terraform Plan
         id: plan
         run: |
           set -e
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
-          terraform plan -var="image_digest=$DIGEST" -var-file="env/${{ inputs.environment }}.tfvars" \
+          terraform plan -var="image_digest=$DIGEST" -var="app_version=$APP_VERSION" -var-file="env/${{ inputs.environment }}.tfvars" \
           -out ${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
       - name: Validate the changes
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,7 @@ jobs:
     with:
       environment: ${{ inputs.environment }}
       image_tag: ${{ needs.determine-git-sha.outputs.git-sha }}
+      git_ref_to_deploy: ${{ inputs.git_ref_to_deploy || github.ref_name }}
   deploy-application:
     permissions:
       id-token: write

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-path = Rails.root.join("public/ref")
+version = ENV["APP_VERSION"]
+if Rails.env.production? && version.present? &&
+     !version.match?(/\Av\d+(\.\d+)+\z/)
+  version = nil
+end
 
-version = File.read(path).strip if File.exist?(path)
 APP_VERSION = version.presence

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -157,6 +157,12 @@ variable "enable_splunk" {
   nullable    = false
 }
 
+variable "app_version" {
+  type        = string
+  description = "The version identifier for the MAVIS application deployment"
+  nullable    = false
+}
+
 locals {
   is_production = var.environment == "production"
   parameter_store_variables = tomap({
@@ -202,6 +208,10 @@ locals {
     {
       name  = "MAVIS__SPLUNK__ENABLED"
       value = var.enable_splunk ? "true" : "false"
+    },
+    {
+      name  = "APP_VERSION"
+      value = var.app_version
     }
   ]
   task_secrets = concat([


### PR DESCRIPTION
The previous implementation to display the Mavis version number in the footer of the app used the deploy git ref to create a file with the version number which was baked into the image. With the current deploy strategy, the image is only built during deploys to QA and test, before the version tag is even created. So the version number isn't displayed appropriately in production.

This change uses environment variables to set the version number instead. The MAVIS_APP_VERSION environment variable is now set during infrastructure deployment and passed to the ECS containers. For production deployments, the version format is validated to ensure it follows semantic versioning (v1.2.3 format).

This ensures the correct version number is displayed regardless of when the Docker image was built, as the version is determined at deployment time rather than build time.