### PR TITLE
Update Flu triage flow to reflect consented vaccine methods

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -110,7 +110,7 @@ class DraftConsentsController < ApplicationController
 
   def update_params
     permitted_attributes = {
-      agree: %i[response],
+      agree: %i[response injection_alternative],
       notes: %i[notes],
       notify_parents: %i[notify_parents],
       parent_details: %i[
@@ -180,6 +180,7 @@ class DraftConsentsController < ApplicationController
       if policy(Triage).new?
         TriageForm.new(
           notes: @draft_consent.triage_notes,
+          vaccine_methods: @draft_consent.vaccine_methods,
           patient_session: @patient_session,
           programme: @programme,
           status_and_vaccine_method:

--- a/app/forms/triage_form.rb
+++ b/app/forms/triage_form.rb
@@ -8,6 +8,7 @@ class TriageForm
 
   attribute :status_and_vaccine_method, :string
   attribute :notes, :string
+  attribute :vaccine_methods, array: true, default: []
 
   validates :status_and_vaccine_method,
             inclusion: {
@@ -60,7 +61,8 @@ class TriageForm
 
   def consented_vaccine_methods
     @consented_vaccine_methods ||=
-      patient.consent_status(programme:).vaccine_methods
+      vaccine_methods.presence ||
+        patient.consent_status(programme:).vaccine_methods
   end
 
   def triage_attributes

--- a/app/views/draft_consents/agree.html.erb
+++ b/app/views/draft_consents/agree.html.erb
@@ -13,8 +13,23 @@
                                      legend: { size: "l",
                                                tag: "h1",
                                                text: title }) do %>
-    <%= f.govuk_radio_button :response, "given",
-                             label: { text: "Yes, they agree" }, link_errors: true %>
+    <% if @draft_consent.programme.flu? %>
+      <%= f.govuk_radio_button :response, "given_nasal",
+                               label: { text: "Yes, for the nasal spray" }, link_errors: true do %>
+        <%= f.govuk_radio_buttons_fieldset :action,
+                                           legend: { text: "Do they also agree to the injected vaccine if the nasal spray is not suitable?", size: "s" },
+                                           hint: { text: "For example, if the child is heavily congested on the day of the vaccination", size: "s" } do %>
+          <%= f.govuk_radio_button :injection_alternative, "true", label: { text: "Yes" } %>
+          <%= f.govuk_radio_button :injection_alternative, "false", label: { text: "No" } %>
+        <% end %>
+      <% end %>
+      <%= f.govuk_radio_button :response, "given_injection",
+                               label: { text: "Yes, for the injected vaccine only" } %>
+    <% else %>
+      <%= f.govuk_radio_button :response, "given",
+                               label: { text: "Yes, they agree" }, link_errors: true %>
+    <% end %>
+
     <%= f.govuk_radio_button :response, "refused",
                              label: { text: "No, they do not agree" } %>
     <% unless @draft_consent.via_self_consent? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,8 @@ en:
               inclusion: Choose if they consent
             route:
               inclusion: Choose how the response was given
+            injection_alternative:
+              inclusion: Select yes or no
         draft_vaccination_record:
           attributes:
             batch_id:

--- a/spec/forms/triage_form_spec.rb
+++ b/spec/forms/triage_form_spec.rb
@@ -14,6 +14,7 @@ describe TriageForm do
     end
 
     it { should_not validate_presence_of(:notes) }
+    it { should_not validate_presence_of(:vaccine_methods) }
     it { should validate_length_of(:notes).is_at_most(1000) }
   end
 end

--- a/spec/models/draft_consent_spec.rb
+++ b/spec/models/draft_consent_spec.rb
@@ -27,6 +27,17 @@ describe DraftConsent do
     }
   end
 
+  let(:valid_given_nasal_attributes) do
+    valid_given_attributes.merge(
+      response: "given_nasal",
+      injection_alternative: false
+    )
+  end
+
+  let(:valid_given_injection_attributes) do
+    valid_given_attributes.merge(response: "given_injection")
+  end
+
   let(:valid_refused_attributes) do
     {
       response: "refused",
@@ -42,6 +53,20 @@ describe DraftConsent do
   describe "validations" do
     context "when given" do
       let(:attributes) { valid_given_attributes }
+
+      it { should be_valid }
+    end
+
+    context "when given nasal" do
+      let(:attributes) { valid_given_nasal_attributes }
+
+      it { should be_valid }
+    end
+
+    context "when given injection" do
+      let(:attributes) do
+        valid_given_attributes.merge(response: "given_injection")
+      end
 
       it { should be_valid }
     end
@@ -68,6 +93,18 @@ describe DraftConsent do
         )
       end
     end
+
+    context "when given nasal" do
+      let(:attributes) { valid_given_nasal_attributes }
+
+      it "sets the response to given" do
+        freeze_time do
+          expect { write_to }.to change(consent, :response).from(nil).to(
+            "given"
+          )
+        end
+      end
+    end
   end
 
   describe "#reset_unused_fields" do
@@ -91,13 +128,71 @@ describe DraftConsent do
       end
     end
 
+    context "when given flu via nasal" do
+      let(:attributes) { valid_given_nasal_attributes }
+
+      it "sets vaccine_methods to nasal" do
+        expect { save! }.to change(draft_consent, :vaccine_methods).to(
+          %w[nasal]
+        )
+      end
+
+      context "when injection allowed as an alternative" do
+        let(:attributes) do
+          valid_given_nasal_attributes.merge(injection_alternative: true)
+        end
+
+        it "sets vaccine_methods to nasal and injection" do
+          expect { save! }.to change(draft_consent, :vaccine_methods).to(
+            %w[nasal injection]
+          )
+        end
+      end
+
+      context "when rejecting injection alternative" do
+        let(:attributes) do
+          valid_given_nasal_attributes.merge(injection_alternative: false)
+        end
+
+        it "sets vaccine_methods to nasal and injection" do
+          expect { save! }.to change(draft_consent, :vaccine_methods).to(
+            %w[nasal]
+          )
+        end
+      end
+    end
+
+    context "when given flu injection" do
+      let(:attributes) { valid_given_injection_attributes }
+
+      it "sets vaccine_methods to injection" do
+        expect { save! }.to change(draft_consent, :vaccine_methods).to(
+          %w[injection]
+        )
+      end
+    end
+
     context "when refused" do
       let(:attributes) do
-        valid_refused_attributes.merge(health_answers: [{ "id" => "0" }])
+        valid_refused_attributes.merge(
+          health_answers: [{ "id" => "0" }],
+          vaccine_methods: %w[nasal],
+          injection_alternative: true
+        )
       end
 
       it "clears the health answers" do
         expect { save! }.to change(draft_consent, :health_answers).to([])
+      end
+
+      it "clears the vaccine methods" do
+        expect { save! }.to change(draft_consent, :vaccine_methods).to([])
+      end
+
+      it "clears injection_alternative" do
+        expect { save! }.to change(draft_consent, :injection_alternative).to(
+          nil
+        )
       end
     end
 

--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -70,7 +70,8 @@ resource "aws_secretsmanager_secret_rotation" "target" {
   secret_id          = aws_rds_cluster.core.master_user_secret[0].secret_arn
   rotate_immediately = false
   rotation_rules {
-    schedule_expression = "cron(0 8 ? * WED *)"
+    schedule_expression = "cron(0 2 ? * WED#4 *)"
+    duration            = "1h"
   }
 }
 


### PR DESCRIPTION
### Context
This enhancement updates the triage flow for Flu to reflect the consented vaccine method(s) provided by parents. It allows clinicians to select an appropriate method where multiple are consented, or restricts options when only one method is permitted.


### Screenshots
| Non-flu programme | Flu programme |
|------------------|---------------------|
| <img width="665" alt="Screenshot 2025-06-25 at 09 43 24" src="https://github.com/user-attachments/assets/6245541e-a95d-4a5f-9941-1aa132630a43" /> | <img width="746" alt="Screenshot 2025-06-25 at 09 36 04" src="https://github.com/user-attachments/assets/dbc1c09a-9fd7-41c4-a47c-a395f89f53ae" /> | 

JIRA: [MAV-1267](https://nhsd-jira.digital.nhs.uk/browse/MAV-1267)

