### PR TITLE
Identity checks

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -13,6 +13,23 @@
         Pre-screening checks
       </h3>
 
+      <%= f.govuk_radio_buttons_fieldset :identity_check_confirmed_by_patient,
+                                         legend: { text: "Has #{patient.given_name} confirmed their identity?", size: nil } do %>
+
+        <%= f.govuk_radio_button :identity_check_confirmed_by_patient, true, label: { text: "Yes" }, link_errors: true %>
+
+        <%= f.govuk_radio_button :identity_check_confirmed_by_patient, false,
+                                 label: { text: "No, it was confirmed by somebody else" } do %>
+
+          <%= f.govuk_text_field :identity_check_confirmed_by_other_name,
+                                 label: { text: "What is the person’s name?" } %>
+
+          <%= f.govuk_text_field :identity_check_confirmed_by_other_relationship,
+                                 label: { text: "What is their relationship to the child?" },
+                                 hint: { text: "For example, parent, teacher or teaching assistant" } %>
+        <% end %>
+      <% end %>
+
       <p><%= patient.given_name %> has confirmed that they:</p>
 
       <ul class="nhsuk-list nhsuk-list--bullet">

--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -15,6 +15,7 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
     @show_notes = show_notes
 
     @batch = vaccination_record.batch
+    @identity_check = vaccination_record.identity_check
     @patient = vaccination_record.patient
     @programme = vaccination_record.programme
     @vaccine = vaccination_record.vaccine
@@ -154,6 +155,20 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
           summary_list.with_row do |row|
             row.with_key { "Dose number" }
             row.with_value { dose_number_value }
+          end
+        end
+      end
+
+      if @identity_check
+        summary_list.with_row do |row|
+          row.with_key { "Child identified by" }
+          row.with_value { helpers.identity_check_label(@identity_check) }
+          if (href = @change_links[:identity])
+            row.with_action(
+              text: "Change",
+              href:,
+              visually_hidden_text: "child identified by"
+            )
           end
         end
       end

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -147,6 +147,11 @@ class DraftVaccinationRecordsController < ApplicationController
       date_and_time: %i[performed_at],
       delivery: %i[delivery_site delivery_method],
       dose: %i[full_dose],
+      identity: %i[
+        identity_check_confirmed_by_patient
+        identity_check_confirmed_by_other_name
+        identity_check_confirmed_by_other_relationship
+      ],
       location: %i[location_name],
       notes: %i[notes],
       outcome: %i[outcome]

--- a/app/controllers/patient_sessions/vaccinations_controller.rb
+++ b/app/controllers/patient_sessions/vaccinations_controller.rb
@@ -27,6 +27,7 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
       steps = draft_vaccination_record.wizard_steps
 
       steps.delete(:notes) # this is on the confirmation page
+      steps.delete(:identity) # this is on the confirmation page
 
       steps.delete(:date_and_time)
       steps.delete(:outcome) if draft_vaccination_record.administered?
@@ -56,6 +57,9 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
         delivery_method
         delivery_site
         dose_sequence
+        identity_check_confirmed_by_other_name
+        identity_check_confirmed_by_other_relationship
+        identity_check_confirmed_by_patient
         pre_screening_confirmed
         pre_screening_notes
         vaccine_id

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -6,6 +6,10 @@ class VaccinateForm
 
   attr_accessor :patient_session, :programme, :current_user, :todays_batch
 
+  attribute :identity_check_confirmed_by_other_name, :string
+  attribute :identity_check_confirmed_by_other_relationship, :string
+  attribute :identity_check_confirmed_by_patient, :boolean
+
   attribute :pre_screening_confirmed, :boolean
   attribute :pre_screening_notes, :string
 
@@ -14,6 +18,19 @@ class VaccinateForm
   attribute :delivery_site, :string
   attribute :dose_sequence, :integer
   attribute :programme_id, :integer
+
+  validates :identity_check_confirmed_by_patient,
+            inclusion: {
+              in: [true, false]
+            }
+  validates :identity_check_confirmed_by_other_name,
+            :identity_check_confirmed_by_other_relationship,
+            presence: {
+              if: -> { identity_check_confirmed_by_patient == false }
+            },
+            length: {
+              maximum: 300
+            }
 
   validates :administered, inclusion: [true, false]
   validates :pre_screening_notes, length: { maximum: 1000 }
