### PR TITLE
Allow default daily batch per vaccine method

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -66,14 +66,11 @@ class AppConsentConfirmationComponent < ViewComponent::Base
         .map do |consent_form_programme|
           programme = consent_form_programme.programme
 
-          if programme.flu?
-            if consent_form_programme.vaccine_method_nasal?
-              "nasal flu"
-            elsif consent_form_programme.vaccine_method_injection?
-              "flu injection"
-            else
-              programme.name_in_sentence
-            end
+          if programme.has_multiple_vaccine_methods?
+            vaccine_method = consent_form_programme.vaccine_methods.first
+            method_prefix =
+              Vaccine.human_enum_name(:method_prefix, vaccine_method)
+            "#{method_prefix} #{programme.name_in_sentence}".lstrip
           else
             programme.name_in_sentence
           end

--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -39,15 +39,11 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
 
   def heading
     vaccination =
-      if programme.flu?
-        if PatientSession
-             .where(patient_id: patient.id)
-             .has_vaccine_method(:nasal, programme:)
-             .exists?
-          "vaccination with nasal spray"
-        else
-          "vaccination with injection"
-        end
+      if programme.has_multiple_vaccine_methods?
+        vaccine_method = patient.approved_vaccine_methods(programme:).first
+        method_string =
+          Vaccine.human_enum_name(:method, vaccine_method).downcase
+        "vaccination with #{method_string}"
       else
         "vaccination"
       end

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -20,9 +20,9 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   def delivery_method
     if patient.approved_vaccine_methods(programme:).include?("nasal")
-      :nasal_spray
+      "nasal_spray"
     else
-      :intramuscular
+      "intramuscular"
     end
   end
 
@@ -31,8 +31,8 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   COMMON_DELIVERY_SITES = {
-    intramuscular: %w[left_arm_upper_position right_arm_upper_position],
-    nasal_spray: %w[nose]
+    "intramuscular" => %w[left_arm_upper_position right_arm_upper_position],
+    "nasal_spray" => %w[nose]
   }.freeze
 
   CommonDeliverySite = Struct.new(:value, :label)
@@ -48,7 +48,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
               CommonDeliverySite.new(value:, label:)
             end
 
-        if delivery_method == :intramuscular
+        if delivery_method.in?(Vaccine::INJECTION_DELIVERY_METHODS)
           options << CommonDeliverySite.new(value: "other", label: "Other")
         end
 
@@ -58,8 +58,12 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   def vaccination_name
     vaccination =
-      if programme.flu?
-        delivery_method == :nasal_spray ? "nasal spray" : "injection"
+      if programme.has_multiple_vaccine_methods?
+        if delivery_method.in?(Vaccine::NASAL_DELIVERY_METHODS)
+          "nasal spray"
+        else
+          "injection"
+        end
       else
         "vaccination"
       end
@@ -71,5 +75,6 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   def ask_not_pregnant? = programme.td_ipv?
 
-  def ask_asthma_flare_up? = programme.flu? && delivery_method == :nasal_spray
+  def ask_asthma_flare_up? =
+    delivery_method.in?(Vaccine::NASAL_DELIVERY_METHODS)
 end

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -59,11 +59,9 @@ class AppVaccinateFormComponent < ViewComponent::Base
   def vaccination_name
     vaccination =
       if programme.has_multiple_vaccine_methods?
-        if delivery_method.in?(Vaccine::NASAL_DELIVERY_METHODS)
-          "nasal spray"
-        else
-          "injection"
-        end
+        vaccine_method =
+          Vaccine.delivery_method_to_vaccine_method(delivery_method)
+        Vaccine.human_enum_name(:method, vaccine_method).downcase
       else
         "vaccination"
       end

--- a/app/controllers/patient_sessions/vaccinations_controller.rb
+++ b/app/controllers/patient_sessions/vaccinations_controller.rb
@@ -68,11 +68,20 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
   end
 
   def set_todays_batch
