### PR TITLE
Sync vaccination records to NHSE Immunisations FHIR API

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -120,6 +120,8 @@ class DraftVaccinationRecordsController < ApplicationController
 
     send_vaccination_confirmation(@vaccination_record) if should_notify_parents
 
+    EnqueueSyncVaccinationRecordToNHSE.call(@vaccination_record)
+
     # In case the user navigates back to try and edit the newly created
     # vaccination record.
     @draft_vaccination_record.update!(editing_id: @vaccination_record.id)

--- a/app/lib/enqueue_sync_vaccination_record_to_nhse.rb
+++ b/app/lib/enqueue_sync_vaccination_record_to_nhse.rb
@@ -1,10 +1,27 @@
 # frozen_string_literal: true
 
 module EnqueueSyncVaccinationRecordToNHSE
+  PROGRAMME_TYPES = %w[flu hpv].freeze
+
   def self.call(vaccination_record)
-    if Flipper.enabled?(:sync_vaccination_records_to_nhse_on_create) &&
-         vaccination_record.programme.type.in?(%w[flu hpv]) &&
-         vaccination_record.administered?
+    return unless Flipper.enabled?(:sync_vaccination_records_to_nhse_on_create)
+
+    vaccination_records =
+      if vaccination_record.respond_to?(:klass)
+        vaccination_record
+          .recorded_in_service
+          .administered
+          .where(programmes: { type: PROGRAMME_TYPES })
+          .includes(:programme)
+      elsif vaccination_record.programme.type.in?(PROGRAMME_TYPES) &&
+            vaccination_record.administered? &&
+            vaccination_record.recorded_in_service?
+        Array(vaccination_record)
+      else
+        return
+      end
+
+    vaccination_records.each do |vaccination_record|
       SyncVaccinationRecordToNHSEJob.perform_later(vaccination_record)
     end
   end

--- a/app/lib/enqueue_sync_vaccination_record_to_nhse.rb
+++ b/app/lib/enqueue_sync_vaccination_record_to_nhse.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module EnqueueSyncVaccinationRecordToNHSE
+  def self.call(vaccination_record)
+    if Flipper.enabled?(:sync_vaccination_records_to_nhse_on_create) &&
+         vaccination_record.programme.type.in?(%w[flu hpv]) &&
+         vaccination_record.administered?
+      SyncVaccinationRecordToNHSEJob.perform_later(vaccination_record)
+    end
+  end
+end

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -109,5 +109,13 @@ class ImmunisationImport < ApplicationRecord
 
   def postprocess_rows!
     StatusUpdater.call(patient: patients)
+
+    vaccination_records
+      .recorded_in_service
+      .administered
+      .includes(:programme)
+      .find_each do |vaccination_record|
+        EnqueueSyncVaccinationRecordToNHSE.call(vaccination_record)
+      end
   end
 end

--- a/app/models/immunisation_import.rb
+++ b/app/models/immunisation_import.rb
@@ -110,12 +110,6 @@ class ImmunisationImport < ApplicationRecord
   def postprocess_rows!
     StatusUpdater.call(patient: patients)
 
-    vaccination_records
-      .recorded_in_service
-      .administered
-      .includes(:programme)
-      .find_each do |vaccination_record|
-        EnqueueSyncVaccinationRecordToNHSE.call(vaccination_record)
-      end
+    EnqueueSyncVaccinationRecordToNHSE.call(vaccination_records)
   end
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -11,3 +11,7 @@ offline_working: Prototype support for using Mavis offline.
 
 immunisations_fhir_api_integration: Master switch to control communications with
   NHS Immunistaions FHIR API.
+
+sync_vaccination_records_to_nhse_on_create:
+  Send new vaccinations recorded by nurses to
+  NHS Immunisations FHIR API.

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -7,11 +7,13 @@ describe "Flu vaccination" do
     given_i_am_signed_in_with_flu_programme
     and_there_is_a_flu_session_today_with_two_patients_ready_to_vaccinate
     and_there_are_nasal_and_injection_batches
+    and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
 
     when_i_go_to_the_nasal_only_patient
     and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     then_i_see_the_check_and_confirm_page_for_nasal_spray
     and_i_get_confirmation_after_recording
+    and_the_vaccination_record_is_synced_to_nhse
   end
 
   scenario "Administered with injection" do
