### PR TITLE
Add `UnsupportedProgramme` exception

### DIFF
--- a/app/lib/programme_grouper.rb
+++ b/app/lib/programme_grouper.rb
@@ -12,9 +12,7 @@ class ProgrammeGrouper
       .to_h
   end
 
-  def self.call(*args, **kwargs)
-    new(*args, **kwargs).call
-  end
+  def self.call(...) = new(...).call
 
   private_class_method :new
 
@@ -30,7 +28,7 @@ class ProgrammeGrouper
     elsif programme.doubles?
       :doubles
     else
-      raise "Unknown programme type #{programme.type}"
+      raise UnsupportedProgramme, programme
     end
   end
 end

--- a/app/lib/unsupported_programme.rb
+++ b/app/lib/unsupported_programme.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class UnsupportedProgramme < RuntimeError
+  def initialize(programme)
+    super("Unsupported programme: #{programme.name}")
+  end
+end

--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -40,7 +40,7 @@ namespace :vaccines do
         elsif programme.td_ipv?
           create_td_ipv_health_questions(vaccine)
         else
-          raise "Unknown programme: #{programme.name}"
+          raise UnsupportedProgramme, programme
         end
       end
     end


### PR DESCRIPTION
This adds an exception to capture the case where an unsupported programme has been passed in to a method. This has no change on behaviour as we already raise exceptions, but rather than raising a `RuntimeError` we can raise a more specific class and handle the message generation in one place.