+    vaccine_method =
+      Vaccine.delivery_method_to_vaccine_method(
+        vaccinate_form_params[:delivery_method]
+      )
+    return if vaccine_method.nil?
+
+    id = todays_batch_id(programme: @programme, vaccine_method:)
+    return if id.nil?
+
     @todays_batch =
       policy_scope(Batch)
         .where(vaccine: @session.vaccines)
         .not_archived
         .not_expired
-        .find_by(id: todays_batch_id(programme: @programme))
+        .find_by(id:)
   end
 end

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -12,6 +12,7 @@ class Sessions::RecordController < ApplicationController
 
   before_action :set_todays_batches, only: :show
   before_action :set_programme, except: :show
+  before_action :set_vaccine_method, except: :show
   before_action :set_batches, except: :show
 
   def show
@@ -41,9 +42,8 @@ class Sessions::RecordController < ApplicationController
   end
 
   def edit_batch
-    @todays_batch =
-      authorize @batches.find_by(id: todays_batch_id(programme: @programme)),
-                :edit?
+    id = todays_batch_id(programme: @programme, vaccine_method: @vaccine_method)
+    @todays_batch = authorize @batches.find(id), :edit?
 
     render :batch
   end
@@ -80,11 +80,16 @@ class Sessions::RecordController < ApplicationController
   def set_todays_batches
     all_batches =
       @session.programmes.index_with do |programme|
-        policy_scope(Batch)
-          .where(vaccine: @session.vaccines)
-          .not_archived
-          .not_expired
-          .find_by(id: todays_batch_id(programme:))
+        programme.vaccine_methods.filter_map do |vaccine_method|
+          id = todays_batch_id(programme:, vaccine_method:)
+          next if id.nil?
+
+          policy_scope(Batch)
+            .where(vaccine: @session.vaccines)
+            .not_archived
+            .not_expired
+            .find_by(id:)
+        end
       end
 
     @todays_batches = all_batches.compact
@@ -94,10 +99,17 @@ class Sessions::RecordController < ApplicationController
     @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 
+  def set_vaccine_method
+    @vaccine_method = params[:vaccine_method]
+  end
+
   def set_batches
+    vaccines =
+      @session.vaccines.where(programme: @programme, method: @vaccine_method)
+
     @batches =
       policy_scope(Batch)
-        .where(vaccine: @session.vaccines.where(programme: @programme))
+        .where(vaccine: vaccines)
         .not_archived
         .not_expired
         .order_by_name_and_expiration

--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -15,9 +15,11 @@ class VaccinesController < ApplicationController
         .order_by_name_and_expiration
         .group_by(&:vaccine_id)
 
-    @todays_batch_id_by_programme =
+    @todays_batch_id_by_programme_and_vaccine_methods =
       policy_scope(Programme).index_with do |programme|
-        todays_batch_id(programme:)
+        programme.vaccine_methods.index_with do |vaccine_method|
+          todays_batch_id(programme:, vaccine_method:)
+        end
       end
   end
 

--- a/app/views/sessions/record/batch.html.erb
+++ b/app/views/sessions/record/batch.html.erb
@@ -2,7 +2,13 @@
   <%= render AppBacklinkComponent.new(session_record_path(@session), name: "record") %>
 <% end %>
 
-<% page_title = "Select a default batch for this session" %>
+<% programme_name_and_method = if @programme.has_multiple_vaccine_methods?
+       "#{@programme.name_in_sentence} #{Vaccine.human_enum_name(:vaccine_method, @vaccine_method)}.downcase"
+     else
+       "#{@programme.name_in_sentence}"
+     end %>
+
+<% page_title = "Select a default #{programme_name_and_method} batch for this session" %>
 <% content_for :page_title, page_title %>
 
 <%= form_with model: @todays_batch, url: batch_session_record_path(@session, @programme), method: :post do |f| %>

--- a/app/views/sessions/record/batch.html.erb
+++ b/app/views/sessions/record/batch.html.erb
@@ -14,11 +14,16 @@
     <% @batches.each_with_index do |batch, index| %>
       <% label = proc do %>
         <span class="app-u-monospace"><%= batch.name %></span>
