### PR TITLE
Allow sessions to not have registration

### DIFF
--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -21,7 +21,8 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
     patient.consent_given_and_safe_to_vaccinate?(programme:, academic_year:) &&
       (
         patient_session.registration_status&.attending? ||
-          patient_session.registration_status&.completed? || false
+          patient_session.registration_status&.completed? ||
+          !patient_session.session.requires_registration?
       )
   end
 

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -27,7 +27,7 @@ class AppSessionActionsComponent < ViewComponent::Base
       no_consent_response_row,
       conflicting_consent_row,
       triage_required_row,
-      register_attendance_row,
+      (register_attendance_row if session.requires_registration?),
       ready_for_vaccinator_row
     ].compact
   end

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -17,13 +17,14 @@ class Sessions::RecordController < ApplicationController
 
   def show
     scope =
-      @session
-        .patient_sessions
-        .includes(
-          :latest_note,
-          patient: %i[consent_statuses triage_statuses vaccination_statuses]
-        )
-        .has_registration_status(%w[attending completed])
+      @session.patient_sessions.includes(
+        :latest_note,
+        patient: %i[consent_statuses triage_statuses vaccination_statuses]
+      )
+
+    if @session.requires_registration?
+      scope = scope.has_registration_status(%w[attending completed])
+    end
 
     patient_sessions =
       @form.apply(scope).consent_given_and_ready_to_vaccinate(

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -7,6 +7,7 @@
 #  id                            :bigint           not null, primary key
 #  academic_year                 :integer          not null
 #  days_before_consent_reminders :integer
+#  requires_registration         :boolean          default(TRUE), not null
 #  send_consent_requests_at      :date
 #  send_invitations_at           :date
 #  slug                          :string           not null
@@ -104,6 +105,8 @@ class Session < ApplicationRecord
         end
   scope :send_invitations,
         -> { scheduled.where("? >= send_invitations_at", Date.current) }
+
+  scope :registration_not_required, -> { where(requires_registration: false) }
 
   validates :send_consent_requests_at,
             presence: true,

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -29,7 +29,7 @@
       <%= render AppRegisterStatusTagComponent.new(@patient_session.registration_status&.status || "unknown") %>
     </li>
 
-    <% if policy(session_attendance).edit? %>
+    <% if policy(session_attendance).edit? && @session.requires_registration? %>
       <li class="app-action-list__item">
         <%= link_to(
               "Update attendance",

--- a/app/views/sessions/_header.html.erb
+++ b/app/views/sessions/_header.html.erb
@@ -23,11 +23,13 @@
         selected: request.path == session_triage_path(@session),
       )
     
-      nav.with_item(
-        href: session_register_path(@session),
-        text: t("sessions.tabs.register"),
-        selected: request.path == session_register_path(@session),
-      )
+      if @session.requires_registration?
+        nav.with_item(
+          href: session_register_path(@session),
+          text: t("sessions.tabs.register"),
+          selected: request.path == session_register_path(@session),
+        )
+      end
     
       nav.with_item(
         href: session_record_path(@session),

--- a/db/migrate/20250717093714_add_requires_registration_field_to_sessions.rb
+++ b/db/migrate/20250717093714_add_requires_registration_field_to_sessions.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddRequiresRegistrationFieldToSessions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :sessions,
+               :requires_registration,
+               :boolean,
+               default: true,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -752,6 +752,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_18_090719) do
     t.integer "days_before_consent_reminders"
     t.string "slug", null: false
     t.date "send_invitations_at"
+    t.boolean "requires_registration", default: true, null: false
     t.index ["location_id"], name: "index_sessions_on_location_id"
     t.index ["organisation_id", "location_id"], name: "index_sessions_on_organisation_id_and_location_id"
   end

--- a/spec/components/app_patient_session_record_component_spec.rb
+++ b/spec/components/app_patient_session_record_component_spec.rb
@@ -40,5 +40,11 @@ describe AppPatientSessionRecordComponent do
 
       it { should be(false) }
     end
+
+    context "session requires no registration" do
+      let(:session) { create(:session, :requires_no_registration, programmes:) }
+
+      it { should be(true) }
+    end
   end
 end

--- a/spec/components/app_session_actions_component_spec.rb
+++ b/spec/components/app_session_actions_component_spec.rb
@@ -47,4 +47,10 @@ describe AppSessionActionsComponent do
   it { should have_link("Review triage needed") }
   it { should have_link("Review register attendance") }
   it { should have_link("Review ready for vaccinator") }
+
+  context "session requires no registration" do
+    let(:session) { create(:session, :requires_no_registration, programmes:) }
+
+    it { should_not have_link("Review register attendance") }
+  end
 end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -7,6 +7,7 @@
 #  id                            :bigint           not null, primary key
 #  academic_year                 :integer          not null
 #  days_before_consent_reminders :integer
+#  requires_registration         :boolean          default(TRUE), not null
 #  send_consent_requests_at      :date
 #  send_invitations_at           :date
 #  slug                          :string           not null
@@ -79,6 +80,10 @@ FactoryBot.define do
 
     trait :completed do
       date { Date.current - 1.week }
+    end
+
+    trait :requires_no_registration do
+      requires_registration { false }
     end
   end
 end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -72,6 +72,21 @@ describe "HPV vaccination" do
     then_i_see_a_success_message
   end
 
+  scenario "Administered without registration" do
+    given_registrations_are_not_required
+    and_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_fill_in_pre_screening_questions
+    and_i_record_that_the_patient_has_been_vaccinated("Other")
+    and_i_select_the_delivery
+    and_i_select_the_batch
+    then_i_see_the_confirmation_page
+
+    when_i_confirm_the_details
+    then_i_see_a_success_message
+  end
+
   def given_i_am_signed_in
     programme = create(:programme, :hpv_all_vaccines)
     organisation =
@@ -93,8 +108,16 @@ describe "HPV vaccination" do
       build(:batch, :expired, organisation:, vaccine: @active_vaccine)
     @expired_batch.save!(validate: false)
 
+    session_traits =
+      @registrations_are_not_required ? [:requires_no_registration] : []
     @session =
-      create(:session, organisation:, programmes: [programme], location:)
+      create(
+        :session,
+        *session_traits,
+        organisation:,
+        programmes: [programme],
+        location:
+      )
     @patient =
       create(
         :patient,
@@ -104,6 +127,12 @@ describe "HPV vaccination" do
       )
 
     sign_in organisation.users.first
+  end
+
+  alias_method :and_i_am_signed_in, :given_i_am_signed_in
+
+  def given_registrations_are_not_required
+    @registrations_are_not_required = true
   end
 
   def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled

--- a/spec/features/manage_attendance_spec.rb
+++ b/spec/features/manage_attendance_spec.rb
@@ -5,7 +5,8 @@ describe "Manage attendance" do
 
   scenario "Recording attendance for a patient" do
     given_my_organisation_is_running_an_hpv_vaccination_programme
-    and_there_is_a_vaccination_session_today_with_a_patient_ready_to_vaccinate
+    and_there_is_a_vaccination_session_today
+    and_the_session_has_patients
 
     when_i_go_to_the_session
     and_i_click_on_the_register_tab
@@ -42,13 +43,26 @@ describe "Manage attendance" do
     then_i_see_the_attendance_event
   end
 
+  scenario "Recording vaccinations where patient does not need registration" do
+    given_my_organisation_is_running_an_hpv_vaccination_programme
+    and_there_is_a_vaccination_session_today_that_requires_no_registration
+    and_the_session_has_patients
+
+    when_i_go_to_the_session
+    then_i_should_not_see_the_register_tab
+
+    when_i_go_to_the_session_outcomes
+    and_i_go_to_a_patient
+    then_i_should_not_see_link_to_update_attendance
+  end
+
   def given_my_organisation_is_running_an_hpv_vaccination_programme
     @programmes = [create(:programme, :hpv_all_vaccines)]
     @organisation =
       create(:organisation, :with_one_nurse, programmes: @programmes)
   end
 
-  def and_there_is_a_vaccination_session_today_with_a_patient_ready_to_vaccinate
+  def and_there_is_a_vaccination_session_today
     location = create(:school, organisation: @organisation)
     @session =
       create(
@@ -58,7 +72,22 @@ describe "Manage attendance" do
         organisation: @organisation,
         location:
       )
+  end
 
+  def and_there_is_a_vaccination_session_today_that_requires_no_registration
+    location = create(:school, organisation: @organisation)
+    @session =
+      create(
+        :session,
+        :today,
+        :requires_no_registration,
+        programmes: @programmes,
+        organisation: @organisation,
+        location:
+      )
+  end
+
+  def and_the_session_has_patients
     create_list(
       :patient_session,
       3,
@@ -79,8 +108,24 @@ describe "Manage attendance" do
     click_link "Register"
   end
 
+  def when_i_click_on_the_record_vaccinations_tab
+    click_link "Record vaccinations"
+  end
+
+  def then_i_should_not_see_the_register_tab
+    expect(page).not_to have_content("Register")
+  end
+
+  def then_i_should_not_see_link_to_update_attendance
+    expect(page).not_to have_content("Update attendance")
+  end
+
   def then_i_see_the_register_tab
     expect(page).to have_content("Registration status")
+  end
+
+  def then_i_see_the_patient
+    expect(page).to have_content("Showing 1 to 1 of 1 children")
   end
 
   def and_i_see_the_actions_required
@@ -118,6 +163,8 @@ describe "Manage attendance" do
                  .patient
                  .full_name
   end
+
+  alias_method :and_i_go_to_a_patient, :when_i_go_to_a_patient
 
   def then_the_patient_is_not_registered_yet
     expect(page).to have_content("Not registered yet")

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -7,6 +7,7 @@
 #  id                            :bigint           not null, primary key
 #  academic_year                 :integer          not null
 #  days_before_consent_reminders :integer
+#  requires_registration         :boolean          default(TRUE), not null
 #  send_consent_requests_at      :date
 #  send_invitations_at           :date
 #  slug                          :string           not null


### PR DESCRIPTION
This PR introduces a new boolean column `requires_registration` to the `Session` model, allowing us to control whether registration is required for a specific session. When registration is not required, the "Register" tab will be hidden, but users can still access all patients under the "Record vaccinations" tab.

JIRA: [MAV-1292](https://nhsd-jira.digital.nhs.uk/browse/MAV-1292)
