### PR TITLE
Aws provider version upgrade

### DIFF
--- a/terraform/account/main.tf
+++ b/terraform/account/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 

--- a/terraform/app/main.tf
+++ b/terraform/app/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
     time = {
       source  = "hashicorp/time"

--- a/terraform/app/modules/dms/main.tf
+++ b/terraform/app/modules/dms/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
     time = {
       source  = "hashicorp/time"

--- a/terraform/app/modules/dns/main.tf
+++ b/terraform/app/modules/dns/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 }

--- a/terraform/app/modules/ecs_service/main.tf
+++ b/terraform/app/modules/ecs_service/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 }

--- a/terraform/app/modules/vpc_endpoint/main.tf
+++ b/terraform/app/modules/vpc_endpoint/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 }

--- a/terraform/backup/destination-bootstrap/main.tf
+++ b/terraform/backup/destination-bootstrap/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 }

--- a/terraform/backup/destination/main.tf
+++ b/terraform/backup/destination/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 

--- a/terraform/backup/source/main.tf
+++ b/terraform/backup/source/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 }

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.87"
+      version = "~> 6.2"
     }
   }
 }


### PR DESCRIPTION
Version upgrade of the terraform provider.

Release notes of the breaking changes: https://github.com/hashicorp/terraform-provider-aws/releases/tag/v6.0.0