@@ -89,6 +91,10 @@ describe "Flu vaccination" do
         organisation: @organisation,
         vaccine: @injection_vaccine
       )
+  end
+
+  def and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
+    Flipper.enable(:sync_vaccination_records_to_nhse_on_create)
   end
 
   def when_i_go_to_the_nasal_only_patient
@@ -169,5 +175,9 @@ describe "Flu vaccination" do
     expect(page).not_to have_checked_field
     choose @injection_batch.name
     click_button "Continue"
+  end
+
+  def and_the_vaccination_record_is_synced_to_nhse
+    assert_enqueued_with(job: SyncVaccinationRecordToNHSEJob)
   end
 end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -5,6 +5,7 @@ describe "HPV vaccination" do
 
   scenario "Administered with common delivery site" do
     given_i_am_signed_in
+    and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_fill_in_pre_screening_questions
@@ -41,6 +42,7 @@ describe "HPV vaccination" do
     then_i_see_a_success_message
     and_i_can_no_longer_vaccinate_the_patient
     and_i_no_longer_see_the_patient_in_the_record_tab
+    and_the_vaccination_record_is_synced_to_nhse
 
     when_i_go_back
     and_i_save_changes
@@ -102,6 +104,10 @@ describe "HPV vaccination" do
       )
 
     sign_in organisation.users.first
+  end
+
+  def and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
+    Flipper.enable(:sync_vaccination_records_to_nhse_on_create)
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
@@ -241,5 +247,9 @@ describe "HPV vaccination" do
       @patient.consents.last.parent.phone,
       :vaccination_administered_hpv
     )
+  end
+
+  def and_the_vaccination_record_is_synced_to_nhse
+    assert_enqueued_with(job: SyncVaccinationRecordToNHSEJob)
   end
 end

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -5,6 +5,7 @@ describe "MenACWY vaccination" do
 
   scenario "Administered" do
     given_i_am_signed_in
+    and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_record_that_the_patient_has_been_vaccinated
@@ -37,6 +38,7 @@ describe "MenACWY vaccination" do
     when_i_confirm_the_details
     then_i_see_a_success_message
     and_i_no_longer_see_the_patient_in_the_record_tab
+    and_the_vaccination_record_is_not_synced_to_nhse
 
     when_i_go_back
     and_i_save_changes
@@ -80,6 +82,10 @@ describe "MenACWY vaccination" do
       )
 
     sign_in organisation.users.first
+  end
+
+  def and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
+    Flipper.enable(:sync_vaccination_records_to_nhse_on_create)
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
@@ -199,5 +205,9 @@ describe "MenACWY vaccination" do
       @patient.consents.last.parent.phone,
       :vaccination_administered_menacwy
     )
+  end
+
+  def and_the_vaccination_record_is_not_synced_to_nhse
+    assert_no_enqueued_jobs(only: SyncVaccinationRecordToNHSEJob)
   end
 end

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -5,6 +5,7 @@ describe "Td/IPV vaccination" do
 
   scenario "Administered" do
     given_i_am_signed_in
+    and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_record_that_the_patient_has_been_vaccinated
@@ -37,6 +38,7 @@ describe "Td/IPV vaccination" do
     when_i_confirm_the_details
     then_i_see_a_success_message
     and_i_no_longer_see_the_patient_in_the_record_tab
+    and_the_vaccination_record_is_not_synced_to_nhse
 
     when_i_go_back
     and_i_save_changes
@@ -80,6 +82,10 @@ describe "Td/IPV vaccination" do
       )
 
     sign_in organisation.users.first
+  end
+
+  def and_sync_vaccination_records_to_nhse_on_create_feature_is_enabled
+    Flipper.enable(:sync_vaccination_records_to_nhse_on_create)
   end
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
@@ -199,5 +205,9 @@ describe "Td/IPV vaccination" do
       @patient.consents.last.parent.phone,
       :vaccination_administered_td_ipv
     )
+  end
+
+  def and_the_vaccination_record_is_not_synced_to_nhse
+    assert_no_enqueued_jobs(only: SyncVaccinationRecordToNHSEJob)
   end
 end

