### PR TITLE
Don't ask full or half dose question by default

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -49,6 +49,9 @@ class DraftVaccinationRecordsController < ApplicationController
       jump_to("confirm")
     end
 
+    set_steps
+    setup_wizard_translated
+
     render_wizard @draft_vaccination_record
   end
 

--- a/app/controllers/patient_sessions/vaccinations_controller.rb
+++ b/app/controllers/patient_sessions/vaccinations_controller.rb
@@ -27,7 +27,8 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
       steps = draft_vaccination_record.wizard_steps
 
       steps.delete(:notes) # this is on the confirmation page
-      steps.delete(:identity) # this is on the confirmation page
+      steps.delete(:identity) # this can only be changed from confirmation page
+      steps.delete(:dose) # this can only be changed from confirmation page
 
       steps.delete(:date_and_time)
       steps.delete(:outcome) if draft_vaccination_record.administered?

--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -59,6 +59,7 @@ class VaccinateForm
 
     draft_vaccination_record.batch_id = todays_batch&.id
     draft_vaccination_record.dose_sequence = dose_sequence
+    draft_vaccination_record.full_dose = true
     draft_vaccination_record.identity_check_confirmed_by_other_name =
       identity_check_confirmed_by_other_name
     draft_vaccination_record.identity_check_confirmed_by_other_relationship =

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -40,13 +40,13 @@ class DraftVaccinationRecord
 
   def wizard_steps
     [
-      :notes,
       :identity,
+      :notes,
       :date_and_time,
       (:outcome if can_change_outcome?),
       (:delivery if administered?),
-      (:batch if administered?),
       (:dose if administered? && can_be_half_dose?),
+      (:batch if administered?),
       (:location if location&.generic_clinic?),
       :confirm
     ].compact
@@ -212,7 +212,6 @@ class DraftVaccinationRecord
   end
 
   delegate :vaccine, to: :batch, allow_nil: true
-  delegate :can_be_half_dose?, to: :vaccine, allow_nil: true
 
   delegate :id, to: :vaccine, prefix: true, allow_nil: true
 
@@ -295,6 +294,10 @@ class DraftVaccinationRecord
       self.identity_check_confirmed_by_other_name = ""
       self.identity_check_confirmed_by_other_relationship = ""
     end
+  end
+
+  def can_be_half_dose?
+    delivery_method.in?(Vaccine::NASAL_DELIVERY_METHODS)
   end
 
   def can_change_outcome?

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -61,8 +61,6 @@ class Vaccine < ApplicationRecord
 
   def contains_gelatine? = programme.flu? && nasal?
 
-  def can_be_half_dose? = nasal?
-
   AVAILABLE_DELIVERY_SITES = {
     "injection" => %w[
       left_arm_upper_position

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -89,7 +89,13 @@ describe "Flu vaccination" do
   end
 
   def and_there_are_nasal_and_injection_batches
-    @nasal_vaccine = create(:vaccine, programme: @programme, method: :nasal)
+    @nasal_vaccine =
+      create(
+        :vaccine,
+        programme: @programme,
+        method: :nasal,
+        dose_volume_ml: 0.2
+      )
     @nasal_batch =
       create(
         :batch,
@@ -150,6 +156,8 @@ describe "Flu vaccination" do
 
     choose @nasal_batch.name
     click_button "Continue"
+
+    expect(page).not_to have_content("Did they get the full dose?")
   end
 
   def when_i_record_that_the_patient_has_been_vaccinated_with_injection
@@ -173,6 +181,7 @@ describe "Flu vaccination" do
     expect(page).to have_content(@nasal_batch.name)
     expect(page).to have_content("Nasal spray")
     expect(page).to have_content("Nose")
+    expect(page).to have_content("Dose volume0.2 ml")
     expect(page).to have_content(@location.name)
     expect(page).to have_content("Vaccinated")
   end

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -58,28 +58,6 @@ describe Vaccine do
     end
   end
 
-  describe "#can_be_half_dose?" do
-    subject { vaccine.can_be_half_dose? }
-
-    context "with a nasal Flu vaccine" do
-      let(:vaccine) { build(:vaccine, :fluenz_tetra) }
-
-      it { should be(true) }
-    end
-
-    context "with an injected Flu vaccine" do
-      let(:vaccine) { build(:vaccine, :quadrivalent_influenza) }
-
-      it { should be(false) }
-    end
-
-    context "with an HPV vaccine" do
-      let(:vaccine) { build(:vaccine, :gardasil_9) }
-
-      it { should be(false) }
-    end
-  end
-
   describe "#available_delivery_methods" do
     subject { vaccine.available_delivery_methods }
 


### PR DESCRIPTION
When recording a vaccination the default should be full dose, and the nurse can change their answer to half dose if they need to. We shouldn't be asking this question by default.

In fact, this question was only being shown when today's batch had been selected due to the order of the questions, but now the behaviour is consistent regardless of whether a default batch has been selected or not.

[Jira Issue - MAV-1504](https://nhsd-jira.digital.nhs.uk/browse/MAV-1504)