### PR TITLE
Ensure triage form records correct vaccine method

### DIFF
--- a/app/forms/triage_form.rb
+++ b/app/forms/triage_form.rb
@@ -73,7 +73,7 @@ class TriageForm
       performed_by: current_user,
       programme:,
       status:,
-      vaccine_method: "injection"
+      vaccine_method:
     }
   end
 

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -84,6 +84,11 @@ FactoryBot.define do
       recorded_by
     end
 
+    trait :given_injection do
+      given
+      vaccine_methods { %w[injection] }
+    end
+
     trait :self_consent do
       route { "self_consent" }
       parent { nil }

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -89,6 +89,11 @@ FactoryBot.define do
       vaccine_methods { %w[injection] }
     end
 
+    trait :given_nasal do
+      given
+      vaccine_methods { %w[nasal] }
+    end
+
     trait :self_consent do
       route { "self_consent" }
       parent { nil }

--- a/spec/factories/patient_consent_statuses.rb
+++ b/spec/factories/patient_consent_statuses.rb
@@ -31,5 +31,15 @@ FactoryBot.define do
       status { "given" }
       vaccine_methods { %w[injection] }
     end
+
+    trait :given_injection_only do
+      status { "given" }
+      vaccine_methods { %w[injection] }
+    end
+
+    trait :given_nasal_only do
+      status { "given" }
+      vaccine_methods { %w[nasal] }
+    end
   end
 end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -103,6 +103,32 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_given_injection_only_triage_needed do
+      patient do
+        association :patient,
+                    :consent_given_injection_only_triage_needed,
+                    performed_by: user,
+                    programmes: session.programmes,
+                    organisation:,
+                    school:,
+                    home_educated:,
+                    year_group:
+      end
+    end
+
+    trait :consent_given_nasal_only_triage_needed do
+      patient do
+        association :patient,
+                    :consent_given_nasal_only_triage_needed,
+                    performed_by: user,
+                    programmes: session.programmes,
+                    organisation:,
+                    school:,
+                    home_educated:,
+                    year_group:
+      end
+    end
+
     trait :consent_refused do
       patient do
         association :patient,

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -297,6 +297,82 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_given_injection_only_triage_needed do
+      consents do
+        programmes.map do |programme|
+          association(
+            :consent,
+            :given_injection,
+            :from_mum,
+            :health_question_notes,
+            patient: instance,
+            organisation:,
+            programme:
+          )
+        end
+      end
+
+      consent_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_consent_status,
+            :given_injection_only,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+
+      triage_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_triage_status,
+            :required,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+    end
+
+    trait :consent_given_nasal_only_triage_needed do
+      consents do
+        programmes.map do |programme|
+          association(
+            :consent,
+            :given_nasal,
+            :from_mum,
+            :health_question_notes,
+            patient: instance,
+            organisation:,
+            programme:
+          )
+        end
+      end
+
+      consent_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_consent_status,
+            :given_nasal_only,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+
+      triage_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_triage_status,
+            :required,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+    end
+
     trait :consent_refused do
       triage_not_required
 

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -50,7 +50,7 @@ describe "Triage" do
 
     # Second patient - nasal only consent
     when_i_go_to_the_session_triage_tab
-    when_i_go_to_the_second_patient_that_needs_triage
+    and_i_go_to_the_second_patient_that_needs_triage
     then_i_see_the_triage_options_for_nasal_only_consent
 
     when_i_record_that_they_need_triage_for_flu
@@ -264,7 +264,7 @@ describe "Triage" do
     )
   end
 
-  def when_i_go_to_the_second_patient_that_needs_triage
+  def and_i_go_to_the_second_patient_that_needs_triage
     choose "Needs triage"
     click_on "Update results"
     click_link @patient_nasal_only.full_name
@@ -289,7 +289,6 @@ describe "Triage" do
 
   def and_the_vaccine_method_is_recorded_as_nasal
     triage = @patient_nasal_only.triages.last
