### PR TITLE
Removing case sensitivity in validation check of clinic name

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -525,7 +525,7 @@ class ImmunisationImportRow
           "is greater than #{MAX_FIELD_LENGTH} characters long"
         )
       elsif clinic_name_required &&
-            !organisation.community_clinics.exists?(name: clinic_name.to_s)
+            !organisation.community_clinics.any? { |clinic| clinic.name.downcase == clinic_name.to_s.downcase }
         errors.add(clinic_name.header, "Enter a clinic name")
       end
     elsif clinic_name_required


### PR DESCRIPTION
This ensures that the validation check on the clinic name is not case sensitive when importing vaccination records for community clinics.

https://nhsd-jira.digital.nhs.uk/browse/MAV-691 