### PR TITLE
Add ability to filter on vaccine method

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -64,6 +64,15 @@ class AppSearchComponent < ViewComponent::Base
           <% end %>
         <% end %>
 
+        <% if vaccine_methods.any? %>
+          <%= f.govuk_radio_buttons_fieldset :vaccine_method, legend: { text: "Vaccination method", size: "s" } do %>
+            <%= f.govuk_radio_button :vaccine_method, "", label: { text: "Any" } %>
+            <% vaccine_methods.each do |vaccine_method| %>
+              <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: Vaccine.human_enum_name(:vaccine_method, vaccine_method) } %>
+            <% end %>
+          <% end %>
+        <% end %>
+
         <% if year_groups.any? %>
           <%= f.govuk_check_boxes_fieldset :year_groups, legend: { text: "Year group", size: "s" } do %>
             <% year_groups.each do |year_group| %>
@@ -120,6 +129,7 @@ class AppSearchComponent < ViewComponent::Base
     register_statuses: [],
     session_statuses: [],
     triage_statuses: [],
+    vaccine_methods: [],
     year_groups: []
   )
     super
@@ -132,6 +142,7 @@ class AppSearchComponent < ViewComponent::Base
     @register_statuses = register_statuses
     @session_statuses = session_statuses
     @triage_statuses = triage_statuses
+    @vaccine_methods = vaccine_methods
     @year_groups = year_groups
   end
 
@@ -144,6 +155,7 @@ class AppSearchComponent < ViewComponent::Base
               :register_statuses,
               :session_statuses,
               :triage_statuses,
+              :vaccine_methods,
               :year_groups
 
   def open_details?

--- a/app/controllers/concerns/search_form_concern.rb
+++ b/app/controllers/concerns/search_form_concern.rb
@@ -17,6 +17,7 @@ module SearchFormConcern
           :register_status,
           :session_status,
           :triage_status,
+          :vaccine_method,
           consent_statuses: [],
           year_groups: []
         ),

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -15,6 +15,8 @@ class Sessions::RecordController < ApplicationController
   before_action :set_batches, except: :show
 
   def show
+    @programmes = @session.programmes
+
     scope =
       @session
         .patient_sessions
@@ -25,7 +27,7 @@ class Sessions::RecordController < ApplicationController
         .in_programmes(@session.programmes)
         .has_registration_status(%w[attending completed])
 
-    scope = @form.apply(scope)
+    scope = @form.apply(scope, programme: @programmes)
 
     patient_sessions =
       scope.select do |patient_session|
@@ -72,7 +74,10 @@ class Sessions::RecordController < ApplicationController
   private
 
   def set_session
-    @session = policy_scope(Session).find_by!(slug: params[:session_slug])
+    @session =
+      policy_scope(Session).includes(programmes: :vaccines).find_by!(
+        slug: params[:session_slug]
+      )
   end
 
   def set_todays_batches

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -18,6 +18,7 @@ class SearchForm
   attribute :register_status, :string
   attribute :session_status, :string
   attribute :triage_status, :string
+  attribute :vaccine_method, :string
   attribute :year_groups, array: true
 
   attr_accessor :session, :request_path
@@ -72,6 +73,10 @@ class SearchForm
 
     if (status = triage_status&.to_sym).present?
       scope = scope.has_triage_status(status, programme:)
+    end
+
+    if vaccine_method.present?
+      scope = scope.has_vaccine_method(vaccine_method, programme:)
     end
 
     scope.order_by_name

--- a/app/models/patient/consent_status.rb
+++ b/app/models/patient/consent_status.rb
@@ -30,6 +30,14 @@ class Patient::ConsentStatus < ApplicationRecord
            -> { not_invalidated.response_provided.includes(:parent, :patient) },
            through: :patient
 
+  scope :has_vaccine_method,
+        ->(vaccine_method) do
+          where(
+            "vaccine_methods @> ARRAY[?]::integer[]",
+            vaccine_methods.fetch(vaccine_method)
+          )
+        end
+
   enum :status,
        { no_response: 0, given: 1, refused: 2, conflicts: 3 },
        default: :no_response,

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -154,6 +154,31 @@ class PatientSession < ApplicationRecord
           )
         end
 
