### PR TITLE
Show secondary consent vaccine methods

### DIFF
--- a/app/components/app_consent_card_component.rb
+++ b/app/components/app_consent_card_component.rb
@@ -59,6 +59,20 @@ class AppConsentCardComponent < ViewComponent::Base
           text: helpers.consent_status_tag(consent)
         }
       }
-    ].compact
+    ].compact +
+      consent
+        .vaccine_methods
+        .drop(1)
+        .map do |vaccine_method|
+          method_name = Vaccine.human_enum_name(:method_prefix, vaccine_method)
+          {
+            key: {
+              text: "Consent also given for #{method_name} vaccine?"
+            },
+            value: {
+              text: "Yes"
+            }
+          }
+        end
   end
 end

--- a/app/components/app_consent_summary_component.rb
+++ b/app/components/app_consent_summary_component.rb
@@ -10,17 +10,35 @@ class AppConsentSummaryComponent < ViewComponent::Base
 
   def call
     govuk_summary_list(actions: @change_links.present?) do |summary_list|
-      if @consent.responded_at.present?
+      summary_list.with_row do |row|
+        row.with_key { "Programme" }
+        row.with_value do
+          tag.strong(
+            programme.name,
+            class: "nhsuk-tag app-tag--attached nhsuk-tag--white"
+          )
+        end
+      end
+
+      if consent.responded_at.present?
         summary_list.with_row do |row|
-          row.with_key { "Response date" }
-          row.with_value { @consent.responded_at.to_fs(:long) }
+          row.with_key { "Date" }
+          row.with_value { consent.responded_at.to_fs(:long) }
+        end
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Method" }
+        row.with_value { consent.human_enum_name(:route).humanize }
+        if (href = change_links[:route])
+          row.with_action(text: "Change", visually_hidden_text: "method", href:)
         end
       end
 
       summary_list.with_row do |row|
         row.with_key { "Decision" }
