### PR TITLE
Fix long batch name

### DIFF
--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -25,8 +25,11 @@
         <%= table.with_body do |body| %>
           <% batches.each do |batch| %>
             <% body.with_row do |row| %>
-              <% row.with_cell(text: batch.name) do %>
-                <%= batch.name %>
+              <% row.with_cell do %>
+                <span class="nhsuk-u-text-break-word">
+                  <%= batch.name %>
+                </span>
+
                 <% if batch.id == @todays_batch_id_by_programme_and_vaccine_methods[vaccine.programme][vaccine.method] %>
                   <br>
                   <span class="nhsuk-caption-m">


### PR DESCRIPTION
Currently long batch names cause the table to look weird. This was not really an issue as we do not have batch names over length 6 on prod. Regardless, a ticket was opened and so here is a fix.

Using this class, batch names are now allowed to wrap inside of the name, allowing the table with to remain limited.

See also https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3652, which is this same PR but from before I had access to the repo.

[Jira Issue - MAV-1240](https://nhsd-jira.digital.nhs.uk/browse/MAV-1240)