### PR TITLE
Add `talk_to_your_child_message` personalisation

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -35,7 +35,6 @@ class GovukNotifyPersonalisation
   def to_h
     {
       batch_name:,
-      can_self_consent:,
       catch_up:,
       consent_deadline:,
       consent_link:,
@@ -63,6 +62,7 @@ class GovukNotifyPersonalisation
       show_additional_instructions:,
       subsequent_session_dates_offered_message:,
       survey_deadline_date:,
+      talk_to_your_child_message:,
       team_email:,
       team_name:,
       team_phone:,
@@ -90,11 +90,6 @@ class GovukNotifyPersonalisation
 
   def batch_name
     vaccination_record&.batch&.name
-  end
-
-  def can_self_consent
-    return nil if patient.nil?
-    patient.year_group >= 7 ? "yes" : "no"
   end
 
   def catch_up
@@ -288,6 +283,20 @@ class GovukNotifyPersonalisation
     return if recorded_at.nil?
 
     (recorded_at + 7.days).to_date.to_fs(:long)
+  end
+
+  def talk_to_your_child_message
+    return nil if patient.nil?
+    return "" if patient.year_group <= 6
+
+    [
+      "## Talk to your child about what they want",
+      "We suggest you talk to your child about the vaccine before you respond to us.",
+      "Young people have the right to refuse vaccinations. " \
+        "Those who show [‘Gillick competence’](https://www.nhs.uk/conditions/consent-to-treatment/children/) " \
+        "have the right to consent to vaccinations themselves. " \
+        "Our team may assess Gillick competence during vaccination sessions."
+    ].join("\n\n")
   end
 
   def team_email

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -48,9 +48,16 @@ describe GovukNotifyPersonalisation do
   let(:vaccination_record) { nil }
 
   it do
-    expect(to_h).to eq(
+    expect(to_h).to match(
       {
-        can_self_consent: "yes",
+        talk_to_your_child_message:
+          "## Talk to your child about what they want\n\n" \
+            "We suggest you talk to your child about the vaccine before you " \
+            "respond to us.\n\nYoung people have the right to refuse " \
+            "vaccinations. Those who show " \
+            "[‘Gillick competence’](https://www.nhs.uk/conditions/consent-to-treatment/children/) " \
+            "have the right to consent to vaccinations themselves. Our team " \
+            "may assess Gillick competence during vaccination sessions.",
         catch_up: "no",
         consent_deadline: "Wednesday 31 December",
         consent_link:
@@ -88,7 +95,7 @@ describe GovukNotifyPersonalisation do
   context "with a patient in primary school" do
     let(:patient) { create(:patient, year_group: 6) }
 
-    it { should include(can_self_consent: "no") }
+    it { should include(talk_to_your_child_message: "") }
   end
 
   context "when the session is today" do


### PR DESCRIPTION
This replaces the `can_self_consent` variable that was added in 37c4891e152b7f4e3423ba192bc342059393dbc2 as we can't use the variable as expected.

It was designed to be used with optional content, but the optional content in this case contains a link which is not supported in optional content. Instead we need to pass the entire block of content as a variable (`talk_to_your_child_message` added in this commit) and that handles the logic about whether to populate it or not.

[Jira Issue - MAV-1277](https://nhsd-jira.digital.nhs.uk/browse/MAV-1277)