### PR TITLE
Unpin Mise GH action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,5 @@ jobs:
       - run: tflint --chdir=terraform --init
       - uses: jdx/mise-action@v2
         with:
-          version: v2025.7.3
           install_args: hk pkl
       - run: hk check --all


### PR DESCRIPTION
The issue of missing linux binaries (see 2d38da390465c3c4149c1ed340269b3266a6485f) has been resolved in the latest version.