### PR TITLE
Manual consent reminders

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -19,6 +19,14 @@ class AppSearchComponent < ViewComponent::Base
             </svg>
           </button>
         </div>
+        
+        <% if programmes.any? %>
+          <%= f.govuk_check_boxes_fieldset :programme_types, legend: { text: "Programme", size: "s" } do %>
+            <% programmes.each do |programme| %>
+              <%= f.govuk_check_box :programme_types, programme.type, label: { text: programme.name } %>
+            <% end %>
+          <% end %>
+        <% end %>
 
         <% if consent_statuses.any? %>
           <%= f.govuk_check_boxes_fieldset :consent_statuses, legend: { text: "Consent status", size: "s" } do %>
@@ -115,6 +123,7 @@ class AppSearchComponent < ViewComponent::Base
   def initialize(
     form:,
     url:,
+    programmes: [],
     consent_statuses: [],
     programme_statuses: [],
     register_statuses: [],
@@ -127,6 +136,7 @@ class AppSearchComponent < ViewComponent::Base
     @form = form
     @url = url
 
+    @programmes = programmes
     @consent_statuses = consent_statuses
     @programme_statuses = programme_statuses
     @register_statuses = register_statuses
@@ -139,6 +149,7 @@ class AppSearchComponent < ViewComponent::Base
 
   attr_reader :form,
               :url,
+              :programmes,
               :consent_statuses,
               :programme_statuses,
               :register_statuses,

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -35,30 +35,47 @@ class AppSessionActionsComponent < ViewComponent::Base
   end
 
   def no_consent_response_row
-    consent_row("No consent response", status: "no_response")
-  end
+    status = "no_response"
 
-  def conflicting_consent_row
-    consent_row("Conflicting consent", status: "conflicts")
-  end
-
-  def consent_row(text, status:)
     count =
       patient_sessions.has_consent_status(status, programme: programmes).count
 
     return nil if count.zero?
 
     href =
-      session_consent_path(session, search_form: { consent_statuses: [status] })
+      session_consent_path(session, search_form: { consent_status: [status] })
 
     {
       key: {
-        text: text
+        text: "No consent response"
       },
       value: {
-        text: I18n.t("children", count:)
+        text: helpers.link_to(I18n.t(:children_with_no_consent_response, count:), href:).html_safe
       },
-      actions: [{ text: "Review", visually_hidden_text: text.downcase, href: }]
+      actions: [
+        { text: "Send reminders", href: }
+      ]
+    }
+  end
+
+  def conflicting_consent_row
+    status = "conflicts"
+
+    count =
+      patient_sessions.has_consent_status(status, programme: programmes).count
+
+    return nil if count.zero?
+
+    href =
+      session_consent_path(session, search_form: { consent_status: [status] })
+
+    {
+      key: {
+        text: "Conflicting consent"
+      },
+      value: {
+        text: helpers.link_to(I18n.t(:children_with_conflicting_consent_response, count:), href:).html_safe
+      },
     }
   end
 
@@ -77,11 +94,8 @@ class AppSessionActionsComponent < ViewComponent::Base
         text: "Triage needed"
       },
       value: {
-        text: I18n.t("children", count:)
-      },
-      actions: [
-        { text: "Review", visually_hidden_text: "triage needed", href: }
-      ]
+        text: helpers.link_to(I18n.t(:children_requiring_triage, count:), href).html_safe
+      }
     }
   end
 
@@ -100,11 +114,8 @@ class AppSessionActionsComponent < ViewComponent::Base
         text: "Register attendance"
       },
       value: {
-        text: I18n.t("children", count:)
-      },
-      actions: [
-        { text: "Review", visually_hidden_text: "register attendance", href: }
-      ]
+        text: helpers.link_to(I18n.t(:children_to_register, count:), href).html_safe
+      }
     }
   end
 
@@ -129,7 +140,7 @@ class AppSessionActionsComponent < ViewComponent::Base
 
     texts =
       counts_by_programme.map do |programme, count|
-        "#{I18n.t("children", count:)} for #{programme.name}"
+        I18n.t(:children_for_programme, count:, programme: programme.name)
       end
 
     href = session_record_path(session)

--- a/app/controllers/concerns/search_form_concern.rb
+++ b/app/controllers/concerns/search_form_concern.rb
@@ -6,22 +6,30 @@ module SearchFormConcern
   def set_search_form
     @form =
       SearchForm.new(
-        **params.fetch(:search_form, {}).permit(
-          :clear_filters,
-          :date_of_birth_day,
-          :date_of_birth_month,
-          :date_of_birth_year,
-          :missing_nhs_number,
-          :programme_status,
-          :q,
-          :register_status,
-          :session_status,
-          :triage_status,
-          consent_statuses: [],
-          year_groups: []
-        ),
-        session: session,
-        request_path: request.path
+        session: @session,
+        request_path: request.path,
+        request_session: session,
+        **search_form_params
       )
+  end
+
+  private
+
+  def search_form_params
+    params.fetch(:search_form, {}).permit(
+      :clear_filters,
+      :date_of_birth_day,
+      :date_of_birth_month,
+      :date_of_birth_year,
+      :missing_nhs_number,
+      :programme_status,
+      :q,
+      :register_status,
+      :session_status,
+      :triage_status,
+      consent_statuses: [],
+      programme_types: [],
+      year_groups: []
+    )
   end
 end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -37,8 +37,9 @@ class ProgrammesController < ApplicationController
         [@programme]
       )
 
