### PR TITLE
Flu recording: reset batch if delivery method changes

### DIFF
--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -296,6 +296,34 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_given_injection_only_triage_not_needed do
+      triage_not_required
+
+      consents do
+        programmes.map do |programme|
+          association(
+            :consent,
+            :given_injection,
+            :from_mum,
+            :health_question_notes,
+            patient: instance,
+            organisation:,
+            programme:
+          )
+        end
+      end
+      consent_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_consent_status,
+            :given_injection_only,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+    end
+
     trait :consent_given_nasal_or_injection_triage_not_needed do
       triage_not_required
 

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+describe "Flu vaccination" do
+  around { |example| travel_to(Time.zone.local(2024, 10, 1)) { example.run } }
+
+  scenario "Administered with nasal spray" do
+    given_i_am_signed_in_with_flu_programme
+    and_there_is_a_flu_session_today_with_two_patients_ready_to_vaccinate
+    and_there_are_nasal_and_injection_batches
+
+    when_i_go_to_the_nasal_only_patient
+    and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+    then_i_see_the_check_and_confirm_page_for_nasal_spray
+    and_i_get_confirmation_after_recording
+  end
+
+  scenario "Administered with injection" do
+    given_i_am_signed_in_with_flu_programme
+    and_there_is_a_flu_session_today_with_two_patients_ready_to_vaccinate
+    and_there_are_nasal_and_injection_batches
+
+    when_i_go_to_the_injection_only_patient
+    and_i_record_that_the_patient_has_been_vaccinated_with_injection
+    then_i_see_the_check_and_confirm_page_for_injection
+    and_i_get_confirmation_after_recording
+  end
+
+  def given_i_am_signed_in_with_flu_programme
+    @programme = create(:programme, :flu)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [@programme])
+    @location = create(:school)
+    @session =
+      create(
+        :session,
+        organisation: @organisation,
+        programmes: [@programme],
+        location: @location
+      )
+    sign_in @organisation.users.first
+  end
+
+  def and_there_is_a_flu_session_today_with_two_patients_ready_to_vaccinate
+    @nasal_patient =
+      create(
+        :patient,
+        :consent_given_nasal_only_triage_not_needed,
+        :in_attendance,
+        session: @session
+      )
+    @injection_patient =
+      create(
+        :patient,
+        :consent_given_injection_only_triage_not_needed,
+        :in_attendance,
+        session: @session
+      )
+  end
+
+  def and_there_are_nasal_and_injection_batches
+    @nasal_vaccine = create(:vaccine, programme: @programme, method: :nasal)
+    @nasal_batch =
+      create(
+        :batch,
+        :not_expired,
+        organisation: @organisation,
+        vaccine: @nasal_vaccine
+      )
+    @injection_vaccine =
+      create(:vaccine, programme: @programme, method: :injection)
+    @injection_batch =
+      create(
+        :batch,
+        :not_expired,
+        organisation: @organisation,
+        vaccine: @injection_vaccine
+      )
+  end
+
+  def when_i_go_to_the_nasal_only_patient
+    visit session_record_path(@session)
+    click_link @nasal_patient.full_name
+  end
+
+  def when_i_go_to_the_injection_only_patient
+    visit session_record_path(@session)
+    click_link @injection_patient.full_name
+  end
+
+  def and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
+
+    within all("section")[1] do
+      choose "Yes"
+      click_button "Continue"
+    end
+
+    choose @nasal_batch.name
+    click_button "Continue"
+  end
+
+  def and_i_record_that_the_patient_has_been_vaccinated_with_injection
+    within all("section")[0] do
+      choose "Yes"
+      check "has confirmed the above statements are true"
+    end
+
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
+
+    choose @injection_batch.name
+    click_button "Continue"
+  end
+
+  def then_i_see_the_check_and_confirm_page_for_nasal_spray
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content(@nasal_patient.full_name)
+    expect(page).to have_content(@nasal_batch.name)
+    expect(page).to have_content("Nasal spray")
+    expect(page).to have_content("Nose")
+    expect(page).to have_content(@location.name)
+    expect(page).to have_content("Vaccinated")
+  end
+
+  def and_i_get_confirmation_after_recording
+    click_button "Confirm"
+    expect(page).to have_content("Vaccination outcome recorded for Flu")
+  end
+
+  def then_i_see_the_check_and_confirm_page_for_injection
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content(@injection_patient.full_name)
+    expect(page).to have_content(@injection_batch.name)
+    expect(page).to have_content("Intramuscular")
+    expect(page).to have_content("Left arm (upper position)")
+    expect(page).to have_content(@location.name)
+    expect(page).to have_content("Vaccinated")
+  end
+end

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -25,6 +25,20 @@ describe "Flu vaccination" do
     and_i_get_confirmation_after_recording
   end
 
