### PR TITLE
Small improvements to `hk` configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,29 @@
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
 *.log
 .DS_Store
 .bundle

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,4 +5,4 @@ awscli      2.13.31
 terraform   1.11.4
 tflint      0.55.1
 pkl         0.28.1
-hk          1.0.0
+hk          1.1.2

--- a/hk.pkl
+++ b/hk.pkl
@@ -10,14 +10,14 @@ local linters = new Mapping<String, Group> {
 
             ["prettier"] = new Step {
                 batch = true
-                glob = List("*.rb", "*.md", "*.js", "*.html", "*.erb", "*.css", "*.ejs", "*.mjs", "*.scss", "*.yaml", "*.json")
+                glob = List("*.rb", "*.rake", "*.md", "*.js", "*.html", "*.erb", "*.css", "*.ejs", "*.mjs", "*.scss", "*.yaml", "*.json")
                 check = "bin/prettier --check --ignore-unknown {{ files }}"
                 check_list_files = "bin/prettier --list-different --ignore-unknown {{ files }}"
                 fix = "bin/prettier --write --ignore-unknown {{ files }}"
             }
 
             ["rubocop"] = new Step {
-                glob = "*.rb"
+                glob = List("*.rb", "*.rake")
                 check = "bin/rubocop {{ files }}"
                 fix = "bin/rubocop --autocorrect-all {{ files }}"
             }

--- a/hk.pkl
+++ b/hk.pkl
@@ -10,6 +10,7 @@ local linters = new Mapping<String, Group> {
 
             ["prettier"] = new Step {
                 batch = true
+                glob = List("*.rb", "*.md", "*.js", "*.html", "*.erb", "*.css", "*.ejs", "*.mjs", "*.scss", "*.yaml", "*.json")
                 check = "bin/prettier --check --ignore-unknown {{ files }}"
                 check_list_files = "bin/prettier --list-different --ignore-unknown {{ files }}"
                 fix = "bin/prettier --write --ignore-unknown {{ files }}"

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.1.2/hk@1.1.2#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.1.2/hk@1.1.2#/Builtins.pkl"
 
 local linters = new Mapping<String, Group> {
     ["all"] = new Group {

--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -116,7 +116,8 @@ def create_flu_health_questions(vaccine)
         title:
           "If your child cannot have the nasal spray, do you agree to them having the injected vaccine instead?",
         hint:
-          "We may decide the nasal spray vaccine is not suitable. In this case, we may offer the injected vaccine instead."
+          "We may decide the nasal spray vaccine is not suitable. " \
+            "In this case, we may offer the injected vaccine instead."
       )
     end
 


### PR DESCRIPTION
This upgrades to the latest version of `hk` and ensures that we're not asking Prettier to lint files that it's not responsible for and cuts down the speed of the linter. I'm also hoping this will help towards the issue we've been seeing where it occasionally hits an error with an invalid JSON response.