-    patients = @form.apply(scope, programme: @programme)
+    @form.programme_types = [@programme.type]
 
+    patients = @form.apply(scope)
     @pagy, @patients = pagy(patients)
   end
 

--- a/app/controllers/sessions/consent_controller.rb
+++ b/app/controllers/sessions/consent_controller.rb
@@ -11,16 +11,14 @@ class Sessions::ConsentController < ApplicationController
 
   def show
     @statuses = Patient::ConsentStatus.statuses.keys
-    @programmes = @session.programmes
 
     scope =
-      @session
-        .patient_sessions
-        .includes_programmes
-        .includes(:latest_note, patient: :consent_statuses)
-        .in_programmes(@programmes)
+      @session.patient_sessions.includes_programmes.includes(
+        :latest_note,
+        patient: :consent_statuses
+      )
 
-    patient_sessions = @form.apply(scope, programme: @programmes)
+    patient_sessions = @form.apply(scope)
     @pagy, @patient_sessions = pagy(patient_sessions)
   end
 

--- a/app/controllers/sessions/manage_consent_reminders_controller.rb
+++ b/app/controllers/sessions/manage_consent_reminders_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Sessions::ManageConsentRemindersController < ApplicationController
+  before_action :set_session
+
+  def show
+    authorize :consent_reminder, :show?
+  end
+
+  def create
+    authorize :consent_reminder, :create?
+    SendSchoolConsentRemindersJob.perform_now(@session)
+
+    redirect_to session_path(@session),
+                flash: {
+                  success: "Manual consent reminders sent."
+                }
+  end
+
+  private
+
+  def set_session
+    @session = authorize sessions_scope.find_by!(slug: params[:session_slug])
+  end
+
+  def sessions_scope
+    policy_scope(Session).includes(:location, :programmes, :session_dates)
+  end
+end

--- a/app/controllers/sessions/outcome_controller.rb
+++ b/app/controllers/sessions/outcome_controller.rb
@@ -11,16 +11,14 @@ class Sessions::OutcomeController < ApplicationController
 
   def show
     @statuses = PatientSession::SessionStatus.statuses.keys
-    @programmes = @session.programmes
 
     scope =
-      @session
-        .patient_sessions
-        .includes_programmes
-        .includes(:latest_note, :session_statuses)
-        .in_programmes(@programmes)
+      @session.patient_sessions.includes_programmes.includes(
+        :latest_note,
+        :session_statuses
+      )
 
-    patient_sessions = @form.apply(scope, programme: @programmes)
+    patient_sessions = @form.apply(scope)
     @pagy, @patient_sessions = pagy(patient_sessions)
   end
 

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -22,14 +22,13 @@ class Sessions::RecordController < ApplicationController
           :latest_note,
           patient: %i[consent_statuses triage_statuses vaccination_statuses]
         )
-        .in_programmes(@session.programmes)
         .has_registration_status(%w[attending completed])
 
     scope = @form.apply(scope)
 
     patient_sessions =
       scope.select do |patient_session|
-        patient_session.programmes.any? do |programme|
+        @form.programmes.any? do |programme|
           patient_session.patient.consent_given_and_safe_to_vaccinate?(
             programme:
           )

--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -17,15 +17,11 @@ class Sessions::RegisterController < ApplicationController
     @statuses = PatientSession::RegistrationStatus.statuses.keys
 
     scope =
-      @session
-        .patient_sessions
-        .includes_programmes
-        .includes(
-          :latest_note,
-          :registration_status,
-          patient: %i[consent_statuses triage_statuses vaccination_statuses]
-        )
-        .in_programmes(@session.programmes)
+      @session.patient_sessions.includes_programmes.includes(
+        :latest_note,
+        :registration_status,
+        patient: %i[consent_statuses triage_statuses vaccination_statuses]
+      )
 
     patient_sessions = @form.apply(scope)
     @pagy, @patient_sessions = pagy(patient_sessions)

--- a/app/controllers/sessions/triage_controller.rb
+++ b/app/controllers/sessions/triage_controller.rb
@@ -11,17 +11,15 @@ class Sessions::TriageController < ApplicationController
 
   def show
     @statuses = Patient::TriageStatus.statuses.keys - %w[not_required]
-    @programmes = @session.programmes
 
     scope =
       @session
         .patient_sessions
         .includes_programmes
         .includes(:latest_note, patient: :triage_statuses)
-        .in_programmes(@programmes)
-        .has_triage_status(@statuses, programme: @programmes)
+        .has_triage_status(@statuses, programme: @form.programmes)
 
-    patient_sessions = @form.apply(scope, programme: @programmes)
+    patient_sessions = @form.apply(scope)
     @pagy, @patient_sessions = pagy(patient_sessions)
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -55,7 +55,13 @@ class SessionsController < ApplicationController
   def make_in_progress
     @session.session_dates.find_or_create_by!(value: Date.current)
 
-    redirect_to session_path, flash: { success: "Session is now in progress" }
+    redirect_to layout: "full", flash: { success: "Session is now in progress" }
+  end
+
+  def send_extra_consent_reminders
+    SendSchoolConsentRemindersJob.perform_now(@session)
+
+    redirect_to edit_session_path(@session), flash: { success: "Consent reminders sent." }
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -58,12 +58,6 @@ class SessionsController < ApplicationController
     redirect_to layout: "full", flash: { success: "Session is now in progress" }
   end
 
