### PR TITLE
Ensure flu is displayed lowercase in sentences

### DIFF
--- a/app/components/app_consent_confirmation_component.rb
+++ b/app/components/app_consent_confirmation_component.rb
@@ -72,10 +72,10 @@ class AppConsentConfirmationComponent < ViewComponent::Base
             elsif consent_form_programme.vaccine_method_injection?
               "flu injection"
             else
-              programme.name.downcase
+              programme.name_in_sentence
             end
           else
-            programme.name
+            programme.name_in_sentence
           end
         end
 

--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -38,15 +38,20 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
   end
 
   def heading
-    return "Record #{programme.name} vaccination" unless programme.flu?
+    vaccination =
+      if programme.flu?
+        if PatientSession
+             .where(patient_id: patient.id)
+             .has_vaccine_method(:nasal, programme:)
+             .exists?
+          "vaccination with nasal spray"
+        else
+          "vaccination with injection"
+        end
+      else
+        "vaccination"
+      end
 
-    if PatientSession
-         .where(patient_id: patient.id)
-         .has_vaccine_method(:nasal, programme:)
-         .exists?
-      "Record flu vaccination with nasal spray"
-    else
-      "Record flu vaccination with injection"
-    end
+    "Record #{programme.name_in_sentence} #{vaccination}"
   end
 end

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -96,7 +96,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
         status = patient_session.next_activity(programme:)
         next if status.nil?
 
-        "#{I18n.t(status, scope: :activity)} for #{programme.name}"
+        "#{I18n.t(status, scope: :activity)} for #{programme.name_in_sentence}"
       end
 
     return if next_activities.empty?

--- a/app/components/app_patient_session_triage_component.html.erb
+++ b/app/components/app_patient_session_triage_component.html.erb
@@ -11,7 +11,7 @@
     <% end %>
 
     <% if triage_status&.vaccination_history_requires_triage? %>
-      <p>Incomplete vaccination history for <%= programme.name %>. Check if the child needs another dose.</p>
+      <p>Incomplete vaccination history for <%= programme.name_in_sentence %>. Check if the child needs another dose.</p>
     <% end %>
 
     <% if helpers.policy(Triage).new? %>

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -129,7 +129,7 @@ class AppSessionActionsComponent < ViewComponent::Base
 
     texts =
       counts_by_programme.map do |programme, count|
-        "#{I18n.t("children", count:)} for #{programme.name}"
+        "#{I18n.t("children", count:)} for #{programme.name_in_sentence}"
       end
 
     href = session_record_path(session)

--- a/app/components/app_session_details_summary_component.rb
+++ b/app/components/app_session_details_summary_component.rb
@@ -62,7 +62,7 @@ class AppSessionDetailsSummaryComponent < ViewComponent::Base
         count =
           patient_sessions.has_session_status(:vaccinated, programme:).count
 
-        "#{I18n.t("vaccinations_given", count:)} for #{programme.name}"
+        "#{I18n.t("vaccinations_given", count:)} for #{programme.name_in_sentence}"
       end
 
     href =

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -57,9 +57,14 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def vaccination_name
-    return "#{programme.name} vaccination" unless programme.flu?
+    vaccination =
+      if programme.flu?
+        delivery_method == :nasal_spray ? "nasal spray" : "injection"
+      else
+        "vaccination"
+      end
 
-    delivery_method == :nasal_spray ? "flu nasal spray" : "flu injection"
+    "#{programme.name_in_sentence} #{vaccination}"
   end
 
   def ask_not_taking_medication? = programme.doubles? || programme.flu?

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -126,7 +126,9 @@ class DraftVaccinationRecordsController < ApplicationController
     # vaccination record.
     @draft_vaccination_record.update!(editing_id: @vaccination_record.id)
 
-    flash[:success] = "Vaccination outcome recorded for #{@programme.name}"
+    flash[
+      :success
+    ] = "Vaccination outcome recorded for #{@programme.name_in_sentence}"
   end
 
   def finish_wizard_path

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -941,7 +941,7 @@ class ImmunisationImportRow
       if programme && vaccine.programme_id != programme.id
         errors.add(
           field.header,
-          "is not given in the #{programme.name} programme"
+          "is not given in the #{programme.name_in_sentence} programme"
         )
       end
     elsif vaccine_nivs_name.present?

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -52,6 +52,8 @@ class Programme < ApplicationRecord
 
   def name = human_enum_name(:type)
 
+  def name_in_sentence = flu? ? name.downcase : name
+
   def doubles? = menacwy? || td_ipv?
 
   def seasonal? = flu?

