### PR TITLE
Add date input to school transfer rake task

### DIFF
--- a/spec/lib/tasks/schools_rake_spec.rb
+++ b/spec/lib/tasks/schools_rake_spec.rb
@@ -2,7 +2,11 @@
 
 describe "schools:move_patients" do
   subject(:invoke) do
-    Rake::Task["schools:move_patients"].invoke(source_urn, target_urn)
+    Rake::Task["schools:move_patients"].invoke(
+      source_urn,
+      target_urn,
+      change_date
+    )
   end
 
   let(:organisation) { create(:organisation) }
@@ -16,39 +20,60 @@ describe "schools:move_patients" do
   let!(:school_move) do
     create(:school_move, patient: patient, school: source_school)
   end
-  let!(:consent_form) do
+  let!(:consent_form_before) do
     create(
       :consent_form,
       school: source_school,
       location: source_school,
-      session:
+      session:,
+      created_at: "2024-12-31"
+    )
+  end
+  let!(:consent_form_after) do
+    create(
+      :consent_form,
+      school: source_school,
+      location: source_school,
+      session:,
+      created_at: "2025-01-02"
     )
   end
   let(:other_org_school) { create(:school, team: other_team) }
 
   let(:source_urn) { source_school.urn.to_s }
   let(:target_urn) { target_school.urn.to_s }
+  let(:change_date) { "2025-01-01" }
 
   after { Rake.application["schools:move_patients"].reenable }
 
   it "transfers associated records from source to target school" do
     expect { invoke }.to change { patient.reload.school }.from(
       source_school
-    ).to(target_school).and change { consent_form.reload.school }.from(
+    ).to(target_school).and change { consent_form_after.reload.school }.from(
             source_school
-          ).to(target_school).and change { consent_form.reload.location }.from(
-                  source_school
-                ).to(target_school).and change { session.reload.location }.from(
-                        source_school
-                      ).to(target_school).and change {
+          ).to(target_school).and change {
+                  consent_form_after.reload.location
+                }.from(source_school).to(target_school).and change {
+                        session.reload.location
+                      }.from(source_school).to(target_school).and change {
                               school_move.reload.school
                             }.from(source_school).to(target_school)
 
     expect(patient.school).to eq(target_school)
-    expect(consent_form.school).to eq(target_school)
-    expect(consent_form.location).to eq(target_school)
+    expect(consent_form_after.school).to eq(target_school)
+    expect(consent_form_after.location).to eq(target_school)
     expect(session.location).to eq(target_school)
     expect(school_move.school).to eq(target_school)
+  end
+
+  it "only transfers consent forms after the change date" do
+    invoke
+
+    expect(consent_form_before.reload.school).to eq(source_school)
+    expect(consent_form_before.reload.location).to eq(source_school)
+
+    expect(consent_form_after.reload.school).to eq(target_school)
+    expect(consent_form_after.reload.location).to eq(target_school)
   end
 
   context "when source school ID is invalid" do


### PR DESCRIPTION
The schools:move_patients task now has a change_date to indicate the date after which all records should be amended with the new school. This makes the task more flexible if to be used with schools that have records on Mavis before and after a change to urn.