### PR TITLE
Fix consent refused confirmation page for flu

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -69,8 +69,10 @@ class AppConsentConfirmationComponent < ViewComponent::Base
           if programme.flu?
             if consent_form_programme.vaccine_method_nasal?
               "nasal flu"
-            else
+            elsif consent_form_programme.vaccine_method_injection?
               "flu injection"
+            else
+              programme.name.downcase
             end
           else
             programme.name

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -42,6 +42,15 @@ describe AppConsentConfirmationComponent do
 
       it { should have_text("is due to get the flu injection vaccination") }
     end
+
+    context "consent refused" do
+      before do
+        consent_form_programme.update!(response: "refused", vaccine_methods: [])
+      end
+
+      it { should have_text("You’ve told us that you do not want") }
+      it { should have_text("to get the flu vaccination at school") }
+    end
   end
 
   context "consent for only MenACWY" do

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -239,7 +239,7 @@ RSpec.feature "Parental consent change answers" do
 
   def then_i_see_the_refused_confirmation_page
     expect(page).to have_content(
-      "Your child will not get a nasal flu vaccination at school"
+      "Your child will not get the flu vaccination at school"
     )
   end
 


### PR DESCRIPTION
Previosuly, the consent refused confirmation page refered to the flu injection specifically. This change removes confusion by referring to the general "flu vaccination".

![image](https://github.com/user-attachments/assets/ea3dcb54-ccd2-453a-8a16-cd51110e4bf1)

https://nhsd-jira.digital.nhs.uk/browse/MAV-1456