--- a/spec/lib/enqueue_sync_vaccination_record_to_nhse_spec.rb
+++ b/spec/lib/enqueue_sync_vaccination_record_to_nhse_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe EnqueueSyncVaccinationRecordToNHSE do
+  context "when the feature flag is disabled" do
+    before { Flipper.disable(:sync_vaccination_records_to_nhse_on_create) }
+
+    let(:vaccination_record) { create(:vaccination_record) }
+
+    it "does not enqueue the job" do
+      expect {
+        described_class.call(vaccination_record)
+      }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
+    end
+  end
+
+  context "when the feature flag is enabled" do
+    before { Flipper.enable(:sync_vaccination_records_to_nhse_on_create) }
+
+    let(:vaccination_record) do
+      create(:vaccination_record, outcome:, programme:)
+    end
+    let(:outcome) { "administered" }
+    let(:programme) { create(:programme, type: "flu") }
+
+    context "when the vaccination record is eligible for syncing" do
+      it "enqueues the job" do
+        expect {
+          described_class.call(vaccination_record)
+        }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
+      end
+    end
+
+    VaccinationRecord.defined_enums["outcome"].each_key do |outcome|
+      next if outcome == "administered"
+
+      context "when the vaccination record outcome is #{outcome}" do
+        let(:outcome) { outcome }
+
+        it "does not enqueue the job" do
+          expect {
+            described_class.call(vaccination_record)
+          }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
+        end
+      end
+    end
+
+    Programme.defined_enums["type"].each_key do |programme_type|
+      next if programme_type.in? %w[flu hpv]
+
+      context "when the programme type is #{programme_type}" do
+        let(:programme) { create(:programme, type: programme_type) }
+
+        it "does not enqueue the job" do
+          expect {
+            described_class.call(vaccination_record)
+          }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/enqueue_sync_vaccination_record_to_nhse_spec.rb
+++ b/spec/lib/enqueue_sync_vaccination_record_to_nhse_spec.rb
@@ -16,14 +16,15 @@ describe EnqueueSyncVaccinationRecordToNHSE do
   context "when the feature flag is enabled" do
     before { Flipper.enable(:sync_vaccination_records_to_nhse_on_create) }
 
-    let(:vaccination_record) do
-      create(:vaccination_record, outcome:, programme:)
-    end
     let(:outcome) { "administered" }
     let(:programme) { create(:programme, type: "flu") }
+    let(:session) { create(:session, programmes: [programme]) }
+    let(:vaccination_record) do
+      create(:vaccination_record, outcome:, programme:, session:)
+    end
 
-    context "when the vaccination record is eligible for syncing" do
-      it "enqueues the job" do
+    context "with a single vaccination record" do
+      it "enqueues the job if the vaccination record is elligible to sync" do
         expect {
           described_class.call(vaccination_record)
         }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
@@ -55,6 +56,70 @@ describe EnqueueSyncVaccinationRecordToNHSE do
             described_class.call(vaccination_record)
           }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
         end
+      end
+    end
+
+    context "with a vaccinaton record relation" do
+      # The strategy is to create a vaccination record for each of the various
+      # variations, and test that only the correct ones are allowed through
+
+      before do
+        # Generate historic vaccination record (no session)
+        create(:vaccination_record, outcome:, programme:)
+
+        # Generate vaccination records for all programme types
+        Programme.defined_enums["type"].each_key do |programme_type|
+          next if programme_type == "flu"
+          programme = create(:programme, type: programme_type)
+          create(:vaccination_record, outcome: "refused", session:, programme:)
+        end
+
+        # Generate vaccination records for all outcomes
+        VaccinationRecord.defined_enums["outcome"].each_key do |outcome|
+          next if outcome == "administered"
+          create(:vaccination_record, outcome:, session:, programme:)
+        end
+      end
+
+      let(:flu_programme) { Programme.flu.first || create(:programme, :flu) }
+      let(:hpv_programme) { Programme.hpv.first || create(:programme, :hpv) }
+      let!(:flu_vaccination_record) do
+        create(
+          :vaccination_record,
+          programme: flu_programme,
+          session:,
+          outcome: :administered
+        )
+      end
+      let!(:hpv_vaccination_record) do
+        create(
+          :vaccination_record,
+          programme: hpv_programme,
+          session:,
+          outcome: :administered
+        )
+      end
+
+      it "enqueues the job for each eligible vaccination record" do
+        expect {
+          described_class.call(VaccinationRecord.all)
+        }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob).exactly(2).times
+      end
+
+      it "enqueues the eligible flu job" do
+        expect {
+          described_class.call(VaccinationRecord.all)
+        }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob).with(
+          flu_vaccination_record
+        )
+      end
+
+      it "enqueues the eligible hpv job" do
+        expect {
+          described_class.call(VaccinationRecord.all)
+        }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob).with(
+          hpv_vaccination_record
+        )
       end
     end
   end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -323,4 +323,124 @@ describe ImmunisationImport do
       end
     end
   end
