### PR TITLE
Update online consent confirmation page for Flu

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -15,7 +15,7 @@ class AppConsentConfirmationComponent < ViewComponent::Base
 
   def title
     if response_given?
-      if refused_programmes.empty?
+      if refused_consent_form_programmes.empty?
         "Consent confirmed"
       else
         "Consent for the #{given_vaccinations} confirmed"
@@ -27,8 +27,8 @@ class AppConsentConfirmationComponent < ViewComponent::Base
 
   private
 
-  delegate :given_programmes,
-           :refused_programmes,
+  delegate :given_consent_form_programmes,
+           :refused_consent_form_programmes,
            :response_given?,
            :parent_email,
            to: :@consent_form
@@ -55,15 +55,27 @@ class AppConsentConfirmationComponent < ViewComponent::Base
     end
   end
 
-  def given_vaccinations = vaccinations_text(given_programmes)
+  def given_vaccinations = vaccinations_text(given_consent_form_programmes)
 
-  def refused_vaccinations = vaccinations_text(refused_programmes)
+  def refused_vaccinations = vaccinations_text(refused_consent_form_programmes)
 
-  def vaccinations_text(programmes)
+  def vaccinations_text(consent_form_programmes)
     programme_names =
-      programmes.map do |programme|
-        programme.type == "flu" ? "nasal flu" : programme.name
-      end
+      consent_form_programmes
+        .includes(:programme)
+        .map do |consent_form_programme|
+          programme = consent_form_programme.programme
+
+          if programme.flu?
+            if consent_form_programme.vaccine_method_nasal?
+              "nasal flu"
+            else
+              "flu injection"
+            end
+          else
+            programme.name
+          end
+        end
 
     "#{programme_names.to_sentence} vaccination".pluralize(
       programme_names.count
@@ -71,7 +83,7 @@ class AppConsentConfirmationComponent < ViewComponent::Base
   end
 
   def given_vaccinations_are
-    "#{given_vaccinations} #{given_programmes.one? ? "is" : "are"}"
+    "#{given_vaccinations} #{given_consent_form_programmes.one? ? "is" : "are"}"
   end
 
   def session_dates

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -14,6 +14,36 @@ describe AppConsentConfirmationComponent do
     )
   end
 
+  context "with Flu programme" do
+    let(:programme) { create(:programme, :flu) }
+    let(:session) { create(:session, programmes: [programme]) }
+    let(:consent_form) { create(:consent_form, :given, session:) }
+
+    let(:consent_form_programme) { consent_form.consent_form_programmes.first }
+
+    context "consent for nasal Flu" do
+      before do
+        consent_form_programme.update!(
+          response: "given",
+          vaccine_methods: %w[nasal injection]
+        )
+      end
+
+      it { should have_text("is due to get the nasal flu vaccination") }
+    end
+
+    context "consent for injected Flu" do
+      before do
+        consent_form_programme.update!(
+          response: "given",
+          vaccine_methods: %w[injection]
+        )
+      end
+
+      it { should have_text("is due to get the flu injection vaccination") }
+    end
+  end
+
   context "consent for only MenACWY" do
     let(:session) do
       create(

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -233,7 +233,7 @@ RSpec.feature "Parental consent change answers" do
     expect(page).to have_content("Consent confirmed")
     expect(page).to have_content(
       "As you answered ‘yes’ to some of the health questions, " \
-        "we need to check the nasal flu vaccination is suitable for Joe Test."
+        "we need to check the flu injection vaccination is suitable for Joe Test."
     )
   end
 
@@ -245,7 +245,7 @@ RSpec.feature "Parental consent change answers" do
 
   def then_i_see_the_given_confirmation_page
     expect(page).to have_content(
-      "is due to get the nasal flu vaccination at school"
+      "is due to get the flu injection vaccination at school"
     )
   end
 


### PR DESCRIPTION
The content needs to vary depending on whether the parents have consented to the Flu vaccine via nasal spray or via injection.

[Jira Issue - MAV-1339](https://nhsd-jira.digital.nhs.uk/browse/MAV-1339)