### PR TITLE
Allow recording injection for nasal patients

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -66,22 +66,40 @@
       <% hint = "Pre-screening checks must be completed for vaccination to go ahead" %>
 
       <%= f.govuk_radio_buttons_fieldset :vaccine_method, legend: nil do %>
-        <% if common_delivery_sites_options.length > 1 %>
-          <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: "Yes" }, hint: { text: hint }, link_errors: true do %>
-            <%= f.govuk_collection_radio_buttons :delivery_site,
-                                                 common_delivery_sites_options,
-                                                 :value,
-                                                 :label,
-                                                 legend: {
-                                                   text: "Where will the injection be given?",
-                                                   size: "s",
-                                                 } %>
+        <% vaccine_methods.each_with_index do |vaccine_method, index| %>
+          <% if index == 1 %>
+            <%= f.govuk_radio_divider %>
           <% end %>
-        <% else %>
-          <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: "Yes" }, hint: { text: hint }, link_errors: true %>
-          <%= f.hidden_field :delivery_site, value: common_delivery_sites_options.first.value %>
+
+          <% label = if index.zero?
+                 "Yes"
+               else
+                 "No — but they can have the #{Vaccine.human_enum_name(:method_prefix, vaccine_method)} #{programme.name_in_sentence} instead"
+               end %>
+
+          <% options = common_delivery_site_options(vaccine_method) %>
+
+          <% if options.length > 1 %>
+            <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: label }, hint: { text: hint }, link_errors: index.zero? do %>
+              <%= f.govuk_collection_radio_buttons :delivery_site,
+                                                   options,
+                                                   :value,
+                                                   :label,
+                                                   legend: {
+                                                     text: "Where will the #{Vaccine.human_enum_name(:method, vaccine_method).downcase} be given?",
+                                                     size: "s",
+                                                   } %>
+            <% end %>
+          <% else %>
+            <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: label }, hint: { text: hint }, link_errors: index.zero? do %>
+              <%= f.hidden_field :delivery_site, value: options.first.value %>
+            <% end %>
+          <% end %>
+
+          <% if index.zero? %>
+            <%= f.govuk_radio_button :vaccine_method, "none", label: { text: "No" } %>
+          <% end %>
         <% end %>
-        <%= f.govuk_radio_button :vaccine_method, "none", label: { text: "No" } %>
       <% end %>
 
       <%= f.hidden_field :dose_sequence, value: dose_sequence %>

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -65,9 +65,9 @@
 
       <% hint = "Pre-screening checks must be completed for vaccination to go ahead" %>
 
-      <%= f.govuk_radio_buttons_fieldset :administered, legend: nil do %>
+      <%= f.govuk_radio_buttons_fieldset :vaccine_method, legend: nil do %>
         <% if common_delivery_sites_options.length > 1 %>
-          <%= f.govuk_radio_button :administered, true, label: { text: "Yes" }, hint: { text: hint }, link_errors: true do %>
+          <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: "Yes" }, hint: { text: hint }, link_errors: true do %>
             <%= f.govuk_collection_radio_buttons :delivery_site,
                                                  common_delivery_sites_options,
                                                  :value,
@@ -78,13 +78,12 @@
                                                  } %>
           <% end %>
         <% else %>
-          <%= f.govuk_radio_button :administered, true, label: { text: "Yes" }, hint: { text: hint }, link_errors: true %>
+          <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: "Yes" }, hint: { text: hint }, link_errors: true %>
           <%= f.hidden_field :delivery_site, value: common_delivery_sites_options.first.value %>
         <% end %>
-        <%= f.govuk_radio_button :administered, false, label: { text: "No" } %>
+        <%= f.govuk_radio_button :vaccine_method, "none", label: { text: "No" } %>
       <% end %>
 
-      <%= f.hidden_field :delivery_method, value: delivery_method %>
       <%= f.hidden_field :dose_sequence, value: dose_sequence %>
       <%= f.hidden_field :programme_id, value: programme.id %>
 

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -22,10 +22,6 @@ class AppVaccinateFormComponent < ViewComponent::Base
     patient.approved_vaccine_methods(programme:).first
   end
 
-  def delivery_method
-    Vaccine::AVAILABLE_DELIVERY_METHODS.fetch(vaccine_method).first
-  end
-
   def dose_sequence
     programme.default_dose_sequence
   end

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -18,8 +18,8 @@ class AppVaccinateFormComponent < ViewComponent::Base
     session_patient_programme_vaccinations_path(session, patient, programme)
   end
 
-  def vaccine_method
-    patient.approved_vaccine_methods(programme:).first
+  def vaccine_methods
+    patient.approved_vaccine_methods(programme:)
   end
 
   def dose_sequence
@@ -33,29 +33,26 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   CommonDeliverySite = Struct.new(:value, :label)
 
