### PR TITLE
Add side effects to vaccines

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -65,7 +65,8 @@ class GovukNotifyPersonalisation
       team_name:,
       team_phone:,
       today_or_date_of_vaccination:,
-      vaccination:
+      vaccination:,
+      vaccine_side_effects:
     }.compact
   end
 
@@ -285,5 +286,21 @@ class GovukNotifyPersonalisation
       programme_name,
       programmes.count == 1 ? "vaccination" : "vaccinations"
     ].join(" ")
+  end
+
+  def vaccine_side_effects
+    side_effects =
+      if vaccination_record
+        vaccination_record.vaccine&.side_effects
+      elsif programmes.present?
+        Vaccine.where(programme: programmes).flat_map(&:side_effects)
+      end
+
+    return if side_effects.nil?
+
+    descriptions =
+      side_effects.map { Vaccine.human_enum_name(:side_effect, it) }.sort.uniq
+
+    descriptions.map { "- #{it}" }.join("\n")
   end
 end

--- a/app/models/concerns/has_side_effects.rb
+++ b/app/models/concerns/has_side_effects.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module HasSideEffects
+  extend ActiveSupport::Concern
+
+  included do
+    extend ArrayEnum
+
+    array_enum side_effects: {
+                 aching: 0,
+                 dizziness: 1,
+                 drowsy: 2,
+                 feeling_sick: 3,
+                 headache: 4,
+                 high_temperature: 5,
+                 irritable: 6,
+                 loss_of_appetite: 8,
+                 pain_in_arms: 9,
+                 raised_temperature: 10,
+                 rash: 11,
+                 runny_blocked_nose: 12,
+                 swelling: 13,
+                 tiredness: 14,
+                 unwell: 15
+               }
+
+    validates :side_effects, subset: side_effects.keys
+  end
+end

--- a/app/models/concerns/has_vaccine_methods.rb
+++ b/app/models/concerns/has_vaccine_methods.rb
@@ -8,7 +8,7 @@ module HasVaccineMethods
 
     array_enum vaccine_methods: { injection: 0, nasal: 1 }
 
-    validates :vaccine_methods, subset: %w[injection nasal]
+    validates :vaccine_methods, subset: vaccine_methods.keys
   end
 
   def vaccine_method_injection? = vaccine_methods.include?("injection")

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -11,6 +11,7 @@
 #  manufacturer        :text             not null
 #  method              :integer          not null
 #  nivs_name           :text             not null
+#  side_effects        :integer          default([]), not null, is an Array
 #  snomed_product_code :string           not null
 #  snomed_product_term :string           not null
 #  created_at          :datetime         not null
@@ -30,6 +31,8 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class Vaccine < ApplicationRecord
+  include HasSideEffects
+
   audited associated_with: :programme
   has_associated_audits
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -231,6 +231,22 @@ en:
           injection: Injection
           nasal: Nasal spray
           nasal_injection: Nasal spray (or injection)
+        side_effects:
+          aching: an aching body
+          dizziness: dizziness
+          drowsy: feeling drowsy
+          feeling_sick: feeling sick
+          headache: a headache
+          high_temperature: a high temperature
+          irritable: feeling irritable
+          loss_of_appetite: loss of appetite
+          pain_in_arms: pain in the arms, hands, fingers
+          raised_temperature: a slightly raised temperature
+          rash: a rash
+          runny_blocked_nose: a runny or blocked nose
+          swelling: swelling or pain where the injection was given
+          tiredness: general tiredness
+          unwell: generally feeling unwell
     errors:
       models:
         class_import:

--- a/db/migrate/20250619125105_add_side_effects_to_vaccines.rb
+++ b/db/migrate/20250619125105_add_side_effects_to_vaccines.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddSideEffectsToVaccines < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vaccines,
+               :side_effects,
+               :integer,
+               array: true,
+               default: [],
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -842,6 +842,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_02_142922) do
     t.text "nivs_name", null: false
     t.boolean "discontinued", default: false, null: false
     t.bigint "programme_id", null: false
+    t.integer "side_effects", default: [], null: false, array: true
     t.index ["manufacturer", "brand"], name: "index_vaccines_on_manufacturer_and_brand", unique: true
     t.index ["nivs_name"], name: "index_vaccines_on_nivs_name", unique: true
     t.index ["programme_id"], name: "index_vaccines_on_programme_id"

