### PR TITLE
Consolidate vaccination administered texts

### DIFF
--- a/config/initializers/govuk_notify.rb
+++ b/config/initializers/govuk_notify.rb
@@ -38,9 +38,6 @@ GOVUK_NOTIFY_SMS_TEMPLATES = {
   session_clinic_initial_invitation: "8ef5712f-bb7f-4911-8f3b-19df6f8a7179",
   session_clinic_subsequent_invitation: "018f146d-e7b7-4b63-ae26-bb07ca6fe2f9",
   session_school_reminder: "6e4c514d-fcc9-4bc8-b7eb-e222a1445681",
-  vaccination_administered_flu: "395a3ea1-df07-4dd6-8af1-64cc597ef383",
-  vaccination_administered_hpv: "69612d3a-d6eb-4f04-8b99-ed14212e7245",
-  vaccination_administered_menacwy: "16ae7602-c2b1-4731-bb74-fd4f1357feca",
-  vaccination_administered_td_ipv: "4c616b22-eee8-423f-84d6-bd5710f744fd",
+  vaccination_administered: "395a3ea1-df07-4dd6-8af1-64cc597ef383",
   vaccination_not_administered: "aae061e0-b847-4d4c-a87a-12508f95a302"
 }.freeze

--- a/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/vaccination_mailer_concern_spec.rb
@@ -43,7 +43,7 @@ describe VaccinationMailerConcern do
 
       it "sends a text message" do
         expect { send_vaccination_confirmation }.to have_delivered_sms(
-          :vaccination_administered_hpv
+          :vaccination_administered
         ).with(parent:, vaccination_record:, sent_by: current_user)
       end
     end
@@ -99,7 +99,7 @@ describe VaccinationMailerConcern do
 
         it "sends a text message" do
           expect { send_vaccination_confirmation }.to have_delivered_sms(
-            :vaccination_administered_hpv
+            :vaccination_administered
           ).with(parent:, vaccination_record:, sent_by: current_user)
         end
       end

--- a/spec/features/doubles_vaccination_administered_spec.rb
+++ b/spec/features/doubles_vaccination_administered_spec.rb
@@ -147,13 +147,13 @@ describe "MenACWY and Td/IPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccinations
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_menacwy,
+      :vaccination_administered,
       :any
     )
 
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_td_ipv,
+      :vaccination_administered,
       :any
     )
   end

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -203,7 +203,7 @@ describe "Flu vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_flu
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -245,7 +245,7 @@ describe "HPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_hpv
+      :vaccination_administered
     )
   end
 

--- a/spec/features/hpv_vaccination_clinic_spec.rb
+++ b/spec/features/hpv_vaccination_clinic_spec.rb
@@ -133,7 +133,7 @@ describe "HPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_hpv
+      :vaccination_administered
     )
   end
 end

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -308,7 +308,7 @@ describe "HPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @vaccinated_patient.consents.last.parent.phone,
-      :vaccination_administered_hpv,
+      :vaccination_administered,
       :any
     )
 

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -203,7 +203,7 @@ describe "MenACWY vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_menacwy
+      :vaccination_administered
     )
   end
 

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -203,7 +203,7 @@ describe "Td/IPV vaccination" do
   def and_a_text_is_sent_to_the_parent_confirming_the_vaccination
     expect_sms_to(
       @patient.consents.last.parent.phone,
-      :vaccination_administered_td_ipv
+      :vaccination_administered
     )
   end
 


### PR DESCRIPTION
Now that the vaccine side effects are dynamic we can consolidate the text messages that are sent when a patient is administered as the only differences between them was the different side effects.

[Jira Issue - MAV-1529](https://nhsd-jira.digital.nhs.uk/browse/MAV-1529)