### PR TITLE
Pre screening questions now directed to nurse

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -30,24 +30,24 @@
         <% end %>
       <% end %>
 
-      <p><%= patient.given_name %> has confirmed that they:</p>
+      <p>Have you checked that <%= patient.given_name %>:</p>
 
       <ul class="nhsuk-list nhsuk-list--bullet">
-        <li>are not acutely unwell</li>
+        <li>is not acutely unwell</li>
         <% if vaccinate_form.ask_not_pregnant? %>
-          <li>are not pregnant</li>
+          <li>is not pregnant</li>
         <% end %>
         <% if vaccinate_form.ask_not_taking_medication? %>
-          <li>are not taking any medication which prevents vaccination</li>
+          <li>is not taking any medication which prevents vaccination</li>
         <% end %>
-        <li>have no allergies which would prevent vaccination</li>
-        <li>have not already had this vaccination</li>
-        <li>know what the vaccination is for, and are happy to have it</li>
+        <li>has no allergies which would prevent vaccination</li>
+        <li>has not already had this vaccination</li>
+        <li>knows what the vaccination is for, and is happy to have it</li>
       </ul>
 
       <%= f.govuk_check_boxes_fieldset :pre_screening_confirmed, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :pre_screening_confirmed, 1, 0, multiple: false, link_errors: true,
-                                                              label: { text: "#{patient.given_name} has confirmed the above statements are true" } %>
+                                                              label: { text: "I have checked that the above statements are true" } %>
       <% end %>
 
       <%= f.govuk_text_area :pre_screening_notes, label: { text: "Pre-screening notes (optional)" }, rows: 3 %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,7 +134,7 @@ en:
             identity_check_confirmed_by_patient:
               inclusion: Choose whether the child confirmed their identity
             pre_screening_confirmed:
-              blank: Select if the child has confirmed all pre-screening statements are true
+              blank: Confirm you’ve checked the pre-screening statements are true
             pre_screening_notes:
               too_long: Enter notes that are less than %{count} characters long
         vaccination_report:

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -71,7 +71,7 @@ describe "MenACWY and Td/IPV vaccination" do
   end
 
   def and_i_fill_out_pre_screening_questions
-    check "has confirmed the above statements are true"
+    check "I have checked that the above statements are true"
   end
 
   def and_i_record_the_vaccination(batch)
@@ -111,7 +111,7 @@ describe "MenACWY and Td/IPV vaccination" do
   end
 
   def and_i_check_the_pre_screening_questions_again
-    check "has confirmed the above statements are true"
+    check "I have checked that the above statements are true"
   end
 
   def then_i_see_the_patient_is_vaccinated_for_td_ipv

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -242,7 +242,7 @@ describe "End-to-end journey" do
     expect(page).to have_content("Update attendance")
 
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -111,7 +111,7 @@ describe "Flu vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do
@@ -125,7 +125,7 @@ describe "Flu vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated_with_injection
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -116,7 +116,7 @@ describe "HPV vaccination" do
   end
 
   def and_i_fill_in_pre_screening_questions
-    check "has confirmed the above statements are true"
+    check "I have checked that the above statements are true"
   end
 
   def and_i_record_that_the_patient_has_been_vaccinated(where)

--- a/spec/features/hpv_vaccination_already_had_spec.rb
+++ b/spec/features/hpv_vaccination_already_had_spec.rb
@@ -50,7 +50,7 @@ describe "HPV vaccination" do
 
   def and_i_record_that_the_patient_wasnt_vaccinated
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -64,7 +64,7 @@ describe "HPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/identity_check_spec.rb
+++ b/spec/features/identity_check_spec.rb
@@ -99,7 +99,7 @@ describe "HPV vaccination identity check" do
 
   def and_i_record_a_vaccination_was_given
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -95,7 +95,7 @@ describe "MenACWY vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/pre_screening_spec.rb
+++ b/spec/features/pre_screening_spec.rb
@@ -68,33 +68,33 @@ describe "Pre-screening" do
 
   def then_i_see_the_pre_screening_questions
     expect(page).to have_content(
-      "know what the vaccination is for, and are happy to have it"
+      "knows what the vaccination is for, and is happy to have it"
     )
-    expect(page).to have_content("have not already had this vaccination")
-    expect(page).to have_content("are not acutely unwell")
+    expect(page).to have_content("has not already had this vaccination")
+    expect(page).to have_content("is not acutely unwell")
     expect(page).to have_content(
-      "have no allergies which would prevent vaccination"
+      "has no allergies which would prevent vaccination"
     )
   end
 
   def and_i_see_the_medication_question
     expect(page).to have_content(
-      "are not taking any medication which prevents vaccination"
+      "is not taking any medication which prevents vaccination"
     )
   end
 
   def and_i_dont_see_the_medication_question
     expect(page).not_to have_content(
-      "are not taking any medication which prevents vaccination"
+      "is not taking any medication which prevents vaccination"
     )
   end
 
   def and_i_see_the_pregnancy_question
-    expect(page).to have_content("are not pregnant")
+    expect(page).to have_content("is not pregnant")
   end
 
   def and_i_dont_see_the_pregnancy_question
-    expect(page).not_to have_content("are not pregnancy")
+    expect(page).not_to have_content("is not pregnant")
   end
 
   def and_i_record_vaccination_without_pre_screening_checks
@@ -107,7 +107,7 @@ describe "Pre-screening" do
 
   def then_i_see_an_error_message
     expect(page).to have_content(
-      "Select if the child has confirmed all pre-screening statements are true"
+      "Confirm you’ve checked the pre-screening statements are true"
     )
   end
 end

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -95,7 +95,7 @@ describe "Td/IPV vaccination" do
 
   def and_i_record_that_the_patient_has_been_vaccinated
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do

--- a/spec/features/vaccination_todays_batch_spec.rb
+++ b/spec/features/vaccination_todays_batch_spec.rb
@@ -67,7 +67,7 @@ describe "Vaccination" do
     click_link @patient.full_name
 
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do
@@ -102,7 +102,7 @@ describe "Vaccination" do
     click_link @patient2.full_name
 
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do
@@ -156,7 +156,7 @@ describe "Vaccination" do
     click_on "MenACWY"
 
     within all("section")[0] do
-      check "has confirmed the above statements are true"
+      check "I have checked that the above statements are true"
     end
 
     within all("section")[1] do


### PR DESCRIPTION
With flu it is a possibility that the child is not old enough to identify themselves. In which case they would also not
be old enough to confirm the pre-screening questions themselves. In that case it makes more sense to direct
the questions to the nurse who can check/confirm with the child accordingly. 

https://nhsd-jira.digital.nhs.uk/browse/MAV-1494
