### PR TITLE
Pass triage to `GovukNotifyPersonalisation`

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -58,7 +58,7 @@ class DraftConsentsController < ApplicationController
     @draft_consent.write_to!(@consent, triage_form: @triage_form)
 
     ActiveRecord::Base.transaction do
-      @triage_form&.save! if @draft_consent.response_given?
+      @triage = @triage_form&.save! if @draft_consent.response_given?
 
       if (parent = @consent.parent)
         parent.save! if parent.changed?
@@ -72,7 +72,7 @@ class DraftConsentsController < ApplicationController
 
     set_patient_session # reload with new statuses
 
-    send_triage_confirmation(@patient_session, @consent)
+    send_triage_confirmation(@patient_session, @consent, @triage)
 
     heading_link_href =
       session_patient_programme_path(@session, @patient, @programme)

--- a/app/controllers/patient_sessions/triages_controller.rb
+++ b/app/controllers/patient_sessions/triages_controller.rb
@@ -34,12 +34,12 @@ class PatientSessions::TriagesController < PatientSessions::BaseController
         **triage_form_params
       )
 
-    if @triage_form.save
+    if (triage = @triage_form.save)
       StatusUpdater.call(patient: @patient)
 
       ConsentGrouper
         .call(@patient.reload.consents, programme: @programme)
-        .each { send_triage_confirmation(@patient_session, it) }
+        .each { send_triage_confirmation(@patient_session, it, triage) }
 
       redirect_to redirect_path, flash: { success: "Triage outcome updated" }
     else

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -10,6 +10,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
     programmes: [],
     sent_by: nil,
     session: nil,
+    triage: nil,
     vaccination_record: nil
   )
     template_id = GOVUK_NOTIFY_EMAIL_TEMPLATES[template_name.to_sym]
@@ -17,12 +18,13 @@ class EmailDeliveryJob < NotifyDeliveryJob
 
     personalisation =
       GovukNotifyPersonalisation.new(
-        session:,
         consent:,
         consent_form:,
         parent:,
         patient:,
         programmes:,
+        session:,
+        triage:,
         vaccination_record:
       )
 

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -10,6 +10,7 @@ class SMSDeliveryJob < NotifyDeliveryJob
     programmes: [],
     sent_by: nil,
     session: nil,
+    triage: nil,
     vaccination_record: nil
   )
     template_id = GOVUK_NOTIFY_SMS_TEMPLATES[template_name.to_sym]
@@ -17,12 +18,13 @@ class SMSDeliveryJob < NotifyDeliveryJob
 
     personalisation =
       GovukNotifyPersonalisation.new(
-        session:,
         consent:,
         consent_form:,
         parent:,
         patient:,
         programmes:,
+        session:,
+        triage:,
         vaccination_record:
       )
 

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -13,6 +13,7 @@ class GovukNotifyPersonalisation
     patient: nil,
     programmes: nil,
     session: nil,
+    triage: nil,
     vaccination_record: nil
   )
     @consent = consent
@@ -25,6 +26,7 @@ class GovukNotifyPersonalisation
     @session =
       session || consent_form&.actual_session ||
         consent_form&.original_session || vaccination_record&.session
+    @triage = triage
     @organisation =
       session&.organisation || consent_form&.organisation ||
         consent&.organisation || vaccination_record&.organisation
@@ -77,6 +79,7 @@ class GovukNotifyPersonalisation
               :programmes,
               :session,
               :team,
+              :triage,
               :organisation,
               :vaccination_record
 

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -30,10 +30,6 @@ class GovukNotifyPersonalisation
         consent&.organisation || vaccination_record&.organisation
     @team = session&.team || consent_form&.team || vaccination_record&.team
     @vaccination_record = vaccination_record
-
-    if @programmes.empty? && @session.present? && @patient.present?
-      @programmes = @session.eligible_programmes_for(patient: @patient)
-    end
   end
 
   def to_h

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -23,11 +23,12 @@ describe TriageMailerConcern do
 
   describe "#send_triage_confirmation" do
     subject(:send_triage_confirmation) do
