### PR TITLE
Adding school URN alongside school names to the dropdown in the class list import screen

### DIFF
--- a/app/views/draft_class_imports/session.html.erb
+++ b/app/views/draft_class_imports/session.html.erb
@@ -13,7 +13,7 @@
     <%= tag.option "", value: "" %>
 
     <% @session_options.each do |session| %>
-      <%= tag.option session.location.name,
+      <%= tag.option "#{session.location.name} (URN: #{session.location.urn})",
                      value: session.id,
                      selected: session.id == @draft_class_import.session_id %>
     <% end %>


### PR DESCRIPTION
This ensures that the dropdown list includes the school names and URN to avoid any confusion with duplicate school names when MaVIS expands to more schools and regions

https://nhsd-jira.digital.nhs.uk/browse/MAV-1131