### PR TITLE
Ensure consented_vaccine_methods_message is set for consents

### DIFF
--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -129,10 +129,15 @@ class GovukNotifyPersonalisation
   end
 
   def consented_vaccine_methods_message
-    return nil if consent_form.nil?
-    return "" if consent_form.programmes.none?(&:flu?)
+    return nil if consent.nil? && consent_form.nil?
 
-    consent_form_programmes = consent_form.consent_form_programmes
+    if (consent && !consent.programme.flu?) ||
+         (consent_form && consent_form.programmes.none?(&:flu?))
+      return ""
+    end
+
+    consent_form_programmes =
+      consent ? [consent] : consent_form.consent_form_programmes
 
     consented_vaccine_methods =
       if consent_form_programmes.any?(&:vaccine_method_injection_and_nasal?)

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -194,10 +194,45 @@ describe GovukNotifyPersonalisation do
     it do
       expect(to_h).to match(
         hash_including(
+          consented_vaccine_methods_message: "",
           reason_for_refusal: "of personal choice",
           survey_deadline_date: "8 January 2024"
         )
       )
+    end
+
+    context "for the flu programme" do
+      let(:programmes) { [create(:programme, :flu)] }
+
+      it do
+        expect(to_h).to include(
+          consented_vaccine_methods_message:
+            "You’ve agreed that John can have the injected flu vaccine."
+        )
+      end
+
+      context "when consented to both nasal and injection" do
+        before { consent.update!(vaccine_methods: %w[nasal injection]) }
+
+        it do
+          expect(to_h).to include(
+            consented_vaccine_methods_message:
+              "You’ve agreed that John can have the nasal spray flu vaccine, " \
+                "or the injected flu vaccine if the nasal spray is not suitable."
+          )
+        end
+      end
+
+      context "when consented only to nasal" do
+        before { consent.update!(vaccine_methods: %w[nasal]) }
+
+        it do
+          expect(to_h).to include(
+            consented_vaccine_methods_message:
+              "You’ve agreed that John can have the nasal spray flu vaccine."
+          )
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This ensures that the personalisation variable `consented_vaccine_methods_message` exists when sending confirmation emails when recording verbal consent.

This fixes two Sentry issues:
- https://good-machine.sentry.io/issues/6272173671/
- https://good-machine.sentry.io/issues/6235087330/