-  def send_extra_consent_reminders
-    SendSchoolConsentRemindersJob.perform_now(@session)
-
-    redirect_to edit_session_path(@session), flash: { success: "Consent reminders sent." }
-  end
-
   private
 
   def set_session

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -14,17 +14,22 @@ class SearchForm
   attribute :date_of_birth_year, :integer
   attribute :missing_nhs_number, :boolean
   attribute :programme_status, :string
+  attribute :programme_types, array: true
   attribute :q, :string
   attribute :register_status, :string
   attribute :session_status, :string
   attribute :triage_status, :string
   attribute :year_groups, array: true
 
-  attr_accessor :session, :request_path
+  attr_accessor :request_path, :request_session, :session
 
   def initialize(params = {})
     super(params)
-    handle_session_filters
+    handle_request_session_filters
+  end
+
+  def programme_types=(values)
+    super(values&.compact_blank || [])
   end
 
   def consent_statuses=(values)
@@ -35,7 +40,16 @@ class SearchForm
     super(values&.compact_blank&.map(&:to_i)&.compact || [])
   end
 
-  def apply(scope, programme: nil)
+  def programmes
+    @programmes ||=
+      if programme_types.present?
+        Programme.where(type: programme_types)
+      else
+        session&.programmes
+      end
+  end
+
+  def apply(scope)
     scope = scope.search_by_name(q) if q.present?
 
     scope = scope.search_by_year_groups(year_groups) if year_groups.present?
@@ -54,16 +68,18 @@ class SearchForm
 
     scope = scope.search_by_nhs_number(nil) if missing_nhs_number.present?
 
+    scope = scope.in_programmes(programmes) if programmes.present?
+
     if (statuses = consent_statuses).present?
-      scope = scope.has_consent_status(statuses, programme:)
+      scope = scope.has_consent_status(statuses, programme: programmes)
     end
 
     if (status = programme_status&.to_sym).present?
-      scope = scope.has_vaccination_status(status, programme:)
+      scope = scope.has_vaccination_status(status, programme: programmes)
     end
 
     if (status = session_status&.to_sym).present?
-      scope = scope.has_session_status(status, programme:)
+      scope = scope.has_session_status(status, programme: programmes)
     end
 
     if (status = register_status&.to_sym).present?
@@ -71,7 +87,7 @@ class SearchForm
     end
 
     if (status = triage_status&.to_sym).present?
-      scope = scope.has_triage_status(status, programme:)
+      scope = scope.has_triage_status(status, programme: programmes)
     end
 
     scope.order_by_name
@@ -79,38 +95,38 @@ class SearchForm
 
   private
 
-  def handle_session_filters
+  def handle_request_session_filters
     if clear_filters
-      clear_from_session
+      clear_from_request_session
     elsif has_filters?
-      store_in_session
+      store_in_request_session
     else
-      load_from_session
+      load_from_request_session
     end
   end
 
-  def store_in_session
-    return if session.nil?
+  def store_in_request_session
+    return if request_session.nil?
 
     if has_filters?
-      session[SESSION_KEY] ||= {}
-      session[SESSION_KEY][path_key] = attributes
+      request_session[SESSION_KEY] ||= {}
+      request_session[SESSION_KEY][path_key] = attributes
     end
   end
 
-  def load_from_session
-    return if session.nil? || session[SESSION_KEY].blank?
+  def load_from_request_session
+    return if request_session.nil? || request_session[SESSION_KEY].blank?
 
-    stored_filters = session[SESSION_KEY][path_key]
+    stored_filters = request_session[SESSION_KEY][path_key]
     return if stored_filters.blank?
 
     assign_attributes(stored_filters)
   end
 
-  def clear_from_session
-    return if session.nil? || session[SESSION_KEY].blank?
+  def clear_from_request_session
+    return if request_session.nil? || request_session[SESSION_KEY].blank?
 
-    session[SESSION_KEY].delete(path_key)
+    request_session[SESSION_KEY].delete(path_key)
   end
 
   def has_filters?

--- a/app/policies/consent_reminder_policy.rb
+++ b/app/policies/consent_reminder_policy.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-class SessionPolicy < ApplicationPolicy
-  def make_in_progress?
+class ConsentReminderPolicy < ApplicationPolicy
+  def show?
+    user.is_nurse? || user.is_admin?
+  end
+
+  def create?
     user.is_nurse? || user.is_admin?
   end
 

--- a/app/policies/session_policy.rb
+++ b/app/policies/session_policy.rb
@@ -5,6 +5,10 @@ class SessionPolicy < ApplicationPolicy
     user.is_nurse? || user.is_admin?
   end
 
+  def send_extra_consent_reminders?
+    update?
+  end
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       scope.where(organisation: user.selected_organisation)

--- a/app/views/sessions/consent/show.html.erb
+++ b/app/views/sessions/consent/show.html.erb
@@ -21,7 +21,9 @@
   <div class="app-grid-column-results">
     <%= render AppSearchResultsComponent.new(@pagy) do %>
       <% @patient_sessions.each do |patient_session| %>
