### PR TITLE
Filter on patients with approriate vaccine method

### DIFF
--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -25,16 +25,11 @@ class Sessions::RecordController < ApplicationController
         )
         .has_registration_status(%w[attending completed])
 
-    scope = @form.apply(scope)
-
     patient_sessions =
-      scope.select do |patient_session|
-        @form.programmes.any? do |programme|
-          patient_session.patient.consent_given_and_safe_to_vaccinate?(
-            programme:
-          )
-        end
-      end
+      @form.apply(scope).consent_given_and_ready_to_vaccinate(
+        programmes: @form.programmes,
+        vaccine_method: @form.vaccine_method
+      )
 
     @pagy, @patient_sessions = pagy_array(patient_sessions)
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -327,15 +327,23 @@ class Patient < ApplicationRecord
       vaccination_statuses.build(programme:)
   end
 
-  def consent_given_and_safe_to_vaccinate?(programme:)
+  def consent_given_and_safe_to_vaccinate?(programme:, vaccine_method: nil)
     return false if vaccination_status(programme:).vaccinated?
 
-    consent_status(programme:).given? &&
-      (
-        triage_status(programme:).safe_to_vaccinate? ||
-          triage_status(programme:).delay_vaccination? ||
-          triage_status(programme:).not_required?
-      )
+    return false unless consent_status(programme:).given?
+
+    unless triage_status(programme:).safe_to_vaccinate? ||
+             triage_status(programme:).delay_vaccination? ||
+             triage_status(programme:).not_required?
+      return false
+    end
+
+    if vaccine_method &&
+         !approved_vaccine_methods(programme:).include?(vaccine_method)
+      return false
+    end
+
+    true
   end
 
   def approved_vaccine_methods(programme:)

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -179,6 +179,20 @@ class PatientSession < ApplicationRecord
           )
         end
 
+  scope :consent_given_and_ready_to_vaccinate,
+        ->(programmes:, vaccine_method:) do
+          select do |patient_session|
+            patient = patient_session.patient
+
+            programmes.any? do |programme|
+              patient.consent_given_and_safe_to_vaccinate?(
+                programme:,
+                vaccine_method:
+              )
+            end
+          end
+        end
+
   scope :destroy_all_if_safe,
         -> do
           includes(

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -10,7 +10,7 @@ describe "Flu vaccination" do
     and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
 
     when_i_go_to_the_nasal_only_patient
-    then_i_see_the_vacciantion_form_for_nasal_spray
+    then_i_see_the_vaccination_form_for_nasal_spray
 
     when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     then_i_see_the_check_and_confirm_page_for_nasal_spray
@@ -28,7 +28,7 @@ describe "Flu vaccination" do
     and_there_are_nasal_and_injection_batches
 
     when_i_go_to_the_injection_only_patient
-    then_i_see_the_vacciantion_form_for_injection
+    then_i_see_the_vaccination_form_for_injection
 
     when_i_record_that_the_patient_has_been_vaccinated_with_injection
     then_i_see_the_check_and_confirm_page_for_injection
@@ -45,7 +45,7 @@ describe "Flu vaccination" do
     and_there_are_nasal_and_injection_batches
 
     when_i_go_to_the_nasal_only_patient
-    then_i_see_the_vacciantion_form_for_nasal_spray
+    then_i_see_the_vaccination_form_for_nasal_spray
 
     when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
     then_i_see_the_check_and_confirm_page_for_nasal_spray
@@ -124,14 +124,14 @@ describe "Flu vaccination" do
     click_link @patient.full_name
   end
 
-  def then_i_see_the_vacciantion_form_for_nasal_spray
+  def then_i_see_the_vaccination_form_for_nasal_spray
     expect(page).to have_content("Record flu vaccination with nasal spray")
     expect(page).to have_content(
       "Is #{@patient.given_name} ready for their flu nasal spray?"
     )
   end
 
-  def then_i_see_the_vacciantion_form_for_injection
+  def then_i_see_the_vaccination_form_for_injection
     expect(page).to have_content("Record flu vaccination with injection")
     expect(page).to have_content(
       "Is #{@patient.given_name} ready for their flu injection?"


### PR DESCRIPTION
When displaying a list of patients who need vaccinating when filtering on the vaccine method we should ensure that the vaccine method is appropriate for the vaccinations left to record. For example, if a patient has consent for flu and HPV, and they've been given the nasal spray vaccine for flu, if you now filter on "nasal spray" this patient should no longer appear in the list as for HPV they're only eligible for the injection.

[Jira Issue - MAV-1463](https://nhsd-jira.digital.nhs.uk/browse/MAV-1463)