### PR TITLE
Add full dose or half dose step

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -139,6 +139,14 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
           summary_list.with_row do |row|
             row.with_key { "Dose volume" }
             row.with_value { dose_volume_value }
+
+            if (href = @change_links[:dose_volume])
+              row.with_action(
+                text: "Change",
+                href:,
+                visually_hidden_text: "dose volume"
+              )
+            end
           end
         end
 

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -81,9 +81,8 @@ class DraftVaccinationRecordsController < ApplicationController
   end
 
   def handle_outcome
-    if @draft_vaccination_record.administered?
-      @draft_vaccination_record.full_dose = true
-    elsif @draft_vaccination_record.location_name.present?
+    if !@draft_vaccination_record.administered? &&
+         @draft_vaccination_record.location_name.present?
       # If not administered and location is set, we can skip to confirm.
       # Otherwise, we need to get the location information from the user.
       jump_to("confirm")
@@ -147,6 +146,7 @@ class DraftVaccinationRecordsController < ApplicationController
       confirm: @draft_vaccination_record.editing? ? [] : %i[notes],
       date_and_time: %i[performed_at],
       delivery: %i[delivery_site delivery_method],
+      dose: %i[full_dose],
       location: %i[location_name],
       notes: %i[notes],
       outcome: %i[outcome]

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -60,7 +60,6 @@ class VaccinateForm
 
     draft_vaccination_record.batch_id = todays_batch&.id
     draft_vaccination_record.dose_sequence = dose_sequence
-    draft_vaccination_record.full_dose = true
     draft_vaccination_record.patient_id = patient_session.patient_id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -55,6 +55,8 @@ class Vaccine < ApplicationRecord
 
   def contains_gelatine? = programme.flu? && nasal?
 
+  def can_be_half_dose? = nasal?
+
   AVAILABLE_DELIVERY_SITES = {
     "injection" => %w[
       left_arm_upper_position

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -18,6 +18,7 @@
      batch: wizard_path("batch"),
      delivery_method: wizard_path("delivery"),
      delivery_site: wizard_path("delivery"),
+     dose_volume: @draft_vaccination_record.wizard_steps.include?(:dose) ? wizard_path("dose") : nil,
      location: @draft_vaccination_record.wizard_steps.include?(:location) ? wizard_path("location") : nil,
      notes: wizard_path("notes"),
      outcome: @draft_vaccination_record.wizard_steps.include?(:outcome) ? wizard_path("outcome") : nil,

--- a/app/views/draft_vaccination_records/dose.html.erb
+++ b/app/views/draft_vaccination_records/dose.html.erb
@@ -1,0 +1,18 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
+<% end %>
+
+<% legend = "Did they get the full dose?" %>
+<% content_for :page_title, legend %>
+
+<%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_collection_radio_buttons :full_dose,
+                                       %i[true false],
+                                       :itself,
+                                       caption: { text: @patient.full_name, size: "l" },
+                                       legend: { text: legend, tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,8 @@ en:
             delivery_site:
               blank: Choose a delivery site
               inclusion: Choose a delivery site
+            full_dose:
+              inclusion: Choose whether they got the full dose
             location_name:
               blank: Enter where the vaccination was given
             notes:
@@ -686,6 +688,7 @@ en:
     date_of_birth: date-of-birth
     dates: dates
     delivery: delivery
+    dose: dose
     education_setting: education-setting
     file_format: file-format
     gp: gp

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -12,6 +12,10 @@ en:
           keep_both: The new and existing records will both be kept.
 
     label:
+      draft_vaccination_record:
+        full_dose_options:
+          true: Yes, they got the full dose
+          false: No, they got half a dose
       import_duplicate_form:
         apply_changes_options:
           apply: Use duplicate record

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -84,6 +84,16 @@ describe DraftVaccinationRecord do
   describe "#reset_unused_fields" do
     subject(:save!) { draft_vaccination_record.save! }
 
+    context "when administered" do
+      let(:attributes) { valid_administered_attributes.except(:full_dose) }
+
+      it "sets full dose to true if half doses cannot be recorded" do
+        expect { save! }.to change(draft_vaccination_record, :full_dose).to(
+          true
+        )
+      end
+    end
+
     context "when not administered" do
       let(:attributes) do
         valid_not_administered_attributes.merge(

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -57,6 +57,28 @@ describe Vaccine do
     end
   end
 
+  describe "#can_be_half_dose?" do
+    subject { vaccine.can_be_half_dose? }
+
+    context "with a nasal Flu vaccine" do
+      let(:vaccine) { build(:vaccine, :fluenz_tetra) }
+
+      it { should be(true) }
+    end
+
+    context "with an injected Flu vaccine" do
+      let(:vaccine) { build(:vaccine, :quadrivalent_influenza) }
+
+      it { should be(false) }
+    end
+
+    context "with an HPV vaccine" do
+      let(:vaccine) { build(:vaccine, :gardasil_9) }
+
+      it { should be(false) }
+    end
+  end
+
   describe "#available_delivery_methods" do
     subject { vaccine.available_delivery_methods }
 


### PR DESCRIPTION
When recording a vaccination, if using a nasal spray, we need to record whether the patient received a full dose or a half dose (meaning the spray was only in one nostril). This builds the step as per the latest designs in the prototype.

This can be safely merged in as no organisations in production are set up with Flu yet.

[Jira Issue](https://nhsd-jira.digital.nhs.uk/browse/MAV-1233)

## Screenshots

<img width="529" alt="Screenshot 2025-06-07 at 22 03 35" src="https://github.com/user-attachments/assets/5d84019c-836f-4b2c-8aed-3f30e5383b54" />
<img width="793" alt="Screenshot 2025-06-07 at 22 03 39" src="https://github.com/user-attachments/assets/c9484803-7f8c-40a9-9099-757b14e85fae" />
<img width="764" alt="Screenshot 2025-06-07 at 22 03 44" src="https://github.com/user-attachments/assets/3de028ee-c30a-4969-a5cc-a1dcc540786d" />
<img width="747" alt="Screenshot 2025-06-07 at 22 03 49" src="https://github.com/user-attachments/assets/ca906a56-100d-4058-90bc-6ff44e150212" />