-        <%= render AppPatientSessionSearchResultCardComponent.new(patient_session, context: :consent) %>
+        <%= render AppPatientSessionSearchResultCardComponent.new(
+              patient_session, context: :consent, programmes: @session.programmes,
+            ) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/sessions/consent/show.html.erb
+++ b/app/views/sessions/consent/show.html.erb
@@ -13,6 +13,7 @@
     <%= render AppSearchComponent.new(
           form: @form,
           url: session_consent_path(@session),
+          programmes: @session.programmes,
           consent_statuses: @statuses,
           year_groups: @session.year_groups,
         ) %>
@@ -22,7 +23,7 @@
     <%= render AppSearchResultsComponent.new(@pagy) do %>
       <% @patient_sessions.each do |patient_session| %>
         <%= render AppPatientSessionSearchResultCardComponent.new(
-              patient_session, context: :consent, programmes: @session.programmes,
+              patient_session, context: :consent, programmes: @form.programmes,
             ) %>
       <% end %>
     <% end %>

--- a/app/views/sessions/manage_consent_reminders/show.html.erb
+++ b/app/views/sessions/manage_consent_reminders/show.html.erb
@@ -1,0 +1,87 @@
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+    { text: t("dashboard.index.title"), href: dashboard_path },
+    { text: t("sessions.index.title"), href: sessions_path },
+    { text: @session.location.name, href: session_path(@session) },
+  ]) %>
+  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
+<% end %>
+
+<%= h1 t('sessions.reminders.title') %>
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+    <% t('sessions.reminders.description').split("\n").each do |paragraph| %>
+      <p class="nhsuk-body"><%= paragraph %></p>
+    <% end %>
+
+    <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-2"><%= t('sessions.dates.label', default: 'Session dates') %></h2>
+    <ul class="nhsuk-list nhsuk-list--bullet">
+      <% @session.dates.each do |date| %>
+        <li><%= date.to_fs(:long_day_of_week) %></li>
+      <% end %>
+    </ul>
+
+    <% if @session.reminder_dates.present? %>
+      <details class="nhsuk-details">
+        <summary class="nhsuk-details__summary">
+          <span class="nhsuk-details__summary-text">
+            <%= t('sessions.reminders.reminder_dates.label') %>
+          </span>
+        </summary>
+        <div class="nhsuk-details__text">
+          <p class="nhsuk-body"><%= t('sessions.reminders.reminder_dates.description') %></p>
+
+          <ul class="nhsuk-list app-list--spaced">
+            <% @session.reminder_dates.each do |date| %>
+              <li><%= date.to_fs(:long_day_of_week) %></li>
+            <% end %>
+          </ul>
+        </div>
+      </details>
+
+      <% if @session.next_reminder_date.present? %>
+        <div class="nhsuk-inset-text">
+          <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">
+            <%= t('sessions.reminders.patients_to_get_consent.text',
+                  default: 'Parents who need to give consent') %>
+          </h3>
+
+          <p class="nhsuk-body">
+            <%= t('sessions.reminders.next_reminder_date.text',
+                  date: @session.next_reminder_date.to_fs(:long_day_of_week)) %>
+          </p>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="nhsuk-inset-text">
+      <p class="nhsuk-body nhsuk-u-font-weight-bold nhsuk-u-margin-bottom-2">
+        <%= t('sessions.reminders.patients_to_get_consent.status', 
+              count: @session.patients_with_no_consent_response_count,
+              total: @session.total_patients_count) %>
+      </p>
+      
+      <% if @session.next_reminder_date.present? %>
+        <p class="nhsuk-body nhsuk-u-margin-bottom-0">
+          <%= t('sessions.reminders.next_reminder_date.text',
+                date: @session.next_reminder_date.to_fs(:long_day_of_week)) %>
+        </p>
+      <% else %>
+        <p class="nhsuk-body nhsuk-u-margin-bottom-0">
+          <%= t('sessions.reminders.next_reminder_date.none') %>
+        </p>
+      <% end %>
+    </div>
+
+    <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-2">Send parents a manual consent reminder</h2>
+    <p class="nhsuk-body">
+      <%= t('sessions.reminders.preConfirm') %>
+    </p>
+
+    <%= button_to t('sessions.reminders.confirm'),
+                  session_manage_consent_reminders_path(@session),
+                  method: :post,
+                  class: "nhsuk-button" %>
+  </div>
+</div>

--- a/app/views/sessions/outcome/show.html.erb
+++ b/app/views/sessions/outcome/show.html.erb
@@ -13,6 +13,7 @@
     <%= render AppSearchComponent.new(
           form: @form,
           url: session_outcome_path(@session),
+          programmes: @session.programmes,
           session_statuses: @statuses,
           year_groups: @session.year_groups,
         ) %>
@@ -22,7 +23,7 @@
     <%= render AppSearchResultsComponent.new(@pagy) do %>
       <% @patient_sessions.each do |patient_session| %>
         <%= render AppPatientSessionSearchResultCardComponent.new(
-              patient_session, context: :outcome, programmes: @session.programmes,
+              patient_session, context: :outcome, programmes: @form.programmes,
             ) %>
       <% end %>
     <% end %>

--- a/app/views/sessions/outcome/show.html.erb
+++ b/app/views/sessions/outcome/show.html.erb
@@ -21,7 +21,9 @@
   <div class="app-grid-column-results">
     <%= render AppSearchResultsComponent.new(@pagy) do %>
       <% @patient_sessions.each do |patient_session| %>
