### PR TITLE
Implement separate email templates for CWPT and other organisations

### DIFF
--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -19,8 +19,11 @@ GOVUK_NOTIFY_EMAIL_TEMPLATES = {
     "c942ce27-590e-4387-9aa8-5b9b4f2796d1",
   consent_school_subsequent_reminder_hpv:
     "5f70d21d-00b6-41e6-bdc9-e64455972b43",
-  session_clinic_initial_invitation: "fc99ac81-9eeb-4df8-9aa0-04f0eb48e37f",
-  session_clinic_subsequent_invitation: "eee59c1b-3af4-4ccd-8653-940887066390",
+  session_clinic_initial_invitation: "88d21cfc-39f6-44a2-98c3-9588e7214ae4",
+  session_clinic_subsequent_invitation: "a86a3b3f-a848-41d8-9a6f-d38174981388",
+  session_clinic_initial_invitation_ryg: "fc99ac81-9eeb-4df8-9aa0-04f0eb48e37f",
+  session_clinic_subsequent_invitation_ryg:
+    "eee59c1b-3af4-4ccd-8653-940887066390",
   session_school_reminder: "8b8a9566-bb03-4b3c-8abc-5bd5a4b8797d",
   triage_vaccination_at_clinic: "9faef718-bd76-4c30-93ea-fbe8584388a6",
   triage_vaccination_will_happen: "279c517c-4c52-4a69-96cb-31355bfa4e21",
@@ -39,8 +42,11 @@ GOVUK_NOTIFY_SMS_TEMPLATES = {
   consent_confirmation_refused: "eb34f3ab-0c58-4e56-b6b1-2c179270dfc3",
   consent_school_reminder: "ee3d36b1-4682-4eb0-a74a-7e0f6c9d0598",
   consent_school_request: "c7bd8150-d09e-4607-817d-db75c9a6a966",
-  session_clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
-  session_clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
+  session_clinic_initial_invitation: "790c9c72-729a-40d6-b44d-d480e38f0990",
+  session_clinic_subsequent_invitation: "ce7a6a1b-465e-4be4-b9e0-47ddb64f3adb",
+  session_clinic_initial_invitation_ryg: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
+  session_clinic_subsequent_invitation_ryg:
+    "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
   session_school_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
   vaccination_administered: "395a3ea1-df07-4dd6-8af1-64cc597ef383",
   vaccination_not_administered: "aae061e0-b847-4d4c-a87a-12508f95a302"

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -175,6 +175,36 @@ describe SessionNotification do
               )
       end
 
+      context "when the organisation is Coventry & Warwickshire Partnership NHS Trust (CWPT)" do
+        let(:organisation) do
+          create(:organisation, ods_code: "RYG", programmes:)
+        end
+
+        it "enqueues an email using the CWPT-specific template" do
+          expect { create_and_send! }.to have_delivered_email(
+            :session_clinic_initial_invitation_ryg
+          ).with(
+            parent: parents.first,
+            patient: patient,
+            programmes:,
+            session: session,
+            sent_by: current_user
+          )
+        end
+
+        it "enqueues an SMS using the CWPT-specific template" do
+          expect { create_and_send! }.to have_delivered_sms(
+            :session_clinic_initial_invitation_ryg
+          ).with(
+            parent: parents.first,
+            patient: patient,
+            programmes:,
+            session: session,
+            sent_by: current_user
+          )
+        end
+      end
+
       context "when parent doesn't want to receive updates by text" do
         let(:parent) { parents.first }
 


### PR DESCRIPTION
### Background:
CWPT (Coventry & Warwickshire Partnership NHS Trust) uses a unique clinic booking system (SwiftQueue) that requires specific instructions in their notifications. We discovered instances where non-CWPT organisations were inadvertently sending CWPT-specific clinic invitation emails and SMS. This occurred because the notification sending process lacked organisation-specific checks, resulting in parents receiving incorrect communications.

JIRA Ticket: [MAV-1024](https://nhsd-jira.digital.nhs.uk/browse/MAV-1024)

### Proposed Changes:
Create two versions of clinic invitation and reminder templates:
  1. The existing CWPT-specific templates on Gov UK Notify gets mapped to new keys postfixed with `_ryg` where RYG is    the `ods_code` for the organisation
  3. New generic templates for all other organisations will use the existing keys but mapped to new template ID's
  4. Some logic to work out which template to use based on the organisation's ODS code

### Reasons for this approach:
1. Minimises development work as CWPT is currently the only organisation using SwiftQueue
2. Keeps CWPT template visible on Gov UK Notify (we had considered storing the template in the database)

### New Email Generic Templates
- [[TEST] Invitation to clinic - generic content (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/88d21cfc-39f6-44a2-98c3-9588e7214ae4)
- [[TEST] Reminder about clinic - generic content (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/a86a3b3f-a848-41d8-9a6f-d38174981388)

### New SMS Generic Templates
- [[TEST] Text that accompanies ‘Invitation to clinic’ - generic content (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/790c9c72-729a-40d6-b44d-d480e38f0990)
- [[TEST] Text that accompanies ‘Reminder about clinic’ - generic content (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/ce7a6a1b-465e-4be4-b9e0-47ddb64f3adb)

### Existing Email Templates reused for CWPT
- [[Live] Invitation to clinic - Cov & Warwickshire (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/fc99ac81-9eeb-4df8-9aa0-04f0eb48e37f)
- [[Live] Reminder about clinic - Cov & Warwickshire (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/eee59c1b-3af4-4ccd-8653-940887066390)

### Existing SMS Templates reused for CWPT
- [[Live] Text that accompanies ‘Invitation to clinic’ - Cov & Warwickshire (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/8ef5712f-bb7f-4911-8f3b-19df6f8a7179)
- [[Live] Text that accompanies ‘Reminder about clinic’ - Cov & Warwickshire (single and multiple vaccines)](https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/018f146d-e7b7-4b63-ae26-bb07ca6fe2f9)