### PR TITLE
Remove unique index constraint from sessions

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -17,7 +17,8 @@
 #
 # Indexes
 #
-#  idx_on_organisation_id_location_id_academic_year_3496b72d0c  (organisation_id,location_id,academic_year) UNIQUE
+#  index_sessions_on_location_id                      (location_id)
+#  index_sessions_on_organisation_id_and_location_id  (organisation_id,location_id)
 #
 # Foreign Keys
 #

--- a/db/migrate/20250609112437_remove_unique_index_from_sessions.rb
+++ b/db/migrate/20250609112437_remove_unique_index_from_sessions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class RemoveUniqueIndexFromSessions < ActiveRecord::Migration[8.0]
+  def up
+    remove_index :sessions,
+                 column: %i[organisation_id location_id academic_year]
+
+    add_index :sessions, %i[organisation_id location_id]
+    add_index :sessions, :location_id
+  end
+
+  def down
+    remove_index :sessions, column: :location_id
+    remove_index :sessions, column: %i[organisation_id location_id]
+    add_index :sessions,
+              %i[organisation_id location_id academic_year],
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_06_070424) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_09_112437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -714,7 +714,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_06_070424) do
     t.integer "days_before_consent_reminders"
     t.string "slug", null: false
     t.date "send_invitations_at"
-    t.index ["organisation_id", "location_id", "academic_year"], name: "idx_on_organisation_id_location_id_academic_year_3496b72d0c", unique: true
+    t.index ["location_id"], name: "index_sessions_on_location_id"
+    t.index ["organisation_id", "location_id"], name: "index_sessions_on_organisation_id_and_location_id"
   end
 
   create_table "teams", force: :cascade do |t|

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -17,7 +17,8 @@
 #
 # Indexes
 #
-#  idx_on_organisation_id_location_id_academic_year_3496b72d0c  (organisation_id,location_id,academic_year) UNIQUE
+#  index_sessions_on_location_id                      (location_id)
+#  index_sessions_on_organisation_id_and_location_id  (organisation_id,location_id)
 #
 # Foreign Keys
 #

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -17,7 +17,8 @@
 #
 # Indexes
 #
-#  idx_on_organisation_id_location_id_academic_year_3496b72d0c  (organisation_id,location_id,academic_year) UNIQUE
+#  index_sessions_on_location_id                      (location_id)
+#  index_sessions_on_organisation_id_and_location_id  (organisation_id,location_id)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
As part of the upcoming flu vaccination feature, we need to support multiple sessions at the same location within the same academic year. This requires removing the unique composite index that previously enforced a one-to-one relationship between locations and sessions.

For query optimisation:
- Added a composite index on `[organisation_id, location_id]` which:
  - Supports queries filtering by both columns together
  - Supports queries filtering by `organisation_id` alone (leftmost prefix rule)
- Added a separate index on `location_id` for queries that filter by location alone (since `location_id` isn't the leftmost column in the composite index)

https://nhsd-jira.digital.nhs.uk/browse/MAV-1276