### PR TITLE
Add Flu vaccine health questions

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -48,9 +48,7 @@ class Programme < ApplicationRecord
 
   def to_param = type
 
-  def name
-    human_enum_name(:type)
-  end
+  def name = human_enum_name(:type)
 
   def doubles? = menacwy? || td_ipv?
 

--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -30,94 +30,120 @@ namespace :vaccines do
 
       next if vaccine.health_questions.exists?
 
-      if programme.hpv?
-        create_hpv_health_questions(vaccine)
-      elsif programme.menacwy?
-        create_menacwy_health_questions(vaccine)
-      elsif programme.td_ipv?
-        create_td_ipv_health_questions(vaccine)
+      ActiveRecord::Base.transaction do
+        if programme.hpv?
+          create_hpv_health_questions(vaccine)
+        elsif programme.menacwy?
+          create_menacwy_health_questions(vaccine)
+        elsif programme.td_ipv?
+          create_td_ipv_health_questions(vaccine)
+        end
       end
     end
   end
 end
 
 def create_hpv_health_questions(vaccine)
-  vaccine.health_questions.create!(
-    title: "Does your child have any severe allergies?",
-    next_question:
-      vaccine.health_questions.create!(
-        title:
-          "Does your child have any medical conditions for which they receive treatment?",
-        next_question:
-          vaccine.health_questions.create!(
-            title:
-              "Has your child ever had a severe reaction to any medicines, including vaccines?",
-            next_question:
-              vaccine.health_questions.create!(
-                title:
-                  "Does your child need extra support during vaccination sessions?",
-                hint: "For example, they’re autistic, or extremely anxious"
-              )
-          )
-      )
-  )
+  severe_allergies =
+    vaccine.health_questions.create!(
+      title: "Does your child have any severe allergies?"
+    )
+
+  medical_conditions =
+    vaccine.health_questions.create!(
+      title:
+        "Does your child have any medical conditions for which they receive treatment?"
+    )
+
+  severe_reaction =
+    vaccine.health_questions.create!(
+      title:
+        "Has your child ever had a severe reaction to any medicines, including vaccines?"
+    )
+
+  extra_support =
+    vaccine.health_questions.create!(
+      title: "Does your child need extra support during vaccination sessions?",
+      hint: "For example, they’re autistic, or extremely anxious"
+    )
+
+  severe_allergies.update!(next_question: medical_conditions)
+  medical_conditions.update!(next_question: severe_reaction)
+  severe_reaction.update!(next_question: extra_support)
 end
 
 def create_menacwy_health_questions(vaccine)
-  vaccine.health_questions.create!(
-    title:
-      "Does your child have a bleeding disorder or another medical condition they receive treatment for?",
-    next_question:
-      vaccine.health_questions.create!(
-        title: "Does your child have any severe allergies?",
-        next_question:
-          vaccine.health_questions.create!(
-            title:
-              "Has your child ever had a severe reaction to any medicines, including vaccines?",
-            next_question:
-              vaccine.health_questions.create!(
-                title:
-                  "Does your child need extra support during vaccination sessions?",
-                hint: "For example, they’re autistic, or extremely anxious",
-                next_question:
-                  vaccine.health_questions.create!(
-                    title:
-                      "Has your child had a meningitis (MenACWY) vaccination in the last 5 years?",
-                    hint:
-                      "It’s usually given once in Year 9 or 10. " \
-                        "Some children may have had it before travelling abroad."
-                  )
-              )
-          )
-      )
-  )
+  bleeding_disorder =
+    vaccine.health_questions.create!(
+      title:
+        "Does your child have a bleeding disorder or another medical condition they receive treatment for?"
+    )
+
+  severe_allergies =
+    vaccine.health_questions.create!(
+      title: "Does your child have any severe allergies?"
+    )
+
+  severe_reaction =
+    vaccine.health_questions.create!(
+      title:
+        "Has your child ever had a severe reaction to any medicines, including vaccines?"
+    )
+
+  extra_support =
+    vaccine.health_questions.create!(
+      title: "Does your child need extra support during vaccination sessions?",
+      hint: "For example, they’re autistic, or extremely anxious"
+    )
+
+  menacwy_previously =
+    vaccine.health_questions.create!(
+      title:
+        "Has your child had a meningitis (MenACWY) vaccination in the last 5 years?",
+      hint:
+        "It’s usually given once in Year 9 or 10. Some children may have had it before travelling abroad."
+    )
+
+  bleeding_disorder.update!(next_question: severe_allergies)
+  severe_allergies.update!(next_question: severe_reaction)
+  severe_reaction.update!(next_question: extra_support)
+  extra_support.update!(next_question: menacwy_previously)
 end
 
 def create_td_ipv_health_questions(vaccine)
-  vaccine.health_questions.create!(
-    title:
-      "Does your child have a bleeding disorder or another medical condition they receive treatment for?",
-    next_question:
-      vaccine.health_questions.create!(
-        title: "Does your child have any severe allergies?",
-        next_question:
-          vaccine.health_questions.create!(
-            title:
-              "Has your child ever had a severe reaction to any medicines, including vaccines?",
-            next_question:
-              vaccine.health_questions.create!(
-                title:
-                  "Does your child need extra support during vaccination sessions?",
-                hint: "For example, they’re autistic, or extremely anxious",
-                next_question:
-                  vaccine.health_questions.create!(
-                    title:
-                      "Has your child had a tetanus, diphtheria and polio vaccination in the last 5 years?",
-                    hint:
-                      "Most children will not have had this vaccination since their 4-in-1 pre-school booster"
-                  )
-              )
-          )
-      )
-  )
+  bleeding_disorder =
+    vaccine.health_questions.create!(
+      title:
+        "Does your child have a bleeding disorder or another medical condition they receive treatment for?"
+    )
+
+  severe_allergies =
+    vaccine.health_questions.create!(
+      title: "Does your child have any severe allergies?"
+    )
+
+  severe_reaction =
+    vaccine.health_questions.create!(
+      title:
+        "Has your child ever had a severe reaction to any medicines, including vaccines?"
+    )
+
+  extra_support =
+    vaccine.health_questions.create!(
+      title: "Does your child need extra support during vaccination sessions?",
+      hint: "For example, they’re autistic, or extremely anxious"
+    )
+
+  td_ipv_previously =
+    vaccine.health_questions.create!(
+      title:
+        "Has your child had a tetanus, diphtheria and polio vaccination in the last 5 years?",
+      hint:
+        "Most children will not have had this vaccination since their 4-in-1 pre-school booster"
+    )
+
+  bleeding_disorder.update!(next_question: severe_allergies)
+  severe_allergies.update!(next_question: severe_reaction)
+  severe_reaction.update!(next_question: extra_support)
+  extra_support.update!(next_question: td_ipv_previously)
 end


### PR DESCRIPTION
This adds the health questions for the Flu vaccines matching the latest content in the prototype.

This can be safely merged in as no organisations in production are set up with Flu yet.