### PR TITLE
MAV-1260 Handle terraform warnings

### DIFF
--- a/terraform/account/main.tf
+++ b/terraform/account/main.tf
@@ -10,6 +10,7 @@ terraform {
   backend "s3" {
     region         = "eu-west-2"
     dynamodb_table = "mavis-terraform-state-lock"
+    use_lockfile   = true
     encrypt        = true
   }
 }

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -1,7 +1,6 @@
 environment         = "preview"
 db_secret_arn       = "arn:aws:secretsmanager:eu-west-2:393416225559:secret:dbAuroraSecret-ysKvF5RMbWMr-lnpooZ"
 dns_certificate_arn = null
-enable_autoscaling  = false
 docker_image        = "mavis/webapp"
 resource_name = {
   dbsubnet_group           = "mavis-preview-addonsstack-1pd6pksn106rk-dbdbsubnetgroup-8pkydanicgra"

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -1,7 +1,6 @@
 environment         = "production"
 db_secret_arn       = "arn:aws:secretsmanager:eu-west-2:820242920762:secret:dbAuroraSecret-zjL6LdCCIV5c-oSfy6Y"
 dns_certificate_arn = ["arn:aws:acm:eu-west-2:820242920762:certificate/dd00edc0-b305-45bd-83aa-7c7f298b0a68"]
-enable_autoscaling  = false
 docker_image        = "mavis/webapp"
 resource_name = {
   dbsubnet_group           = "mavis-production-addonsstack-h6b1986bq928-dbdbsubnetgroup-1dpsuyglv1es"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -1,7 +1,6 @@
 environment         = "qa"
 db_secret_arn       = "arn:aws:secretsmanager:eu-west-2:393416225559:secret:dbAuroraSecret-GBwVtQEAmugK-wPubjU"
 dns_certificate_arn = ["arn:aws:acm:eu-west-2:393416225559:certificate/dafb0f10-ee18-45e2-8971-28d4ab434375"]
-enable_autoscaling  = false
 docker_image        = "mavis/webapp"
 resource_name = {
   dbsubnet_group           = "mavis-qa-addonsstack-z0l4gx5euv3i-dbdbsubnetgroup-fgvafc16exxw"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -1,7 +1,6 @@
 environment         = "test"
 db_secret_arn       = "arn:aws:secretsmanager:eu-west-2:393416225559:secret:dbAuroraSecret-LwdZBGzdPMq6-PkAjKC"
 dns_certificate_arn = ["arn:aws:acm:eu-west-2:393416225559:certificate/7e80f006-e9d8-488f-b950-d97f3cc41e4f"]
-enable_autoscaling  = false
 docker_image        = "mavis/webapp"
 resource_name = {
   dbsubnet_group           = "mavis-test-addonsstack-gb8z9lqvo8of-dbdbsubnetgroup-8hrfkmuyp4c4"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -4,8 +4,7 @@ dns_certificate_arn = [
   "arn:aws:acm:eu-west-2:393416225559:certificate/368edbcb-37c5-4146-9087-ff011bef5e05",
   "arn:aws:acm:eu-west-2:393416225559:certificate/e93e3912-eee4-4f6e-826d-c628bff58527",
 ]
-enable_autoscaling = false
-docker_image       = "mavis/webapp"
+docker_image = "mavis/webapp"
 resource_name = {
   dbsubnet_group           = "mavis-training-addonsstack-1jzsxp7p84221-dbdbsubnetgroup-ybdt5wfbx9jl"
   db_cluster               = "mavis-training-addonsstack-1jzsxp7p842-dbdbcluster-dojxjwailzmh"

--- a/terraform/app/main.tf
+++ b/terraform/app/main.tf
@@ -12,7 +12,8 @@ terraform {
   }
 
   backend "s3" {
-    encrypt = true
+    encrypt      = true
+    use_lockfile = true
   }
 }
 

--- a/terraform/backup/destination/main.tf
+++ b/terraform/backup/destination/main.tf
@@ -11,6 +11,7 @@ terraform {
     bucket         = "mavisbackup-terraform-state"
     region         = "eu-west-2"
     dynamodb_table = "mavisbackup-terraform-state-lock"
+    use_lockfile   = true
     encrypt        = true
   }
 }

--- a/terraform/backup/source/main.tf
+++ b/terraform/backup/source/main.tf
@@ -9,6 +9,7 @@ terraform {
 
   backend "s3" {
     region         = "eu-west-2"
+    use_lockfile   = true
     dynamodb_table = "mavis-terraform-state-lock"
     encrypt        = true
   }

--- a/terraform/data_replication/main.tf
+++ b/terraform/data_replication/main.tf
@@ -8,7 +8,8 @@ terraform {
   }
 
   backend "s3" {
-    encrypt = true
+    use_lockfile = true
+    encrypt      = true
   }
 }
 

--- a/terraform/resources/github_actions_policy.json
+++ b/terraform/resources/github_actions_policy.json
@@ -112,6 +112,7 @@
         "s3:DeleteBucketPolicy",
         "s3:DeleteObject",
         "s3:DeleteObjectVersion",
+        "s3:GetObject",
         "s3:PutBucketLogging",
         "s3:PutBucketPolicy",
         "s3:PutBucketPublicAccessBlock",


### PR DESCRIPTION
* Remove value for undeclared variable
* Move from deprecated DynamoDB state locking to state locking via lockfile. To avoid clashes, the new method needs to be rolled out first to all environments, before the DynamoDB lock mechanism can be removed