@@ -42,6 +59,12 @@ class VaccinateForm
 
     draft_vaccination_record.batch_id = todays_batch&.id
     draft_vaccination_record.dose_sequence = dose_sequence
+    draft_vaccination_record.identity_check_confirmed_by_other_name =
+      identity_check_confirmed_by_other_name
+    draft_vaccination_record.identity_check_confirmed_by_other_relationship =
+      identity_check_confirmed_by_other_relationship
+    draft_vaccination_record.identity_check_confirmed_by_patient =
+      identity_check_confirmed_by_patient
     draft_vaccination_record.patient_id = patient_session.patient_id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user

--- a/app/helpers/identity_checks_helper.rb
+++ b/app/helpers/identity_checks_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module IdentityChecksHelper
+  def identity_check_label(identity_check)
+    if identity_check.confirmed_by_patient?
+      "The child"
+    else
+      "#{identity_check.confirmed_by_other_name} (#{identity_check.confirmed_by_other_relationship})"
+    end
+  end
+end

--- a/app/models/identity_check.rb
+++ b/app/models/identity_check.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: identity_checks
+#
+#  id                              :bigint           not null, primary key
+#  confirmed_by_other_name         :string           default(""), not null
+#  confirmed_by_other_relationship :string           default(""), not null
+#  confirmed_by_patient            :boolean          not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  vaccination_record_id           :bigint           not null
+#
+# Indexes
+#
+#  index_identity_checks_on_vaccination_record_id  (vaccination_record_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vaccination_record_id => vaccination_records.id) ON DELETE => cascade
+#
+class IdentityCheck < ApplicationRecord
+  audited
+
+  belongs_to :vaccination_record
+
+  scope :confirmed_by_patient, -> { where(confirmed_by_patient: true) }
+
+  scope :confirmed_by_other, -> { where(confirmed_by_patient: false) }
+
+  validates :confirmed_by_other_name,
+            :confirmed_by_other_relationship,
+            presence: {
+              if: :confirmed_by_other?
+            },
+            absence: {
+              if: :confirmed_by_patient?
+            }
+
+  def confirmed_by_other? = !confirmed_by_patient
+end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -90,7 +90,7 @@ class VaccinationRecord < ApplicationRecord
   belongs_to :patient
   belongs_to :session, optional: true
 
-  has_one :identity_check, dependent: :destroy
+  has_one :identity_check, autosave: true, dependent: :destroy
   has_one :location, through: :session
   has_one :organisation, through: :session
   has_one :team, through: :session

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -90,6 +90,7 @@ class VaccinationRecord < ApplicationRecord
   belongs_to :patient
   belongs_to :session, optional: true
 
+  has_one :identity_check, dependent: :destroy
   has_one :location, through: :session
   has_one :organisation, through: :session
   has_one :team, through: :session

--- a/app/views/draft_vaccination_records/confirm.html.erb
+++ b/app/views/draft_vaccination_records/confirm.html.erb
@@ -19,6 +19,7 @@
      delivery_method: wizard_path("delivery"),
      delivery_site: wizard_path("delivery"),
      dose_volume: @draft_vaccination_record.wizard_steps.include?(:dose) ? wizard_path("dose") : nil,
+     identity: wizard_path("identity"),
      location: @draft_vaccination_record.wizard_steps.include?(:location) ? wizard_path("location") : nil,
      notes: wizard_path("notes"),
      outcome: @draft_vaccination_record.wizard_steps.include?(:outcome) ? wizard_path("outcome") : nil,

--- a/app/views/draft_vaccination_records/identity.html.erb
+++ b/app/views/draft_vaccination_records/identity.html.erb
@@ -1,0 +1,28 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(@back_link_path) %>
+<% end %>
+
+<% legend = "Who confirmed #{@patient.given_name}’s identity?" %>
+<% content_for :page_title, legend %>
+
+<%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_radio_buttons_fieldset :identity_check_confirmed_by_patient,
+                                     legend: { text: legend, tag: "h1", size: "l" },
+                                     caption: { text: @patient.full_name, size: "l" } do %>
+
+    <%= f.govuk_radio_button :identity_check_confirmed_by_patient, true, label: { text: "The child" }, link_errors: true %>
+
+    <%= f.govuk_radio_button :identity_check_confirmed_by_patient, false, label: { text: "Someone else" } do %>
+      <%= f.govuk_text_field :identity_check_confirmed_by_other_name,
+                             label: { text: "What is the person’s name?" } %>
+
+      <%= f.govuk_text_field :identity_check_confirmed_by_other_relationship,
+                             label: { text: "What is their relationship to the child?" },
+                             hint: { text: "For example, parent, teacher or teaching assistant" } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,12 @@ en:
               injection_cannot_be_nose: Site cannot be nose for intramuscular or subcutaneous injections
             full_dose:
               inclusion: Choose whether they got the full dose
