### PR TITLE
Triage for flu: UI changes

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -215,12 +215,17 @@ class AppActivityLogComponent < ViewComponent::Base
 
   def triage_events
     triages.map do |triage|
+      programmes = programmes_for(triage)
+      title = "Triaged decision: #{triage.human_enum_name(:status)}"
+      title +=
+        " with #{triage.human_enum_name(:vaccine_method)}" if triage.vaccine_method.present? &&
+        programmes.first.has_multiple_vaccine_methods?
       {
-        title: "Triaged decision: #{triage.human_enum_name(:status)}",
+        title:,
         body: triage.notes,
         at: triage.created_at,
         by: triage.performed_by,
-        programmes: programmes_for(triage)
+        programmes:
       }
     end
   end

--- a/app/components/app_patient_search_result_card_component.rb
+++ b/app/components/app_patient_search_result_card_component.rb
@@ -92,13 +92,19 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
   end
 
   def render_status_tag(status_type, outcome)
-    status =
-      @patient.public_send(
-        "#{status_type}_status",
-        programme: @programme
-      ).status
+    status_model =
+      @patient.public_send("#{status_type}_status", programme: @programme)
+
+    status_key =
+      if status_type == :triage && status_model.vaccine_method.present? &&
+           @programme.has_multiple_vaccine_methods?
+        "#{status_model.status}_#{status_model.vaccine_method}"
+      else
+        status_model.status
+      end
+
     render AppProgrammeStatusTagsComponent.new(
-             { @programme => { status: } },
+             { @programme => { status: status_key } },
              outcome: outcome
            )
   end

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -158,7 +158,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
           render(
             AppProgrammeStatusTagsComponent.new(
               programmes.index_with do |programme|
-                patient.triage_status(programme:).slice(:status)
+                triage_status_tag(patient.triage_status(programme:), programme)
               end,
               outcome: :triage
             )
@@ -178,6 +178,18 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
           )
       }
     end
+  end
+
+  def triage_status_tag(triage_status, programme)
+    status =
+      if triage_status.vaccine_method.present? &&
+           programme.has_multiple_vaccine_methods?
+        triage_status.status + "_#{triage_status.vaccine_method}"
+      else
+        triage_status.status
+      end
+
+    { status: status }
   end
 
   def note_to_log_event(note)

--- a/app/components/app_patient_session_triage_component.html.erb
+++ b/app/components/app_patient_session_triage_component.html.erb
@@ -6,10 +6,6 @@
   <% if latest_triage.nil? || latest_triage.needs_follow_up? %>
     <p>You need to decide if it’s safe to vaccinate.</p>
 
-    <% if triage_status&.consent_requires_triage? %>
-      <p>Responses to health questions need triage.</p>
-    <% end %>
-
     <% if triage_status&.vaccination_history_requires_triage? %>
       <p>Incomplete vaccination history for <%= programme.name_in_sentence %>. Check if the child needs another dose.</p>
     <% end %>
@@ -22,11 +18,15 @@
     <% end %>
   <% elsif latest_triage %>
     <% if latest_triage.ready_to_vaccinate? %>
-      <p><%= latest_triage.performed_by.full_name %> decided that <%= patient.full_name %> is safe to vaccinate.</p>
+      <% if latest_triage.vaccine_method.present? && programme.has_multiple_vaccine_methods? %>
+        <p><%= latest_triage.performed_by.full_name %> decided that <%= patient.full_name %> is safe to vaccinate using the <%= vaccination_method %> vaccine only.</p>
+      <% else %>
+        <p><%= latest_triage.performed_by.full_name %> decided that <%= patient.full_name %> is safe to vaccinate.</p>
+      <% end %>
     <% elsif latest_triage.do_not_vaccinate? %>
       <p><%= latest_triage.performed_by.full_name %> decided that <%= patient.full_name %> should not be vaccinated.</p>
-    <% elsif latest_triage.do_not_vaccinate? %>
-      <p><%= latest_triage.performed_by.full_name %> decided that <%= patient.full_name %>’s vaccination should be delayed.</p>
+    <% elsif latest_triage.delay_vaccination? %>
+      <p><%= latest_triage.performed_by.full_name %> decided that <%= patient.full_name %>'s vaccination should be delayed.</p>
     <% end %>
 
     <div class="app-button-group nhsuk-u-margin-bottom-4">

--- a/app/components/app_patient_session_triage_component.rb
+++ b/app/components/app_patient_session_triage_component.rb
@@ -35,6 +35,10 @@ class AppPatientSessionTriageComponent < ViewComponent::Base
         .find_by(programme:)
   end
 
+  def vaccination_method
+    Vaccine.human_enum_name(:method_prefix, triage_status.vaccine_method)
+  end
+
   delegate :status, to: :triage_status
 
   def latest_triage

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -1,10 +1,15 @@
 <%= form_with model: triage_form, url:, method:, builder: do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
