### PR TITLE
Add `vaccination_and_method` personalisation variable

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -68,6 +68,7 @@ class GovukNotifyPersonalisation
       team_phone:,
       today_or_date_of_vaccination:,
       vaccination:,
+      vaccination_and_method:,
       vaccine_brand:,
       vaccine_is_injection:,
       vaccine_is_nasal:,
@@ -315,10 +316,36 @@ class GovukNotifyPersonalisation
   end
 
   def vaccination
-    [
-      programmes.map(&:name).to_sentence,
-      programmes.count == 1 ? "vaccination" : "vaccinations"
-    ].join(" ")
+    names = programmes.map(&:name)
+    "#{names.to_sentence} vaccination".pluralize(names.length)
+  end
+
+  def vaccination_and_method
+    names =
+      programmes.map do |programme|
+        next programme.name unless programme.flu?
+
+        if vaccination_record
+          if vaccination_record.delivery_method_nasal_spray?
+            "nasal spray flu"
+          else
+            "injected flu"
+          end
+        elsif patient &&
+              (
+                vaccine_methods = patient.approved_vaccine_methods(programme:)
+              ).present?
+          if vaccine_methods.first == "nasal"
+            "nasal spray flu"
+          else
+            "injected flu"
+          end
+        else
+          "flu"
+        end
+      end
+
+    "#{names.to_sentence} vaccination".pluralize(names.length)
   end
 
   def vaccine_brand

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -75,6 +75,7 @@ describe GovukNotifyPersonalisation do
         team_name: "Organisation",
         team_phone: "01234 567890 (option 1)",
         vaccination: "HPV vaccination",
+        vaccination_and_method: "HPV vaccination",
         vaccine_is_injection: "no",
         vaccine_is_nasal: "no",
         vaccine_side_effects: ""
@@ -406,6 +407,48 @@ describe GovukNotifyPersonalisation do
             vaccine_side_effects:
               "- generally feeling unwell\n- swelling or pain where the injection was given"
           )
+        )
+      end
+    end
+  end
+
+  context "with the flu programme" do
+    let(:programmes) { [create(:programme, :flu)] }
+
+    it do
+      expect(to_h).to include(
+        vaccination: "Flu vaccination",
+        vaccination_and_method: "flu vaccination"
+      )
+    end
+
+    context "with an administered injected vaccination record" do
+      let(:vaccination_record) do
+        create(:vaccination_record, patient:, programme: programmes.first)
+      end
+
+      it do
+        expect(to_h).to include(
+          vaccination: "Flu vaccination",
+          vaccination_and_method: "injected flu vaccination"
+        )
+      end
+    end
+
+    context "with an administered nasal spray vaccination record" do
+      let(:vaccination_record) do
+        create(
+          :vaccination_record,
+          patient:,
+          programme: programmes.first,
+          delivery_method: "nasal_spray"
+        )
+      end
+
+      it do
+        expect(to_h).to include(
+          vaccination: "Flu vaccination",
+          vaccination_and_method: "nasal spray flu vaccination"
         )
       end
     end


### PR DESCRIPTION
This adds a new personalisation variable which includes both the vaccination that was given plus the delivery method (if appropriate). This will only be shown for flu where there's a distinction between nasal spray and injection.

[Jira Issue - MAV-1529](https://nhsd-jira.digital.nhs.uk/browse/MAV-1529)