### PR TITLE
Identity check default

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_radio_buttons_fieldset :identity_check_confirmed_by_patient,
                                          legend: { text: "Has #{patient.given_name} confirmed their identity?", size: nil } do %>
 
-        <%= f.govuk_radio_button :identity_check_confirmed_by_patient, true, label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :identity_check_confirmed_by_patient, true, label: { text: "Yes" }, checked: true, link_errors: true %>
 
         <%= f.govuk_radio_button :identity_check_confirmed_by_patient, false,
                                  label: { text: "No, it was confirmed by somebody else" } do %>

--- a/spec/features/community_clinic_vaccination_session_spec.rb
+++ b/spec/features/community_clinic_vaccination_session_spec.rb
@@ -41,10 +41,6 @@ describe "Community clinic vaccination session" do
     visit session_record_path(@session)
     click_link @patient.full_name
 
-    within all("section")[0] do
-      choose "Yes"
-    end
-
     within all("section")[1] do
       choose "No"
       click_button "Continue"

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -75,10 +75,6 @@ describe "MenACWY and Td/IPV vaccination" do
   end
 
   def and_i_record_the_vaccination(batch)
-    within all("section")[0] do
-      choose "Yes"
-    end
-
     within all("section")[1] do
       choose "Yes"
       choose "Left arm (upper position)"

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -242,7 +242,6 @@ describe "End-to-end journey" do
     expect(page).to have_content("Update attendance")
 
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -105,7 +105,6 @@ describe "Flu vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 
@@ -120,7 +119,6 @@ describe "Flu vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated_with_injection
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -7,7 +7,6 @@ describe "HPV vaccination" do
     given_i_am_signed_in
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    and_i_confirm_the_identity
     and_i_fill_in_pre_screening_questions
     and_i_record_that_the_patient_has_been_vaccinated(
       "Left arm (upper position)"
@@ -61,7 +60,6 @@ describe "HPV vaccination" do
     given_i_am_signed_in
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
-    and_i_confirm_the_identity
     and_i_fill_in_pre_screening_questions
     and_i_record_that_the_patient_has_been_vaccinated("Other")
     and_i_select_the_delivery
@@ -109,12 +107,6 @@ describe "HPV vaccination" do
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
     click_link @patient.full_name
-  end
-
-  def and_i_confirm_the_identity
-    within all("section")[0] do
-      choose "Yes"
-    end
   end
 
   def and_i_fill_in_pre_screening_questions

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -50,7 +50,6 @@ describe "HPV vaccination" do
 
   def and_i_record_that_the_patient_wasnt_vaccinated
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -64,7 +64,6 @@ describe "HPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 

--- a/spec/features/hpv_vaccination_delayed_spec.rb
+++ b/spec/features/hpv_vaccination_delayed_spec.rb
@@ -55,10 +55,6 @@ describe "HPV vaccination" do
   end
 
   def and_i_record_that_the_patient_was_unwell
-    within all("section")[0] do
-      choose "Yes"
-    end
-
     within all("section")[1] do
       choose "No"
       click_button "Continue"

--- a/spec/features/identity_check_spec.rb
+++ b/spec/features/identity_check_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+describe "HPV vaccination identity check" do
+  scenario "Identity confirmed by child (default)" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_record_a_vaccination_was_given
+    and_i_confirm_the_details
+
+    when_i_go_to_the_vaccination_record
+    then_i_see_that_child_identified_by_shows_the_child
+  end
+
+  scenario "Identity confirmed by someone else" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_confirm_the_patient_identity_was_confirmed_by_someone_else
+    and_i_record_a_vaccination_was_given
+
+    and_i_confirm_the_details
+
+    when_i_go_to_the_vaccination_record
+    then_i_see_that_child_identified_by_shows_the_person_and_relationship
+  end
+
+  scenario "Identity confirmed by someone else for non-vaccination" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_confirm_the_patient_identity_was_confirmed_by_someone_else
+    and_i_record_that_the_patient_was_unwell
+
+    and_i_confirm_the_details
+
+    when_i_go_to_the_vaccination_record
+    then_i_see_that_child_identified_by_shows_the_person_and_relationship
+  end
+
+  scenario "Identity check validation - missing person details" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_select_identity_confirmed_by_someone_else_but_leave_fields_blank
+    and_i_try_to_continue
+    then_i_see_errors_about_missing_person_name_and_relationship
+  end
+
+  scenario "Identity check validation - missing person name only" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_select_identity_confirmed_by_someone_else_with_only_relationship
+    and_i_try_to_continue
+    then_i_see_error_about_missing_person_name
+  end
+
+  scenario "Identity check validation - missing relationship only" do
+    given_i_am_signed_in
+
+    when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    and_i_select_identity_confirmed_by_someone_else_with_only_name
+    and_i_try_to_continue
+    then_i_see_error_about_missing_person_relationship
+  end
+
+  def given_i_am_signed_in
+    programmes = [create(:programme, :hpv)]
+    @organisation = create(:organisation, :with_one_nurse, programmes:)
+
+    location = create(:school)
+    @batch =
+      create(
+        :batch,
+        :not_expired,
+        organisation: @organisation,
+        vaccine: programmes.first.vaccines.active.first
+      )
+
+    @session =
+      create(:session, organisation: @organisation, programmes:, location:)
+    @patient =
+      create(
+        :patient,
+        :consent_given_triage_not_needed,
+        :in_attendance,
+        session: @session
+      )
+
+    sign_in @organisation.users.first
+  end
+
+  def when_i_go_to_a_patient_that_is_ready_to_vaccinate
+    visit session_record_path(@session)
+    click_link @patient.full_name
+  end
+
+  def and_i_confirm_the_patient_identity_was_confirmed_by_child
+    choose "Yes"
+    click_button "Continue"
+  end
+
+  def and_i_confirm_the_patient_identity_was_confirmed_by_someone_else
+    choose "No, it was confirmed by somebody else"
+    fill_in "What is the person’s name?", with: "Sadie Smith"
+    fill_in "What is their relationship to the child", with: "teacher"
+    click_button "Continue"
+  end
+
+  def and_i_record_a_vaccination_was_given
+    within all("section")[0] do
+      check "has confirmed the above statements are true"
+    end
+
+    within all("section")[1] do
+      choose "Yes"
+      choose "Left arm (upper position)"
+      click_button "Continue"
+    end
+
+    choose @batch.name
+    click_button "Continue"
+  end
+
+  def and_i_record_that_the_patient_was_unwell
+    within all("section")[1] do
+      choose "No"
+      click_button "Continue"
+    end
+
+    choose "They were not well enough"
+    click_button "Continue"
+  end
+
+  def and_i_confirm_the_details
+    click_button "Confirm"
+    puts "Vaccination outcome recorded for HPV"
+  end
+
+  def when_i_go_to_the_vaccination_record
+    click_on Date.current.to_fs(:long)
+  end
+
+  def then_i_see_that_child_identified_by_shows_the_child
+    expect(page).to have_content("Child identified by")
+    expect(page).to have_content("The child")
+  end
+
+  def then_i_see_that_child_identified_by_shows_the_person_and_relationship
+    expect(page).to have_content("Child identified by")
+    expect(page).to have_content("Sadie Smith (teacher)")
+  end
+
+  def and_i_try_to_continue
+    click_button "Continue"
+  end
+
+  def then_i_see_an_error_about_selecting_identity_confirmation
+    expect(page).to have_content(
+      "Select whether the child confirmed their identity"
+    )
+  end
+
+  def and_i_select_identity_confirmed_by_someone_else_but_leave_fields_blank
+    choose "No, it was confirmed by somebody else"
+  end
+
+  def then_i_see_errors_about_missing_person_name_and_relationship
+    expect(page).to have_content("Enter the person’s name")
+    expect(page).to have_content("Enter the person’s relationship")
+  end
+
+  def and_i_select_identity_confirmed_by_someone_else_with_only_relationship
+    choose "No, it was confirmed by somebody else"
+    fill_in "What is their relationship to the child", with: "teacher"
+  end
+
+  def then_i_see_error_about_missing_person_name
+    expect(page).to have_content("Enter the person’s name")
+    expect(page).not_to have_content("Enter the person’s relationship")
+  end
+
+  def and_i_select_identity_confirmed_by_someone_else_with_only_name
+    choose "No, it was confirmed by somebody else"
+    fill_in "What is the person’s name?", with: "Sadie Smith"
+  end
+
+  def then_i_see_error_about_missing_person_relationship
+    expect(page).to have_content("Enter the person’s relationship")
+    expect(page).not_to have_content("Enter the person’s name")
+  end
+end

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -89,7 +89,6 @@ describe "MenACWY vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 

--- a/spec/features/pre_screening_spec.rb
+++ b/spec/features/pre_screening_spec.rb
@@ -98,10 +98,6 @@ describe "Pre-screening" do
   end
 
   def and_i_record_vaccination_without_pre_screening_checks
-    within all("section")[0] do
-      choose "Yes"
-    end
-
     within all("section")[1] do
       choose "Yes"
       choose "Left arm (upper position)"

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -89,7 +89,6 @@ describe "Td/IPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -67,7 +67,6 @@ describe "Vaccination" do
     click_link @patient.full_name
 
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 
@@ -103,7 +102,6 @@ describe "Vaccination" do
     click_link @patient2.full_name
 
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 
@@ -158,7 +156,6 @@ describe "Vaccination" do
     click_on "MenACWY"
 
     within all("section")[0] do
-      choose "Yes"
       check "has confirmed the above statements are true"
     end
 


### PR DESCRIPTION
During the identity check pre-vaccination, the child is now selected by default, reducing the number of clicks most vaccination flows will have. This is because a vast majority of children will be able to  identify themselves.

Also adds feature tests for the identity check flow.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1349