+        (<%= batch.vaccine.brand %>)
+      <% end %>
+
+      <% hint = proc do %>
         <% if (expiry = batch.expiry) %>
-          (expires <%= expiry.to_fs(:long) %>)
+          Expires <%= expiry.to_fs(:long) %>
         <% end %>
       <% end %>
-      <%= f.govuk_radio_button :id, batch.id, label:, link_errors: index.zero? %>
+
+      <%= f.govuk_radio_button :id, batch.id, label:, hint:, link_errors: index.zero? %>
     <% end %>
   <% end %>
 

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -17,11 +17,15 @@
     </h2>
 
     <ul class="nhsuk-list nhsuk-list--bullet">
-      <% @todays_batches.each do |programme, batch| %>
-        <li>
-          <%= batch.vaccine.brand %> (<%= programme.name %>): <span class="app-u-monospace"><%= batch.name %></span>
-          <a class="nhsuk-link nhsuk-u-margin-left-2" href="<%= batch_session_record_path(@session, programme) %>">Change default batch<span class="nhsuk-u-visually-hidden"> for <%= batch.vaccine.brand %></span></a>
-        </li>
+      <% @todays_batches.each do |programme, batches| %>
+        <% batches.each do |batch| %>
+          <li>
+            <%= batch.vaccine.brand %> (<%= programme.name %>): <span class="app-u-monospace"><%= batch.name %></span>
+            <a class="nhsuk-link nhsuk-u-margin-left-2" href="<%= batch_session_record_path(@session, programme, batch.vaccine.method) %>">
+              Change default batch<span class="nhsuk-u-visually-hidden"> for <%= batch.vaccine.brand %></span>
+            </a>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -19,8 +19,14 @@
     <ul class="nhsuk-list nhsuk-list--bullet">
       <% @todays_batches.each do |programme, batches| %>
         <% batches.each do |batch| %>
+          <% programme_name = if programme.has_multiple_vaccine_methods?
+                 "#{programme.name_in_sentence} #{batch.vaccine.human_enum_name(:method).downcase}"
+               else
+                 programme.name_in_sentence
+               end %>
+
           <li>
-            <%= batch.vaccine.brand %> (<%= programme.name %>): <span class="app-u-monospace"><%= batch.name %></span>
+            <%= batch.vaccine.brand %> (<%= programme_name %>): <span class="app-u-monospace"><%= batch.name %></span>
             <a class="nhsuk-link nhsuk-u-margin-left-2" href="<%= batch_session_record_path(@session, programme, batch.vaccine.method) %>">
               Change default batch<span class="nhsuk-u-visually-hidden"> for <%= batch.vaccine.brand %></span>
             </a>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -27,7 +27,7 @@
             <% body.with_row do |row| %>
               <% row.with_cell(text: batch.name) do %>
                 <%= batch.name %>
-                <% if batch.id == @todays_batch_id_by_programme[vaccine.programme] %>
+                <% if batch.id == @todays_batch_id_by_programme_and_vaccine_methods[vaccine.programme][vaccine.method] %>
                   <br>
                   <span class="nhsuk-caption-m">
                     (Your default)

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -36,7 +36,7 @@
         Method
       </dt>
       <dd class="nhsuk-summary-list__value">
-        <%= @vaccine.human_enum_name(:method).humanize %>
+        <%= @vaccine.human_enum_name(:method) %>
       </dd>
     </div>
     <div class="nhsuk-summary-list__row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,6 +233,9 @@ en:
           injection: Injection
           nasal: Nasal spray
           nasal_injection: Nasal spray (or injection)
+        method_prefixes:
+          injection: injected
+          nasal: nasal spray
         side_effects:
           aching: an aching body
           dizziness: dizziness

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,8 +214,10 @@ Rails.application.routes.draw do
       post ":patient_id/:status", as: :create, action: :create
     end
     resource :record, only: :show, controller: "sessions/record" do
-      get "batch/:programme_type", action: :edit_batch, as: :batch
-      post "batch/:programme_type", action: :update_batch
+      get "batch/:programme_type/:vaccine_method",
+          action: :edit_batch,
+          as: :batch
+      post "batch/:programme_type/:vaccine_method", action: :update_batch
     end
     resource :outcome, only: :show, controller: "sessions/outcome"
 