-  <%= f.govuk_collection_radio_buttons :status_and_vaccine_method,
-                                       triage_form.status_and_vaccine_method_options,
-                                       :itself,
-                                       **fieldset_options %>
+    <%= f.govuk_radio_buttons_fieldset :status_and_vaccine_method, **fieldset_options do %>
+      <% triage_form.safe_to_vaccinate_options.each do |option| %>
+        <%= f.govuk_radio_button :status_and_vaccine_method, option %>
+      <% end %>
+      <%= f.govuk_radio_divider %>
+      <% triage_form.other_options.each do |option| %>
+        <%= f.govuk_radio_button :status_and_vaccine_method, option %>
+      <% end %>
+    <% end %>
 
   <%= f.govuk_text_area :notes, label: { text: "Triage notes (optional)" }, rows: 5 %>
 

--- a/app/components/app_triage_table_component.rb
+++ b/app/components/app_triage_table_component.rb
@@ -22,7 +22,7 @@ class AppTriageTableComponent < ViewComponent::Base
     @triages ||=
       patient
         .triages
-        .includes(:performed_by)
+        .includes(:performed_by, :programme)
         .where(programme:)
         .order(created_at: :desc)
   end

--- a/app/forms/triage_form.rb
+++ b/app/forms/triage_form.rb
@@ -39,16 +39,20 @@ class TriageForm
     Triage.create!(triage_attributes)
   end
 
-  def status_and_vaccine_method_options
-    safe_to_vaccinate_choices =
-      if programme.has_multiple_vaccine_methods?
-        consented_vaccine_methods.map { |method| "safe_to_vaccinate_#{method}" }
-      else
-        ["safe_to_vaccinate"]
-      end
+  def safe_to_vaccinate_options
+    if programme.has_multiple_vaccine_methods?
+      consented_vaccine_methods.map { |method| "safe_to_vaccinate_#{method}" }
+    else
+      ["safe_to_vaccinate"]
+    end
+  end
 
-    safe_to_vaccinate_choices +
-      %w[keep_in_triage delay_vaccination do_not_vaccinate]
+  def other_options
+    %w[keep_in_triage delay_vaccination do_not_vaccinate]
+  end
+
+  def status_and_vaccine_method_options
+    safe_to_vaccinate_options + other_options
   end
 
   def consented_to_injection? = consented_vaccine_methods.include?("injection")

--- a/app/helpers/triages_helper.rb
+++ b/app/helpers/triages_helper.rb
@@ -2,7 +2,15 @@
 
 module TriagesHelper
   def triage_status_tag(triage)
-    text = triage.human_enum_name(:status)
+    status_method =
+      if triage.programme.has_multiple_vaccine_methods? &&
+           triage.vaccine_method.present?
+        triage.status + "_#{triage.vaccine_method}"
+      else
+        triage.status
+      end
+
+    text = Triage.human_enum_name(:status, status_method)
 
     colour =
       if triage.invalidated?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,8 @@ en:
           do_not_vaccinate: Do not vaccinate in programme
           needs_follow_up: Keep in triage
           ready_to_vaccinate: Safe to vaccinate
+          ready_to_vaccinate_injection: Safe to vaccinate with injection  
+          ready_to_vaccinate_nasal: Safe to vaccinate with nasal spray
         vaccine_methods:
           injection: injection
           nasal: nasal spray

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -209,6 +209,9 @@ en:
           do_not_vaccinate: Do not vaccinate in programme
           needs_follow_up: Keep in triage
           ready_to_vaccinate: Safe to vaccinate
+        vaccine_methods:
+          injection: injection
+          nasal: nasal spray
       vaccination_record:
         delivery_methods:
           intramuscular: Intramuscular (IM) injection

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -23,12 +23,16 @@ en:
         not_required: No triage needed
         required: Needs triage
         safe_to_vaccinate: Safe to vaccinate
+        safe_to_vaccinate_injection: Safe to vaccinate with injection
+        safe_to_vaccinate_nasal: Safe to vaccinate with nasal spray
       colour:
         delay_vaccination: dark-orange
         do_not_vaccinate: red
         not_required: grey
         required: blue
         safe_to_vaccinate: aqua-green
+        safe_to_vaccinate_injection: aqua-green
+        safe_to_vaccinate_nasal: aqua-green
     register:
       label:
         attending: Attending session

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -26,6 +26,7 @@ describe "Triage" do
     when_i_record_that_they_are_safe_to_vaccinate
     then_i_see_the_update_triage_link
     and_i_see_the_safe_triage_decision
+    and_i_see_the_triage_status_tag
     and_vaccination_will_happen_emails_are_sent_to_both_parents
   end
 
@@ -47,6 +48,7 @@ describe "Triage" do
     when_i_record_that_they_are_safe_to_vaccinate_with_injection
     then_i_see_the_update_triage_link
     and_i_see_the_safe_triage_decision_with_method("injected")
+    and_i_see_the_triage_status_tag(method: "injection")
     and_vaccination_will_happen_emails_are_sent_to_both_parents
     and_the_vaccine_method_is_recorded_as_injection
 
@@ -63,6 +65,7 @@ describe "Triage" do
     and_i_record_that_they_are_safe_to_vaccinate_with_nasal
     then_i_see_the_update_triage_link
     and_i_see_the_safe_triage_decision_with_method("nasal spray")