-        row.with_value { helpers.consent_status_tag(@consent) }
-        if (href = @change_links[:response])
+        row.with_value { helpers.consent_status_tag(consent) }
+        if (href = change_links[:response])
           row.with_action(
             text: "Change",
             visually_hidden_text: "decision",
@@ -29,38 +47,37 @@ class AppConsentSummaryComponent < ViewComponent::Base
         end
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Response method" }
-        row.with_value do
-          Consent.human_enum_name(:route, @consent.route).humanize
-        end
-        if (href = @change_links[:route])
-          row.with_action(
-            text: "Change",
-            visually_hidden_text: "response method",
-            href:
-          )
-        end
-      end
+      consent
+        .vaccine_methods
+        .drop(1)
+        .each do |vaccine_method|
+          method_name = Vaccine.human_enum_name(:method_prefix, vaccine_method)
 
-      if @consent.reason_for_refusal.present?
-        summary_list.with_row do |row|
-          row.with_key { "Reason for refusal" }
-          row.with_value do
-            Consent.human_enum_name(
-              :reason_for_refusal,
-              @consent.reason_for_refusal
-            )
+          summary_list.with_row do |row|
+            row.with_key { "Consent also given for #{method_name} vaccine?" }
+            row.with_value { "Yes" }
           end
         end
+
+      if consent.reason_for_refusal.present?
+        summary_list.with_row do |row|
+          row.with_key { "Reason for refusal" }
+          row.with_value { consent.human_enum_name(:reason_for_refusal) }
+        end
       end
 
-      if @consent.notes.present?
+      if consent.notes.present?
         summary_list.with_row do |row|
           row.with_key { "Notes" }
-          row.with_value { @consent.notes }
+          row.with_value { consent.notes }
         end
       end
     end
   end
+
+  private
+
+  attr_reader :consent, :change_links
+
+  delegate :programme, to: :consent
 end

--- a/app/helpers/consents_helper.rb
+++ b/app/helpers/consents_helper.rb
@@ -24,7 +24,7 @@ module ConsentsHelper
       if consent.vaccine_methods.present? &&
            consent.programme.has_multiple_vaccine_methods?
         tag.span(
-          Vaccine.human_enum_name(:method, consent.vaccine_methods.join("_")),
+          Vaccine.human_enum_name(:method, consent.vaccine_methods.first),
           class: "nhsuk-u-secondary-text-color"
         )
       end

--- a/app/views/patient_sessions/consents/show.html.erb
+++ b/app/views/patient_sessions/consents/show.html.erb
@@ -22,7 +22,7 @@
 </ul>
 
 <%= render AppCardComponent.new do |card| %>
-  <% card.with_heading { "Consent" } %>
+  <% card.with_heading { "Response" } %>
   <%= render AppConsentSummaryComponent.new(@consent) %>
 <% end %>
 

--- a/spec/components/app_consent_card_component_spec.rb
+++ b/spec/components/app_consent_card_component_spec.rb
@@ -38,4 +38,18 @@ describe AppConsentCardComponent do
 
   it { should have_content("Decision") }
   it { should have_content("Consent given") }
+
+  it { should_not have_content("Consent also given for injected vaccine?") }
+
+  context "when consenting to multiple vaccine methods" do
+    let(:programme) { create(:programme, :flu) }
+
+    before { consent.update!(vaccine_methods: %w[nasal injection]) }
+
+    it { should have_content("Decision") }
+    it { should have_content("Consent givenNasal spray") }
+
+    it { should have_content("Consent also given for injected vaccine?") }
+    it { should have_content("Yes") }
+  end
 end

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -7,13 +7,14 @@ describe AppConsentSummaryComponent do
 
   let(:consent) { create(:consent) }
 
+  it { should have_content("Programme") }
+  it { should have_content("Method") }
   it { should have_content("Decision") }
-  it { should have_content("Response method") }
 
   context "when recorded" do
     let(:consent) { create(:consent) }
 
-    it { should have_content("Response date") }
+    it { should have_content("Date") }
   end
 
   context "when refused" do
@@ -32,5 +33,20 @@ describe AppConsentSummaryComponent do
     let(:consent) { create(:consent, :refused, notes: "Some notes.") }
 
     it { should have_content("Notes") }
+  end
+
+  it { should_not have_content("Consent also given for injected vaccine?") }
+
+  context "when consenting to multiple vaccine methods" do
+    let(:programme) { create(:programme, :flu) }
+    let(:consent) do
+      create(:consent, programme:, vaccine_methods: %w[nasal injection])
+    end
+
+    it { should have_content("Decision") }
+    it { should have_content("Consent givenNasal spray") }
+
+    it { should have_content("Consent also given for injected vaccine?") }
+    it { should have_content("Yes") }
   end
 end

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -236,7 +236,7 @@ describe "Self-consent" do
   end
 
   def and_the_child_can_give_their_own_consent_that_the_nurse_records
-    click_on "Change response method"
+    click_on "Change method"
     choose "Child (Gillick competent)"
     5.times { click_on "Continue" }
 
@@ -246,7 +246,7 @@ describe "Self-consent" do
   end
 
   def and_changes_the_response_method_to_the_parent
-    click_on "Change response method"
+    click_on "Change method"
     choose @parent.full_name
     click_on "Continue"
 

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -59,7 +59,7 @@ describe "Verbal consent" do
 
     # Confirm
     expect(page).to have_content("Check and confirm answers")
-    expect(page).to have_content(["Response method", "By phone"].join)
+    expect(page).to have_content(["Method", "By phone"].join)
     click_button "Confirm"
 
     # Back on the consent responses page

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -100,7 +100,7 @@ describe "Verbal consent" do
 
     # Confirm
     expect(page).to have_content("Check and confirm answers")
-    expect(page).to have_content(["Response method", "By phone"].join)
+    expect(page).to have_content(["Method", "By phone"].join)
     click_button "Confirm"
 
     # Back on the consent responses page
@@ -116,11 +116,9 @@ describe "Verbal consent" do
     click_link @parent.full_name
 
     expect(page).to have_content("Consent response from #{@parent.full_name}")
-    expect(page).to have_content(
-      ["Response date", Date.current.to_fs(:long)].join
-    )
+    expect(page).to have_content(["Date", Date.current.to_fs(:long)].join)
     expect(page).to have_content(["Decision", "Consent given"].join)
-    expect(page).to have_content(["Response method", "By phone"].join)
+    expect(page).to have_content(["Method", "By phone"].join)
 
     expect(page).to have_content(["Full name", @patient.full_name].join)
     expect(page).to have_content(

--- a/spec/features/verbal_consent_refused_personal_choice_spec.rb
+++ b/spec/features/verbal_consent_refused_personal_choice_spec.rb
@@ -69,11 +69,9 @@ describe "Verbal consent" do
     parent = @patient.parents.first
     click_link parent.full_name
 
-    expect(page).to have_content(
-      ["Response date", Time.zone.today.to_fs(:long)].join
-    )
+    expect(page).to have_content(["Date", Time.zone.today.to_fs(:long)].join)
     expect(page).to have_content(["Decision", "Consent refused"].join)
-    expect(page).to have_content(["Response method", "By phone"].join)
+    expect(page).to have_content(["Method", "By phone"].join)
     expect(page).to have_content(["Reason for refusal", "Personal choice"].join)
     expect(page).not_to have_content("Notes")
 

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -70,11 +70,9 @@ describe "Verbal consent" do
   def and_i_can_see_the_consent_response_details
     click_link @parent.full_name
 
-    expect(page).to have_content(
-      ["Response date", Date.current.to_fs(:long)].join
-    )
+    expect(page).to have_content(["Date", Date.current.to_fs(:long)].join)
     expect(page).to have_content(["Decision", "Consent refused"].join)
-    expect(page).to have_content(["Response method", "By phone"].join)
+    expect(page).to have_content(["Method", "By phone"].join)
     expect(page).to have_content(["Reason for refusal", "Medical reasons"].join)
     expect(page).to have_content(
       ["Notes", "They have a medical condition"].join


### PR DESCRIPTION
When displaying a consent either on the patient session page or when viewing a consent directly, we should show if the parent also consented to any alternative vaccine methods. This is only relevant for the flu programme where you can consent to both the nasal spray and the injection.

To support this I've also updated the summary list showing the consent response to match the latest designs in the prototype.

[Jira Issue - MAV-1473](https://nhsd-jira.digital.nhs.uk/browse/MAV-1473)

## Screenshots

<img width="877" height="420" alt="Screenshot 2025-07-15 at 09 41 03" src="https://github.com/user-attachments/assets/6d989b0a-42fb-4c88-81ff-27213bbe3f3e" />

<img width="785" height="362" alt="Screenshot 2025-07-15 at 09 38 47" src="https://github.com/user-attachments/assets/96324fd3-4168-4d4e-85cd-7ea6c0d351e0" />
