### PR TITLE
Improve Data replication workflow

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -1,5 +1,5 @@
 name: Data replication pipeline
-run-name: ${{ inputs.action }} data replication resources for ${{ inputs.environment }}
+run-name: ${{ inputs.deployment_type }} for data replication resources for ${{ inputs.environment }}
 
 on:
   workflow_dispatch:
@@ -15,18 +15,17 @@ on:
           - qa
           - sandbox-alpha
           - sandbox-beta
+      deployment_type:
+        description: Deployment type
+        required: true
+        type: choice
+        options:
+          - Deployment with DB recreation
+          - Application only deployment
       image_tag:
         description: Docker image tag to deploy
         required: false
         type: string
-      action:
-        description: Action to perform on data replication env
-        required: true
-        type: choice
-        options:
-          - Destroy
-          - Recreate
-        default: Recreate
       db_snapshot_arn:
         description: ARN of the DB snapshot to use (optional)
         required: false
@@ -50,8 +49,8 @@ concurrency:
   group: deploy-data-replica-${{ inputs.environment }}
 
 jobs:
-  prepare:
-    if: ${{ inputs.action == 'Recreate' }}
+  prepare-db-replica:
+    if: ${{ inputs.deployment_type == 'Deployment with DB recreation' }}
     name: Prepare data replica
     runs-on: ubuntu-latest
     permissions:
@@ -95,6 +94,23 @@ jobs:
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
           DB_SECRET_ARN=$(terraform output --raw db_secret_arn)
           echo "DB_SECRET_ARN=$DB_SECRET_ARN" >> $GITHUB_OUTPUT
+    outputs:
+      SNAPSHOT_ARN: ${{ steps.get-latest-snapshot.outputs.SNAPSHOT_ARN }}
+      DB_SECRET_ARN: ${{ steps.get-db-secret-arn.outputs.DB_SECRET_ARN }}
+
+  prepare-webapp:
+    name: Prepare webapp
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
       - name: ECR login
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -108,81 +124,22 @@ jobs:
           DIGEST="${DOCKER_DIGEST#*@}"
           echo "DIGEST=$DIGEST" >> $GITHUB_OUTPUT
     outputs:
-      SNAPSHOT_ARN: ${{ steps.get-latest-snapshot.outputs.SNAPSHOT_ARN }}
-      DB_SECRET_ARN: ${{ steps.get-db-secret-arn.outputs.DB_SECRET_ARN }}
       DOCKER_DIGEST: ${{ steps.get-docker-image-digest.outputs.DIGEST }}
-
-  plan-destroy:
-    name: Plan destruction job
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.aws_role }}
-          aws-region: eu-west-2
-      - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.11.4
-      - name: Terraform Plan
-        run: |
-          set -e
-          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
-          terraform plan -destroy -var-file="env/${{ inputs.environment }}.tfvars" -var="image_digest=filler_value" \
-          -var="db_secret_arn=filler_value" -var="imported_snapshot=filler_value" \
-          -out ${{ runner.temp }}/tfplan_destroy | tee ${{ runner.temp }}/tf_stdout
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tfplan_destroy_infrastructure-${{ inputs.environment }}
-          path: ${{ runner.temp }}/tfplan_destroy
-
-  destroy:
-    name: Destroy data replication infrastructure
-    runs-on: ubuntu-latest
-    needs: plan-destroy
-    environment: ${{ inputs.environment }}
-    permissions:
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.aws_role }}
-          aws-region: eu-west-2
-      - name: Install terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.11.4
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: tfplan_destroy_infrastructure-${{ inputs.environment }}
-          path: ${{ runner.temp }}
-      - name: Terraform Destroy
-        id: destroy
-        run: |
-          set -e
-          terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
-          terraform apply ${{ runner.temp }}/tfplan_destroy
 
   plan:
     name: Terraform plan
     runs-on: ubuntu-latest
     needs:
-      - prepare
-      - destroy
+      - prepare-db-replica
+      - prepare-webapp
+    if: ${{ !cancelled() &&
+          (needs.prepare-db-replica.result == 'success' || needs.prepare-db-replica.result == 'skipped') &&
+          needs.prepare-webapp.result == 'success' }}
     env:
