### PR TITLE
MAV-1212 Fail confirmation when child is not attending.

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -72,6 +72,16 @@ class DraftVaccinationRecordsController < ApplicationController
         render_wizard nil, status: :unprocessable_entity
       end
     end
+
+    if current_step == :confirm
+      patient = Patient.find(@draft_vaccination_record.patient_id)
+      session_id = @draft_vaccination_record.session_id
+      unless patient.is_attending?(session_id:)
+        @draft_vaccination_record.errors.add(:session_id,
+                                             :child_not_attending, name: patient.full_name)
+        render_wizard nil, status: :unprocessable_entity
+      end
+    end
   end
 
   def handle_date_and_time

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -309,6 +309,10 @@ class Patient < ApplicationRecord
     !deceased? && !restricted? && !invalidated?
   end
 
+  def is_attending?(session_id:)
+    session_attendance_ids.include? session_id
+  end
+
   def update_from_pds!(pds_patient)
     if nhs_number.nil? || nhs_number != pds_patient.nhs_number
       raise NHSNumberMismatch

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,8 @@ en:
               missing_year: Enter a year
               invalid: Enter a valid date and time
               less_than_or_equal_to: Enter a time in the past
+            session_id:
+              child_not_attending: "%{name} is not registered as attending for this session. If you are certain you have the right child, please go back to the registration tab and mark them as attending and then redo the vaccination registration."
         health_answer:
           attributes:
             notes:


### PR DESCRIPTION
Ideally we would get the error message to be a direct link to the registration page, see
https://github.com/x-govuk/govuk-form-builder/issues/566 for why this is not yet possible.