### PR TITLE
Save parent relationship when editing consent

### DIFF
--- a/spec/features/verbal_consent_change_answers_spec.rb
+++ b/spec/features/verbal_consent_change_answers_spec.rb
@@ -18,6 +18,10 @@ describe "Verbal consent" do
       relationship: "Dad"
     )
     then_i_see_the_confirmation_page
+
+    when_i_confirm_the_consent
+    and_i_click_on_the_patient
+    then_i_see_the_new_parent_details
   end
 
   def given_a_patient_is_in_an_hpv_programme
@@ -83,5 +87,18 @@ describe "Verbal consent" do
 
   def when_i_click_on_change_name
     click_link "Change name"
+  end
+
+  def when_i_confirm_the_consent
+    click_button "Confirm"
+  end
+
+  def and_i_click_on_the_patient
+    click_link @patient.full_name, match: :first
+  end
+
+  def then_i_see_the_new_parent_details
+    expect(page).to have_content("New parent name")
+    expect(page).to have_content("Dad")
   end
 end


### PR DESCRIPTION
This follows on from 46c2fa53e07f6b0b94fe396170873bdb390cbe59 which didn't solve the original problem. In that commit only the check and confirm page was updated to show the correct parent relationship, but when we came to actually confirming the consent, the parent relationship itself still wasn't changing.

This fixes that by replacing the use of `find_or_initialize_by` with a simple `find` which ensures that the parent relationships remain attached to the parent and therefore can be saved. I've also updated the test to ensure this is working as expected and won't regress in the future.

[Jira Issue - MAV-790](https://nhsd-jira.digital.nhs.uk/browse/MAV-790)