### PR TITLE
Hide default batches heading if there are none

### DIFF
--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -92,7 +92,7 @@ class Sessions::RecordController < ApplicationController
         end
       end
 
-    @todays_batches = all_batches.compact
+    @todays_batches = all_batches.compact_blank
   end
 
   def set_programme

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -112,6 +112,7 @@ describe "HPV vaccination" do
 
   def when_i_go_to_a_patient_that_is_ready_to_vaccinate
     visit session_record_path(@session)
+    expect(page).not_to have_content("Default batches")
     click_link @patient.full_name
   end
 


### PR DESCRIPTION
This ensures that if no default batches have been selected the heading isn't displayed as there will be no content below it which looks strange.