### PR TITLE
Remove `--ensure-latest` when running Brakeman

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,4 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
-
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
This removes this flag by default when running Brakeman. With this flag, an Internet connection is required to run `bin/brakeman` which may not always be available, and we already have Dependabot available to upgrade Brakeman when a new version is available.