### PR TITLE
Add `has_multiple_dates` personalisation variable

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -44,6 +44,7 @@ class GovukNotifyPersonalisation
       consent_link:,
       day_month_year_of_vaccination:,
       full_and_preferred_patient_name:,
+      has_multiple_dates:,
       location_name:,
       next_or_today_session_date:,
       next_or_today_session_dates:,
@@ -132,6 +133,16 @@ class GovukNotifyPersonalisation
 
   def full_and_preferred_patient_name
     (consent_form || patient).full_name_with_known_as(context: :parents)
+  end
+
+  def has_multiple_dates
+    return nil if session.nil?
+
+    if session.today_or_future_dates.length > 1
+      "yes"
+    else
+      "no"
+    end
   end
 
   def host

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -57,6 +57,7 @@ describe GovukNotifyPersonalisation do
         consent_link:
           "http://localhost:4000/consents/#{session.slug}/hpv/start",
         full_and_preferred_patient_name: "John Smith",
+        has_multiple_dates: "no",
         location_name: "Hogwarts",
         next_or_today_session_date: "Thursday 1 January",
         next_or_today_session_dates: "Thursday 1 January",
@@ -128,6 +129,7 @@ describe GovukNotifyPersonalisation do
       expect(to_h).to match(
         hash_including(
           consent_deadline: "Wednesday 31 December",
+          has_multiple_dates: "yes",
           next_or_today_session_date: "Thursday 1 January",
           next_or_today_session_dates:
             "Thursday 1 January and Friday 2 January",


### PR DESCRIPTION
This is a variable that will be passed to GOV.UK Notify and will be used to customise the content shown in a number of emails according to whether the session has lots of dates or not.

[Jira Issue - MAV-1277](https://nhsd-jira.digital.nhs.uk/browse/MAV-1277) &middot; [Jira Issue - MAV-1527](https://nhsd-jira.digital.nhs.uk/browse/MAV-1527)