+  scenario "Switching between nasal and injection" do
+    given_i_am_signed_in_with_flu_programme
+    and_there_is_a_flu_session_today_with_two_patients_ready_to_vaccinate
+    and_there_are_nasal_and_injection_batches
+
+    when_i_go_to_the_nasal_only_patient
+    and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+    then_i_see_the_check_and_confirm_page_for_nasal_spray
+
+    when_i_change_the_vaccine_method_to_injection
+    and_i_pick_a_batch_for_injection
+    then_i_see_the_check_and_confirm_page_for_injection
+  end
+
   def given_i_am_signed_in_with_flu_programme
     @programme = create(:programme, :flu)
     @organisation =
@@ -79,12 +93,14 @@ describe "Flu vaccination" do
 
   def when_i_go_to_the_nasal_only_patient
     visit session_record_path(@session)
-    click_link @nasal_patient.full_name
+    @patient = @nasal_patient
+    click_link @patient.full_name
   end
 
   def when_i_go_to_the_injection_only_patient
     visit session_record_path(@session)
-    click_link @injection_patient.full_name
+    @patient = @injection_patient
+    click_link @patient.full_name
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
@@ -120,7 +136,7 @@ describe "Flu vaccination" do
 
   def then_i_see_the_check_and_confirm_page_for_nasal_spray
     expect(page).to have_content("Check and confirm")
-    expect(page).to have_content(@nasal_patient.full_name)
+    expect(page).to have_content(@patient.full_name)
     expect(page).to have_content(@nasal_batch.name)
     expect(page).to have_content("Nasal spray")
     expect(page).to have_content("Nose")
@@ -135,11 +151,25 @@ describe "Flu vaccination" do
 
   def then_i_see_the_check_and_confirm_page_for_injection
     expect(page).to have_content("Check and confirm")
-    expect(page).to have_content(@injection_patient.full_name)
+    expect(page).to have_content(@patient.full_name)
     expect(page).to have_content(@injection_batch.name)
     expect(page).to have_content("Intramuscular")
     expect(page).to have_content("Left arm (upper position)")
     expect(page).to have_content(@location.name)
     expect(page).to have_content("Vaccinated")
+  end
+
+  def when_i_change_the_vaccine_method_to_injection
+    click_link "Change method"
+    choose "Intramuscular"
+    choose "Left arm (upper position)"
+    click_button "Continue"
+  end
+
+  def and_i_pick_a_batch_for_injection
+    expect(page).not_to have_content(@nasal_batch.name)
+    expect(page).not_to have_checked_field
+    choose @injection_batch.name
+    click_button "Continue"
   end
 end

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -247,4 +247,57 @@ describe DraftVaccinationRecord do
       it { should eq(vaccine.dose_volume_ml * 0.5) }
     end
   end
+
+  describe "#delivery_method=" do
+    context "when setting delivery method for the first time" do
+      let(:attributes) do
+        valid_administered_attributes.except(:delivery_method)
+      end
+
+      it "does not clear the batch_id" do
+        expect {
+          draft_vaccination_record.delivery_method = "intramuscular"
+        }.not_to change(draft_vaccination_record, :batch_id)
+      end
+    end
+
+    shared_examples "clears batch when switching delivery methods" do |from_method, to_method|
+      context "when changing from #{from_method} to #{to_method}" do
+        let(:attributes) do
+          valid_administered_attributes.merge(delivery_method: from_method)
+        end
+
+        it "clears the batch_id" do
+          expect {
+            draft_vaccination_record.delivery_method = to_method
+          }.to change(draft_vaccination_record, :batch_id).to(nil)
+        end
+      end
+    end
+
+    include_examples "clears batch when switching delivery methods",
+                     "intramuscular",
+                     "nasal_spray"
+    include_examples "clears batch when switching delivery methods",
+                     "subcutaneous",
+                     "nasal_spray"
+    include_examples "clears batch when switching delivery methods",
+                     "nasal_spray",
+                     "intramuscular"
+    include_examples "clears batch when switching delivery methods",
+                     "nasal_spray",
+                     "subcutaneous"
+
+    context "when changing between injection methods" do
+      let(:attributes) do
+        valid_administered_attributes.merge(delivery_method: "intramuscular")
+      end
+
+      it "does not clear the batch_id" do
+        expect {
+          draft_vaccination_record.delivery_method = "subcutaneous"
+        }.not_to change(draft_vaccination_record, :batch_id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
For flu vaccination recording, the delivery method (broadly nasal vs injection), the delivery site (part of the body) and the vaccine product need to be consistent.

If a vaccinator starts recording a nasal flu vaccination, changes prior to confirmation to an injection (or vice versa), they need to pick the vaccine product & batch again to avoid inconsistencies.

This PR makes this change, as well as adding feature spec coverage for flu vaccination administration.

JIRA: [MAV-1460](https://nhsd-jira.digital.nhs.uk/browse/MAV-1460), [MAV-1461](https://nhsd-jira.digital.nhs.uk/browse/MAV-1461)