### PR TITLE
Vary vaccination flow depending on consented vaccination method

### DIFF
--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -27,8 +27,11 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def delivery_method
-    # TODO: Check which method has been consented to.
-    programme.flu? ? :nasal_spray : :intramuscular
+    if patient.consent_status(programme:).vaccine_method_nasal?
+      :nasal_spray
+    else
+      :intramuscular
+    end
   end
 
   def dose_sequence

--- a/app/models/patient/consent_status.rb
+++ b/app/models/patient/consent_status.rb
@@ -58,6 +58,8 @@ class Patient::ConsentStatus < ApplicationRecord
       end
   end
 
+  def vaccine_method_nasal? = vaccine_methods.include?("nasal")
+
   private
 
   def status_should_be_given?

--- a/app/models/patient/consent_status.rb
+++ b/app/models/patient/consent_status.rb
@@ -4,10 +4,11 @@
 #
 # Table name: patient_consent_statuses
 #
-#  id           :bigint           not null, primary key
-#  status       :integer          default("no_response"), not null
-#  patient_id   :bigint           not null
-#  programme_id :bigint           not null
+#  id              :bigint           not null, primary key
+#  status          :integer          default("no_response"), not null
+#  vaccine_methods :integer          default([]), not null, is an Array
+#  patient_id      :bigint           not null
+#  programme_id    :bigint           not null
 #
 # Indexes
 #
@@ -20,6 +21,8 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class Patient::ConsentStatus < ApplicationRecord
+  include HasVaccineMethods
+
   belongs_to :patient
   belongs_to :programme
 
@@ -32,6 +35,8 @@ class Patient::ConsentStatus < ApplicationRecord
        default: :no_response,
        validate: true
 
+  validates :vaccine_methods, presence: true, if: :given?
+
   def assign_status
     self.status =
       if status_should_be_given?
@@ -43,16 +48,20 @@ class Patient::ConsentStatus < ApplicationRecord
       else
         :no_response
       end
+
+    self.vaccine_methods =
+      if status_should_be_given?
+        consents_for_status
+          .select(&:response_given?)
+          .map(&:vaccine_methods)
+          .inject(&:intersection)
+      end
   end
 
   private
 
   def status_should_be_given?
-    if self_consents.any?
-      self_consents.all?(&:response_given?)
-    else
-      parental_consents.any? && parental_consents.all?(&:response_given?)
-    end
+    consents_for_status.any? && consents_for_status.all?(&:response_given?)
   end
 
   def status_should_be_refused?
@@ -60,13 +69,12 @@ class Patient::ConsentStatus < ApplicationRecord
   end
 
   def status_should_be_conflicts?
-    if self_consents.any?
-      self_consents.any?(&:response_refused?) &&
-        self_consents.any?(&:response_given?)
-    else
-      parental_consents.any?(&:response_refused?) &&
-        parental_consents.any?(&:response_given?)
-    end
+    consents_for_status.any?(&:response_refused?) &&
+      consents_for_status.any?(&:response_given?)
+  end
+
+  def consents_for_status
+    self_consents.any? ? self_consents : parental_consents
   end
 
   def self_consents

--- a/db/migrate/20250608172900_add_vaccine_methods_to_consent_statuses.rb
+++ b/db/migrate/20250608172900_add_vaccine_methods_to_consent_statuses.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddVaccineMethodsToConsentStatuses < ActiveRecord::Migration[8.0]
+  def change
+    add_column :patient_consent_statuses,
+               :vaccine_methods,
+               :integer,
+               array: true,
+               default: [],
+               null: false
+
+    reversible do |dir|
+      dir.up do
+        # We don't support nasal spray yet.
+        Patient::ConsentStatus.given.update_all(vaccine_methods: %w[injection])
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -549,6 +549,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_09_112437) do
     t.bigint "patient_id", null: false
     t.bigint "programme_id", null: false
     t.integer "status", default: 0, null: false
+    t.integer "vaccine_methods", default: [], null: false, array: true
     t.index ["patient_id", "programme_id"], name: "index_patient_consent_statuses_on_patient_id_and_programme_id", unique: true
     t.index ["status"], name: "index_patient_consent_statuses_on_status"
   end

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -47,8 +47,12 @@ describe AppVaccinateFormComponent do
 
     it { should have_css(".nhsuk-card") }
 
-    context "with a Flu programme" do
+    context "with a Flu programme and consent to nasal spray" do
       let(:programme) { create(:programme, :flu) }
+
+      before do
+        patient.consent_status(programme:).update!(vaccine_methods: %w[nasal])
+      end
 
       it { should have_heading("Is Hari ready for their Flu vaccination?") }
 

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -76,6 +76,8 @@ FactoryBot.define do
 
     submitted_at { consent_form&.recorded_at || Time.current }
 
+    traits_for_enum :vaccine_method
+
     trait :given_verbally do
       given
       route { "phone" }

--- a/spec/factories/patient_consent_statuses.rb
+++ b/spec/factories/patient_consent_statuses.rb
@@ -4,10 +4,11 @@
 #
 # Table name: patient_consent_statuses
 #