-        <%= render AppPatientSessionSearchResultCardComponent.new(patient_session, context: :outcome) %>
+        <%= render AppPatientSessionSearchResultCardComponent.new(
+              patient_session, context: :outcome, programmes: @session.programmes,
+            ) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -40,7 +40,9 @@
     <div class="app-grid-column-results">
       <%= render AppSearchResultsComponent.new(@pagy) do %>
         <% @patient_sessions.each do |patient_session| %>
-          <%= render AppPatientSessionSearchResultCardComponent.new(patient_session, context: :record) %>
+          <%= render AppPatientSessionSearchResultCardComponent.new(
+                patient_session, context: :record, programmes: @session.programmes,
+              ) %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -33,6 +33,7 @@
       <%= render AppSearchComponent.new(
             form: @form,
             url: session_record_path(@session),
+            programmes: @session.programmes,
             year_groups: @session.year_groups,
           ) %>
     </div>
@@ -41,7 +42,7 @@
       <%= render AppSearchResultsComponent.new(@pagy) do %>
         <% @patient_sessions.each do |patient_session| %>
           <%= render AppPatientSessionSearchResultCardComponent.new(
-                patient_session, context: :record, programmes: @session.programmes,
+                patient_session, context: :record, programmes: @form.programmes,
               ) %>
         <% end %>
       <% end %>

--- a/app/views/sessions/register/show.html.erb
+++ b/app/views/sessions/register/show.html.erb
@@ -22,7 +22,9 @@
     <div class="app-grid-column-results">
       <%= render AppSearchResultsComponent.new(@pagy) do %>
         <% @patient_sessions.each do |patient_session| %>
-          <%= render AppPatientSessionSearchResultCardComponent.new(patient_session, context: :register) %>
+          <%= render AppPatientSessionSearchResultCardComponent.new(
+                patient_session, context: :register,
+              ) %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/sessions/register/show.html.erb
+++ b/app/views/sessions/register/show.html.erb
@@ -14,6 +14,7 @@
       <%= render AppSearchComponent.new(
             form: @form,
             url: session_register_path(@session),
+            programmes: @session.programmes,
             register_statuses: @statuses,
             year_groups: @session.year_groups,
           ) %>
@@ -23,7 +24,7 @@
       <%= render AppSearchResultsComponent.new(@pagy) do %>
         <% @patient_sessions.each do |patient_session| %>
           <%= render AppPatientSessionSearchResultCardComponent.new(
-                patient_session, context: :register,
+                patient_session, context: :register, programmes: @form.programmes,
               ) %>
         <% end %>
       <% end %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -58,11 +58,6 @@
   </div>
 </div>
 
-<%= button_to "Send extra consent reminders",
-              send_extra_consent_reminders_session_path(@session),
-              method: :post,
-              class: "nhsuk-button nhsuk-button--secondary" %>
-
 <% content_for :after_main do %>
   <%= render(AppDevToolsComponent.new) do %>
     <p class="nhsuk-u-reading-width">

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -58,6 +58,11 @@
   </div>
 </div>
 
+<%= button_to "Send extra consent reminders",
+              send_extra_consent_reminders_session_path(@session),
+              method: :post,
+              class: "nhsuk-button nhsuk-button--secondary" %>
+
 <% content_for :after_main do %>
   <%= render(AppDevToolsComponent.new) do %>
     <p class="nhsuk-u-reading-width">

--- a/app/views/sessions/triage/show.html.erb
+++ b/app/views/sessions/triage/show.html.erb
@@ -13,6 +13,7 @@
     <%= render AppSearchComponent.new(
           form: @form,
           url: session_triage_path(@session),
+          programmes: @session.programmes,
           triage_statuses: %w[safe_to_vaccinate do_not_vaccinate delay_vaccination required],
           year_groups: @session.year_groups,
         ) %>
@@ -22,7 +23,7 @@
     <%= render AppSearchResultsComponent.new(@pagy) do %>
       <% @patient_sessions.each do |patient_session| %>
         <%= render AppPatientSessionSearchResultCardComponent.new(
-              patient_session, context: :triage, programmes: @session.programmes,
+              patient_session, context: :triage, programmes: @form.programmes,
             ) %>
       <% end %>
     <% end %>

--- a/app/views/sessions/triage/show.html.erb
+++ b/app/views/sessions/triage/show.html.erb
@@ -21,7 +21,9 @@
   <div class="app-grid-column-results">
     <%= render AppSearchResultsComponent.new(@pagy) do %>
       <% @patient_sessions.each do |patient_session| %>
-        <%= render AppPatientSessionSearchResultCardComponent.new(patient_session, context: :triage) %>
+        <%= render AppPatientSessionSearchResultCardComponent.new(
+              patient_session, context: :triage, programmes: @session.programmes,
+            ) %>
       <% end %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -444,6 +444,30 @@ en:
     zero: No children
     one: 1 child
     other: "%{count} children"