--- a/spec/components/app_consent_confirmation_component_spec.rb
+++ b/spec/components/app_consent_confirmation_component_spec.rb
@@ -29,7 +29,7 @@ describe AppConsentConfirmationComponent do
         )
       end
 
-      it { should have_text("is due to get the nasal flu vaccination") }
+      it { should have_text("is due to get the nasal spray flu vaccination") }
     end
 
     context "consent for injected Flu" do
@@ -40,7 +40,7 @@ describe AppConsentConfirmationComponent do
         )
       end
 
-      it { should have_text("is due to get the flu injection vaccination") }
+      it { should have_text("is due to get the injected flu vaccination") }
     end
 
     context "consent refused" do

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -233,7 +233,7 @@ RSpec.feature "Parental consent change answers" do
     expect(page).to have_content("Consent confirmed")
     expect(page).to have_content(
       "As you answered ‘yes’ to some of the health questions, " \
-        "we need to check the flu injection vaccination is suitable for Joe Test."
+        "we need to check the injected flu vaccination is suitable for Joe Test."
     )
   end
 
@@ -245,7 +245,7 @@ RSpec.feature "Parental consent change answers" do
 
   def then_i_see_the_given_confirmation_page
     expect(page).to have_content(
-      "is due to get the flu injection vaccination at school"
+      "is due to get the injected flu vaccination at school"
     )
   end
 

--- a/spec/features/todays_batch_spec.rb
+++ b/spec/features/todays_batch_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-describe "Vaccination" do
+describe "Today’s batch" do
   around { |example| travel_to(Time.zone.local(2024, 2, 1)) { example.run } }
 
-  scenario "Today's batch" do
-    given_i_am_signed_in
+  before { given_i_am_signed_in }
 
+  scenario "injection only" do
     when_i_vaccinate_a_patient_with_hpv
+    and_i_choose_a_default_batch(@hpv_batch)
     then_i_see_the_default_batch_banner_with_batch_1
 
     when_i_click_the_change_batch_link
@@ -19,12 +20,27 @@ describe "Vaccination" do
     then_i_see_the_default_batch_on_the_confirmation_page
     and_i_see_the_default_batch_on_the_patient_page
 
-    when_i_vaccinate_a_patient_with_menacwy
+    when_i_vaccinate_a_patient_with_flu
     then_i_am_required_to_choose_a_batch
   end
 
+  scenario "nasal spray and injection" do
+    when_i_vaccinate_a_patient_with_flu
+    then_i_dont_see_the_batch(@flu_nasal_batch)
+    and_i_choose_a_default_batch(@flu_injection_batch)
+
+    when_i_vaccinate_a_second_patient_with_flu
+    then_i_am_required_to_choose_a_batch
+    and_i_dont_see_the_batch(@flu_injection_batch)
+    and_i_choose_a_default_batch(@flu_nasal_batch)
+    then_i_see_the_default_flu_batches_banner
+  end
+
   def given_i_am_signed_in
-    programmes = [create(:programme, :hpv), create(:programme, :menacwy)]
+    flu_programme = create(:programme, :flu)
+    hpv_programme = create(:programme, :hpv)
+
+    programmes = [hpv_programme, flu_programme]
 
     organisation = create(:organisation, :with_one_nurse, programmes:)
 
@@ -37,6 +53,8 @@ describe "Vaccination" do
 
     @hpv_batch = batches.first.first
     @hpv_batch2 = batches.first.second
+    @flu_injection_batch = batches.second.find { it.vaccine.injection? }
+    @flu_nasal_batch = batches.second.find { it.vaccine.nasal? }
 
     @session = create(:session, organisation:, programmes:)
 
@@ -58,6 +76,10 @@ describe "Vaccination" do
         year_group: 8
       )
 
+    @patient2.consent_status(programme: flu_programme).update!(
+      vaccine_methods: %w[nasal]
+    )
+
     sign_in organisation.users.first
   end
 
