### PR TITLE
Show full vaccine method label when consent for multiple delivery methods exist

### DIFF
--- a/app/components/app_programme_status_tags_component.rb
+++ b/app/components/app_programme_status_tags_component.rb
@@ -12,11 +12,9 @@ class AppProgrammeStatusTagsComponent < ViewComponent::Base
     safe_join(
       programme_statuses.map do |programme, hash|
         status = hash[:status]
-        vaccine_method =
-          if programme.has_multiple_delivery_methods?
-            hash[:vaccine_methods]&.first
-          end
-        programme_status_tag(programme, status, vaccine_method)
+        vaccine_methods =
+          (hash[:vaccine_methods] if programme.has_multiple_delivery_methods?)
+        programme_status_tag(programme, status, vaccine_methods)
       end
     )
   end
@@ -25,7 +23,7 @@ class AppProgrammeStatusTagsComponent < ViewComponent::Base
 
   attr_reader :programme_statuses, :outcome
 
-  def programme_status_tag(programme, status, vaccine_method)
+  def programme_status_tag(programme, status, vaccine_methods)
     programme_tag =
       tag.strong(
         programme.name,
@@ -38,9 +36,9 @@ class AppProgrammeStatusTagsComponent < ViewComponent::Base
     status_tag = tag.strong(label, class: "nhsuk-tag nhsuk-tag--#{colour}")
 
     vaccine_methods_span =
-      if vaccine_method.present?
+      if vaccine_methods.present?
         tag.span(
-          Vaccine.human_enum_name(:method, vaccine_method),
+          Vaccine.human_enum_name(:method, vaccine_methods.join("_")),
           class: "nhsuk-u-secondary-text-color"
         )
       end

--- a/app/helpers/consents_helper.rb
+++ b/app/helpers/consents_helper.rb
@@ -24,7 +24,7 @@ module ConsentsHelper
       if consent.vaccine_methods.present? &&
            consent.programme.has_multiple_delivery_methods?
         tag.span(
-          Vaccine.human_enum_name(:method, consent.vaccine_methods.first),
+          Vaccine.human_enum_name(:method, consent.vaccine_methods.join("_")),
           class: "nhsuk-u-secondary-text-color"
         )
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,7 @@ en:
         methods:
           injection: Injection
           nasal: Nasal spray
+          nasal_injection: Nasal spray (or injection)
     errors:
       models:
         class_import:

--- a/spec/components/app_programme_status_tags_component_spec.rb
+++ b/spec/components/app_programme_status_tags_component_spec.rb
@@ -19,12 +19,12 @@ describe AppProgrammeStatusTagsComponent do
       },
       flu_programme => {
         status: :given,
-        vaccine_methods: %w[injection]
+        vaccine_methods: %w[nasal injection]
       }
     }
   end
 
   it { should have_content("MenACWYConsent given") }
   it { should have_content("Td/IPVConsent refused") }
-  it { should have_content("FluConsent givenInjection") }
+  it { should have_content("FluConsent givenNasal spray (or injection)") }
 end


### PR DESCRIPTION
Updates the programme status tag component to display "Nasal spray (or injection)" when multiple delivery methods are associated with a programme (flu). This replaces the previous behaviour of showing only the first vaccine method, ensuring consistency with how delivery methods are communicated to users in the prototype.

![image](https://github.com/user-attachments/assets/d8331743-f663-4c2f-adf1-209feb763665)

https://nhsd-jira.digital.nhs.uk/browse/MAV-1234