### PR TITLE
Fix the :status_and_vaccine_method validation

### DIFF
--- a/spec/forms/triage_form_spec.rb
+++ b/spec/forms/triage_form_spec.rb
@@ -10,9 +10,7 @@ describe TriageForm do
     it do
       expect(form).to validate_inclusion_of(
         :status_and_vaccine_method
-      ).in_array(
-        %w[safe_to_vaccinate do_not_vaccinate keep_in_triage delay_vaccination]
-      )
+      ).in_array(form.status_and_vaccine_method_options)
     end
 
     it { should_not validate_presence_of(:notes) }


### PR DESCRIPTION
This validation was failing whenever the form was randomly initialized
with flu data (or anything that has multiple vaccination method) as in
those cases the status_and_vaccine_method could take on arbitrary values
depending on what methods were available. Instead, we now validate based
on :status_and_vaccine_method_options which should always contain 
exactly the right values.