### PR TITLE
Add `consented_vaccine_methods_message` personalisation

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -38,6 +38,7 @@ class GovukNotifyPersonalisation
       catch_up:,
       consent_deadline:,
       consent_link:,
+      consented_vaccine_methods_message:,
       day_month_year_of_vaccination:,
       full_and_preferred_patient_name:,
       location_name:,
@@ -122,6 +123,23 @@ class GovukNotifyPersonalisation
         session,
         programmes.map(&:to_param).join("-")
       )
+  end
+
+  def consented_vaccine_methods_message
+    return if consent_form.nil? || consent_form.programmes.none?(&:flu?)
+
+    consent_form_programmes = consent_form.consent_form_programmes
+
+    consented_vaccine_methods =
+      if consent_form_programmes.any?(&:vaccine_method_injection_and_nasal?)
+        "nasal spray flu vaccine, or the injected flu vaccine if the nasal spray is not suitable"
+      elsif consent_form_programmes.any?(&:vaccine_method_nasal?)
+        "nasal spray flu vaccine"
+      else
+        "injected flu vaccine"
+      end
+
+    "You’ve agreed that #{short_patient_name} can have the #{consented_vaccine_methods}."
   end
 
   def day_month_year_of_vaccination

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -188,7 +188,8 @@ describe GovukNotifyPersonalisation do
         :consent_form,
         :refused,
         session:,
-        recorded_at: Date.new(2024, 1, 1)
+        recorded_at: Date.new(2024, 1, 1),
+        given_name: "Tom"
       )
     end
 
@@ -218,6 +219,48 @@ describe GovukNotifyPersonalisation do
       before { create(:session, location: school, programmes:, organisation:) }
 
       it { should include(location_name: "Waterloo Road") }
+    end
+
+    context "for the flu programme" do
+      let(:programmes) { [create(:programme, :flu)] }
+
+      it do
+        expect(to_h).to include(
+          consented_vaccine_methods_message:
+            "You’ve agreed that Tom can have the injected flu vaccine."
+        )
+      end
+
+      context "when consented to both nasal and injection" do
+        before do
+          consent_form.consent_form_programmes.update!(
+            vaccine_methods: %w[nasal injection]
+          )
+        end
+
+        it do
+          expect(to_h).to include(
+            consented_vaccine_methods_message:
+              "You’ve agreed that Tom can have the nasal spray flu vaccine, " \
+                "or the injected flu vaccine if the nasal spray is not suitable."
+          )
+        end
+      end
+
+      context "when consented only to nasal" do
+        before do
+          consent_form.consent_form_programmes.update!(
+            vaccine_methods: %w[nasal]
+          )
+        end
+
+        it do
+          expect(to_h).to include(
+            consented_vaccine_methods_message:
+              "You’ve agreed that Tom can have the nasal spray flu vaccine."
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This adds a new variable which will be used in GOV.UK Notify templates for flu where it includes the list of methods that the parents have consented to. This is a variable as we need a fully customisable string according to the consented methods and it's difficult to recreate this purely using the Notify template format.

[Jira Issue - MAV-1503](https://nhsd-jira.digital.nhs.uk/browse/MAV-1503)