### PR TITLE
Fix flaky search form test

### DIFF
--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -544,7 +544,8 @@ describe SearchForm do
         create(
           :vaccination_record,
           patient:,
-          performed_ods_code: organisation.ods_code
+          performed_ods_code: organisation.ods_code,
+          programme: create(:programme, :hpv)
         )
       end
 


### PR DESCRIPTION
The test tries to create a vaccination record with a different programme to that currently being search across, however because the vaccination record factory picks programmes at random it's possible that sometimes the two programmes will match. There's a unique index on the type of programme meaning when two programmes of the same type are created we get a unique constraint failure.

Example failures:

- https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/16131100054/job/45518594025?pr=3889
- https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/16131000767/attempts/1?pr=3888
- https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/16130163178/attempts/1?pr=3887