+            identity_check_confirmed_by_other_name:
+              blank: Enter the person’s name
+            identity_check_confirmed_by_other_relationship:
+              blank: Enter the person’s relationship
+            identity_check_confirmed_by_patient:
+              inclusion: Choose who confirmed their child’s identity
             location_name:
               blank: Enter where the vaccination was given
             notes:
@@ -631,6 +637,7 @@ en:
     file_format: file-format
     gp: gp
     health_question: health-question
+    identity: identity
     injection_alternative: injection-alternative
     location: location
     name: name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,14 @@ en:
               inclusion: Choose if they are ready to vaccinate
             delivery_site:
               blank: Choose where the injection will be given
+            identity_check_confirmed_by_other_name:
+              blank: Enter the person’s name
+              too_long: Enter a name that is less than %{count} characters long
+            identity_check_confirmed_by_other_relationship:
+              blank: Enter the person’s relationship
+              too_long: Enter a relationship that is less than %{count} characters long
+            identity_check_confirmed_by_patient:
+              inclusion: Choose whether the child confirmed their identity
             pre_screening_confirmed:
               blank: Select if the child has confirmed all pre-screening statements are true
             pre_screening_notes:

--- a/db/migrate/20250618190014_create_identity_checks.rb
+++ b/db/migrate/20250618190014_create_identity_checks.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateIdentityChecks < ActiveRecord::Migration[8.0]
+  def change
+    create_table :identity_checks do |t|
+      t.boolean :confirmed_by_patient, null: false
+      t.string :confirmed_by_other_name, null: false, default: ""
+      t.string :confirmed_by_other_relationship, null: false, default: ""
+      t.references :vaccination_record,
+                   null: false,
+                   foreign_key: {
+                     on_delete: :cascade
+                   }
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -400,6 +400,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_142922) do
     t.index ["vaccine_id"], name: "index_health_questions_on_vaccine_id"
   end
 
+  create_table "identity_checks", force: :cascade do |t|
+    t.boolean "confirmed_by_patient", null: false
+    t.string "confirmed_by_other_name", default: "", null: false
+    t.string "confirmed_by_other_relationship", default: "", null: false
+    t.bigint "vaccination_record_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["vaccination_record_id"], name: "index_identity_checks_on_vaccination_record_id"
+  end
+
   create_table "immunisation_imports", force: :cascade do |t|
     t.text "csv_data"
     t.bigint "uploaded_by_user_id", null: false
@@ -885,6 +895,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_142922) do
   add_foreign_key "health_questions", "health_questions", column: "follow_up_question_id"
   add_foreign_key "health_questions", "health_questions", column: "next_question_id"
   add_foreign_key "health_questions", "vaccines"
+  add_foreign_key "identity_checks", "vaccination_records", on_delete: :cascade
   add_foreign_key "immunisation_imports", "organisations"
   add_foreign_key "immunisation_imports", "users", column: "uploaded_by_user_id"
   add_foreign_key "immunisation_imports_patient_sessions", "immunisation_imports"

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -33,6 +33,9 @@ describe AppVaccinateFormComponent do
       patient.consent_status(programme:).update!(vaccine_methods: %w[nasal])
     end
 
+    it { should have_content("Has Hari confirmed their identity?") }
+    it { should have_field("No, it was confirmed by somebody else") }
+
     it { should have_heading("Is Hari ready for their Flu vaccination?") }
 
     it { should have_field("Yes") }
@@ -46,6 +49,9 @@ describe AppVaccinateFormComponent do
 
   context "with a Flu programme" do
     let(:programme) { create(:programme, :flu) }
