### PR TITLE
Add `can_self_consent` personalisation variable

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -39,6 +39,7 @@ class GovukNotifyPersonalisation
   def to_h
     {
       batch_name:,
+      can_self_consent:,
       catch_up:,
       consent_deadline:,
       consent_link:,
@@ -88,6 +89,11 @@ class GovukNotifyPersonalisation
 
   def batch_name
     vaccination_record&.batch&.name
+  end
+
+  def can_self_consent
+    return nil if patient.nil?
+    patient.year_group >= 7 ? "yes" : "no"
   end
 
   def catch_up

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -52,6 +52,7 @@ describe GovukNotifyPersonalisation do
   it do
     expect(to_h).to eq(
       {
+        can_self_consent: "yes",
         catch_up: "no",
         consent_deadline: "Wednesday 31 December",
         consent_link:
@@ -79,6 +80,12 @@ describe GovukNotifyPersonalisation do
         vaccine_side_effects: ""
       }
     )
+  end
+
+  context "with a patient in primary school" do
+    let(:patient) { create(:patient, year_group: 6) }
+
+    it { should include(can_self_consent: "no") }
   end
 
   context "when the session is today" do


### PR DESCRIPTION
This is a variable that will be passed to GOV.UK Notify and will be used to customise the content shown in a number of emails according to whether or not the patient is able to self-consent via Gillick competence.

[Jira Issue - MAV-1277](https://nhsd-jira.digital.nhs.uk/browse/MAV-1277)