-    skip "Bug: should be nasal but currently injection"
-    expect(triage.vaccine_method).to eq("injection")
+    expect(triage.vaccine_method).to eq("nasal")
   end
 end

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -113,18 +113,19 @@ describe "Triage" do
   end
 
   def and_patients_with_different_flu_consent_types_exist
-    @patient_injection_only, @patient_nasal_only =
-      create_list(
+    @patient_injection_only =
+      create(
         :patient_session,
-        2,
-        :consent_given_triage_needed,
+        :consent_given_injection_only_triage_needed,
         session: @session
-      ).map(&:patient)
+      ).patient
 
-    @patient_injection_only.consents.first.update(vaccine_methods: %w[injection])
-    @patient_injection_only.consent_statuses.first.update(vaccine_methods: %w[injection])
-    @patient_nasal_only.consents.first.update(vaccine_methods: %w[nasal])
-    @patient_nasal_only.consent_statuses.first.update(vaccine_methods: %w[nasal])
+    @patient_nasal_only =
+      create(
+        :patient_session,
+        :consent_given_nasal_only_triage_needed,
+        session: @session
+      ).patient
 
     @patient_injection_only.reload
     @patient_nasal_only.reload
@@ -215,28 +216,32 @@ describe "Triage" do
   end
 
   def and_needs_triage_emails_are_sent_to_both_parents
-    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient =
+      @patient_triage_needed || @patient_injection_only || @patient_nasal_only
     current_patient.parents.each do |parent|
       expect_email_to parent.email, :consent_confirmation_triage, :any
     end
   end
 
   def and_vaccination_wont_happen_emails_are_sent_to_both_parents
-    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient =
+      @patient_triage_needed || @patient_injection_only || @patient_nasal_only
     current_patient.parents.each do |parent|
       expect_email_to parent.email, :triage_vaccination_wont_happen, :any
     end
   end
 
   def and_vaccination_will_happen_emails_are_sent_to_both_parents
-    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient =
+      @patient_triage_needed || @patient_injection_only || @patient_nasal_only
     current_patient.parents.each do |parent|
       expect_email_to parent.email, :triage_vaccination_will_happen, :any
     end
   end
 
   def and_the_vaccine_method_is_recorded_as_injection
-    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient =
+      @patient_triage_needed || @patient_injection_only || @patient_nasal_only
     triage = current_patient.triages.last
     expect(triage.vaccine_method).to eq("injection")
   end

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -28,18 +28,16 @@ describe "Triage" do
     and_vaccination_will_happen_emails_are_sent_to_both_parents
   end
 
-  scenario "nurse can triage a patient for a flu programme (injection only)" do
+  scenario "nurse can triage patients for a flu programme with different consent types" do
     given_a_flu_programme_with_a_running_session
-    and_a_patient_who_needs_triage_for_flu_exists
+    and_patients_with_different_flu_consent_types_exist
 
     when_i_go_to_the_session_triage_tab
-    then_i_see_the_patient_who_needs_triage
+    then_i_see_both_patients_who_need_triage
 
-    when_i_go_to_the_patient_that_needs_triage
-    then_i_see_the_triage_options_with_vaccine_method
-
-    when_i_save_the_triage_without_choosing_an_option
-    then_i_see_a_validation_error
+    # First patient - injection only consent
+    when_i_go_to_the_first_patient_that_needs_triage
+    then_i_see_the_triage_options_for_injection_only_consent
 
     when_i_record_that_they_need_triage_for_flu
     then_i_see_the_triage_page
@@ -49,6 +47,21 @@ describe "Triage" do
     then_i_see_the_update_triage_link
     and_vaccination_will_happen_emails_are_sent_to_both_parents
     and_the_vaccine_method_is_recorded_as_injection
+
+    # Second patient - nasal only consent
+    when_i_go_to_the_session_triage_tab
+    when_i_go_to_the_second_patient_that_needs_triage
+    then_i_see_the_triage_options_for_nasal_only_consent
+
+    when_i_record_that_they_need_triage_for_flu
+    then_i_see_the_triage_page
+    and_needs_triage_emails_are_sent_to_both_parents
+
+    when_i_go_to_the_second_patient
+    and_i_record_that_they_are_safe_to_vaccinate_with_nasal
+    then_i_see_the_update_triage_link
+    and_vaccination_will_happen_emails_are_sent_to_both_parents
+    and_the_vaccine_method_is_recorded_as_nasal
   end
 
   def given_a_programme_with_a_running_session
