### PR TITLE
Ensure duplicate patients aren't shown

### DIFF
--- a/spec/policies/patient_policy_spec.rb
+++ b/spec/policies/patient_policy_spec.rb
@@ -4,18 +4,31 @@ describe PatientPolicy do
   describe "Scope#resolve" do
     subject { PatientPolicy::Scope.new(user, Patient).resolve }
 
-    let(:organisation) { create(:organisation) }
-    let(:another_organisation) { create(:organisation) }
-    let(:school) { create(:school, organisation:) }
+    let(:programmes) { [create(:programme)] }
+    let(:organisation) { create(:organisation, programmes:) }
+    let(:another_organisation) { create(:organisation, programmes:) }
     let(:user) { create(:user, organisation:) }
 
-    let(:patient_in_organisation) do
-      create(:patient, session: create(:session, organisation:))
-    end
-    let(:patient_not_in_organisation) { create(:patient) }
+    context "when patient is in a session" do
+      let(:patient_in_session) { create(:patient) }
+      let(:patient_not_in_session) { create(:patient) }
 
-    it { should include(patient_in_organisation) }
-    it { should_not include(patient_not_in_organisation) }
+      before do
+        create(
+          :patient_session,
+          patient: patient_in_session,
+          session: create(:session, organisation:, programmes:)
+        )
+        create(
+          :patient_session,
+          patient: patient_not_in_session,
+          session:
+            create(:session, organisation: another_organisation, programmes:)
+        )
+      end
+
+      it { should contain_exactly(patient_in_session) }
+    end
 
     context "when the patient not in the org but pending joining the cohort" do
       let(:patient_with_move_in_cohort) { create(:patient) }
@@ -36,13 +49,14 @@ describe PatientPolicy do
         )
       end
 
-      it { should include(patient_with_move_in_cohort) }
-      it { should_not include(patient_with_move_in_another_cohort) }
+      it { should contain_exactly(patient_with_move_in_cohort) }
     end
 
     context "when the patient not in the org but pending joining the school" do
       let(:patient_with_move_in_school) { create(:patient) }
-      let(:patient_with_move_in_another_school) { create(:patient) }
+      let!(:patient_with_move_in_another_school) { create(:patient) }
+
+      let(:school) { create(:school, organisation:) }
 
       before do
         create(
@@ -59,32 +73,29 @@ describe PatientPolicy do
         )
       end
 
-      it { should include(patient_with_move_in_school) }
-      it { should_not include(patient_with_move_in_another_school) }
+      it { should contain_exactly(patient_with_move_in_school) }
     end
 
     context "when the patient not in the org but was vaccinated by them" do
       let(:patient_with_vaccination_record) { create(:patient) }
       let(:patient_with_another_vaccination_record) { create(:patient) }
 
-      let(:programme) { create(:programme) }
-
       before do
         create(
           :vaccination_record,
           patient: patient_with_vaccination_record,
           performed_ods_code: organisation.ods_code,
-          programme:
+          programme: programmes.first
         )
         create(
           :vaccination_record,
           patient: patient_with_another_vaccination_record,
-          programme:
+          performed_ods_code: nil,
+          programme: programmes.first
         )
       end
 
-      it { should include(patient_with_vaccination_record) }
-      it { should_not include(patient_with_another_vaccination_record) }
+      it { should contain_exactly(patient_with_vaccination_record) }
     end
   end
 end


### PR DESCRIPTION
When filtering on patients that an organisation is allowed to see, using a left outer join means that each patient will be returned for each school move, session or vaccination record they have. This means duplicate patients are shown in various parts of the UI.

Instead, we can use an `EXISTS` query, which is actually more performant as it can short-circuit the conditionals, and avoids duplicate patients being shown.