### PR TITLE
Reduce transactions going to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,7 +7,7 @@ Sentry.init do |config|
 
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
-  config.traces_sample_rate = 0.2
+  config.traces_sample_rate = 0.01
 
   config.before_send_transaction =
     lambda do |event, _hint|


### PR DESCRIPTION
We've reached our limit on spans so we should try to reduce the number of transactions going to Sentry while still being useful for debugging.