### PR TITLE
Allow testing Flu programme

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -49,15 +49,20 @@
     </h2>
 
     <%= f.govuk_radio_buttons_fieldset :administered, legend: nil do %>
-      <%= f.govuk_radio_button :administered, true, label: { text: "Yes" }, link_errors: true do %>
-        <%= f.govuk_collection_radio_buttons :delivery_site,
-                                             common_delivery_sites_options,
-                                             :value,
-                                             :label,
-                                             legend: {
-                                               text: "Where will the injection be given?",
-                                               size: "s",
-                                             } %>
+      <% if common_delivery_sites_options.length > 1 %>
+        <%= f.govuk_radio_button :administered, true, label: { text: "Yes" }, link_errors: true do %>
+          <%= f.govuk_collection_radio_buttons :delivery_site,
+                                               common_delivery_sites_options,
+                                               :value,
+                                               :label,
+                                               legend: {
+                                                 text: "Where will the injection be given?",
+                                                 size: "s",
+                                               } %>
+        <% end %>
+      <% else %>
+        <%= f.govuk_radio_button :administered, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.hidden_field :delivery_site, value: common_delivery_sites_options.first.value %>
       <% end %>
       <%= f.govuk_radio_button :administered, false, label: { text: "No" } %>
     <% end %>

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -16,6 +16,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
 
     @batch = vaccination_record.batch
     @patient = vaccination_record.patient
+    @programme = vaccination_record.programme
     @vaccine = vaccination_record.vaccine
   end
 
@@ -218,10 +219,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   end
 
   def programme_value
-    highlight_if(
-      @vaccination_record.programme.name,
-      @vaccination_record.programme_id_changed?
-    )
+    highlight_if(@programme.name, @vaccination_record.programme_id_changed?)
   end
 
   def vaccine_value
@@ -318,7 +316,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
   end
 
   def dose_number
-    return nil if @vaccine&.seasonal?
+    return nil if @programme.seasonal?
 
     dose_sequence = @vaccination_record.dose_sequence
 

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -199,7 +199,7 @@ class DraftVaccinationRecordsController < ApplicationController
 
     method =
       if @draft_vaccination_record.delivery_method == "nasal_spray"
-        "nasal_spray"
+        "nasal"
       else
         "injection"
       end

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -79,15 +79,6 @@ class Programme < ApplicationRecord
     vaccines.flat_map(&:available_delivery_sites).uniq
   end
 
