### PR TITLE
Ensure consented_vaccine_methods_message exists

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -134,7 +134,8 @@ class GovukNotifyPersonalisation
   end
 
   def consented_vaccine_methods_message
-    return if consent_form.nil? || consent_form.programmes.none?(&:flu?)
+    return nil if consent_form.nil?
+    return "" if consent_form.programmes.none?(&:flu?)
 
     consent_form_programmes = consent_form.consent_form_programmes
 

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -206,9 +206,10 @@ describe GovukNotifyPersonalisation do
 
     it do
       expect(to_h).to include(
+        consented_vaccine_methods_message: "",
+        location_name: "Hogwarts",
         reason_for_refusal: "of personal choice",
-        survey_deadline_date: "8 January 2024",
-        location_name: "Hogwarts"
+        survey_deadline_date: "8 January 2024"
       )
     end
 


### PR DESCRIPTION
This ensures that the variable is available in GOV.UK Notify even if it has no value. Specifically this is to handle non-flu programmes where we don't include this text content in the emails and texts.

This fixes two Sentry issues:
- https://good-machine.sentry.io/issues/6272173671/
- https://good-machine.sentry.io/issues/6235087330/