### PR TITLE
Fix data replication policy

### DIFF
--- a/terraform/account/resources/iam_policy_DeployDataReplicationResources.json
+++ b/terraform/account/resources/iam_policy_DeployDataReplicationResources.json
@@ -47,7 +47,6 @@
         "kms:ScheduleKeyDeletion",
         "kms:Revoke*",
         "kms:Disable*",
-        "kms:CreateGrant",
         "kms:CancelKeyDeletion",
         "kms:PutKeyPolicy",
         "kms:ReplicateKey",


### PR DESCRIPTION
* The `kms:CreateGrant` permission is needed and can not be denied. This has been applied already but not committed