-  def common_delivery_sites_options
-    @common_delivery_sites_options ||=
-      begin
-        options =
-          COMMON_DELIVERY_SITES
-            .fetch(vaccine_method)
-            .map do |value|
-              label = VaccinationRecord.human_enum_name(:delivery_site, value)
-              CommonDeliverySite.new(value:, label:)
-            end
-
-        if vaccine_method == "injection"
-          options << CommonDeliverySite.new(value: "other", label: "Other")
+  def common_delivery_site_options(vaccine_method)
+    options =
+      COMMON_DELIVERY_SITES
+        .fetch(vaccine_method)
+        .map do |value|
+          label = VaccinationRecord.human_enum_name(:delivery_site, value)
+          CommonDeliverySite.new(value:, label:)
         end
 
-        options
-      end
+    if vaccine_method == "injection"
+      options << CommonDeliverySite.new(value: "other", label: "Other")
+    end
+
+    options
   end
 
   def vaccination_name
     vaccination =
       if programme.has_multiple_vaccine_methods?
-        Vaccine.human_enum_name(:method, vaccine_method).downcase
+        Vaccine.human_enum_name(:method, vaccine_methods.first).downcase
       else
         "vaccination"
       end
@@ -67,5 +64,5 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   def ask_not_pregnant? = programme.td_ipv?
 
-  def ask_asthma_flare_up? = vaccine_method == "nasal"
+  def ask_asthma_flare_up? = vaccine_methods.include?("nasal")
 end

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -18,12 +18,12 @@ class AppVaccinateFormComponent < ViewComponent::Base
     session_patient_programme_vaccinations_path(session, patient, programme)
   end
 
+  def vaccine_method
+    patient.approved_vaccine_methods(programme:).first
+  end
+
   def delivery_method
-    if patient.approved_vaccine_methods(programme:).include?("nasal")
-      "nasal_spray"
-    else
-      "intramuscular"
-    end
+    Vaccine::AVAILABLE_DELIVERY_METHODS.fetch(vaccine_method).first
   end
 
   def dose_sequence
@@ -31,8 +31,8 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   COMMON_DELIVERY_SITES = {
-    "intramuscular" => %w[left_arm_upper_position right_arm_upper_position],
-    "nasal_spray" => %w[nose]
+    "injection" => %w[left_arm_upper_position right_arm_upper_position],
+    "nasal" => %w[nose]
   }.freeze
 
   CommonDeliverySite = Struct.new(:value, :label)
@@ -42,13 +42,13 @@ class AppVaccinateFormComponent < ViewComponent::Base
       begin
         options =
           COMMON_DELIVERY_SITES
-            .fetch(delivery_method)
+            .fetch(vaccine_method)
             .map do |value|
               label = VaccinationRecord.human_enum_name(:delivery_site, value)
               CommonDeliverySite.new(value:, label:)
             end
 
-        if delivery_method.in?(Vaccine::INJECTION_DELIVERY_METHODS)
+        if vaccine_method == "injection"
           options << CommonDeliverySite.new(value: "other", label: "Other")
         end
 
@@ -59,8 +59,6 @@ class AppVaccinateFormComponent < ViewComponent::Base
   def vaccination_name
     vaccination =
       if programme.has_multiple_vaccine_methods?
-        vaccine_method =
-          Vaccine.delivery_method_to_vaccine_method(delivery_method)
         Vaccine.human_enum_name(:method, vaccine_method).downcase
       else
         "vaccination"
@@ -73,6 +71,5 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   def ask_not_pregnant? = programme.td_ipv?
 
-  def ask_asthma_flare_up? =
-    delivery_method.in?(Vaccine::NASAL_DELIVERY_METHODS)
+  def ask_asthma_flare_up? = vaccine_method == "nasal"
 end

--- a/app/controllers/patient_sessions/vaccinations_controller.rb
+++ b/app/controllers/patient_sessions/vaccinations_controller.rb
@@ -54,8 +54,6 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
   def vaccinate_form_params
     params.expect(
       vaccinate_form: %i[
-        administered
-        delivery_method
         delivery_site
         dose_sequence
         identity_check_confirmed_by_other_name
@@ -64,15 +62,13 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
         pre_screening_confirmed
         pre_screening_notes
         vaccine_id
+        vaccine_method
       ]
     )
   end
 
   def set_todays_batch
-    vaccine_method =
-      Vaccine.delivery_method_to_vaccine_method(
-        vaccinate_form_params[:delivery_method]
-      )
+    vaccine_method = vaccinate_form_params[:vaccine_method]
     return if vaccine_method.nil?
 
     id = todays_batch_id(programme: @programme, vaccine_method:)

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -296,9 +296,11 @@ class DraftVaccinationRecord
     end
   end
 
-  def can_be_half_dose?
-    delivery_method.in?(Vaccine::NASAL_DELIVERY_METHODS)
+  def vaccine_method
+    Vaccine.delivery_method_to_vaccine_method(delivery_method)
   end
