### PR TITLE
Hide previous years seasonal vaccinations

### DIFF
--- a/app/components/app_patient_vaccination_table_component.rb
+++ b/app/components/app_patient_vaccination_table_component.rb
@@ -21,5 +21,6 @@ class AppPatientVaccinationTableComponent < ViewComponent::Base
       .then { programme ? it.where(programme:) : it }
       .includes(:location, :programme)
       .order(performed_at: :desc)
+      .select(&:show_this_academic_year?)
   end
 end

--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -11,7 +11,7 @@ class VaccinatedCriteria
     vaccination_records_for_programme =
       vaccination_records.select { it.programme_id == programme.id }
 
-    if programme.flu?
+    if programme.seasonal?
       vaccination_records_for_programme
         .select { it.administered? || it.already_had? }
         .any?(&:performed_this_academic_year?)

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -179,6 +179,10 @@ class VaccinationRecord < ApplicationRecord
     academic_year == Date.current.academic_year
   end
 
+  def show_this_academic_year?
+    programme.seasonal? ? performed_this_academic_year? : true
+  end
+
   private
 
   def requires_location_name?

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -24,6 +24,8 @@ describe AppPatientVaccinationTableComponent do
 
     let(:vaccination_record_programme) { create(:programme, :hpv) }
 
+    let(:performed_at) { Time.zone.local(2024, 1, 1) }
+
     before do
       create(
         :vaccination_record,
@@ -35,7 +37,7 @@ describe AppPatientVaccinationTableComponent do
             programmes: [vaccination_record_programme]
           ),
         programme: vaccination_record_programme,
-        performed_at: Time.zone.local(2024, 1, 1)
+        performed_at:
       )
     end
 
@@ -60,6 +62,18 @@ describe AppPatientVaccinationTableComponent do
       it { should_not have_content("Waterloo Road, London, SE1 8TY") }
       it { should_not have_content("Vaccinated") }
       it { should_not have_content("HPV") }
+    end
+
+    context "with a Flu vaccination record from a previous year" do
+      let(:vaccination_record_programme) { create(:programme, :flu) }
+      let(:programme) { vaccination_record_programme }
+      let(:performed_at) { Time.zone.local(2022, 1, 1) }
+
+      it { should_not have_link("1 January 2022") }
+      it { should_not have_content("Test School") }
+      it { should_not have_content("Waterloo Road, London, SE1 8TY") }
+      it { should_not have_content("Vaccinated") }
+      it { should_not have_content("Flu") }
     end
   end
 end


### PR DESCRIPTION
If displaying a table of vaccination records for Flu we should hide any that were performed in the previous academic year, as the Flu programme is administered yearly.

[Jira Issue - MAV-1359](https://nhsd-jira.digital.nhs.uk/browse/MAV-1359)