+  scope :has_vaccine_method,
+        ->(vaccine_method, programme:) do
+          where(
+            Patient::TriageStatus
+              .where("patient_id = patient_sessions.patient_id")
+              .where(vaccine_method:, programme:)
+              .arel
+              .exists
+          ).or(
+            where(
+              Patient::TriageStatus
+                .where("patient_id = patient_sessions.patient_id")
+                .where(status: "not_required", programme:)
+                .arel
+                .exists
+            ).where(
+              Patient::ConsentStatus
+                .where("patient_id = patient_sessions.patient_id")
+                .has_vaccine_method(vaccine_method)
+                .arel
+                .exists
+            )
+          )
+        end
+
   scope :destroy_all_if_safe,
         -> do
           includes(

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -69,6 +69,8 @@ class Programme < ApplicationRecord
     year_groups.map(&:to_birth_academic_year)
   end
 
+  def vaccine_methods = vaccines.map(&:method).uniq
+
   def available_delivery_methods
     vaccines.flat_map(&:available_delivery_methods).uniq
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -160,6 +160,10 @@ class Session < ApplicationRecord
     programmes.flat_map(&:year_groups).uniq.sort
   end
 
+  def vaccine_methods
+    programmes.flat_map(&:vaccine_methods).uniq.sort
+  end
+
   def dates
     session_dates.map(&:value).compact
   end

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -34,6 +34,7 @@
             form: @form,
             url: session_record_path(@session),
             year_groups: @session.year_groups,
+            vaccine_methods: @session.vaccine_methods.then { it.length > 1 ? it : [] },
           ) %>
     </div>
 

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -16,6 +16,7 @@ describe SearchForm do
   let(:register_status) { nil }
   let(:session_status) { nil }
   let(:triage_status) { nil }
+  let(:vaccine_method) { nil }
   let(:year_groups) { %w[8 9 10 11] }
 
   let(:params) do
@@ -30,6 +31,7 @@ describe SearchForm do
       register_status:,
       session_status:,
       triage_status:,
+      vaccine_method:,
       year_groups:
     }
   end
@@ -266,6 +268,45 @@ describe SearchForm do
             programmes: [programme]
           )
         expect(form.apply(scope, programme:)).to include(patient_session)
+      end
+    end
+
+    context "filtering on vaccine method" do
+      let(:consent_statuses) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
+      let(:missing_nhs_number) { nil }
+      let(:programme_status) { nil }
+      let(:q) { nil }
+      let(:register_status) { nil }
+      let(:triage_status) { nil }
+      let(:vaccine_method) { "nasal" }
+      let(:year_groups) { nil }
+
+      let(:programme) { create(:programme) }
+
+      it "filters on vaccine method" do
+        nasal_patient_session =
+          create(
+            :patient_session,
+            :consent_given_triage_not_needed,
+            programmes: [programme]
+          )
+
+        nasal_patient_session.patient.consent_statuses.first.update!(
+          vaccine_methods: %w[nasal injection]
+        )
+
+        create(
+          :patient_session,
+          :consent_given_triage_not_needed,
+          programmes: [programme]
+        )
+
+        expect(form.apply(scope, programme:)).to contain_exactly(
+          nasal_patient_session
+        )
       end
     end
   end

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -67,7 +67,7 @@ describe Programme do
   end
 
   describe "#year_groups" do
-    subject(:year_groups) { programme.year_groups }
+    subject { programme.year_groups }
 
     context "with a Flu programme" do
       let(:programme) { build(:programme, :flu) }
@@ -79,6 +79,22 @@ describe Programme do
       let(:programme) { build(:programme, :hpv) }
 
       it { should eq([8, 9, 10, 11]) }
+    end
+  end
+
+  describe "#vaccine_methods" do
+    subject { programme.vaccine_methods }
+
+    context "with a Flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should contain_exactly("injection", "nasal") }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should contain_exactly("injection") }
     end
   end
 

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -152,6 +152,19 @@ describe Session do
     it { should contain_exactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11) }
   end
 
+  describe "#vaccine_methods" do
+    subject { session.vaccine_methods }
+
+    let(:flu_programme) { create(:programme, :flu) }
+    let(:hpv_programme) { create(:programme, :hpv) }
+
+    let(:session) do
+      create(:session, programmes: [flu_programme, hpv_programme])
+    end
+
+    it { should contain_exactly("injection", "nasal") }
+  end
+
   describe "#today_or_future_dates" do
     subject(:today_or_future_dates) do
       travel_to(today) { session.today_or_future_dates }


### PR DESCRIPTION
This adds new filter options when viewing the "Record vaccinations" tab allowing users to filter on the consented or triaged vaccine methods for each patient.

[Jira Issue - MAV-1337](https://nhsd-jira.digital.nhs.uk/browse/MAV-1337)

## Screenshot

<img width="347" alt="Screenshot 2025-06-18 at 20 27 07" src="https://github.com/user-attachments/assets/5322a8d7-9b61-4d54-9f7d-9a29fca42d9f" />
