### PR TITLE
Allow custom image build for production ECR

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -2,6 +2,10 @@ name: Build and push image
 
 on:
   workflow_dispatch:
+    inputs:
+      git-sha:
+        description: The FULL git commit sha to build the image from (optional).
+        type: string
   workflow_call:
     inputs:
       git-sha:


### PR DESCRIPTION
* To build and push an image from a custom commit, the FULL commit sha can be passed as input. 

> [!Warning]  
> The short commit sha doesn't work as the Checkout GitHub workflow action behaves different in this case and will fail
