### PR TITLE
Fix layout of patient session for narrower viewports

### DIFF
--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -1,16 +1,35 @@
-// Search filters and results
-.app-grid-column-filters .nhsuk-card--feature.app-filters,
-.app-grid-column-results > .nhsuk-card--feature,
-.app-grid-column-results > .nhsuk-warning-callout {
-  margin-top: nhsuk-spacing(3);
+// Patient session and record
+.app-grid-column-patient-session {
+  @include nhsuk-grid-column(
+    three-quarters,
+    $float: right,
+    $at: large-desktop,
+    $class: false
+  );
 }
 
+.app-grid-column-patient-record {
+  @include nhsuk-grid-column(
+    one-quarter,
+    $float: right,
+    $at: large-desktop,
+    $class: false
+  );
+}
+
+// Search filters and results
 .app-grid-column-filters {
   @include nhsuk-grid-column(filters, $at: large-desktop, $class: false);
 }
 
 .app-grid-column-results {
   @include nhsuk-grid-column(results, $at: large-desktop, $class: false);
+}
+
+.app-grid-column-filters .nhsuk-card--feature.app-filters,
+.app-grid-column-results > .nhsuk-card--feature,
+.app-grid-column-results > .nhsuk-warning-callout {
+  margin-top: nhsuk-spacing(3);
 }
 
 // Sticky column

--- a/app/views/patient_sessions/programmes/show.html.erb
+++ b/app/views/patient_sessions/programmes/show.html.erb
@@ -1,7 +1,11 @@
 <%= render "patient_sessions/header" %>
 
 <div class="nhsuk-grid-row">
-  <div class="nhsuk-grid-column-three-quarters">
+  <div class="app-grid-column-patient-record">
+    <%= render AppPatientSummaryComponent.new(@patient) %>
+  </div>
+
+  <div class="app-grid-column-patient-session">
     <%= render AppPatientSessionConsentComponent.new(@patient_session, programme: @programme) %>
 
     <%= render AppPatientSessionTriageComponent.new(@patient_session, programme: @programme, triage: @triage) %>
@@ -9,9 +13,5 @@
     <%= render AppPatientSessionRecordComponent.new(@patient_session, programme: @programme, vaccinate_form: @vaccinate_form) %>
 
     <%= render AppPatientSessionOutcomeComponent.new(@patient_session, programme: @programme) %>
-  </div>
-
-  <div class="nhsuk-grid-column-one-quarter">
-    <%= render AppPatientSummaryComponent.new(@patient) %>
   </div>
 </div>


### PR DESCRIPTION
Add custom grid columns that `float: right` instead of `float: left`. This allows us to have the patient record in the source order first, but have it appear on the right at larger breakpoints.