### PR TITLE
Make `AddResponseToConsentFormProgrammes` reversible

### DIFF
--- a/db/migrate/20250605084740_add_response_to_consent_form_programmes.rb
+++ b/db/migrate/20250605084740_add_response_to_consent_form_programmes.rb
@@ -1,46 +1,67 @@
 # frozen_string_literal: true
 
 class AddResponseToConsentFormProgrammes < ActiveRecord::Migration[8.0]
-  def change
+  # 0 = given
+  # 1 = refused
+  # 2 = given_one
+
+  def up
     add_column :consent_form_programmes, :response, :integer
 
-    # 0 = given
-    # 1 = refused
-    # 2 = given_one
+    ConsentFormProgramme
+      .joins(:consent_form)
+      .where(consent_forms: { response: 0 })
+      .update_all(response: 0)
 
-    reversible do |dir|
-      dir.up do
-        ConsentFormProgramme
-          .joins(:consent_form)
-          .where(consent_forms: { response: 0 })
-          .update_all(response: 0)
+    ConsentFormProgramme
+      .joins(:consent_form)
+      .where(consent_forms: { response: 1 })
+      .update_all(response: 1)
 
-        ConsentFormProgramme
-          .joins(:consent_form)
-          .where(consent_forms: { response: 1 })
-          .update_all(response: 1)
+    ConsentFormProgramme
+      .includes(:consent_form, :programme)
+      .where(consent_forms: { response: 2 })
+      .find_each do |consent_form_programme|
+        consent_form = consent_form_programme.consent_form
+        programme = consent_form_programme.programme
 
-        ConsentFormProgramme
-          .includes(:consent_form, :programme)
-          .where(consent_forms: { response: 2 })
-          .find_each do |consent_form_programme|
-            consent_form = consent_form_programme.consent_form
-            programme = consent_form_programme.programme
+        next if consent_form.chosen_vaccine.blank?
 
-            next if consent_form.chosen_vaccine.blank?
-
-            if programme.type == consent_form.chosen_vaccine
-              consent_form_programme.update_column(:response, 0)
-            else
-              consent_form_programme.update_column(:response, 1)
-            end
-          end
+        if programme.type == consent_form.chosen_vaccine
+          consent_form_programme.update_column(:response, 0)
+        else
+          consent_form_programme.update_column(:response, 1)
+        end
       end
-    end
 
     change_table :consent_forms, bulk: true do |t|
-      t.remove :response, type: :integer
-      t.remove :chosen_vaccine, type: :string
+      t.remove :response
+      t.remove :chosen_vaccine
     end
+  end
+
+  def down
+    change_table :consent_forms, bulk: true do |t|
+      t.integer :response
+      t.string :chosen_vaccine
+    end
+
+    ConsentForm
+      .includes(consent_form_programmes: :programme)
+      .find_each do |consent_form|
+        consent_form_programmes = consent_form.consent_form_programmes
+
+        if consent_form_programmes.all?(&:response_given?)
+          consent_form.update_column(:response, 0)
+        elsif consent_form_programmes.all?(&:response_refused?)
+          consent_form.update_column(:response, 1)
+        elsif consent_form_programmes.none? { it.response.nil? }
+          chosen_vaccine =
+            consent_form_programmes.find(&:response_given?).programme.type
+          consent_form.update_columns(response: 2, chosen_vaccine:)
+        end
+      end
+
+    remove_column :consent_form_programmes, :response
   end
 end


### PR DESCRIPTION
We may need this when testing the original migration, so opening this to make it available if we need it.