-      SNAPSHOT_ARN: ${{ needs.prepare.outputs.SNAPSHOT_ARN }}
-      DB_SECRET_ARN: ${{ needs.prepare.outputs.DB_SECRET_ARN }}
-      DOCKER_DIGEST: ${{ needs.prepare.outputs.DOCKER_DIGEST }}
+      SNAPSHOT_ARN: ${{ needs.prepare-db-replica.outputs.SNAPSHOT_ARN }}
+      DB_SECRET_ARN: ${{ needs.prepare-db-replica.outputs.DB_SECRET_ARN || 'arn:aws:secretsmanager:eu-west-2:000000000000:secret:placeholder' }}
+      DOCKER_DIGEST: ${{ needs.prepare-webapp.outputs.DOCKER_DIGEST }}
+      REPLACE_DB_CLUSTER: ${{ inputs.deployment_type == 'Deployment with DB recreation' }}
     permissions:
       id-token: write
     steps:
@@ -200,12 +157,24 @@ jobs:
       - name: Terraform Plan
         id: plan
         run: |
-          set -e
+          set -eo pipefail
           terraform init -backend-config="env/${{ inputs.environment }}-backend.hcl" -upgrade
-          terraform plan -var="image_digest=${{ env.DOCKER_DIGEST }}" -var="db_secret_arn=${{ env.DB_SECRET_ARN }}" \
-          -var="imported_snapshot=${{ env.SNAPSHOT_ARN }}" -var-file="env/${{ inputs.environment }}.tfvars" \
-          -var='allowed_egress_cidr_blocks=${{ inputs.egress_cidr }}' \
-          -out ${{ runner.temp }}/tfplan | tee ${{ runner.temp }}/tf_stdout
+          
+          CIDR_BLOCKS='${{ inputs.egress_cidr }}'
+          PLAN_ARGS=(
+            "plan"
+            "-var=image_digest=${{ env.DOCKER_DIGEST }}"
+            "-var=db_secret_arn=${{ env.DB_SECRET_ARN }}"
+            "-var=imported_snapshot=${{ env.SNAPSHOT_ARN }}"
+            "-var-file=env/${{ inputs.environment }}.tfvars"
+            "-var=allowed_egress_cidr_blocks=$CIDR_BLOCKS"
+            "-out=${{ runner.temp }}/tfplan"
+          )
+          
+          if [ "${{ env.REPLACE_DB_CLUSTER }}" = "true" ]; then
+            PLAN_ARGS+=("-replace" "aws_rds_cluster.cluster")
+          fi
+          terraform "${PLAN_ARGS[@]}" | tee ${{ runner.temp }}/tf_stdout
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -216,6 +185,7 @@ jobs:
     name: Terraform apply
     runs-on: ubuntu-latest
     needs: plan
+    if: ${{ !cancelled() && needs.plan.result == 'success' }}
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write

--- a/terraform/data_replication/rds.tf
+++ b/terraform/data_replication/rds.tf
@@ -17,7 +17,7 @@ resource "aws_security_group_rule" "rds_inbound" {
 }
 
 resource "aws_rds_cluster" "cluster" {
-  cluster_identifier     = "${local.name_prefix}-rds"
+  cluster_identifier     = "${local.name_prefix}-rds-${formatdate("hh-mm-ss", timestamp())}"
   engine                 = "aurora-postgresql"
   engine_mode            = "provisioned"
   database_name          = "manage_vaccinations"
@@ -34,14 +34,22 @@ resource "aws_rds_cluster" "cluster" {
     max_capacity = var.max_aurora_capacity_units
     min_capacity = 0.5
   }
+
+  lifecycle {
+    ignore_changes = [cluster_identifier]
+  }
 }
 
 resource "aws_rds_cluster_instance" "instance" {
   cluster_identifier   = aws_rds_cluster.cluster.id
-  identifier           = "${local.name_prefix}-rds-instance"
+  identifier           = "${local.name_prefix}-rds-instance-${formatdate("hh-mm-ss", timestamp())}"
   instance_class       = "db.serverless"
   engine               = aws_rds_cluster.cluster.engine
   engine_version       = aws_rds_cluster.cluster.engine_version
   db_subnet_group_name = aws_db_subnet_group.dbsg.name
   promotion_tier       = 1
+
+  lifecycle {
+    ignore_changes = [identifier]
+  }
 }


### PR DESCRIPTION
This PR contains some improvements for the data replication workflow

* DB destruction and recreation is done in a single job, that shortens the workflow duration and requires just 1 approval
* The workflow stops if there was an error in the terraform plan job
* Added an option to deploy just a new web app, skipping the DB recreation altogether