@@ -99,24 +112,22 @@ describe "Triage" do
     @patient_triage_needed.reload # Make sure both consents are accessible
   end
 
-  def and_a_patient_who_needs_triage_for_flu_exists
-    @patient_triage_needed =
-      create(
+  def and_patients_with_different_flu_consent_types_exist
+    @patient_injection_only, @patient_nasal_only =
+      create_list(
         :patient_session,
+        2,
         :consent_given_triage_needed,
         session: @session
-      ).patient
+      ).map(&:patient)
 
-    create(
-      :consent,
-      :given_injection,
-      :health_question_notes,
-      :from_granddad,
-      patient: @patient_triage_needed,
-      programme: @session.programmes.first
-    )
+    @patient_injection_only.consents.first.update(vaccine_methods: %w[injection])
+    @patient_injection_only.consent_statuses.first.update(vaccine_methods: %w[injection])
+    @patient_nasal_only.consents.first.update(vaccine_methods: %w[nasal])
+    @patient_nasal_only.consent_statuses.first.update(vaccine_methods: %w[nasal])
 
-    @patient_triage_needed.reload # Make sure both consents are accessible
+    @patient_injection_only.reload
+    @patient_nasal_only.reload
   end
 
   def and_a_patient_who_doesnt_need_triage_exists
@@ -137,6 +148,11 @@ describe "Triage" do
     expect(page).to have_content(@patient_triage_needed.full_name)
   end
 
+  def then_i_see_both_patients_who_need_triage
+    expect(page).to have_content(@patient_injection_only.full_name)
+    expect(page).to have_content(@patient_nasal_only.full_name)
+  end
+
   def and_i_dont_see_the_patient_who_doesnt_need_triage
     expect(page).not_to have_content(@patient_triage_not_needed.full_name)
   end
@@ -149,18 +165,6 @@ describe "Triage" do
 
   def then_i_see_the_triage_options
     expect(page).to have_selector :heading, "Is it safe to vaccinate"
-  end
-
-  def then_i_see_the_triage_options_with_vaccine_method
-    expect(page).to have_selector :heading,
-                  "Is it safe to vaccinate #{@patient_triage_needed.given_name}?"
-    expect(page).to have_content(
-      "The parent has consented to the injected vaccine only"
-    )
-    expect(page).to have_field(
-      "Yes, it’s safe to vaccinate with injected vaccine",
-      type: "radio"
-    )
   end
 
   def when_i_record_that_they_need_triage
@@ -181,6 +185,11 @@ describe "Triage" do
 
   def when_i_record_that_they_are_safe_to_vaccinate_with_injection
     choose "Yes, it’s safe to vaccinate with injected vaccine"
+    click_button "Save triage"
+  end
+
+  def and_i_record_that_they_are_safe_to_vaccinate_with_nasal
+    choose "Yes, it’s safe to vaccinate with nasal spray"
     click_button "Save triage"
   end
 
@@ -206,25 +215,76 @@ describe "Triage" do
   end
 
   def and_needs_triage_emails_are_sent_to_both_parents
-    @patient_triage_needed.parents.each do |parent|
+    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient.parents.each do |parent|
       expect_email_to parent.email, :consent_confirmation_triage, :any
     end
   end
 
   def and_vaccination_wont_happen_emails_are_sent_to_both_parents
-    @patient_triage_needed.parents.each do |parent|
+    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient.parents.each do |parent|
       expect_email_to parent.email, :triage_vaccination_wont_happen, :any
     end
   end
 
   def and_vaccination_will_happen_emails_are_sent_to_both_parents
-    @patient_triage_needed.parents.each do |parent|
+    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    current_patient.parents.each do |parent|
       expect_email_to parent.email, :triage_vaccination_will_happen, :any
     end
   end
 
   def and_the_vaccine_method_is_recorded_as_injection