+  children_with_no_consent_response:
+    zero: No children with no response
+    one: 1 child with no response
+    other: "%{count} children with no response"
+  children_with_conflicting_consent_response:
+    zero: No children with conflicting responses
+    one: 1 child with conflicting response
+    other: "%{count} children with conflicting responses"
+  :children_requiring_triage:
+    zero: No children requiring triage
+    one: 1 child requiring triage
+    other: "%{count} children requiring triage"
+  children_to_followup:
+    zero: No children to follow up
+    one: 1 child to follow up
+    other: "%{count} children to follow up"
+  children_to_register:
+    zero: No children to register
+    one: 1 child to register
+    other: "%{count} children to register"
+  :children_for_programme:
+    zero: "No children for %{programme}"
+    one: "1 child for %{programme}"
+    other: "%{count} children for %{programme}"
   cohorts:
     index:
       title: Cohorts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -605,6 +605,33 @@ en:
       register: Register
       record: Record vaccinations
       outcome: Session outcomes
+    dates:
+      label: Session dates
+    reminders:
+      label: "Send reminders"
+      title: "Manage consent reminders"
+      description: >
+        Mavis automatically sends email and text reminders to parents who have not
+        responded to the initial consent request.
+
+        Automatic reminders are sent 14, 7 and 3 days before a session.
+
+        You can also send reminders manually. Mavis will then skip the next automatic
+        reminder if it's due to be sent within 3 days.
+      reminder_dates:
+        label: "Automatic consent reminder schedule"
+        description: "Reminders will be sent automatically on these dates:"
+      patients_to_get_consent:
+        label: "Parents who need to give consent"
+        status: "%{count} parents out of %{total} have not responded yet"
+      next_reminder_date:
+        label: "Next reminder"
+        text: "The next automatic consent reminder will be sent on %{date}"
+        none: "There are no more automatic consent reminders to be sent"
+      preConfirm: "Mavis will skip the next automatic reminder if it's scheduled to be sent within 3 days."
+      confirm: "Send manual consent reminders"
+      success: "Manual consent reminders sent"
+
   table:
     no_filtered_results: We couldn’t find any children that matched your filters.
     no_results: No results

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,9 +208,9 @@ Rails.application.routes.draw do
   end
 
   resources :sessions, only: %i[edit index show], param: :slug do
-    member do
-      post :send_extra_consent_reminders
-    end
+    resource :manage_consent_reminders,
+             only: %i[show create],
+             controller: "sessions/manage_consent_reminders"
 
     resource :consent, only: :show, controller: "sessions/consent"
     resource :triage, only: :show, controller: "sessions/triage"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,10 @@ Rails.application.routes.draw do
   end
 
   resources :sessions, only: %i[edit index show], param: :slug do
+    member do
+      post :send_extra_consent_reminders
+    end
+
     resource :consent, only: :show, controller: "sessions/consent"
     resource :triage, only: :show, controller: "sessions/triage"
     resource :register, only: :show, controller: "sessions/register" do

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -3,7 +3,9 @@
 describe AppPatientSessionSearchResultCardComponent do
   subject(:rendered) { render_inline(component) }
 