-      sample.send_triage_confirmation(patient_session, consent)
+      sample.send_triage_confirmation(patient_session, consent, triage)
     end
 
     let(:session) { create(:session, programmes: [programme]) }
     let(:consent) { patient.consents.first }
+    let(:triage) { patient.triages.first }
 
     context "when the parents agree, triage is required and it is safe to vaccinate" do
       let(:patient_session) do
@@ -37,7 +38,7 @@ describe TriageMailerConcern do
       it "sends an email saying triage was needed and vaccination will happen" do
         expect { send_triage_confirmation }.to have_delivered_email(
           :triage_vaccination_will_happen
-        ).with(consent:, session:, sent_by: current_user)
+        ).with(consent:, session:, sent_by: current_user, triage:)
       end
 
       it "doesn't send a text message" do
@@ -53,7 +54,7 @@ describe TriageMailerConcern do
       it "sends an email saying triage was needed but vaccination won't happen" do
         expect { send_triage_confirmation }.to have_delivered_email(
           :triage_vaccination_wont_happen
-        ).with(consent:, session:, sent_by: current_user)
+        ).with(consent:, session:, sent_by: current_user, triage:)
       end
 
       it "doesn't send a text message" do
@@ -69,7 +70,7 @@ describe TriageMailerConcern do
       it "sends an email saying triage was needed but vaccination won't happen" do
         expect { send_triage_confirmation }.to have_delivered_email(
           :triage_vaccination_at_clinic
-        ).with(consent:, session:, sent_by: current_user)
+        ).with(consent:, session:, sent_by: current_user, triage:)
       end
 
       it "doesn't send a text message" do

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -36,6 +36,7 @@ describe EmailDeliveryJob do
         patient:,
         programmes:,
         sent_by:,
+        triage:,
         vaccination_record:
       )
     end
@@ -55,6 +56,7 @@ describe EmailDeliveryJob do
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
     let(:sent_by) { create(:user) }
+    let(:triage) { create(:triage, programme: programmes.first) }
     let(:vaccination_record) { nil }
 
     it "generates personalisation" do
@@ -65,6 +67,7 @@ describe EmailDeliveryJob do
         parent:,
         patient:,
         programmes:,
+        triage:,
         vaccination_record:
       ).and_call_original
       perform_now

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -36,6 +36,7 @@ describe SMSDeliveryJob do
         patient:,
         programmes:,
         sent_by:,
+        triage:,
         vaccination_record:
       )
     end
@@ -48,6 +49,7 @@ describe SMSDeliveryJob do
     let(:consent_form) { nil }
     let(:patient) { create(:patient) }
     let(:sent_by) { create(:user) }
+    let(:triage) { create(:triage, programme: programmes.first) }
     let(:vaccination_record) { nil }
 
     it "generates personalisation" do
@@ -58,6 +60,7 @@ describe SMSDeliveryJob do
         parent:,
         patient:,
         programmes:,
+        triage:,
         vaccination_record:
       ).and_call_original
       perform_now

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 describe GovukNotifyPersonalisation do
-  subject(:to_h) { described_class.new(**params).to_h }
-
-  let(:params) do
-    {
+  subject(:to_h) do
+    described_class.new(
       patient:,
       session:,
       consent:,
       consent_form:,
       programmes:,
       vaccination_record:
-    }
+    ).to_h
   end
 
   let(:programmes) { [create(:programme, :hpv)] }
@@ -257,21 +255,6 @@ describe GovukNotifyPersonalisation do
             "- generally feeling unwell\n- swelling or pain where the injection was given"
         )
       )
-    end
-
-    context "when programmes comes from the session" do
-      let(:params) do
-        { patient:, session:, consent:, consent_form:, vaccination_record: }
-      end
-
-      it do
-        expect(to_h).to match(
-          hash_including(
-            vaccine_side_effects:
-              "- generally feeling unwell\n- swelling or pain where the injection was given"
-          )
-        )
-      end
     end
   end
 end


### PR DESCRIPTION
This allows for emails and texts to include personalisation content according to the triage. Specifically we need this for Flu where content will be different according to the vaccine method chosen at the triage stage.

To support this I've also been able to simplify the `TriageMailerConcern`.