-    triage = @patient_triage_needed.triages.last
+    current_patient = @patient_triage_needed || @patient_injection_only || @patient_nasal_only
+    triage = current_patient.triages.last
+    expect(triage.vaccine_method).to eq("injection")
+  end
+
+  def when_i_go_to_the_first_patient_that_needs_triage
+    choose "Needs triage"
+    click_on "Update results"
+    click_link @patient_injection_only.full_name
+  end
+
+  def then_i_see_the_triage_options_for_injection_only_consent
+    expect(page).to have_selector :heading,
+                  "Is it safe to vaccinate #{@patient_injection_only.given_name}?"
+    expect(page).to have_content(
+      "The parent has consented to the injected vaccine only"
+    )
+    expect(page).to have_field(
+      "Yes, it’s safe to vaccinate with injected vaccine",
+      type: "radio"
+    )
+  end
+
+  def when_i_go_to_the_second_patient_that_needs_triage
+    choose "Needs triage"
+    click_on "Update results"
+    click_link @patient_nasal_only.full_name
+  end
+
+  def then_i_see_the_triage_options_for_nasal_only_consent
+    expect(page).to have_selector :heading,
+                  "Is it safe to vaccinate #{@patient_nasal_only.given_name}?"
+    expect(page).to have_content(
+      "The parent has consented to the nasal spray only"
+    )
+    expect(page).to have_field(
+      "Yes, it’s safe to vaccinate with nasal spray",
+      type: "radio"
+    )
+  end
+
+  def when_i_go_to_the_second_patient
+    click_link "Triage"
+    click_link @patient_nasal_only.full_name, match: :first
+  end
+
+  def and_the_vaccine_method_is_recorded_as_nasal
+    triage = @patient_nasal_only.triages.last
+    skip "Bug: should be nasal but currently injection"
     expect(triage.vaccine_method).to eq("injection")
   end
 end

--- a/spec/forms/triage_form_spec.rb
+++ b/spec/forms/triage_form_spec.rb
@@ -17,4 +17,61 @@ describe TriageForm do
     it { should_not validate_presence_of(:vaccine_methods) }
     it { should validate_length_of(:notes).is_at_most(1000) }
   end
+
+  describe "when the patient is safe to vaccinate for HPV" do
+    subject(:form) do
+      described_class.new(
+        patient_session:,
+        programme:,
+        current_user: create(:user),
+        notes: "test",
+        status_and_vaccine_method: "safe_to_vaccinate"
+      )
+    end
+
+    let(:programme) { create(:programme, :hpv) }
+    let(:patient_session) do
+      create(
+        :patient_session,
+        :consent_given_triage_needed,
+        programmes: [programme]
+      )
+    end
+
+    it "sets the vaccine method to injection" do
+      form.save!
+
+      triage = patient_session.reload.patient.triages.last
+      expect(triage.vaccine_method).to eq("injection")
+    end
+  end
+
+  describe "when the patient has a nasal only consent" do
+    subject(:form) do
+      described_class.new(
+        patient_session:,
+        programme:,
+        current_user: create(:user),
+        notes: "test",
+        status_and_vaccine_method: "safe_to_vaccinate_nasal"
+      )
+    end
+
+    let(:programme) { create(:programme, :flu) }
+    let(:patient_session) do
+      create(
+        :patient_session,
+        :consent_given_nasal_only_triage_needed,
+        programmes: [programme]
+      )
+    end
+
+    it "sets the vaccine method to nasal" do
+      form.save!
+
+      triage = patient_session.reload.patient.triages.last
+      expect(triage.vaccine_method).to eq("nasal")
+      expect(triage.notes).to eq("test")
+    end
+  end
 end


### PR DESCRIPTION
* Ensure triage form records correct vaccine method, so if a patient is triaged as needing to receive nasal spray, that's what the recording flow asks for
* Extend the triage feature spec to cover injection-only and nasal-only consents

[JIRA ticket](https://nhsd-jira.digital.nhs.uk/browse/MAV-1421)