### PR TITLE
Limit programmes to those that are safe to vaccinate

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -30,10 +30,6 @@ class GovukNotifyPersonalisation
         consent&.organisation || vaccination_record&.organisation
     @team = session&.team || consent_form&.team || vaccination_record&.team
     @vaccination_record = vaccination_record
-
-    if @programmes.empty? && @session.present? && @patient.present?
-      @programmes = @session.eligible_programmes_for(patient: @patient)
-    end
   end
 
   def to_h

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -82,8 +82,23 @@ class SessionNotification < ApplicationRecord
       sent_by: current_user
     )
 
+    programmes =
+      if type == :school_reminder
+        patient_session.programmes.select do |programme|
+          patient.consent_given_and_safe_to_vaccinate?(programme:)
+        end
+      else
+        patient_session.programmes
+      end
+
     parents.each do |parent|
-      params = { parent:, patient:, session:, sent_by: current_user }
+      params = {
+        parent:,
+        patient:,
+        programmes:,
+        session:,
+        sent_by: current_user
+      }
 
       EmailDeliveryJob.perform_later(:"session_#{type}", **params)
 

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 describe GovukNotifyPersonalisation do
-  subject(:to_h) { described_class.new(**params).to_h }
-
-  let(:params) do
-    {
+  subject(:to_h) do
+    described_class.new(
       patient:,
       session:,
       consent:,
       consent_form:,
       programmes:,
       vaccination_record:
-    }
+    ).to_h
   end
 
   let(:programmes) { [create(:programme, :hpv)] }
@@ -257,21 +255,6 @@ describe GovukNotifyPersonalisation do
             "- generally feeling unwell\n- swelling or pain where the injection was given"
         )
       )
-    end
-
-    context "when programmes comes from the session" do
-      let(:params) do
-        { patient:, session:, consent:, consent_form:, vaccination_record: }
-      end
-
-      it do
-        expect(to_h).to match(
-          hash_including(
-            vaccine_side_effects:
-              "- generally feeling unwell\n- swelling or pain where the injection was given"
-          )
-        )
-      end
     end
   end
 end


### PR DESCRIPTION
When sending out the session reminder emails to parents, we should only include information (vaccine side effects) about programmes that the patient is going to be vaccinated for, specifically ignoring those where the patient has already been vaccinated or those that the parent didn't give consent for.

[Jira Issue - MAV-1335](https://nhsd-jira.digital.nhs.uk/browse/MAV-1355)