@@ -65,6 +87,7 @@ describe "Vaccination" do
     visit session_record_path(@session)
 
     click_link @patient.full_name
+    click_on "HPV"
 
     within all("section")[0] do
       check "I have checked that the above statements are true"
@@ -75,11 +98,19 @@ describe "Vaccination" do
       choose "Left arm (upper position)"
       click_button "Continue"
     end
+  end
 
-    choose @hpv_batch.name
+  def then_i_dont_see_the_batch(batch)
+    expect(page).not_to have_content(batch.name)
+  end
+
+  alias_method :and_i_dont_see_the_batch, :then_i_dont_see_the_batch
+
+  def and_i_choose_a_default_batch(batch)
+    choose batch.name
 
     # Find the selected radio button element
-    selected_radio_button = find(:radio_button, @hpv_batch.name, checked: true)
+    selected_radio_button = find(:radio_button, batch.name, checked: true)
 
     # Find the "Default to this batch for this session" checkbox immediately below and check it
     checkbox_below =
@@ -100,6 +131,7 @@ describe "Vaccination" do
     visit session_record_path(@session)
 
     click_link @patient2.full_name
+    click_on "HPV"
 
     within all("section")[0] do
       check "I have checked that the above statements are true"
@@ -149,11 +181,11 @@ describe "Vaccination" do
     expect(page).to have_content(@hpv_batch2.name)
   end
 
-  def when_i_vaccinate_a_patient_with_menacwy
+  def when_i_vaccinate_a_patient_with_flu
     visit session_record_path(@session)
 
     click_link @patient.full_name
-    click_on "MenACWY"
+    click_on "Flu"
 
     within all("section")[0] do
       check "I have checked that the above statements are true"
@@ -166,7 +198,32 @@ describe "Vaccination" do
     end
   end
 
+  def when_i_vaccinate_a_second_patient_with_flu
+    visit session_record_path(@session)
+
+    click_link @patient2.full_name
+    click_on "Flu"
+
+    within all("section")[0] do
+      check "I have checked that the above statements are true"
+    end
+
+    within all("section")[1] do
+      choose "Yes"
+      click_button "Continue"
+    end
+  end
+
   def then_i_am_required_to_choose_a_batch
     expect(page).to have_content("Which batch did you use?")
+  end
+
+  def then_i_see_the_default_flu_batches_banner
+    expect(page).to have_content(
+      "Adjuvanted Quadrivalent - aQIV (Flu): #{@flu_injection_batch.name}"
+    )
+    expect(page).to have_content(
+      "Fluenz Tetra - LAIV (Flu): #{@flu_nasal_batch.name}"
+    )
   end
 end

--- a/spec/features/todays_batch_spec.rb
+++ b/spec/features/todays_batch_spec.rb
@@ -157,7 +157,7 @@ describe "Today’s batch" do
   end
 
   def then_i_see_the_change_batch_page
-    expect(page).to have_content("Select a default batch for this session")
+    expect(page).to have_content("Select a default HPV batch for this session")
     expect(page).to have_selector(:label, @hpv_batch.name)
     expect(page).to have_selector(:label, @hpv_batch2.name)
   end
@@ -220,10 +220,10 @@ describe "Today’s batch" do
 
   def then_i_see_the_default_flu_batches_banner
     expect(page).to have_content(
-      "Adjuvanted Quadrivalent - aQIV (Flu): #{@flu_injection_batch.name}"
+      "Adjuvanted Quadrivalent - aQIV (flu injection): #{@flu_injection_batch.name}"
     )
     expect(page).to have_content(
-      "Fluenz Tetra - LAIV (Flu): #{@flu_nasal_batch.name}"
+      "Fluenz Tetra - LAIV (flu nasal spray): #{@flu_nasal_batch.name}"
     )
   end
 end


### PR DESCRIPTION
This ensures that when administered vaccinations for a programme like flu where there are multiple vaccine methods (injection vs nasal), the default batch for the day is different for the two vaccine methods.

[Jira Issue - MAV-1431](https://nhsd-jira.digital.nhs.uk/browse/MAV-1431)