+    and_i_see_the_triage_status_tag(method: "nasal spray")
     and_vaccination_will_happen_emails_are_sent_to_both_parents
     and_the_vaccine_method_is_recorded_as_nasal
   end
@@ -219,6 +222,14 @@ describe "Triage" do
     expect(page).to have_content(
       "#{@user.full_name} decided that #{@patient_triage_needed.full_name} is safe to vaccinate."
     )
+  end
+
+  def and_i_see_the_triage_status_tag(method: nil)
+    if method.present?
+      expect(page).to have_content("Safe to vaccinate with #{method}")
+    else
+      expect(page).to have_content("Safe to vaccinate")
+    end
   end
 
   def and_i_see_the_safe_triage_decision_with_method(method)

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -25,6 +25,7 @@ describe "Triage" do
 
     when_i_record_that_they_are_safe_to_vaccinate
     then_i_see_the_update_triage_link
+    and_i_see_the_safe_triage_decision
     and_vaccination_will_happen_emails_are_sent_to_both_parents
   end
 
@@ -45,6 +46,7 @@ describe "Triage" do
 
     when_i_record_that_they_are_safe_to_vaccinate_with_injection
     then_i_see_the_update_triage_link
+    and_i_see_the_safe_triage_decision_with_method("injected")
     and_vaccination_will_happen_emails_are_sent_to_both_parents
     and_the_vaccine_method_is_recorded_as_injection
 
@@ -60,6 +62,7 @@ describe "Triage" do
     when_i_go_to_the_second_patient
     and_i_record_that_they_are_safe_to_vaccinate_with_nasal
     then_i_see_the_update_triage_link
+    and_i_see_the_safe_triage_decision_with_method("nasal spray")
     and_vaccination_will_happen_emails_are_sent_to_both_parents
     and_the_vaccine_method_is_recorded_as_nasal
   end
@@ -141,7 +144,8 @@ describe "Triage" do
   end
 
   def when_i_go_to_the_session_triage_tab
-    sign_in @organisation.users.first
+    @user = @organisation.users.first
+    sign_in @user
     visit session_triage_path(@session)
   end
 
@@ -209,6 +213,27 @@ describe "Triage" do
 
   def then_i_see_the_update_triage_link
     expect(page).to have_link "Update triage"
+  end
+
+  def and_i_see_the_safe_triage_decision
+    expect(page).to have_content(
+      "#{@user.full_name} decided that #{@patient_triage_needed.full_name} is safe to vaccinate."
+    )
+  end
+
+  def and_i_see_the_safe_triage_decision_with_method(method)
+    patient =
+      (
+        if method == "injected"
+          @patient_injection_only
+        else
+          @patient_nasal_only
+        end
+      )
+
+    expect(page).to have_content(
+      "#{@user.full_name} decided that #{patient.full_name} is safe to vaccinate using the #{method} vaccine only."
+    )
   end
 
   def then_i_see_the_triage_page

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -15,6 +15,7 @@ describe "Verbal consent" do
     given_an_flu_programme_is_underway
     and_i_am_signed_in
     when_i_record_that_verbal_nasal_consent_was_given
+    and_the_patients_status_is_safe_to_vaccinate_with_nasal_spray
   end
 
   def given_an_hpv_programme_is_underway
@@ -110,6 +111,11 @@ describe "Verbal consent" do
   def and_the_patients_status_is_safe_to_vaccinate
     click_link @patient.full_name, match: :first
     expect(page).to have_content("Safe to vaccinate")
+  end
+
+  def and_the_patients_status_is_safe_to_vaccinate_with_nasal_spray
+    click_link @patient.full_name, match: :first
+    expect(page).to have_content("Safe to vaccinate with nasal spray")
   end
 
   def and_i_can_see_the_consent_response_details


### PR DESCRIPTION
Make vaccine method explicit in relation to triage for the flu programme and other minor visual changes to the triage form

- Display vaccine method in status tags on session >triage pages, patient session pages and programme>children page
- Add an "or" divider between yes and no options on the triage form (applies to all programmes)
- Add hints to flu triage form to indicate the vaccine method the nurse has triaged safe for
- Add the vaccine method to the "safe to vaccinate" triage entry in the activity log for all flu triages

https://nhsd-jira.digital.nhs.uk/browse/MAV-1413
https://nhsd-jira.digital.nhs.uk/browse/MAV-1500

<img width="862" height="825" alt="Triage form" src="https://github.com/user-attachments/assets/3445c516-a5e3-46d6-ba1c-3b5d91886aec" />
<img width="858" height="239" alt="Activity log" src="https://github.com/user-attachments/assets/29b4d705-d2c6-45be-aad4-496709fc553c" />
<img width="865" height="548" alt="Patient session page" src="https://github.com/user-attachments/assets/1a45e9c9-51c8-4cbb-af02-31817ae70a15" />
<img width="1166" height="756" alt="Session triage page" src="https://github.com/user-attachments/assets/dee36b01-b972-495e-bc5f-5c8800806caa" />
<img width="1194" height="701" alt="Programme children page" src="https://github.com/user-attachments/assets/522f6567-3ad6-4bc4-bedb-ac695d90f8fa" />




