### PR TITLE
Add `vaccine_is_injection` and `vaccine_is_nasal`

### DIFF
--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -74,6 +74,8 @@ describe GovukNotifyPersonalisation do
         team_name: "Organisation",
         team_phone: "01234 567890 (option 1)",
         vaccination: "HPV vaccination",
+        vaccine_is_injection: "no",
+        vaccine_is_nasal: "no",
         vaccine_side_effects: ""
       }
     )
@@ -240,6 +242,64 @@ describe GovukNotifyPersonalisation do
           outcome_not_administered: "yes"
         )
       )
+    end
+  end
+
+  context "with vaccine methods" do
+    context "and an injection-only programme" do
+      before do
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme: programmes.first
+        )
+      end
+
+      it { should include(vaccine_is_injection: "yes", vaccine_is_nasal: "no") }
+    end
+
+    context "and a nasal spray programme" do
+      let(:programmes) { [create(:programme, :flu)] }
+
+      before do
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme: programmes.first,
+          vaccine_methods: %w[nasal injection]
+        )
+      end
+
+      it { should include(vaccine_is_injection: "no", vaccine_is_nasal: "yes") }
+    end
+
+    context "and multiple programmes" do
+      let(:programmes) { [create(:programme, :hpv), create(:programme, :flu)] }
+
+      before do
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme: programmes.first,
+          vaccine_methods: %w[nasal injection]
+        )
+        create(
+          :patient_consent_status,
+          :given,
+          patient:,
+          programme: programmes.second
+        )
+      end
+
+      it do
+        expect(to_h).to include(
+          vaccine_is_injection: "yes",
+          vaccine_is_nasal: "yes"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
This adds two new personalisation variables that will be sent to GOV.UK Notify when sending an email or text message to allow for the templates to be customised according to the type of vaccine that will be given to the patient.

[Jira Issue - MAV-1355](https://nhsd-jira.digital.nhs.uk/browse/MAV-1355)