### PR TITLE
Send flu reminders also when vaccination/consent were received last year

### DIFF
--- a/app/jobs/send_school_consent_reminders_job.rb
+++ b/app/jobs/send_school_consent_reminders_job.rb
@@ -44,8 +44,11 @@ class SendSchoolConsentRemindersJob < ApplicationJob
 
     has_consent_or_vaccinated =
       programmes.all? do |programme|
-        patient.consents.any? { it.programme_id == programme.id } ||
-          patient.vaccination_records.any? { it.programme_id == programme.id }
+        VaccinatedCriteria.call(
+          programme:,
+          patient:,
+          vaccination_records: patient.vaccination_records
+        ) || ConsentedCriteria.call(programme:, patient:)
       end
 
     return false if has_consent_or_vaccinated

--- a/app/jobs/send_school_consent_requests_job.rb
+++ b/app/jobs/send_school_consent_requests_job.rb
@@ -33,8 +33,11 @@ class SendSchoolConsentRequestsJob < ApplicationJob
 
     has_consent_or_vaccinated =
       programmes.all? do |programme|
-        patient.consents.any? { it.programme_id == programme.id } ||
-          patient.vaccination_records.any? { it.programme_id == programme.id }
+        VaccinatedCriteria.call(
+          programme:,
+          patient:,
+          vaccination_records: patient.vaccination_records
+        ) || ConsentedCriteria.call(programme:, patient:)
       end
 
     return false if has_consent_or_vaccinated

--- a/app/lib/consented_criteria.rb
+++ b/app/lib/consented_criteria.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ConsentedCriteria
+  def initialize(programme:, patient:)
+    @programme = programme
+    @patient = patient
+    @consents = patient.consents
+  end
+
+  def call
+    consents_for_programme = consents.select { it.programme_id == programme.id }
+
+    if programme.seasonal?
+      consents_for_programme.any?(&:submitted_this_academic_year?)
+    else
+      return true if consents_for_programme.any?
+    end
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :programme, :patient, :consents
+end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -195,6 +195,10 @@ class Consent < ApplicationRecord
       (response_refused? && !reason_for_refusal_personal_choice?)
   end
 
+  def submitted_this_academic_year?
+    submitted_at.to_date.academic_year == Date.current.academic_year
+  end
+
   class ConsentFormNotRecorded < StandardError
   end
 end


### PR DESCRIPTION
There was a bug that would prevent consent notifications from being sent when the parent had already consented last year or when the child had already been vaccinated last year. This behavior is incorrect for seasonal vaccines for which consent is requested again every year and which need to be taken again every year too.

This fixes [MAV-1524](https://nhsd-jira.digital.nhs.uk/browse/MAV-1524)