### PR TITLE
Validate `DraftVaccinationRecord` `notes` length

### DIFF
--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -82,8 +82,13 @@ class DraftVaccinationRecord
     validates :location_name, presence: true
   end
 
+  on_wizard_step :notes, exact: true do
+    validates :notes, length: { maximum: 1000 }
+  end
+
   on_wizard_step :confirm, exact: true do
     validates :outcome, presence: true
+    validates :notes, length: { maximum: 1000 }
   end
 
   with_options on: :update,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,7 +77,7 @@ en:
             location_name:
               blank: Enter where the vaccination was given
             notes:
-              too_long: Enter notes that are less than 1000 characters long
+              too_long: Enter notes that are less than %{count} characters long
             outcome:
               inclusion: Choose an outcome
             performed_at:

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -63,6 +63,22 @@ describe DraftVaccinationRecord do
         )
       end
     end
+
+    context "on notes step" do
+      let(:attributes) { valid_administered_attributes }
+
+      before { draft_vaccination_record.wizard_step = :notes }
+
+      it { should validate_length_of(:notes).is_at_most(1000).on(:update) }
+    end
+
+    context "on confirm step" do
+      let(:attributes) { valid_administered_attributes }
+
+      before { draft_vaccination_record.wizard_step = :confirm }
+
+      it { should validate_length_of(:notes).is_at_most(1000).on(:update) }
+    end
   end
 
   describe "#write_to!" do


### PR DESCRIPTION
It must be less than 1000 characters as that is what the model requires, and without this the user sees an error page when we try to save the model to the database.

[Sentry Issue](https://good-machine.sentry.io/issues/6334292237/)

## Screenshot

<img width="756" alt="Screenshot 2025-06-09 at 18 12 30" src="https://github.com/user-attachments/assets/15cb0a5d-8205-4f43-9136-382a87798623" />