-  def common_delivery_sites
-    if hpv? || menacwy? || td_ipv?
-      %w[left_arm_upper_position right_arm_upper_position]
-    else
-      raise NotImplementedError,
-            "Common delivery sites not implemented for #{type} vaccines."
-    end
-  end
-
   DOSE_SEQUENCES = {
     "flu" => 1,
     "hpv" => 1,

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -46,17 +46,15 @@ class Programme < ApplicationRecord
        { flu: "flu", hpv: "hpv", menacwy: "menacwy", td_ipv: "td_ipv" },
        validate: true
 
-  def to_param
-    type
-  end
-
-  def doubles?
-    menacwy? || td_ipv?
-  end
+  def to_param = type
 
   def name
     human_enum_name(:type)
   end
+
+  def doubles? = menacwy? || td_ipv?
+
+  def seasonal? = flu?
 
   YEAR_GROUPS_BY_TYPE = {
     "flu" => (0..11).to_a,

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -56,9 +56,14 @@ class Vaccine < ApplicationRecord
   def contains_gelatine? = programme.flu? && nasal?
 
   AVAILABLE_DELIVERY_SITES = {
-    "injection" =>
-      VaccinationRecord.delivery_sites.keys -
-        %w[left_buttock right_buttock nose],
+    "injection" => %w[
+      left_arm_upper_position
+      left_arm_lower_position
+      right_arm_upper_position
+      right_arm_lower_position
+      left_thigh
+      right_thigh
+    ],
     "nasal" => %w[nose]
   }.freeze
 

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -51,17 +51,9 @@ class Vaccine < ApplicationRecord
 
   delegate :first_health_question, to: :health_questions
 
-  def active?
-    !discontinued
-  end
+  def active? = !discontinued
 
-  def contains_gelatine?
-    programme.flu? && nasal?
-  end
-
-  def seasonal?
-    programme.flu?
-  end
+  def contains_gelatine? = programme.flu? && nasal?
 
   AVAILABLE_DELIVERY_SITES = {
     "injection" =>

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 describe AppVaccinateFormComponent do
-  subject { render_inline(component) }
-
-  let(:heading) { "A Heading" }
-  let(:body) { "A Body" }
-  let(:programmes) { [create(:programme, :hpv)] }
+  let(:programme) { create(:programme) }
+  let(:programmes) { [programme] }
   let(:session) { create(:session, :today, programmes:) }
   let(:patient) do
     create(
@@ -19,20 +16,11 @@ describe AppVaccinateFormComponent do
     create(:patient_session, :in_attendance, programmes:, patient:, session:)
   end
 
-  let(:vaccinate_form) do
-    VaccinateForm.new(patient_session:, programme: programmes.first)
-  end
+  let(:vaccinate_form) { VaccinateForm.new(patient_session:, programme:) }
 
   let(:component) { described_class.new(vaccinate_form) }
 
   before { patient_session.strict_loading!(false) }
-
-  it { should have_css(".nhsuk-card") }
-
-  it { should have_heading("Is Hari ready for their HPV vaccination?") }
-
-  it { should have_field("Yes") }
-  it { should have_field("No") }
 
   describe "#render?" do
     subject(:render) { component.render? }
@@ -51,6 +39,40 @@ describe AppVaccinateFormComponent do
       end
 
       it { should be(false) }
+    end
+  end
+
+  describe "rendered content" do
+    subject { render_inline(component) }
+
+    it { should have_css(".nhsuk-card") }
+
+    context "with a Flu programme" do
+      let(:programme) { create(:programme, :flu) }
+
+      it { should have_heading("Is Hari ready for their Flu vaccination?") }
+
+      it { should have_field("Yes") }
+      it { should have_field("No") }
+
+      it { should_not have_field("Left arm (upper position)") }
+      it { should_not have_field("Right arm (upper position)") }
+      it { should_not have_field("Nose") }
+      it { should_not have_field("Other") }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { create(:programme, :hpv) }
+
+      it { should have_heading("Is Hari ready for their HPV vaccination?") }
+
+      it { should have_field("Yes") }
+      it { should have_field("No") }
+
+      it { should have_field("Left arm (upper position)") }
+      it { should have_field("Right arm (upper position)") }
+      it { should_not have_field("Nose") }
+      it { should have_field("Other") }
     end
   end
 end

--- a/spec/factories/programmes.rb
+++ b/spec/factories/programmes.rb
@@ -39,15 +39,7 @@ FactoryBot.define do
       vaccines do
         [
           association(:vaccine, :adjuvanted_quadrivalent, programme: instance),
-          association(:vaccine, :cell_quadrivalent, programme: instance),
-          association(:vaccine, :fluenz_tetra, programme: instance),
-          association(:vaccine, :quadrivalent_influenza, programme: instance),
-          association(
-            :vaccine,
-            :quadrivalent_influvac_tetra,
-            programme: instance
-          ),
-          association(:vaccine, :supemtek, programme: instance)
+          association(:vaccine, :fluenz_tetra, programme: instance)
         ]
       end
     end

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -72,7 +72,7 @@ FactoryBot.define do
 
     vaccine do
       if session
-        programme.vaccines.active.first || association(:vaccine, programme:)
+        programme.vaccines.active.sample || association(:vaccine, programme:)
       end
     end
 

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -38,6 +38,34 @@ describe Programme do
     end
   end
 
+  describe "#seasonal?" do
+    subject { programme.seasonal? }
+
+    context "with a Flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should be(true) }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should be(false) }
+    end
+
+    context "with an MenACWY programme" do
+      let(:programme) { build(:programme, :menacwy) }
+
+      it { should be(false) }
+    end
+
+    context "with an Td/IPV programme" do
+      let(:programme) { build(:programme, :td_ipv) }
+
+      it { should be(false) }
+    end
+  end
+
   describe "#year_groups" do
     subject(:year_groups) { programme.year_groups }
 

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -110,38 +110,8 @@ describe Programme do
     end
   end
 
-  describe "#common_delivery_sites" do
-    subject(:common_delivery_sites) { programme.common_delivery_sites }
-
-    context "with a Flu programme" do
-      let(:programme) { build(:programme, :flu) }
-
-      it "raises an error" do
-        expect { common_delivery_sites }.to raise_error(NotImplementedError)
-      end
-    end
-
-    context "with an HPV programme" do
-      let(:programme) { build(:programme, :hpv) }
-
-      it { should eq(%w[left_arm_upper_position right_arm_upper_position]) }
-    end
-
-    context "with an MenACWY programme" do
-      let(:programme) { build(:programme, :menacwy) }
-
-      it { should eq(%w[left_arm_upper_position right_arm_upper_position]) }
-    end
-
-    context "with an Td/IPV programme" do
-      let(:programme) { build(:programme, :td_ipv) }
-
-      it { should eq(%w[left_arm_upper_position right_arm_upper_position]) }
-    end
-  end
-
   describe "#vaccinated_dose_sequence" do
-    subject(:vaccinated_dose_sequence) { programme.vaccinated_dose_sequence }
+    subject { programme.vaccinated_dose_sequence }
 
     context "with a Flu programme" do
       let(:programme) { build(:programme, :flu) }

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -57,22 +57,6 @@ describe Vaccine do
     end
   end
 
-  describe "#seasonal?" do
-    subject { vaccine.seasonal? }
-
-    context "with a Flu vaccine" do
-      let(:vaccine) { build(:vaccine, :flu) }
-
-      it { should be(true) }
-    end
-
-    context "with an HPV vaccine" do
-      let(:vaccine) { build(:vaccine, :hpv) }
-
-      it { should be(false) }
-    end
-  end
-
   describe "#available_delivery_methods" do
     subject { vaccine.available_delivery_methods }
 


### PR DESCRIPTION
This adds the minimum configuration to allow us to start testing the Flu programme. Specifically, it adds Flu to the list of programmes in the seeds and makes it possible to record a Flu vaccination even if this doesn't yet follow the designs.

This can be safely merged in as no organisations in production are set up with Flu yet.