### PR TITLE
Don't add answers without a response

### DIFF
--- a/app/models/consolidated_health_answers.rb
+++ b/app/models/consolidated_health_answers.rb
@@ -8,6 +8,8 @@ class ConsolidatedHealthAnswers
   end
 
   def add_answer(responder:, question:, answer:, notes: nil)
+    return if answer.nil?
+
     @answers[question] ||= []
     @answers[question] << { responder:, answer:, notes: }
   end

--- a/spec/models/consolidated_health_answers_spec.rb
+++ b/spec/models/consolidated_health_answers_spec.rb
@@ -23,6 +23,12 @@ describe ConsolidatedHealthAnswers do
         answer: "Yes",
         notes: "Notes"
       )
+      consolidated_health_answers.add_answer(
+        responder: nil,
+        question: "Follow up question?",
+        answer: nil,
+        notes: nil
+      )
     end
 
     it do


### PR DESCRIPTION
Some answers won't have a response, specifically if they are part of follow up questions which only require a response if the root of the follow up questions was responded to with "No".

[Sentry Issue](https://good-machine.sentry.io/issues/6686274636/)