### PR TITLE
Ensure StatusUpdater sets vaccine_methods

### DIFF
--- a/app/lib/status_updater.rb
+++ b/app/lib/status_updater.rb
@@ -43,7 +43,7 @@ class StatusUpdater
           batch,
           on_duplicate_key_update: {
             conflict_target: [:id],
-            columns: %i[status]
+            columns: %i[status vaccine_methods]
           }
         )
       end

--- a/app/models/concerns/has_vaccine_methods.rb
+++ b/app/models/concerns/has_vaccine_methods.rb
@@ -10,4 +10,12 @@ module HasVaccineMethods
 
     validates :vaccine_methods, subset: %w[injection nasal]
   end
+
+  def vaccine_method_injection? = vaccine_methods.include?("injection")
+
+  def vaccine_method_nasal? = vaccine_methods.include?("nasal")
+
+  def vaccine_method_injection_and_nasal?
+    vaccine_method_injection? && vaccine_method_nasal?
+  end
 end

--- a/app/models/consent_form_programme.rb
+++ b/app/models/consent_form_programme.rb
@@ -30,14 +30,6 @@ class ConsentFormProgramme < ApplicationRecord
 
   enum :response, { given: 0, refused: 1 }, prefix: true
 
-  def vaccine_method_injection? = vaccine_methods.include?("injection")
-
-  def vaccine_method_nasal? = vaccine_methods.include?("nasal")
-
-  def vaccine_method_injection_and_nasal?
-    vaccine_method_injection? && vaccine_method_nasal?
-  end
-
   def vaccines
     Vaccine.active.where(programme_id:, method: vaccine_methods)
   end

--- a/spec/lib/status_updater_spec.rb
+++ b/spec/lib/status_updater_spec.rb
@@ -30,6 +30,47 @@ describe StatusUpdater do
     end
   end
 
+  context "with an Flu session and eligible patient" do
+    let(:programmes) { [create(:programme, :flu)] }
+    let(:patient) { create(:patient, year_group: 8) }
+
+    it "creates a consent status" do
+      expect { call }.to change(patient.consent_statuses, :count).by(1)
+      expect(patient.consent_statuses.first).to be_no_response
+    end
+
+    context "when consent is given" do
+      before { create(:consent, patient:, programme: programmes.first) }
+
+      it "sets the vaccine methods" do
+        expect { call }.to change(patient.consent_statuses, :count).by(1)
+        expect(patient.consent_statuses.first).to be_vaccine_method_injection
+      end
+    end
+
+    it "creates a registration status" do
+      expect { call }.to change {
+        patient_session.reload.registration_status
+      }.from(nil)
+      expect(patient_session.registration_status).to be_unknown
+    end
+
+    it "creates a triage status" do
+      expect { call }.to change(patient.triage_statuses, :count).by(1)
+      expect(patient.triage_statuses.first).to be_not_required
+    end
+
+    it "creates a patient vaccination status" do
+      expect { call }.to change(patient.vaccination_statuses, :count).by(1)
+      expect(patient.vaccination_statuses.first).to be_none_yet
+    end
+
+    it "creates a patient session session vaccination status" do
+      expect { call }.to change(patient_session.session_statuses, :count).by(1)
+      expect(patient_session.session_statuses.first).to be_none_yet
+    end
+  end
+
   context "with an HPV session and eligible patient" do
     let(:programmes) { [create(:programme, :hpv)] }
     let(:patient) { create(:patient, year_group: 8) }


### PR DESCRIPTION
This is a new column on the `ConsentStatus` model so we need to ensure that it's being saved to the database as well as the existing `status` column.