### PR TITLE
Fix data replication deployment

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -71,12 +71,18 @@ jobs:
           if [ -z "${{ inputs.db_snapshot_arn }}" ]; then
               echo "No snapshot ARN provided, fetching the latest snapshot"
               SNAPSHOT_ARN=$(aws rds describe-db-cluster-snapshots \
-              --query 'DBClusterSnapshots[?contains(DBClusterSnapshotIdentifier, `${{ inputs.environment}}`)].[DBClusterSnapshotArn, SnapshotCreateTime]' \
+              --query "DBClusterSnapshots[?DBClusterIdentifier=='mavis-${{ inputs.environment }}'].[DBClusterSnapshotArn, SnapshotCreateTime]" \
               --output text | sort -k2 -r | head -n 1 | cut -f1)
+          
+              if [ -z "$SNAPSHOT_ARN" ]; then
+                  echo "No snapshots found for mavis-${{ inputs.environment }}"
+                  exit 1
+              fi
           else
               echo "Using provided snapshot ARN: ${{ inputs.db_snapshot_arn }}"
               SNAPSHOT_ARN="${{ inputs.db_snapshot_arn }}"
           fi
+          echo "Using snapshot ARN: $SNAPSHOT_ARN"
           echo "SNAPSHOT_ARN=$SNAPSHOT_ARN" >> $GITHUB_OUTPUT
       - name: Install terraform
         uses: hashicorp/setup-terraform@v3

--- a/terraform/account/resources/iam_policy_DeployDataReplicationResources.json
+++ b/terraform/account/resources/iam_policy_DeployDataReplicationResources.json
@@ -23,7 +23,8 @@
       "NotResource": [
         "arn:aws:s3:::nhse-mavis-terraform-state-production",
         "arn:aws:s3:::nhse-mavis-terraform-state",
-        "arn:aws:kms:eu-west-2:*:key/*"
+        "arn:aws:kms:eu-west-2:*:key/*",
+        "arn:aws:rds:eu-west-2:*:cluster-snapshot:*"
       ],
       "Condition": {
         "StringEquals": {
@@ -45,7 +46,12 @@
         "kms:Delete*",
         "kms:ScheduleKeyDeletion",
         "kms:Revoke*",
-        "kms:Disable*"
+        "kms:Disable*",
+        "kms:CreateGrant",
+        "kms:CancelKeyDeletion",
+        "kms:PutKeyPolicy",
+        "kms:ReplicateKey",
+        "kms:RetireGrant"
       ],
       "Resource": "*"
     },

--- a/terraform/account/resources/iam_policy_DeployDataReplicationResources.json
+++ b/terraform/account/resources/iam_policy_DeployDataReplicationResources.json
@@ -22,7 +22,8 @@
       "Action": ["*"],
       "NotResource": [
         "arn:aws:s3:::nhse-mavis-terraform-state-production",
-        "arn:aws:s3:::nhse-mavis-terraform-state"
+        "arn:aws:s3:::nhse-mavis-terraform-state",
+        "arn:aws:kms:eu-west-2:*:key/*"
       ],
       "Condition": {
         "StringEquals": {
@@ -37,6 +38,16 @@
           ]
         }
       }
+    },
+    {
+      "Effect": "Deny",
+      "Action": [
+        "kms:Delete*",
+        "kms:ScheduleKeyDeletion",
+        "kms:Revoke*",
+        "kms:Disable*"
+      ],
+      "Resource": "*"
     },
     {
       "Effect": "Allow",

--- a/terraform/account/resources/iam_policy_DeployMavisResources.json
+++ b/terraform/account/resources/iam_policy_DeployMavisResources.json
@@ -128,6 +128,7 @@
         "secretsmanager:GetSecretValue",
         "secretsmanager:RotateSecret",
         "secretsmanager:DeleteSecret",
+        "secretsmanager:CancelRotateSecret",
         "ssm:DeleteParameter",
         "ssm:DeleteParameters",
         "ssm:PutParameter"


### PR DESCRIPTION
* Now that the DB uses a custom KMS key, the role for deploying data replication resources needs access to this key.
* To keep the restrictions restrictive, any actions that would disable the key are still denied