### PR TITLE
Fix: year group filters not filtering as expected

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -104,11 +104,28 @@ class Patient < ApplicationRecord
 
   scope :with_notice, -> { deceased.or(restricted).or(invalidated) }
 
+  scope :eligible_for_programmes,
+        ->(programmes) do
+          birth_academic_years =
+            programmes.flat_map(&:birth_academic_years).sort.uniq
+
+          Patient
+            .where("patients.id = patient_sessions.patient_id")
+            .where(birth_academic_year: birth_academic_years)
+            .arel
+            .exists
+        end
+
   scope :in_programmes,
         ->(programmes) do
           where(
-            birth_academic_year:
-              programmes.flat_map(&:birth_academic_years).sort.uniq
+            PatientSession
+              .joins(session: :session_programmes)
+              .where(session_programmes: { programme: programmes })
+              .where("patient_sessions.patient_id = patients.id")
+              .where(eligible_for_programmes(programmes))
+              .arel
+              .exists
           )
         end
 

--- a/spec/features/filtering_by_programme_spec.rb
+++ b/spec/features/filtering_by_programme_spec.rb
@@ -20,6 +20,15 @@ describe "Filtering" do
     and_i_see_only_the_menacwy_statuses
   end
 
+  scenario "By year group" do
+    given_a_session_exists_with_programmes([:hpv])
+    and_patients_are_in_the_session
+
+    when_i_visit_the_session_outcomes
+    and_i_filter_on_year_group_eight
+    the_i_should_only_see_patients_for_year_eight
+  end
+
   scenario "With only one programme in session" do
     given_a_session_exists_with_programmes([:hpv])
     and_patients_are_in_the_session
@@ -98,5 +107,17 @@ describe "Filtering" do
   def and_i_see_only_the_menacwy_statuses
     expect(page).not_to have_content("HPVNo outcome yet")
     expect(page).to have_content("MenACWYNo outcome yet").once
+  end
+
+  def and_i_filter_on_year_group_eight
+    check "Year 8"
+    click_on "Update results"
+  end
+
+  def the_i_should_only_see_patients_for_year_eight
+    expect(page).to have_content(@patient_eligible_for_hpv.full_name)
+    expect(page).not_to have_content(
+      @patient_eligible_for_hpv_and_menacwy.full_name
+    )
   end
 end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -117,7 +117,12 @@ describe SearchForm do
       let(:programme) { create(:programme, :menacwy) }
 
       context "with a patient eligible for the programme" do
-        let(:patient) { create(:patient, year_group: 9) }
+        let(:patient) do
+          create(:patient, programmes: [programme]).tap do |patient|
+            session = create(:session, programmes: [programme])
+            create(:patient_session, patient:, session:)
+          end
+        end
 
         it "is included" do
           expect(form.apply(scope)).to include(patient)
@@ -151,6 +156,9 @@ describe SearchForm do
 
       it "filters on session status" do
         patient = create(:patient, :vaccinated, programmes: [programme])
+        session = create(:session, programmes: [programme])
+        create(:patient_session, patient:, session:)
+
         expect(form.apply(scope)).to include(patient)
       end
     end


### PR DESCRIPTION
The register and record-vaccinations tabs now show a “Year group” filter, intended to list only the pupils in the chosen year (e.g., Year 8). The filter appears but doesn’t work as intended as the full pupil list still displays.

The reason it wasn't working is that the original scope was overriding a previous scope `search_by_year_groups`. The new version considers the programme as it should but makes sure it returns patients who are eligible for that programme.

### Screenshots
| Before | After |
|------------------|---------------------|
| <img width="1135" alt="Screenshot 2025-07-02 at 16 36 37" src="https://github.com/user-attachments/assets/6aed26d7-80bd-4c0d-be97-a57f834ff210" /> | <img width="1116" alt="Screenshot 2025-07-02 at 16 37 14" src="https://github.com/user-attachments/assets/143bde97-def8-4a19-80e3-d47ceb3d2abf" />  | 