### PR TITLE
Remove `programme_name` personalisation variable

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -53,7 +53,6 @@ class GovukNotifyPersonalisation
       outcome_administered:,
       outcome_not_administered:,
       patient_date_of_birth:,
-      programme_name:,
       reason_did_not_vaccinate:,
       reason_for_refusal:,
       short_patient_name:,
@@ -203,10 +202,6 @@ class GovukNotifyPersonalisation
     patient&.date_of_birth&.to_fs(:long)
   end
 
-  def programme_name
-    programmes.map(&:name).to_sentence
-  end
-
   def reason_did_not_vaccinate
     return if vaccination_record.nil? || vaccination_record.administered?
 
@@ -285,7 +280,7 @@ class GovukNotifyPersonalisation
 
   def vaccination
     [
-      programme_name,
+      programmes.map(&:name).to_sentence,
       programmes.count == 1 ? "vaccination" : "vaccinations"
     ].join(" ")
   end

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -66,7 +66,6 @@ describe GovukNotifyPersonalisation do
         organisation_privacy_notice_url: "https://example.com/privacy-notice",
         organisation_privacy_policy_url: "https://example.com/privacy-policy",
         patient_date_of_birth: "1 February 2012",
-        programme_name: "HPV",
         short_patient_name: "John",
         short_patient_name_apos: "John’s",
         subsequent_session_dates_offered_message: "",


### PR DESCRIPTION
As far as I can tell it's not being used in any of our templates so we can remove this variable.