### PR TITLE
Save parent relationship when editing consent

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -57,7 +57,11 @@ class DraftConsentsController < ApplicationController
     ActiveRecord::Base.transaction do
       @triage&.save! if @draft_consent.response_given?
 
-      @consent.parent&.save!
+      if (parent = @consent.parent)
+        parent.save! if parent.changed?
+        parent.parent_relationships.select(&:changed?).each(&:save!)
+      end
+
       @consent.save!
 
       StatusUpdater.call(patient: @patient)

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -132,7 +132,7 @@ class Consent < ApplicationRecord
   end
 
   def parent_relationship
-    patient.parent_relationships.find { _1.parent_id == parent_id }
+    patient.parent_relationships.find { it.parent_id == parent_id }
   end
 
   def health_answers_require_follow_up?

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -297,8 +297,12 @@ class DraftConsent
   def parent_relationship
     parent
       &.parent_relationships
-      &.find { _1.patient_id == patient_id }
-      .tap { _1&.patient = patient } # acts as preload
+      &.find { it.patient_id == patient_id }
+      &.tap do
+        it.patient = patient # acts as preload
+        it.type = parent_relationship_type
+        it.other_name = parent_relationship_other_name
+      end
   end
 
   private

--- a/spec/features/verbal_consent_change_answers_spec.rb
+++ b/spec/features/verbal_consent_change_answers_spec.rb
@@ -6,11 +6,17 @@ describe "Verbal consent" do
 
     when_i_get_consent_for_the_patient
     and_i_choose_the_parent
-    and_i_fill_out_the_consent_details(parent_name: @parent.full_name)
+    and_i_fill_out_the_consent_details(
+      parent_name: @parent.full_name,
+      relationship: "Mum"
+    )
     then_i_see_the_confirmation_page
 
     when_i_click_on_change_name
-    and_i_fill_out_the_consent_details(parent_name: "New parent name")
+    and_i_fill_out_the_consent_details(
+      parent_name: "New parent name",
+      relationship: "Dad"
+    )
     then_i_see_the_confirmation_page
   end
 
@@ -23,7 +29,10 @@ describe "Verbal consent" do
     @session = create(:session, organisation:, programmes:)
 
     @parent = create(:parent)
-    @patient = create(:patient, session: @session, parents: [@parent])
+    @patient = create(:patient, session: @session)
+
+    @parent_relationship =
+      create(:parent_relationship, :mother, patient: @patient, parent: @parent)
   end
 
   def when_i_get_consent_for_the_patient
@@ -39,16 +48,15 @@ describe "Verbal consent" do
       "Choose who you are trying to get consent from"
     )
 
-    choose "#{@parent.full_name} (#{@patient.parent_relationships.first.label})"
+    choose "#{@parent.full_name} (Mum)"
     click_button "Continue"
   end
 
-  def and_i_fill_out_the_consent_details(parent_name:)
-    expect(page).to have_content(
-      "Details for #{parent_name} (#{@patient.parent_relationships.first.label})"
-    )
+  def and_i_fill_out_the_consent_details(parent_name:, relationship:)
+    expect(page).to have_content("Details for #{parent_name} (#{relationship})")
 
     fill_in "Full name", with: "New parent name"
+    choose "Dad"
     click_button "Continue"
 
     choose "By phone"
@@ -69,6 +77,8 @@ describe "Verbal consent" do
 
   def then_i_see_the_confirmation_page
     expect(page).to have_content("Check and confirm answers")
+    expect(page).to have_content("New parent name")
+    expect(page).to have_content("Dad")
   end
 
   def when_i_click_on_change_name


### PR DESCRIPTION
When going through the consent journey, if we're changing the details of an existing parent, we should make sure that the parent relationship is also saved.

This follows on from https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3253 which mostly implemented this behaviour except for the parent relationships.

[Jira Issue - MAV-790](https://nhsd-jira.digital.nhs.uk/browse/MAV-790)