--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -26,6 +26,8 @@ namespace :vaccines do
       vaccine.snomed_product_term = data["snomed_product_term"]
       vaccine.programme = programme
 
+      vaccine.side_effects = side_effects_for(programme, data["method"])
+
       vaccine.save!
 
       next if vaccine.health_questions.exists?
@@ -44,6 +46,61 @@ namespace :vaccines do
         end
       end
     end
+  end
+end
+
+def side_effects_for(programme, method)
+  if programme.flu?
+    if method == "nasal"
+      %w[runny_blocked_nose headache tiredness loss_of_appetite]
+    else
+      %w[
+        swelling
+        headache
+        high_temperature
+        feeling_sick
+        irritable
+        drowsy
+        loss_of_appetite
+        unwell
+      ]
+    end
+  elsif programme.hpv?
+    %w[
+      swelling
+      headache
+      high_temperature
+      feeling_sick
+      irritable
+      drowsy
+      loss_of_appetite
+      unwell
+    ]
+  elsif programme.menacwy?
+    %w[
+      drowsy
+      feeling_sick
+      headache
+      high_temperature
+      irritable
+      loss_of_appetite
+      rash
+      swelling
+      unwell
+    ]
+  elsif programme.td_ipv?
+    %w[
+      drowsy
+      feeling_sick
+      headache
+      high_temperature
+      irritable
+      loss_of_appetite
+      swelling
+      unwell
+    ]
+  else
+    raise UnsupportedProgramme, programme
   end
 end
 

--- a/spec/factories/vaccines.rb
+++ b/spec/factories/vaccines.rb
@@ -11,6 +11,7 @@
 #  manufacturer        :text             not null
 #  method              :integer          not null
 #  nivs_name           :text             not null
+#  side_effects        :integer          default([]), not null, is an Array
 #  snomed_product_code :string           not null
 #  snomed_product_term :string           not null
 #  created_at          :datetime         not null

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -73,7 +73,8 @@ describe GovukNotifyPersonalisation do
         team_email: "organisation@example.com",
         team_name: "Organisation",
         team_phone: "01234 567890 (option 1)",
-        vaccination: "HPV vaccination"
+        vaccination: "HPV vaccination",
+        vaccine_side_effects: ""
       }
     )
   end
@@ -237,6 +238,21 @@ describe GovukNotifyPersonalisation do
           today_or_date_of_vaccination: "1 January 2024",
           outcome_administered: "no",
           outcome_not_administered: "yes"
+        )
+      )
+    end
+  end
+
+  context "with vaccine side effects" do
+    before do
+      programmes.first.vaccines.first.update!(side_effects: %w[swelling unwell])
+    end
+
+    it do
+      expect(to_h).to match(
+        hash_including(
+          vaccine_side_effects:
+            "- generally feeling unwell\n- swelling or pain where the injection was given"
         )
       )
     end

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -11,6 +11,7 @@
 #  manufacturer        :text             not null
 #  method              :integer          not null
 #  nivs_name           :text             not null
+#  side_effects        :integer          default([]), not null, is an Array
 #  snomed_product_code :string           not null
 #  snomed_product_term :string           not null
 #  created_at          :datetime         not null


### PR DESCRIPTION
We need to add support for storing the side effects of each vaccine so these can be displayed dynamically in the emails for the session reminders and the vaccination confirmations. This allows them to be included in emails we send out to users, either before a session for all programmes, or after a session for a vaccination record.

The `vaccines:seed[...]` task needs to be run for HPV, MenACWY and Td/IPV. We don't run it for Flu yet.

Duplicate https://www.notifications.service.gov.uk/services/629645d8-feb9-4fc1-93f4-759c93ac0e21/templates/79e131b2-7816-46d0-9c74-ae14956dd77d and deploy a branch that uses new template, where new template has `((vaccine_side_effects))` instead of hard coded list.

[Jira Issue - MAV-1354](https://nhsd-jira.digital.nhs.uk/browse/MAV-1354)
[Jira Issue - MAV-1355](https://nhsd-jira.digital.nhs.uk/browse/MAV-1355)