### PR TITLE
Change triage options text

### DIFF
--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -30,10 +30,12 @@ class AppTriageFormComponent < ViewComponent::Base
     text = "Is it safe to vaccinate #{patient.given_name}?"
     hint =
       if programme.has_multiple_delivery_methods?
-        if triage_form.consented_to_injection?
-          "The parent has consented to the injected vaccine being offered instead"
+        if triage_form.consented_to_injection_only?
+          "The parent has consented to the injected vaccine only"
+        elsif triage_form.consented_to_injection?
+          "The parent has consented to the injected vaccine being offered if the nasal spray is not suitable"
         else
-          "The parent has not given consent for the injected vaccine"
+          "The parent has consented to the nasal spray only"
         end
       end
 

--- a/app/forms/triage_form.rb
+++ b/app/forms/triage_form.rb
@@ -40,8 +40,8 @@ class TriageForm
 
   def status_and_vaccine_method_options
     safe_to_vaccinate_choices =
-      if consented_vaccine_methods.length > 1
-        consented_vaccine_methods.map { "safe_to_vaccinate_#{it}" }
+      if programme.has_multiple_delivery_methods?
+        consented_vaccine_methods.map { |method| "safe_to_vaccinate_#{method}" }
       else
         ["safe_to_vaccinate"]
       end
@@ -51,6 +51,8 @@ class TriageForm
   end
 
   def consented_to_injection? = consented_vaccine_methods.include?("injection")
+
+  def consented_to_injection_only? = consented_vaccine_methods == ["injection"]
 
   private
 

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -27,8 +27,8 @@ en:
           do_not_vaccinate: No, do not vaccinate
           keep_in_triage: No, keep in triage
           safe_to_vaccinate: Yes, it’s safe to vaccinate
-          safe_to_vaccinate_injection: Yes, it’s safe to vaccinate (with injected vaccine only)
-          safe_to_vaccinate_nasal: Yes, it’s safe to vaccinate
+          safe_to_vaccinate_injection: Yes, it’s safe to vaccinate with injected vaccine
+          safe_to_vaccinate_nasal: Yes, it’s safe to vaccinate with nasal spray
       vaccination_report:
         file_format_options:
           careplus: CarePlus

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 describe AppTriageFormComponent do
-  subject { render_inline(component) }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) { described_class.new(triage_form, url:) }
+  let(:url) { "/triage" }
 
   let(:programme) { create(:programme) }
   let(:patient_session) { create(:patient_session, programmes: [programme]) }
   let(:patient) { patient_session.patient }
 
   let(:triage_form) { TriageForm.new(patient_session:, programme:) }
-  let(:url) { "/triage" }
 
   it { should have_css("h2") }
   it { should have_text("Is it safe to vaccinate") }
@@ -20,5 +20,103 @@ describe AppTriageFormComponent do
     let(:component) { described_class.new(triage_form, url:, heading: false) }
 
     it { should have_css(".app-fieldset__legend--reset") }
+  end
+
+  describe "hint text and triage options for consented delivery method(s)" do
+    let(:programme) { create(:programme, :flu) }
+
+    context "when only injection is consented to" do
+      before do
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[injection]
+        )
+      end
+
+      it "shows the correct hint about injection only" do
+        expect(rendered).to have_text(
+          "The parent has consented to the injected vaccine only"
+        )
+      end
+
+      it "shows the correct safe triage option for injection only" do
+        expect(rendered).to have_text("safe to vaccinate with injected vaccine")
+        expect(rendered).not_to have_text("safe to vaccinate with nasal spray")
+      end
+    end
+
+    context "when both nasal and injection are consented to" do
+      before do
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[injection nasal]
+        )
+      end
+
+      it "shows the correct hint about injection being offered" do
+        expect(rendered).to have_text(
+          "The parent has consented to the injected vaccine being offered if the nasal spray is not suitable"
+        )
+      end
+
+      it "shows the correct safe triage options for nasal and injection" do
+        expect(rendered).to have_text("safe to vaccinate with injected vaccine")
+        expect(rendered).to have_text("safe to vaccinate with nasal spray")
+      end
+    end
+
+    context "when only nasal is consented to" do
+      before do
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme:,
+          vaccine_methods: %w[nasal]
+        )
+      end
+
+      it "shows the correct hint about nasal spray only" do
+        expect(rendered).to have_text(
+          "The parent has consented to the nasal spray only"
+        )
+      end
+
+      it "shows the correct safe triage option for nasal only" do
+        expect(rendered).not_to have_text(
+          "safe to vaccinate with injected vaccine"
+        )
+        expect(rendered).to have_text("safe to vaccinate with nasal spray")
+      end
+    end
+  end
+
+  context "when programme does not have multiple delivery methods" do
+    let(:programme) { create(:programme, :hpv) }
+
+    before do
+      create(
+        :patient_consent_status,
+        :given,
+        patient:,
+        programme:,
+        vaccine_methods: %w[injection]
+      )
+    end
+
+    it "shows only the generic safe to vaccinate option, and no hint" do
+      expect(rendered).to have_text("safe to vaccinate")
+      expect(rendered).not_to have_text(
+        "safe to vaccinate with injected vaccine"
+      )
+      expect(rendered).not_to have_text("safe to vaccinate with nasal spray")
+      expect(rendered).not_to have_text("The parent has consented to")
+    end
   end
 end


### PR DESCRIPTION
The triage form now specifies which delivery method in every safe to vaccinate option, for programmes with multiple delivery methods. The hint is also more explicit on what method(s) the parent has consented to.

![image](https://github.com/user-attachments/assets/1daf7978-8924-4b1b-a246-fb9dbe6fc7d4)

https://nhsd-jira.digital.nhs.uk/browse/MAV-1285
https://nhsd-jira.digital.nhs.uk/browse/MAV-1398