-  let(:component) { described_class.new(patient_session, context:) }
+  let(:component) do
+    described_class.new(patient_session, context:, programmes: [programme])
+  end
 
   let(:patient) do
     create(

--- a/spec/features/filtering_by_programme_spec.rb
+++ b/spec/features/filtering_by_programme_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+describe "Filtering" do
+  around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
+
+  scenario "By programme" do
+    given_a_session_exists
+    and_patients_are_in_the_session
+
+    when_i_visit_the_session_outcomes
+    then_i_see_all_the_patients
+    and_i_see_all_the_statuses
+
+    when_i_filter_on_hpv
+    then_i_see_all_the_patients
+    and_i_see_only_the_hpv_statuses
+
+    when_i_filter_on_menacwy
+    then_i_see_only_patients_eligible_for_menacwy
+    and_i_see_only_the_menacwy_statuses
+  end
+
+  def given_a_session_exists
+    programmes = [create(:programme, :hpv), create(:programme, :menacwy)]
+
+    organisation = create(:organisation, programmes:)
+    @nurse = create(:nurse, organisation:)
+
+    @session = create(:session, organisation:, programmes:)
+  end
+
+  def and_patients_are_in_the_session
+    @patient_eligible_for_hpv =
+      create(:patient, year_group: 8, session: @session)
+
+    @patient_eligible_for_hpv_and_menacwy =
+      create(:patient, year_group: 9, session: @session)
+  end
+
+  def when_i_visit_the_session_outcomes
+    sign_in @nurse
+    visit session_outcome_path(@session)
+  end
+
+  def then_i_see_all_the_patients
+    expect(page).to have_content(@patient_eligible_for_hpv.full_name)
+    expect(page).to have_content(
+      @patient_eligible_for_hpv_and_menacwy.full_name
+    )
+  end
+
+  def and_i_see_all_the_statuses
+    expect(page).to have_content("HPVNo outcome yet").twice
+    expect(page).to have_content("MenACWYNo outcome yet").once
+  end
+
+  def when_i_filter_on_hpv
+    check "HPV"
+    click_on "Update results"
+  end
+
+  def and_i_see_only_the_hpv_statuses
+    expect(page).to have_content("HPVNo outcome yet").twice
+    expect(page).not_to have_content("MenACWYNo outcome yet")
+  end
+
+  def when_i_filter_on_menacwy
+    uncheck "HPV"
+    check "MenACWY"
+    click_on "Update results"
+  end
+
+  def then_i_see_only_patients_eligible_for_menacwy
+    expect(page).not_to have_content(@patient_eligible_for_hpv.full_name)
+    expect(page).to have_content(
+      @patient_eligible_for_hpv_and_menacwy.full_name
+    )
+  end
+
+  def and_i_see_only_the_menacwy_statuses
+    expect(page).not_to have_content("HPVNo outcome yet")
+    expect(page).to have_content("MenACWYNo outcome yet").once
+  end
+end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 describe SearchForm do
-  subject(:form) { described_class.new(**params, session:, request_path:) }
+  subject(:form) do
+    described_class.new(**params, request_session:, request_path:, session:)
+  end
 
-  let(:session) { {} }
+  let(:request_session) { {} }
   let(:request_path) { "/a-path" }
+  let(:session) { nil }
 
   let(:consent_statuses) { nil }
   let(:date_of_birth_day) { Date.current.day }
@@ -12,6 +15,7 @@ describe SearchForm do
   let(:date_of_birth_year) { Date.current.year }
   let(:missing_nhs_number) { true }
   let(:programme_status) { nil }
+  let(:programme_types) { nil }
   let(:q) { "query" }
   let(:register_status) { nil }
   let(:session_status) { nil }
@@ -26,6 +30,7 @@ describe SearchForm do
       date_of_birth_year:,
       missing_nhs_number:,
       programme_status:,
+      programme_types:,
       q:,
       register_status:,
       session_status:,
@@ -93,6 +98,39 @@ describe SearchForm do
       end
     end
 
+    context "filtering on programmes" do
+      let(:consent_status) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
+      let(:missing_nhs_number) { nil }
+      let(:programme_status) { nil }
+      let(:programme_types) { [programme.type] }
+      let(:q) { nil }
+      let(:register_status) { nil }
+      let(:session_status) { nil }
+      let(:triage_status) { nil }
+      let(:year_groups) { nil }
+
+      let(:programme) { create(:programme, :menacwy) }
+
+      context "with a patient eligible for the programme" do
+        let(:patient) { create(:patient, year_group: 9) }
+
+        it "is included" do
+          expect(form.apply(scope)).to include(patient)
+        end
+      end
+
+      context "with a patient not eligible for the programme" do
+        let(:patient) { create(:patient, year_group: 8) }
+
+        it "is not included" do
+          expect(form.apply(scope)).not_to include(patient)
+        end
+      end
+    end
+
     context "filtering on programme status" do
       let(:consent_statuses) { nil }
       let(:date_of_birth_day) { nil }
@@ -100,6 +138,7 @@ describe SearchForm do
       let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { "vaccinated" }
+      let(:programme_types) { [programme.type] }
       let(:q) { nil }
       let(:register_status) { nil }
       let(:session_status) { nil }
@@ -110,7 +149,7 @@ describe SearchForm do
 
       it "filters on session status" do
         patient = create(:patient, :vaccinated, programmes: [programme])
-        expect(form.apply(scope, programme:)).to include(patient)
+        expect(form.apply(scope)).to include(patient)
       end
     end
 
@@ -170,6 +209,47 @@ describe SearchForm do
       expect { form.apply(scope) }.not_to raise_error
     end
 
+    context "filtering on programmes" do
+      let(:consent_status) { nil }
+      let(:date_of_birth_day) { nil }
+      let(:date_of_birth_month) { nil }
+      let(:date_of_birth_year) { nil }
+      let(:missing_nhs_number) { nil }
+      let(:programme_status) { nil }
+      let(:programme_types) { [programme.type] }
+      let(:q) { nil }
+      let(:register_status) { nil }
+      let(:session_status) { nil }
+      let(:triage_status) { nil }
+      let(:year_groups) { nil }
+
+      let(:programme) { create(:programme, :menacwy) }
+
+      context "with a patient session eligible for the programme" do
+        let(:patient) { create(:patient, year_group: 9) }
+
+        let(:patient_session) do
+          create(:patient_session, patient:, programmes: [programme])
+        end
+
+        it "is included" do
+          expect(form.apply(scope)).to include(patient_session)
+        end
+      end
+
+      context "with a patient session not eligible for the programme" do
+        let(:patient) { create(:patient, year_group: 8) }
+
+        let(:patient_session) do
+          create(:patient_session, patient:, programmes: [programme])
+        end
+
+        it "is not included" do
+          expect(form.apply(scope)).not_to include(patient_session)
+        end
+      end
+    end
+
     context "filtering on consent status" do
       let(:consent_statuses) { %w[given refused] }
       let(:date_of_birth_day) { nil }
@@ -177,6 +257,7 @@ describe SearchForm do
       let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
+      let(:programme_types) { [programme.type] }
       let(:q) { nil }
       let(:register_status) { nil }
       let(:triage_status) { nil }
@@ -195,7 +276,7 @@ describe SearchForm do
         patient_session_refused =
           create(:patient_session, :consent_refused, programmes: [programme])
 
-        expect(form.apply(scope, programme:)).to contain_exactly(
+        expect(form.apply(scope)).to contain_exactly(
           patient_session_given,
           patient_session_refused
         )
@@ -209,6 +290,7 @@ describe SearchForm do
       let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
+      let(:programme_types) { [programme.type] }
       let(:q) { nil }
       let(:register_status) { nil }
       let(:session_status) { "vaccinated" }
@@ -220,7 +302,7 @@ describe SearchForm do
       it "filters on session status" do
         patient_session =
           create(:patient_session, :vaccinated, programmes: [programme])
-        expect(form.apply(scope, programme:)).to include(patient_session)
+        expect(form.apply(scope)).to include(patient_session)
       end
     end
 
@@ -250,6 +332,7 @@ describe SearchForm do
       let(:date_of_birth_year) { nil }
       let(:missing_nhs_number) { nil }
       let(:programme_status) { nil }
+      let(:programme_types) { [programme.type] }
       let(:q) { nil }
       let(:register_status) { nil }
       let(:session_status) { nil }
@@ -265,7 +348,7 @@ describe SearchForm do
             :consent_given_triage_needed,
             programmes: [programme]
           )
-        expect(form.apply(scope, programme:)).to include(patient_session)
+        expect(form.apply(scope)).to include(patient_session)
       end
     end
   end
@@ -275,57 +358,65 @@ describe SearchForm do
 
     context "when clear_filters param is present" do
       it "only clears filters for the current path" do
-        described_class.new(q: "John", session:, request_path:)
-        described_class.new(q: "Jane", session:, request_path: another_path)
+        described_class.new(q: "John", request_session:, request_path:)
+        described_class.new(
+          q: "Jane",
+          request_session:,
+          request_path: another_path
+        )
 
-        described_class.new(clear_filters: "true", session:, request_path:)
+        described_class.new(
+          clear_filters: "true",
+          request_session:,
+          request_path:
+        )
 
-        form1 = described_class.new(**empty_params, session:, request_path:)
+        form1 = described_class.new(request_session:, request_path:)
         expect(form1.q).to be_nil
 
         form2 =
-          described_class.new(
-            **empty_params,
-            session:,
-            request_path: another_path
-          )
+          described_class.new(request_session:, request_path: another_path)
         expect(form2.q).to eq("Jane")
       end
     end
 
     context "when filters are present in params" do
       it "persists filters to be loaded in subsequent requests" do
-        described_class.new(q: "John", session:, request_path:)
+        described_class.new(q: "John", request_session:, request_path:)
 
-        form = described_class.new(**empty_params, session:, request_path:)
+        form = described_class.new(request_session:, request_path:)
         expect(form.q).to eq("John")
       end
 
       it "overwrites previously stored filters" do
-        described_class.new(q: "John", session:, request_path:)
+        described_class.new(q: "John", request_session:, request_path:)
 
-        form1 = described_class.new(q: "Jane", session:, request_path:)
+        form1 = described_class.new(q: "Jane", request_session:, request_path:)
         expect(form1.q).to eq("Jane")
 
-        form2 = described_class.new(**empty_params, session:, request_path:)
+        form2 = described_class.new(request_session:, request_path:)
         expect(form2.q).to eq("Jane")
       end
 
       it "overrides session filters when 'Any' option is selected (empty string)" do
         described_class.new(
           consent_statuses: %w[given],
-          session:,
+          request_session:,
           request_path:
         )
 
-        form1 = described_class.new(**empty_params, session:, request_path:)
+        form1 = described_class.new(request_session:, request_path:)
         expect(form1.consent_statuses).to eq(%w[given])
 
         form2 =
-          described_class.new(consent_statuses: nil, session:, request_path:)
+          described_class.new(
+            consent_statuses: nil,
+            request_session:,
+            request_path:
+          )
         expect(form2.consent_statuses).to eq([])
 
-        form3 = described_class.new(**empty_params, session:, request_path:)
+        form3 = described_class.new(request_session:, request_path:)
         expect(form3.consent_statuses).to eq([])
       end
     end
@@ -336,13 +427,13 @@ describe SearchForm do
           q: "John",
           year_groups: %w[8 11],
           consent_statuses: %w[given],
-          session:,
+          request_session:,
           request_path:
         )
       end
 
       it "loads filters from the session" do
