### PR TITLE
Check flipper before running CLI imms API sync command

### DIFF
--- a/app/lib/mavis_cli/vaccination_records/sync.rb
+++ b/app/lib/mavis_cli/vaccination_records/sync.rb
@@ -11,6 +11,11 @@ module MavisCLI
       def call(vaccination_record_id:, **)
         MavisCLI.load_rails
 
+        unless Flipper.enabled?(:immunisations_fhir_api_integration)
+          puts "Cannot sync vaccination record: the `immunisations_fhir_api_integration` feature flag is disabled"
+          return
+        end
+
         vaccination_record =
           ::VaccinationRecord.find_by(id: vaccination_record_id)
 


### PR DESCRIPTION
This change adds a check at the beginning of the vaccination records sync command to verify that the `immunisations_fhir_api_integration` feature flag is enabled before initiating the sync operation.

Previously, the command claimed that the sync was successful, even though nothing had happened.