--- a/app/views/draft_vaccination_records/batch.html.erb
+++ b/app/views/draft_vaccination_records/batch.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% content_for :page_title, "Which batch did you use for the #{@programme.name} vaccination?" %>
+<% content_for :page_title, "Which batch did you use for the #{@programme.name_in_sentence} vaccination?" %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/draft_vaccination_records/date_and_time.html.erb
+++ b/app/views/draft_vaccination_records/date_and_time.html.erb
@@ -6,7 +6,7 @@
   <%= f.govuk_error_summary %>
 
   <span class="nhsuk-caption-l"><%= @patient.full_name %></span>
-  <%= h1 "When was the #{@programme.name} vaccination given?" %>
+  <%= h1 "When was the #{@programme.name_in_sentence} vaccination given?" %>
 
   <%= f.govuk_date_field :performed_at,
                          legend: { text: "Date" },

--- a/app/views/draft_vaccination_records/delivery.html.erb
+++ b/app/views/draft_vaccination_records/delivery.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% page_title = "How was the #{@programme.name} vaccination given?" %>
+<% page_title = "How was the #{@programme.name_in_sentence} vaccination given?" %>
 
 <%= h1 page_title: do %>
   <span class="nhsuk-caption-l">

--- a/app/views/draft_vaccination_records/location.html.erb
+++ b/app/views/draft_vaccination_records/location.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBacklinkComponent.new(@back_link_path) %>
 <% end %>
 
-<% title = "Where was the #{@programme.name} vaccination offered?" %>
+<% title = "Where was the #{@programme.name_in_sentence} vaccination offered?" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>

--- a/app/views/draft_vaccination_records/outcome.html.erb
+++ b/app/views/draft_vaccination_records/outcome.html.erb
@@ -4,7 +4,7 @@
 
 <% editing = @draft_vaccination_record.editing? || @draft_vaccination_record.outcome.present? %>
 
-<% title = editing ? "Vaccination outcome" : "Why was the #{@programme.name} vaccination not given?" %>
+<% title = editing ? "Vaccination outcome" : "Why was the #{@programme.name_in_sentence} vaccination not given?" %>
 <% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>

--- a/app/views/parent_relationships/destroy.html.erb
+++ b/app/views/parent_relationships/destroy.html.erb
@@ -17,7 +17,7 @@
     <p><%= @parent.label %> has submitted the following consent responses for this child:</p>
     <ul class="govuk-list govuk-list--bullet">
       <% @patient.consents.includes(:programme).not_invalidated.where(parent: @parent).find_each do |consent| %>
-        <li><%= consent.human_enum_name(:response).upcase_first %> (<%= consent.created_at.to_date.to_fs(:long) %> for <%= consent.programme.name %>)</li>
+        <li><%= consent.human_enum_name(:response).upcase_first %> (<%= consent.created_at.to_date.to_fs(:long) %> for <%= consent.programme.name_in_sentence %>)</li>
       <% end %>
     </ul>
     <p>You should review these before continuing.</p>

--- a/lib/tasks/health_questions.rake
+++ b/lib/tasks/health_questions.rake
@@ -23,7 +23,7 @@ namespace :health_questions do
     raise "Vaccine not found for the given programme" if vaccine.nil?
 
     existing_health_questions = vaccine.health_questions.in_order
-    puts "Existing health questions for #{programme.name}'s vaccine #{vaccine.brand}"
+    puts "Existing health questions for #{programme.name_in_sentence}'s vaccine #{vaccine.brand}"
     if existing_health_questions.any?
       existing_health_questions.each do |health_question|
         puts Rainbow("  #{health_question.title}").yellow
@@ -62,7 +62,7 @@ namespace :health_questions do
       next
     end
 
-    puts "\nThese will be the health questions for #{programme.name}'s vaccine #{vaccine.brand}:"
+    puts "\nThese will be the health questions for #{programme.name_in_sentence}'s vaccine #{vaccine.brand}:"
     unless replace
       existing_health_questions.each do |health_question|
         puts Rainbow("  [old] #{health_question.title}").black

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -179,7 +179,7 @@ describe "Flu vaccination" do
 
   def and_i_get_confirmation_after_recording
     click_button "Confirm"
-    expect(page).to have_content("Vaccination outcome recorded for Flu")
+    expect(page).to have_content("Vaccination outcome recorded for flu")
   end
 
   def then_i_see_the_check_and_confirm_page_for_injection

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -23,12 +23,28 @@ describe Programme do
   end
 
   describe "#name" do
-    subject(:name) { programme.name }
+    subject { programme.name }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
       it { should eq("Flu") }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should eq("HPV") }
+    end
+  end
+
+  describe "#name_in_sentence" do
+    subject(:name) { programme.name_in_sentence }
+
+    context "with a flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should eq("flu") }
     end
 
     context "with an HPV programme" do


### PR DESCRIPTION
This adds a new method on the `Programme` model which can be used to get the name of the programme appropriate for rendering in the middle of a sentence. For most programmes this will be the same as their name, but for flu, when rendered in a sentence it should have a lowercase first letter.

By having this method we can also start to replace the hard-coded instances of `"flu"`.