-        form = described_class.new(**empty_params, session:, request_path:)
+        form = described_class.new(request_session:, request_path:)
 
         expect(form.q).to eq("John")
         expect(form.year_groups).to eq([8, 11])
@@ -352,18 +443,18 @@ describe SearchForm do
 
     context "with path-specific filters" do
       it "maintains separate filters for different paths" do
-        described_class.new(q: "John", session:, request_path:)
-        described_class.new(q: "Jane", session:, request_path: another_path)
+        described_class.new(q: "John", request_session:, request_path:)
+        described_class.new(
+          q: "Jane",
+          request_session:,
+          request_path: another_path
+        )
 
-        form1 = described_class.new(**empty_params, session:, request_path:)
+        form1 = described_class.new(request_session:, request_path:)
         expect(form1.q).to eq("John")
 
         form2 =
-          described_class.new(
-            **empty_params,
-            session:,
-            request_path: another_path
-          )
+          described_class.new(request_session:, request_path: another_path)
         expect(form2.q).to eq("Jane")
       end
     end


### PR DESCRIPTION
This PR handles the management of manual consent reminders mentioned in [MAV-886](https://nhsd-jira.digital.nhs.uk/browse/MAV-886).

It creates a new screen to inform the user of the automatic consent reminders for upcoming sessions, allows for the sending of manual consent reminders to the patient's guardians, and streamlines the rerouting of the some links on the session overview page as per the prototype in this [PR](https://github.com/nhsuk/manage-vaccinations-in-schools-prototype/pull/106).