### PR TITLE
Hide programme filter checkboxes when session has only one programme

### DIFF
--- a/app/components/app_search_component.rb
+++ b/app/components/app_search_component.rb
@@ -20,7 +20,7 @@ class AppSearchComponent < ViewComponent::Base
           </button>
         </div>
         
-        <% if programmes.any? %>
+        <% if programmes.size > 1 %>
           <%= f.govuk_check_boxes_fieldset :programme_types, legend: { text: "Programme", size: "s" } do %>
             <% programmes.each do |programme| %>
               <%= f.govuk_check_box :programme_types, programme.type, label: { text: programme.name } %>


### PR DESCRIPTION
Previously, the programme filter checkboxes were displayed whenever any programmes existed in a session, even when there was only one programme. This created a confusing UX where users could see a filter option that wouldn't actually filter anything meaningful.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1452
