### PR TITLE
Make flu vaccination form titles clearer

### DIFF
--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -2,7 +2,7 @@
 
 class AppPatientSessionRecordComponent < ViewComponent::Base
   erb_template <<-ERB
-    <h2 class="nhsuk-heading-m">Record vaccination</h2>
+    <h2 class="nhsuk-heading-m"><%= heading %></h2>
     
     <% if helpers.policy(VaccinationRecord).new? %>
       <%= render AppVaccinateFormComponent.new(vaccinate_form) %>
@@ -35,5 +35,18 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
     pre_screening_confirmed = patient.pre_screenings.today.exists?(programme:)
 
     VaccinateForm.new(patient_session:, programme:, pre_screening_confirmed:)
+  end
+
+  def heading
+    return "Record #{programme.name} vaccination" unless programme.flu?
+
+    if PatientSession
+         .where(patient_id: patient.id)
+         .has_vaccine_method(:nasal, programme:)
+         .exists?
+      "Record flu vaccination with nasal spray"
+    else
+      "Record flu vaccination with injection"
+    end
   end
 end

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -57,7 +57,7 @@
 
     <section>
       <h3 class="nhsuk-card__heading nhsuk-heading-s">
-        Is <%= patient.given_name %> ready for their <%= programme.name %> vaccination?
+        Is <%= patient.given_name %> ready for their <%= vaccination_name %>?
       </h3>
 
       <% hint = "Pre-screening checks must be completed for vaccination to go ahead" %>

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -55,4 +55,10 @@ class AppVaccinateFormComponent < ViewComponent::Base
         options
       end
   end
+
+  def vaccination_name
+    return "#{programme.name} vaccination" unless programme.flu?
+
+    delivery_method == :nasal_spray ? "flu nasal spray" : "flu injection"
+  end
 end

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -36,7 +36,7 @@ describe AppVaccinateFormComponent do
     it { should have_content("Has Hari confirmed their identity?") }
     it { should have_field("No, it was confirmed by somebody else") }
 
-    it { should have_heading("Is Hari ready for their Flu vaccination?") }
+    it { should have_heading("Is Hari ready for their flu nasal spray?") }
 
     it { should have_field("Yes") }
     it { should have_field("No") }
@@ -53,7 +53,7 @@ describe AppVaccinateFormComponent do
     it { should have_content("Has Hari confirmed their identity?") }
     it { should have_field("No, it was confirmed by somebody else") }
 
-    it { should have_heading("Is Hari ready for their Flu vaccination?") }
+    it { should have_heading("Is Hari ready for their flu injection?") }
 
     it { should have_field("Yes") }
     it { should have_field("No") }
@@ -77,7 +77,7 @@ describe AppVaccinateFormComponent do
       )
     end
 
-    it { should have_heading("Is Hari ready for their Flu vaccination?") }
+    it { should have_heading("Is Hari ready for their flu injection?") }
 
     it { should have_field("Yes") }
     it { should have_field("No") }

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -10,7 +10,9 @@ describe "Flu vaccination" do
     and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
 
     when_i_go_to_the_nasal_only_patient
-    and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+    then_i_see_the_vacciantion_form_for_nasal_spray
+
+    when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     then_i_see_the_check_and_confirm_page_for_nasal_spray
     and_i_get_confirmation_after_recording
     and_the_vaccination_record_is_synced_to_nhs
@@ -26,7 +28,9 @@ describe "Flu vaccination" do
     and_there_are_nasal_and_injection_batches
 
     when_i_go_to_the_injection_only_patient
-    and_i_record_that_the_patient_has_been_vaccinated_with_injection
+    then_i_see_the_vacciantion_form_for_injection
+
+    when_i_record_that_the_patient_has_been_vaccinated_with_injection
     then_i_see_the_check_and_confirm_page_for_injection
     and_i_get_confirmation_after_recording
 
@@ -41,7 +45,9 @@ describe "Flu vaccination" do
     and_there_are_nasal_and_injection_batches
 
     when_i_go_to_the_nasal_only_patient
-    and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+    then_i_see_the_vacciantion_form_for_nasal_spray
+
+    when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     then_i_see_the_check_and_confirm_page_for_nasal_spray
 
     when_i_change_the_vaccine_method_to_injection
@@ -118,7 +124,21 @@ describe "Flu vaccination" do
     click_link @patient.full_name
   end
 
-  def and_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+  def then_i_see_the_vacciantion_form_for_nasal_spray
+    expect(page).to have_content("Record flu vaccination with nasal spray")
+    expect(page).to have_content(
+      "Is #{@patient.given_name} ready for their flu nasal spray?"
+    )
+  end
+
+  def then_i_see_the_vacciantion_form_for_injection
+    expect(page).to have_content("Record flu vaccination with injection")
+    expect(page).to have_content(
+      "Is #{@patient.given_name} ready for their flu injection?"
+    )
+  end
+
+  def when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     within all("section")[0] do
       check "has confirmed the above statements are true"
     end
@@ -132,7 +152,7 @@ describe "Flu vaccination" do
     click_button "Continue"
   end
 
-  def and_i_record_that_the_patient_has_been_vaccinated_with_injection
+  def when_i_record_that_the_patient_has_been_vaccinated_with_injection
     within all("section")[0] do
       check "has confirmed the above statements are true"
     end


### PR DESCRIPTION
The form is now makes explicit what vaccine method is being used in the case of flu vaccines. The title for the record section and the vaccination question include the method.

For non-flu programmes, the programme name is now specified in the record section title.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1414

<img width="423" height="581" alt="Screenshot 2025-07-10 150212" src="https://github.com/user-attachments/assets/cd6cfa83-93ad-45e9-8114-abdbe84cd3a2" />
<img width="426" height="550" alt="Screenshot 2025-07-10 150200" src="https://github.com/user-attachments/assets/97550f50-2f34-4ec7-9cb2-af00ae53bd4f" />
<img width="428" height="650" alt="Screenshot 2025-07-10 145505" src="https://github.com/user-attachments/assets/486d7e7c-a9a5-4f0d-8e14-dfaa76a9de4a" />

