### PR TITLE
Correct & enhance the README entry on creating test users

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,10 +229,19 @@ You can generate an example programme by seeding the database with `rails db:see
 
 #### Adding a test user
 
-You can add a new user to an environment using the `users:create` rake task:
+You can add a new user to an environment using the `users:create` [rake task](docs/rake-tasks.md#userscreateemailpasswordgiven_namefamily_nameorganisation_ods_code):
 
 ```shell
-rails users:create['user@example.com','password123','John Doe',1]
+
+# With no arguments, it will prompt you for all the information it needs:
+rails users:create
+
+# Or, create a user belonging to the organisation with ODS code 'R1L' (this is created in db/seeds.rb):
+rails users:create['user@example.com','password123','John', 'Doe','R1L']
+
+# Note that on some Mac machines, this syntax can throw an error saying something like 'zsh: bad pattern', in which case you may need to remove the single quotes and escape the square brackets:
+rails users:create\[user@example.com,password123,John,Doe,R1L\]
+
 ```
 
 ### Previewing view components

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -76,6 +76,7 @@ This creates a new team within an organisation.
 - `given_name` - The first name of the new user.
 - `family_name` - The last name of the new user.
 - `organisation_ods_code` - The ODS code for the organisation they belong to.
+- `fallback_role` - _(optional)_ - The role they will have if the application is not connecting to CIS2. Defaults to "nurse"
 
 If none of the arguments are provided (`rake users:create`), the user will be prompted for responses.
 


### PR DESCRIPTION
This is a **documentation-only** change.  
The given example invocation did not work - it was missing some new parameters added / updated in #2357:

*  A users name must now be split across two parameters, `:given_name` and `:family_name`
* `:organisation_ods_code` is required
* `:fallback_role` is optional, but not mentioned in the given command line example

Also added a note about escaping the brackets on Macs running `zsh`, linked it to the corresponding entry in the rake tasks documents, and added some information about the new `:fallback_role` parameter in that page too.