+
+  def can_be_half_dose? = vaccine_method == "nasal"
 
   def can_change_outcome?
     outcome != "already_had" || editing? || session.nil? || session.today?
@@ -312,14 +314,14 @@ class DraftVaccinationRecord
       return
     end
 
-    case delivery_method
-    when *Vaccine::NASAL_DELIVERY_METHODS
-      if delivery_site != "nose"
-        errors.add(:delivery_site, :nasal_spray_must_be_nose)
-      end
-    when *Vaccine::INJECTION_DELIVERY_METHODS
-      if delivery_site == "nose"
+    allowed_delivery_sites =
+      Vaccine::AVAILABLE_DELIVERY_SITES.fetch(vaccine_method)
+
+    unless delivery_site.in?(allowed_delivery_sites)
+      if vaccine_method == "injection"
         errors.add(:delivery_site, :injection_cannot_be_nose)
+      else
+        errors.add(:delivery_site, :nasal_spray_must_be_nose)
       end
     end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -333,7 +333,6 @@ class Patient < ApplicationRecord
     return false unless consent_status(programme:).given?
 
     unless triage_status(programme:).safe_to_vaccinate? ||
-             triage_status(programme:).delay_vaccination? ||
              triage_status(programme:).not_required?
       return false
     end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -77,12 +77,9 @@ class Vaccine < ApplicationRecord
     AVAILABLE_DELIVERY_SITES.fetch(method)
   end
 
-  NASAL_DELIVERY_METHODS = %w[nasal_spray].freeze
-  INJECTION_DELIVERY_METHODS = %w[intramuscular subcutaneous].freeze
-
   AVAILABLE_DELIVERY_METHODS = {
-    "nasal" => NASAL_DELIVERY_METHODS,
-    "injection" => INJECTION_DELIVERY_METHODS
+    "nasal" => %w[nasal_spray].freeze,
+    "injection" => %w[intramuscular subcutaneous].freeze
   }.freeze
 
   def available_delivery_methods

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,8 +121,6 @@ en:
               inclusion: Choose a status
         vaccinate_form:
           attributes:
-            administered:
-              inclusion: Choose if they are ready to vaccinate
             delivery_site:
               blank: Choose where the injection will be given
             identity_check_confirmed_by_other_name:
@@ -137,6 +135,8 @@ en:
               blank: Confirm you’ve checked the pre-screening statements are true
             pre_screening_notes:
               too_long: Enter notes that are less than %{count} characters long
+            vaccine_method:
+              inclusion: Choose if they are ready to vaccinate
         vaccination_report:
           attributes:
             file_format:

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -19,7 +19,8 @@ describe "Triage" do
 
     when_i_view_the_child_record
     then_they_should_have_the_status_banner_delay_vaccination
-    and_i_am_able_to_record_a_vaccination
+    and_i_am_not_able_to_record_a_vaccination
+    and_i_am_able_to_update_the_triage
   end
 
   def given_a_programme_with_a_running_session
@@ -99,7 +100,11 @@ describe "Triage" do
     expect(page).to have_content("Delay vaccination")
   end
 
-  def and_i_am_able_to_record_a_vaccination
-    expect(page).to have_content("ready for their HPV vaccination?")
+  def and_i_am_not_able_to_record_a_vaccination
+    expect(page).not_to have_content("ready for their HPV vaccination?")
+  end
+
+  def and_i_am_able_to_update_the_triage
+    expect(page).to have_content("Update triage outcome")
   end
 end

--- a/spec/forms/vaccinate_form_spec.rb
+++ b/spec/forms/vaccinate_form_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 describe VaccinateForm do
-  subject(:form) { described_class.new }
+  subject(:form) { described_class.new(programme:) }
+
+  let(:programme) { create(:programme) }
 
   describe "validations" do
     it do
@@ -24,7 +26,10 @@ describe VaccinateForm do
 
     context "when confirmed by someone else" do
       subject(:form) do
-        described_class.new(identity_check_confirmed_by_patient: false)
+        described_class.new(
+          identity_check_confirmed_by_patient: false,
+          programme:
+        )
       end
 
       it do


### PR DESCRIPTION
This adds the ability for nurses to record an injection for a patient if they've got consent for both the nasal spray and the injection. See individual commits for more details.

[Jira Issue - MAV-1338](https://nhsd-jira.digital.nhs.uk/browse/MAV-1338)

## Screenshots

<img width="880" height="466" alt="Screenshot 2025-07-14 at 22 02 55" src="https://github.com/user-attachments/assets/36d3a2aa-5a42-42c9-a428-26fac4570118" />

<img width="874" height="679" alt="Screenshot 2025-07-14 at 22 03 01" src="https://github.com/user-attachments/assets/e4b99250-bda0-452c-bdc0-726c7b9f6bd4" />