+
+    it { should have_content("Has Hari confirmed their identity?") }
+    it { should have_field("No, it was confirmed by somebody else") }
 
     it { should have_heading("Is Hari ready for their Flu vaccination?") }
 
@@ -84,6 +90,9 @@ describe AppVaccinateFormComponent do
 
   context "with an HPV programme" do
     let(:programme) { create(:programme, :hpv) }
+
+    it { should have_content("Has Hari confirmed their identity?") }
+    it { should have_field("No, it was confirmed by somebody else") }
 
     it { should have_heading("Is Hari ready for their HPV vaccination?") }
 

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -249,6 +249,28 @@ describe AppVaccinationRecordSummaryComponent do
     end
   end
 
+  describe "identity check row" do
+    it do
+      expect(rendered).not_to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Child identified by"
+      )
+    end
+
+    context "with an identity check" do
+      before do
+        create(:identity_check, :confirmed_by_patient, vaccination_record:)
+      end
+
+      it do
+        expect(rendered).to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Child identified by\nThe child"
+        )
+      end
+    end
+  end
+
   describe "location row" do
     it do
       expect(rendered).to have_css(

--- a/spec/factories/identity_checks.rb
+++ b/spec/factories/identity_checks.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: identity_checks
+#
+#  id                              :bigint           not null, primary key
+#  confirmed_by_other_name         :string           default(""), not null
+#  confirmed_by_other_relationship :string           default(""), not null
+#  confirmed_by_patient            :boolean          not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  vaccination_record_id           :bigint           not null
+#
+# Indexes
+#
+#  index_identity_checks_on_vaccination_record_id  (vaccination_record_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vaccination_record_id => vaccination_records.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :identity_check do
+    vaccination_record
+
+    trait :confirmed_by_patient do
+      confirmed_by_patient { true }
+      confirmed_by_other_name { "" }
+      confirmed_by_other_relationship { "" }
+    end
+
+    trait :confirmed_by_other do
+      confirmed_by_patient { false }
+      confirmed_by_other_name { Faker::Name.name }
+      confirmed_by_other_relationship { Faker::Relationship.familial }
+    end
+  end
+end

--- a/spec/features/community_clinic_vaccination_session_spec.rb
+++ b/spec/features/community_clinic_vaccination_session_spec.rb
@@ -41,8 +41,14 @@ describe "Community clinic vaccination session" do
     visit session_record_path(@session)
     click_link @patient.full_name
 
-    choose "No"
-    click_button "Continue"
+    within all("section")[0] do
+      choose "Yes"
+    end
+
+    within all("section")[1] do
+      choose "No"
+      click_button "Continue"
+    end
 
     choose "They refused"
     click_button "Continue"

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -75,9 +75,15 @@ describe "MenACWY and Td/IPV vaccination" do
   end
 
   def and_i_record_the_vaccination(batch)
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_on "Continue"
+    within all("section")[0] do
+      choose "Yes"
+    end
+
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
 
     choose batch.name
     click_on "Continue"

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -241,11 +241,16 @@ describe "End-to-end journey" do
 
     expect(page).to have_content("Update attendance")
 
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
 
     choose @batch.name
     click_button "Continue"

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -7,6 +7,7 @@ describe "HPV vaccination" do
     given_i_am_signed_in
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_confirm_the_identity
     and_i_fill_in_pre_screening_questions
     and_i_record_that_the_patient_has_been_vaccinated(
       "Left arm (upper position)"
@@ -60,6 +61,7 @@ describe "HPV vaccination" do
     given_i_am_signed_in
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_confirm_the_identity
     and_i_fill_in_pre_screening_questions
     and_i_record_that_the_patient_has_been_vaccinated("Other")
     and_i_select_the_delivery
@@ -109,14 +111,22 @@ describe "HPV vaccination" do
     click_link @patient.full_name
   end
 
+  def and_i_confirm_the_identity
+    within all("section")[0] do
+      choose "Yes"
+    end
+  end
+
   def and_i_fill_in_pre_screening_questions
     check "has confirmed the above statements are true"
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated(where)
-    choose "Yes"
-    choose where
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose where
+      click_button "Continue"
+    end
   end
 
   def and_i_see_only_not_expired_batches

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -49,10 +49,15 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_wasnt_vaccinated
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "No"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "No"
+      click_button "Continue"
+    end
   end
 
   def and_i_select_the_reason_why

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -63,11 +63,16 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
   end
 
   def and_i_select_the_batch

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -55,8 +55,14 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_was_unwell
-    choose "No"
-    click_button "Continue"
+    within all("section")[0] do
+      choose "Yes"
+    end
+
+    within all("section")[1] do
+      choose "No"
+      click_button "Continue"
+    end
 
     choose "They were not well enough"
     click_button "Continue"

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -88,11 +88,16 @@ describe "MenACWY vaccination" do
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
   end
 
   def and_i_see_only_not_expired_batches

--- a/spec/features/pre_screening_spec.rb
+++ b/spec/features/pre_screening_spec.rb
@@ -98,9 +98,15 @@ describe "Pre-screening" do
   end
 
   def and_i_record_vaccination_without_pre_screening_checks
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[0] do
+      choose "Yes"
+    end
+
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
   end
 
   def then_i_see_an_error_message

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -88,11 +88,16 @@ describe "Td/IPV vaccination" do
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
   end
 
   def and_i_see_only_not_expired_batches

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -66,11 +66,16 @@ describe "Vaccination" do
 
     click_link @patient.full_name
 
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
 
     choose @hpv_batch.name
 
@@ -97,11 +102,16 @@ describe "Vaccination" do
 
     click_link @patient2.full_name
 
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
   end
 
   def then_i_see_the_default_batch_banner_with_batch_1
@@ -147,11 +157,16 @@ describe "Vaccination" do
     click_link @patient.full_name
     click_on "MenACWY"
 
-    check "has confirmed the above statements are true"
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
 
-    choose "Yes"
-    choose "Left arm (upper position)"
-    click_button "Continue"
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
   end
 
   def then_i_am_required_to_choose_a_batch

--- a/spec/forms/vaccinate_form_spec.rb
+++ b/spec/forms/vaccinate_form_spec.rb
@@ -4,6 +4,42 @@ describe VaccinateForm do
   subject(:form) { described_class.new }
 
   describe "validations" do
+    it do
+      expect(form).to allow_values(true, false).for(
+        :identity_check_confirmed_by_patient
+      )
+    end
+
+    it do
+      expect(form).to validate_length_of(
+        :identity_check_confirmed_by_other_name
+      ).is_at_most(300)
+    end
+
+    it do
+      expect(form).to validate_length_of(
+        :identity_check_confirmed_by_other_relationship
+      ).is_at_most(300)
+    end
+
+    context "when confirmed by someone else" do
+      subject(:form) do
+        described_class.new(identity_check_confirmed_by_patient: false)
+      end
+
+      it do
+        expect(form).to validate_presence_of(
+          :identity_check_confirmed_by_other_name
+        )
+      end
+
+      it do
+        expect(form).to validate_presence_of(
+          :identity_check_confirmed_by_other_relationship
+        )
+      end
+    end
+
     it { should validate_length_of(:pre_screening_notes).is_at_most(1000) }
   end
 end

--- a/spec/helpers/identity_checks_helper_spec.rb
+++ b/spec/helpers/identity_checks_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe IdentityChecksHelper do
+  describe "#identity_check_label" do
+    subject { helper.identity_check_label(identity_check) }
+
+    context "when confirmed by the patient" do
+      let(:identity_check) { create(:identity_check, :confirmed_by_patient) }
+
+      it { should eq("The child") }
+    end
+
+    context "when confirmed by someone else" do
+      let(:identity_check) do
+        create(
+          :identity_check,
+          :confirmed_by_other,
+          confirmed_by_other_name: "Arthur Dent",
+          confirmed_by_other_relationship: "Friend"
+        )
+      end
+
+      it { should eq("Arthur Dent (Friend)") }
+    end
+  end
+end

--- a/spec/models/identity_check_spec.rb
+++ b/spec/models/identity_check_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: identity_checks
+#
+#  id                              :bigint           not null, primary key
+#  confirmed_by_other_name         :string           default(""), not null
+#  confirmed_by_other_relationship :string           default(""), not null
+#  confirmed_by_patient            :boolean          not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  vaccination_record_id           :bigint           not null
+#
+# Indexes
+#
+#  index_identity_checks_on_vaccination_record_id  (vaccination_record_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vaccination_record_id => vaccination_records.id) ON DELETE => cascade
+#
+describe IdentityCheck do
+  describe "associations" do
+    it { should belong_to(:vaccination_record) }
+  end
+
+  describe "scopes" do
+    let(:confirmed_by_patient) do
+      create(:identity_check, :confirmed_by_patient)
+    end
+    let(:confirmed_by_other) { create(:identity_check, :confirmed_by_other) }
+
+    describe "#confirmed_by_patient" do
+      subject(:scope) { described_class.confirmed_by_patient }
+
+      it { should include(confirmed_by_patient) }
+      it { should_not include(confirmed_by_other) }
+    end
+
+    describe "#confirmed_by_other" do
+      subject(:scope) { described_class.confirmed_by_other }
+
+      it { should include(confirmed_by_other) }
+      it { should_not include(confirmed_by_patient) }
+    end
+  end
+
+  describe "validations" do
+    context "when confirmed by patient" do
+      subject { build(:identity_check, :confirmed_by_patient) }
+
+      it { should validate_absence_of(:confirmed_by_other_name) }
+      it { should validate_absence_of(:confirmed_by_other_relationship) }
+    end
+
+    context "when confirmed by someone else" do
+      subject { build(:identity_check, :confirmed_by_other) }
+
+      it { should validate_presence_of(:confirmed_by_other_name) }
+      it { should validate_presence_of(:confirmed_by_other_relationship) }
+    end
+  end
+
+  describe "#confirmed_by_patient?" do
+    subject { identity_check.confirmed_by_patient? }
+
+    context "when confirmed by patient" do
+      let(:identity_check) { build(:identity_check, :confirmed_by_patient) }
+
+      it { should be(true) }
+    end
+
+    context "when confirmed by someone else" do
+      let(:identity_check) { build(:identity_check, :confirmed_by_other) }
+
+      it { should be(false) }
+    end
+  end
+
+  describe "#confirmed_by_other?" do
+    subject { identity_check.confirmed_by_other? }
+
+    context "when confirmed by patient" do
+      let(:identity_check) { build(:identity_check, :confirmed_by_patient) }
+
+      it { should be(false) }
+    end
+
+    context "when confirmed by someone else" do
+      let(:identity_check) { build(:identity_check, :confirmed_by_other) }
+
+      it { should be(true) }
+    end
+  end
+end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -53,6 +53,10 @@
 describe VaccinationRecord do
   subject(:vaccination_record) { build(:vaccination_record) }
 
+  describe "associations" do
+    it { should have_one(:identity_check).dependent(:destroy) }
+  end
+
   describe "validations" do
     context "when administered" do
       it { should allow_values(true, false).for(:full_dose) }

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -54,7 +54,7 @@ describe VaccinationRecord do
   subject(:vaccination_record) { build(:vaccination_record) }
 
   describe "associations" do
-    it { should have_one(:identity_check).dependent(:destroy) }
+    it { should have_one(:identity_check).autosave(true).dependent(:destroy) }
   end
 
   describe "validations" do


### PR DESCRIPTION
This adds the functionality requiring nurses to record the identity check they performed before recording a vaccination. I've decided to create a new `IdentityCheck` model to store this information as not all vaccination records will have an identity check and this helps with keeping the concerns of identity check vs vaccination records separate.

[Jira Issue - MAV-1349](https://nhsd-jira.digital.nhs.uk/browse/MAV-1349)

## Screenshots

<img width="867" alt="Screenshot 2025-06-18 at 22 03 59" src="https://github.com/user-attachments/assets/a0c571f9-1814-42a0-a2ce-6590fee4c0db" />
<img width="636" alt="Screenshot 2025-06-18 at 22 11 58" src="https://github.com/user-attachments/assets/d642e253-15b2-4a9d-a330-be7baa1371be" />

<img width="859" alt="Screenshot 2025-06-18 at 22 13 28" src="https://github.com/user-attachments/assets/a5f4278b-bb52-483a-b4f9-8493a817a1aa" />
<img width="772" alt="Screenshot 2025-06-18 at 22 14 00" src="https://github.com/user-attachments/assets/40874caa-b612-46c4-9ea0-3823ba96a67d" />
