### PR TITLE
Start of follow up questions shouldn't trigger triage

### DIFF
--- a/app/helpers/consent_forms_helper.rb
+++ b/app/helpers/consent_forms_helper.rb
@@ -2,8 +2,8 @@
 
 module ConsentFormsHelper
   def health_answer_response(health_answer)
-    if health_answer.response == "yes"
-      ["Yes", health_answer.notes].join(" – ")
+    if health_answer.response_yes?
+      ["Yes", health_answer.notes].compact_blank.join(" – ")
     else
       "No"
     end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -136,7 +136,7 @@ class Consent < ApplicationRecord
   end
 
   def health_answers_require_follow_up?
-    health_answers.any? { |question| question.response&.downcase == "yes" }
+    health_answers.select(&:counts_for_triage?).any?(&:response_yes?)
   end
 
   def matched_manually?

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -319,11 +319,7 @@ class ConsentForm < ApplicationRecord
   end
 
   def needs_triage?
-    any_health_answers_truthy?
-  end
-
-  def any_health_answers_truthy?
-    health_answers.any? { it.response == "yes" }
+    health_answers.select(&:counts_for_triage?).any?(&:response_yes?)
   end
 
   def reason_notes_must_be_provided?

--- a/app/models/health_answer.rb
+++ b/app/models/health_answer.rb
@@ -13,9 +13,7 @@ class HealthAnswer
 
   validates :response, inclusion: { in: %w[yes no] }
 
-  validates :notes,
-            presence: true,
-            if: -> { requires_notes? && response == "yes" }
+  validates :notes, presence: true, if: -> { requires_notes? && response_yes? }
   validates :notes, length: { maximum: 1000 }
 
   def attributes
@@ -31,11 +29,7 @@ class HealthAnswer
   end
 
   def next_health_answer_index
-    if response == "no"
-      next_question
-    else
-      follow_up_question || next_question
-    end
+    response_no? ? next_question : follow_up_question || next_question
   end
 
   def assign_attributes(attrs)
@@ -43,7 +37,13 @@ class HealthAnswer
     super(attrs)
   end
 
-  def requires_notes? = follow_up_question.nil?
+  def counts_for_triage? = follow_up_question.nil?
+
+  def requires_notes? = counts_for_triage?
+
+  def response_yes? = response == "yes"
+
+  def response_no? = response == "no"
 
   def self.from_health_questions(health_questions)
     hq_id_map = Hash[health_questions.map.with_index { |hq, i| [hq.id, i] }]

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -445,21 +445,32 @@ describe ConsentForm do
     end
   end
 
-  describe "#any_health_answers_truthy?" do
+  describe "#needs_triage?" do
+    subject { consent_form.needs_triage? }
+
     let(:consent_form) do
       build(:consent_form, :with_health_answers_no_branching)
     end
 
-    context "no responses are yes" do
-      it "returns false" do
-        expect(consent_form.any_health_answers_truthy?).to be(false)
-      end
-    end
+    it { should be(false) }
 
     context "some responses are yes" do
-      it "returns true" do
-        consent_form.health_answers[0].response = "yes"
-        expect(consent_form.any_health_answers_truthy?).to be(true)
+      before { consent_form.health_answers[0].response = "yes" }
+
+      it { should be(true) }
+    end
+
+    context "with follow-up questions" do
+      let(:consent_form) do
+        build(:consent_form, :with_health_answers_asthma_branching)
+      end
+
+      it { should be(false) }
+
+      context "when follow-up question is yes" do
+        before { consent_form.health_answers[1].response = "yes" }
+
+        it { should be(true) }
       end
     end
   end


### PR DESCRIPTION
When a parent fills out health questions, if they're answering the start of a set of follow up questions, their answer to that question should have no impact on whether the patient needs to be triaged or not.

Instead, only if any of the follow up health questions are responded to with yes should the patient be triaged.