### PR TITLE
Reorder injection alternative question

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -308,9 +308,9 @@ class ConsentForm < ApplicationRecord
             :reason_notes
           end
         ),
+        (:injection_alternative if can_offer_injection_as_alternative?),
         (:address if response_given?),
         (:health_question if response_given?),
-        (:injection_alternative if can_offer_injection_as_alternative?),
         (:reason if refused_and_given),
         (:reason_notes if refused_and_given && reason_notes_must_be_provided?)
       ].compact

--- a/lib/tasks/vaccines.rake
+++ b/lib/tasks/vaccines.rake
@@ -155,13 +155,13 @@ def create_flu_health_questions(vaccine)
       )
     end
 
-  # TODO: This is only relevant for injected vaccines, but we don't know if the parents have consented to injection
-  #  until after the health questions have been given.
   bleeding_disorder =
-    vaccine.health_questions.create!(
-      title:
-        "Does your child have a bleeding disorder or are they taking anticoagulant therapy?"
-    )
+    if vaccine.injection?
+      vaccine.health_questions.create!(
+        title:
+          "Does your child have a bleeding disorder or are they taking anticoagulant therapy?"
+      )
+    end
 
   egg_allergy =
     if vaccine.nasal?

--- a/spec/features/parental_consent_change_answers_spec.rb
+++ b/spec/features/parental_consent_change_answers_spec.rb
@@ -52,6 +52,9 @@ RSpec.feature "Parental consent change answers" do
     then_i_see_the_consent_form_confirmation_page
 
     when_i_change_my_consent_to_accepted
+    then_i_see_the_injection_alternative_page
+
+    when_i_input_the_injection_alternative
     then_i_see_the_address_page
 
     when_i_input_my_address
@@ -247,6 +250,17 @@ RSpec.feature "Parental consent change answers" do
     expect(page).to have_content(
       "is due to get the injected flu vaccination at school"
     )
+  end
+
+  def then_i_see_the_injection_alternative_page
+    expect(page).to have_content(
+      "If your child cannot have the nasal spray, do you agree to them having the injected vaccine instead?"
+    )
+  end
+
+  def when_i_input_the_injection_alternative
+    choose "Yes"
+    click_button "Continue"
   end
 
   def then_i_see_the_address_page

--- a/spec/features/parental_consent_flu_spec.rb
+++ b/spec/features/parental_consent_flu_spec.rb
@@ -10,7 +10,6 @@ describe "Parental consent" do
     then_i_see_the_first_health_question
 
     when_i_answer_no_to_all_health_questions
-    and_i_answer_yes_to_alternative_injection
     then_i_see_the_confirmation_page
 
     when_i_change_my_answer_to_the_first_health_question
@@ -66,6 +65,10 @@ describe "Parental consent" do
     choose "Yes, I agree to them having the nasal spray vaccine"
     click_button "Continue"
 
+    # Injection alternative
+    choose "Yes"
+    click_button "Continue"
+
     # Home address
     fill_in "Address line 1", with: "1 High Street"
     fill_in "Town or city", with: "London"
@@ -82,15 +85,6 @@ describe "Parental consent" do
       choose "No"
       click_button "Continue"
     end
-  end
-
-  def and_i_answer_yes_to_alternative_injection
-    expect(page).to have_content(
-      "do you agree to them having the injected vaccine instead?"
-    )
-
-    choose "Yes"
-    click_button "Continue"
   end
 
   def then_i_see_the_confirmation_page


### PR DESCRIPTION
When submitting consent this updates the injection alternative question to appear before the health questions, allowing for the questions to be customised according to the vaccine method.

[Jira Issue - MAV-1565](https://nhsd-jira.digital.nhs.uk/browse/MAV-1565)