-#  id           :bigint           not null, primary key
-#  status       :integer          default("no_response"), not null
-#  patient_id   :bigint           not null
-#  programme_id :bigint           not null
+#  id              :bigint           not null, primary key
+#  status          :integer          default("no_response"), not null
+#  vaccine_methods :integer          default([]), not null, is an Array
+#  patient_id      :bigint           not null
+#  programme_id    :bigint           not null
 #
 # Indexes
 #
@@ -25,5 +26,10 @@ FactoryBot.define do
     programme
 
     traits_for_enum :status
+
+    trait :given do
+      status { "given" }
+      vaccine_methods { %w[injection] }
+    end
   end
 end

--- a/spec/models/patient/consent_status_spec.rb
+++ b/spec/models/patient/consent_status_spec.rb
@@ -4,10 +4,11 @@
 #
 # Table name: patient_consent_statuses
 #
-#  id           :bigint           not null, primary key
-#  status       :integer          default("no_response"), not null
-#  patient_id   :bigint           not null
-#  programme_id :bigint           not null
+#  id              :bigint           not null, primary key
+#  status          :integer          default("no_response"), not null
+#  vaccine_methods :integer          default([]), not null, is an Array
+#  patient_id      :bigint           not null
+#  programme_id    :bigint           not null
 #
 # Indexes
 #
@@ -27,6 +28,8 @@ describe Patient::ConsentStatus do
   let(:patient) { create(:patient) }
   let(:programme) { create(:programme) }
 
+  before { patient.strict_loading!(false) }
+
   it { should belong_to(:patient) }
   it { should belong_to(:programme) }
 
@@ -37,9 +40,7 @@ describe Patient::ConsentStatus do
   end
 
   describe "#status" do
-    subject { patient_consent_status.assign_status }
-
-    before { patient.strict_loading!(false) }
+    subject { patient_consent_status.tap(&:assign_status).status.to_sym }
 
     context "with no consent" do
       it { should be(:no_response) }
@@ -149,6 +150,156 @@ describe Patient::ConsentStatus do
         end
 
         it { should be(:given) }
+      end
+    end
+  end
+
+  describe "#vaccine_methods" do
+    subject { patient_consent_status.tap(&:assign_status).vaccine_methods }
+
+    context "with no consent" do
+      it { should be_empty }
+    end
+
+    context "with an invalidated consent" do
+      before { create(:consent, :invalidated, patient:, programme:) }
+
+      it { should be_empty }
+    end
+
+    context "with a not provided consent" do
+      before { create(:consent, :not_provided, patient:, programme:) }
+
+      it { should be_empty }
+    end
+
+    context "with both an invalidated and not provided consent" do
+      before do
+        create(:consent, :invalidated, patient:, programme:)
+        create(:consent, :not_provided, patient:, programme:)
+      end
+
+      it { should be_empty }
+    end
+
+    context "with a refused consent" do
+      before { create(:consent, :refused, patient:, programme:) }
+
+      it { should be_empty }
+    end
+
+    context "with an injection given consent" do
+      before do
+        create(
+          :consent,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[injection]
+        )
+      end
+
+      it { should contain_exactly("injection") }
+    end
+
+    context "with a nasal given consent" do
+      before do
+        create(
+          :consent,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[nasal]
+        )
+      end
+
+      it { should contain_exactly("nasal") }
+    end
+
+    context "with both nasal and injection given consent" do
+      before do
+        create(
+          :consent,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[nasal injection]
+        )
+      end
+
+      it { should eq(%w[nasal injection]) }
+    end
+
+    context "with one parent nasal and one parent both" do
+      before do
+        create(
+          :consent,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[nasal]
+        )
+        create(
+          :consent,
+          :given,
+          patient:,
+          programme:,
+          parent: create(:parent),
+          vaccine_methods: %w[nasal injection]
+        )
+      end
+
+      it { should contain_exactly("nasal") }
+    end
+
+    context "with conflicting consent" do
+      before do
+        create(:consent, :given, patient:, programme:)
+        create(
+          :consent,
+          :refused,
+          patient:,
+          programme:,
+          parent: create(:parent)
+        )
+      end
+
+      it { should be_empty }
+    end
+
+    context "with an invalidated refused and given consent" do
+      before do
+        create(:consent, :refused, :invalidated, patient:, programme:)
+        create(:consent, :given, patient:, programme:)
+      end
+
+      it { should contain_exactly("injection") }
+    end
+
+    context "with self-consent" do
+      before { create(:consent, :self_consent, :given, patient:, programme:) }
+
+      it { should contain_exactly("injection") }
+
+      context "and refused parental consent" do
+        before { create(:consent, :refused, patient:, programme:) }
+
+        it { should contain_exactly("injection") }
+      end
+
+      context "and conflicting parental consent" do
+        before do
+          create(:consent, :refused, patient:, programme:)
+          create(
+            :consent,
+            :given,
+            patient:,
+            programme:,
+            parent: create(:parent)
+          )
+        end
+
+        it { should contain_exactly("injection") }
       end
     end
   end


### PR DESCRIPTION
This ensures than when recording a vaccination we set the default delivery method according to the consent that was given.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1232)