### PR TITLE
Set default dose sequence for flu to 1

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -103,7 +103,7 @@ class Programme < ApplicationRecord
   end
 
   def default_dose_sequence
-    hpv? ? vaccinated_dose_sequence : nil
+    hpv? || flu? ? vaccinated_dose_sequence : nil
   end
 
   def maximum_dose_sequence

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -955,7 +955,7 @@ describe Reports::OfflineSessionExporter do
   context "Flu programme" do
     let(:programme) { create(:programme, :flu) }
     let(:expected_programme) { "Flu" }
-    let(:expected_dose_sequence) { nil }
+    let(:expected_dose_sequence) { 1 }
 
     include_examples "generates a report"
   end

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -160,7 +160,7 @@ describe Programme do
     context "with a Flu programme" do
       let(:programme) { build(:programme, :flu) }
 
-      it { should be_nil }
+      it { should eq(1) }
     end
 
     context "with an HPV programme" do


### PR DESCRIPTION
As per discussions within the team, Mavis should be defaulting to dose 1 for flu.