+
+  describe "#postprocess_row!" do
+    subject(:immunisation_import) do
+      create(
+        :immunisation_import,
+        organisation:,
+        vaccination_records: [
+          flu_record,
+          hpv_record,
+          td_ipv_record,
+          menacwy_record
+        ]
+      )
+    end
+
+    before { Flipper.enable :sync_vaccination_records_to_nhse_on_create }
+
+    let(:hpv_programme) { Programme.hpv.first || create(:programme, :hpv) }
+    let(:flu_programme) { Programme.flu.first || create(:programme, :flu) }
+    let(:menacwy_programme) { create(:programme, :menacwy) }
+    let(:td_ipv_programme) { create(:programme, :td_ipv) }
+    let(:organisation) do
+      create(
+        :organisation,
+        :with_generic_clinic,
+        ods_code: "R1L",
+        programmes: [
+          hpv_programme,
+          flu_programme,
+          menacwy_programme,
+          td_ipv_programme
+        ]
+      )
+    end
+    let(:session) do
+      create(
+        :session,
+        programmes: [
+          hpv_programme,
+          flu_programme,
+          menacwy_programme,
+          td_ipv_programme
+        ]
+      )
+    end
+
+    let(:flu_record) do
+      create(:vaccination_record, programme: flu_programme, session:)
+    end
+    let(:hpv_record) do
+      create(:vaccination_record, programme: hpv_programme, session:)
+    end
+    let(:td_ipv_record) do
+      create(:vaccination_record, programme: td_ipv_programme, session:)
+    end
+    let(:menacwy_record) do
+      create(:vaccination_record, programme: menacwy_programme, session:)
+    end
+    let(:historic_flu_record) do
+      create(:vaccination_record, programme: flu_programme)
+    end
+    let(:refused_hpv_record) do
+      create(
+        :vaccination_record,
+        programme: hpv_programme,
+        session:,
+        outcome: "refused"
+      )
+    end
+
+    it "syncs the flu vaccination record to the NHSE Immunisations API" do
+      expect {
+        immunisation_import.send(:postprocess_rows!)
+      }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
+        .with(flu_record)
+        .once
+        .on_queue(:immunisation_api)
+    end
+
+    it "syncs the hpv vaccination record to the NHSE Immunisations API" do
+      expect {
+        immunisation_import.send(:postprocess_rows!)
+      }.to have_enqueued_job(SyncVaccinationRecordToNHSEJob)
+        .with(hpv_record)
+        .once
+        .on_queue(:immunisation_api)
+    end
+
+    it "does not sync the menacwy vaccination record to the NHSE Immunisations API" do
+      expect {
+        immunisation_import.send(:postprocess_rows!)
+      }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob).with(
+        menacwy_record
+      )
+    end
+
+    it "does not sync the td_ipv vaccination record to the NHSE Immunisations API" do
+      expect {
+        immunisation_import.send(:postprocess_rows!)
+      }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob).with(
+        td_ipv_record
+      )
+    end
+
+    it "does not sync the historic flu vaccination record to the NHSE Immunisations API" do
+      expect {
+        immunisation_import.send(:postprocess_rows!)
+      }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob).with(
+        historic_flu_record
+      )
+    end
+
+    it "does not sync the refused hpv vaccination record to the NHSE Immunisations API" do
+      expect {
+        immunisation_import.send(:postprocess_rows!)
+      }.not_to have_enqueued_job(SyncVaccinationRecordToNHSEJob).with(
+        refused_hpv_record
+      )
+    end
+  end
 end


### PR DESCRIPTION
Vaccination records recorded in Mavis need to be sent to the NHSE via the Immunisations FHIR API. Providing it is an HPV or flu vaccination, and the outcome is administered. This includes vaccinations recorded in the UI and via the offline import functionality.

NB: This PR requires that the flu vaccination records get a dose number recorded. Currently that isn't the case, but the PR this one, #3882 is based on adds that change.

[MAV-1482](https://nhsd-jira.digital.nhs.uk/browse/MAV-1482)