### PR TITLE
Refactor programme controllers

### DIFF
--- a/app/components/app_patient_vaccination_table_component.html.erb
+++ b/app/components/app_patient_vaccination_table_component.html.erb
@@ -17,7 +17,7 @@
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Vaccination date</span>
             <%= link_to vaccination_record.performed_at.to_date.to_fs(:long),
-                        programme_vaccination_record_path(vaccination_record.programme, vaccination_record) %>
+                        vaccination_record_path(vaccination_record) %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -35,9 +35,9 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
       )
 
       nav.with_item(
-        href: programme_vaccination_records_path(programme),
-        text: I18n.t("vaccination_records.index.title"),
-        selected: active == :vaccination_records
+        href: programme_vaccinations_path(programme),
+        text: I18n.t("programmes.vaccinations.index.title"),
+        selected: active == :vaccinations
       )
     end
   end

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -16,33 +16,19 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
         selected: active == :overview
       )
 
-      nav.with_item(
-        href: programme_cohorts_path(programme),
-        text: I18n.t("programmes.cohorts.index.title"),
-        selected: active == :cohorts
-      )
-
-      nav.with_item(
-        href: sessions_programme_path(programme),
-        text: I18n.t("sessions.index.title"),
-        selected: active == :sessions
-      )
-
-      nav.with_item(
-        href: programme_patients_path(programme),
-        text: I18n.t("programmes.patients.index.title"),
-        selected: active == :patients
-      )
-
-      nav.with_item(
-        href: programme_vaccinations_path(programme),
-        text: I18n.t("programmes.vaccinations.index.title"),
-        selected: active == :vaccinations
-      )
+      SECTIONS.each do |section|
+        nav.with_item(
+          href: public_send("programme_#{section}_path", programme),
+          text: I18n.t("title", scope: [:programmes, section, :index]),
+          selected: active == session
+        )
+      end
     end
   end
 
   private
 
   attr_reader :programme, :active
+
+  SECTIONS = %i[cohorts sessions patients vaccinations].freeze
 end

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -29,8 +29,8 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
       )
 
       nav.with_item(
-        href: patients_programme_path(programme),
-        text: I18n.t("patients.index.title"),
+        href: programme_patients_path(programme),
+        text: I18n.t("programmes.patients.index.title"),
         selected: active == :patients
       )
 

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -18,7 +18,7 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
 
       nav.with_item(
         href: programme_cohorts_path(programme),
-        text: I18n.t("cohorts.index.title"),
+        text: I18n.t("programmes.cohorts.index.title"),
         selected: active == :cohorts
       )
 

--- a/app/components/app_programme_navigation_component.rb
+++ b/app/components/app_programme_navigation_component.rb
@@ -10,17 +10,13 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
 
   def call
     render AppSecondaryNavigationComponent.new do |nav|
-      nav.with_item(
-        href: programme_path(programme),
-        text: "Overview",
-        selected: active == :overview
-      )
-
       SECTIONS.each do |section|
+        action = section == :overview ? :show : :index
+
         nav.with_item(
           href: public_send("programme_#{section}_path", programme),
-          text: I18n.t("title", scope: [:programmes, section, :index]),
-          selected: active == session
+          text: I18n.t("title", scope: [:programmes, section, action]),
+          selected: active == section
         )
       end
     end
@@ -30,5 +26,5 @@ class AppProgrammeNavigationComponent < ViewComponent::Base
 
   attr_reader :programme, :active
 
-  SECTIONS = %i[cohorts sessions patients vaccinations].freeze
+  SECTIONS = %i[overview cohorts sessions patients vaccinations].freeze
 end

--- a/app/components/app_programme_stats_component.html.erb
+++ b/app/components/app_programme_stats_component.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: programme_vaccination_records_path(@programme), colour: "reversed", data: true) do |card| %>
+    <%= render AppCardComponent.new(link_to: programme_vaccinations_path(@programme), colour: "reversed", data: true) do |card| %>
       <% card.with_heading { "Vaccinations" } %>
       <% card.with_description { vaccinations_count.to_s } %>
     <% end %>

--- a/app/components/app_vaccination_record_table_component.html.erb
+++ b/app/components/app_vaccination_record_table_component.html.erb
@@ -18,8 +18,7 @@
             <span class="nhsuk-table-responsive__heading">Full name</span>
 
             <% if can_link_to?(vaccination_record) %>
-              <%= link_to vaccination_record.patient.full_name,
-                          programme_vaccination_record_path(vaccination_record.programme, vaccination_record) %>
+              <%= link_to vaccination_record.patient.full_name, vaccination_record_path(vaccination_record) %>
             <% else %>
               <%= vaccination_record.patient.full_name %>
             <% end %>

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -143,7 +143,7 @@ class DraftVaccinationRecordsController < ApplicationController
         return_to: "record"
       )
     else
-      programme_vaccination_record_path(@programme, @vaccination_record)
+      vaccination_record_path(@vaccination_record)
     end
   end
 
@@ -231,7 +231,7 @@ class DraftVaccinationRecordsController < ApplicationController
     @back_link_path =
       if @draft_vaccination_record.editing?
         if current_step == :confirm
-          programme_vaccination_record_path(@programme, @vaccination_record)
+          vaccination_record_path(@vaccination_record)
         else
           wizard_path("confirm")
         end

--- a/app/controllers/programmes/base_controller.rb
+++ b/app/controllers/programmes/base_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Programmes::BaseController < ApplicationController
+  before_action :set_programme
+
+  layout "full"
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/controllers/programmes/cohorts_controller.rb
+++ b/app/controllers/programmes/cohorts_controller.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Programmes::CohortsController < ApplicationController
+class Programmes::CohortsController < Programmes::BaseController
   include Pagy::Backend
-
-  before_action :set_programme
-
-  layout "full"
 
   def index
     birth_academic_years = @programme.birth_academic_years
@@ -34,10 +30,6 @@ class Programmes::CohortsController < ApplicationController
   end
 
   private
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
-  end
 
   def patients_in_organisation
     current_user.selected_organisation.patients

--- a/app/controllers/programmes/cohorts_controller.rb
+++ b/app/controllers/programmes/cohorts_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CohortsController < ApplicationController
+class Programmes::CohortsController < ApplicationController
   include Pagy::Backend
 
   before_action :set_programme

--- a/app/controllers/programmes/overview_controller.rb
+++ b/app/controllers/programmes/overview_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Programmes::OverviewController < ApplicationController
+  before_action :set_programme
+
+  layout "full"
+
+  def show
+    patients = policy_scope(Patient).in_programmes([@programme])
+
+    @consents =
+      policy_scope(Consent).where(patient: patients, programme: @programme)
+  end
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/controllers/programmes/overview_controller.rb
+++ b/app/controllers/programmes/overview_controller.rb
@@ -1,20 +1,10 @@
 # frozen_string_literal: true
 
-class Programmes::OverviewController < ApplicationController
-  before_action :set_programme
-
-  layout "full"
-
+class Programmes::OverviewController < Programmes::BaseController
   def show
     patients = policy_scope(Patient).in_programmes([@programme])
 
     @consents =
       policy_scope(Consent).where(patient: patients, programme: @programme)
-  end
-
-  private
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/programmes/patients_controller.rb
+++ b/app/controllers/programmes/patients_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Programmes::PatientsController < ApplicationController
+  include Pagy::Backend
+  include SearchFormConcern
+
+  before_action :set_programme
+  before_action :set_search_form
+
+  layout "full"
+
+  def index
+    scope =
+      policy_scope(Patient).includes(:vaccination_statuses).in_programmes(
+        [@programme]
+      )
+
+    @form.programme_types = [@programme.type]
+
+    patients = @form.apply(scope)
+    @pagy, @patients = pagy(patients)
+  end
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/controllers/programmes/patients_controller.rb
+++ b/app/controllers/programmes/patients_controller.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-class Programmes::PatientsController < ApplicationController
+class Programmes::PatientsController < Programmes::BaseController
   include Pagy::Backend
   include SearchFormConcern
 
-  before_action :set_programme
   before_action :set_search_form
-
-  layout "full"
 
   def index
     scope =
@@ -19,11 +16,5 @@ class Programmes::PatientsController < ApplicationController
 
     patients = @form.apply(scope)
     @pagy, @patients = pagy(patients)
-  end
-
-  private
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/programmes/reports_controller.rb
+++ b/app/controllers/programmes/reports_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Programmes::ReportsController < ApplicationController
+  before_action :set_programme
+
+  def create
+    vaccination_report =
+      VaccinationReport.new(request_session: session, current_user:)
+
+    vaccination_report.reset!
+    vaccination_report.update!(programme: @programme)
+
+    redirect_to vaccination_report_path(Wicked::FIRST_STEP)
+  end
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/controllers/programmes/reports_controller.rb
+++ b/app/controllers/programmes/reports_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-class Programmes::ReportsController < ApplicationController
-  before_action :set_programme
-
+class Programmes::ReportsController < Programmes::BaseController
   def create
     vaccination_report =
       VaccinationReport.new(request_session: session, current_user:)
@@ -11,11 +9,5 @@ class Programmes::ReportsController < ApplicationController
     vaccination_report.update!(programme: @programme)
 
     redirect_to vaccination_report_path(Wicked::FIRST_STEP)
-  end
-
-  private
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/programmes/sessions_controller.rb
+++ b/app/controllers/programmes/sessions_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-class Programmes::SessionsController < ApplicationController
-  before_action :set_programme
-
-  layout "full"
-
+class Programmes::SessionsController < Programmes::BaseController
   def index
     @sessions =
       policy_scope(Session)
@@ -12,11 +8,5 @@ class Programmes::SessionsController < ApplicationController
         .for_current_academic_year
         .includes(:location, :session_dates)
         .order("locations.name")
-  end
-
-  private
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/programmes/sessions_controller.rb
+++ b/app/controllers/programmes/sessions_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Programmes::SessionsController < ApplicationController
+  before_action :set_programme
+
+  layout "full"
+
+  def index
+    @sessions =
+      policy_scope(Session)
+        .has_programme(@programme)
+        .for_current_academic_year
+        .includes(:location, :session_dates)
+        .order("locations.name")
+  end
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/controllers/programmes/vaccinations_controller.rb
+++ b/app/controllers/programmes/vaccinations_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Programmes::VaccinationsController < ApplicationController
+  include Pagy::Backend
+
+  before_action :set_programme
+
+  layout "full"
+
+  def index
+    scope =
+      policy_scope(VaccinationRecord)
+        .where(programme: @programme)
+        .includes(:patient, :programme)
+        .order(:performed_at)
+
+    @pagy, @vaccination_records = pagy(scope)
+  end
+
+  private
+
+  def set_programme
+    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
+  end
+end

--- a/app/controllers/programmes/vaccinations_controller.rb
+++ b/app/controllers/programmes/vaccinations_controller.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class Programmes::VaccinationsController < ApplicationController
+class Programmes::VaccinationsController < Programmes::BaseController
   include Pagy::Backend
-
-  before_action :set_programme
-
-  layout "full"
 
   def index
     scope =
@@ -15,11 +11,5 @@ class Programmes::VaccinationsController < ApplicationController
         .order(:performed_at)
 
     @pagy, @vaccination_records = pagy(scope)
-  end
-
-  private
-
-  def set_programme
-    @programme = policy_scope(Programme).find_by!(type: params[:programme_type])
   end
 end

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -16,15 +16,6 @@ class ProgrammesController < ApplicationController
       policy_scope(Consent).where(patient: patients, programme: @programme)
   end
 
-  def sessions
-    @sessions =
-      policy_scope(Session)
-        .has_programme(@programme)
-        .for_current_academic_year
-        .includes(:location, :session_dates)
-        .order("locations.name")
-  end
-
   def consent_form
     send_file(
       "public/consent_forms/#{@programme.type}.pdf",

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -10,12 +10,6 @@ class ProgrammesController < ApplicationController
       policy_scope(Programme).order(:type).includes(:active_vaccines)
   end
 
-  def show
-    patients = policy_scope(Patient).in_programmes([@programme])
-    @consents =
-      policy_scope(Consent).where(patient: patients, programme: @programme)
-  end
-
   def consent_form
     send_file(
       "public/consent_forms/#{@programme.type}.pdf",

--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require "pagy/extras/array"
-
 class ProgrammesController < ApplicationController
-  include Pagy::Backend
-  include SearchFormConcern
-
   before_action :set_programme, except: :index
-  before_action :set_search_form, only: :patients
 
   layout "full"
 
@@ -29,18 +23,6 @@ class ProgrammesController < ApplicationController
         .for_current_academic_year
         .includes(:location, :session_dates)
         .order("locations.name")
-  end
-
-  def patients
-    scope =
-      policy_scope(Patient).includes(:vaccination_statuses).in_programmes(
-        [@programme]
-      )
-
-    @form.programme_types = [@programme.type]
-
-    patients = @form.apply(scope)
-    @pagy, @patients = pagy(patients)
   end
 
   def consent_form

--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pagy/extras/array"
-
 class Sessions::RegisterController < ApplicationController
   include Pagy::Backend
   include SearchFormConcern

--- a/app/controllers/vaccination_reports_controller.rb
+++ b/app/controllers/vaccination_reports_controller.rb
@@ -2,19 +2,20 @@
 
 class VaccinationReportsController < ApplicationController
   before_action :set_vaccination_report
-  before_action :set_programme, only: %i[show update]
+  before_action :set_programme
 
   include WizardControllerConcern
 
-  skip_after_action :verify_policy_scoped, only: %i[show update download]
+  skip_after_action :verify_policy_scoped
 
-  def create
-    @programme = policy_scope(Programme).find_by(type: params[:programme_type])
+  def show
+    render_wizard
+  end
 
-    @vaccination_report.reset!
-    @vaccination_report.update!(programme: @programme)
+  def update
+    @vaccination_report.assign_attributes(update_params)
 
-    redirect_to vaccination_report_path(Wicked::FIRST_STEP)
+    render_wizard @vaccination_report
   end
 
   def download
@@ -26,16 +27,6 @@ class VaccinationReportsController < ApplicationController
     else
       redirect_to vaccination_report_path(Wicked::FIRST_STEP)
     end
-  end
-
-  def show
-    render_wizard
-  end
-
-  def update
-    @vaccination_report.assign_attributes(update_params)
-
-    render_wizard @vaccination_report
   end
 
   private

--- a/app/views/programmes/cohorts/index.html.erb
+++ b/app/views/programmes/cohorts/index.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: @programme.name, href: programme_overview_path(@programme) },
                                         ]) %>
 <% end %>
 

--- a/app/views/programmes/cohorts/index.html.erb
+++ b/app/views/programmes/cohorts/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@programme.name} – #{t("cohorts.index.title")}" %>
+<%= content_for :page_title, "#{@programme.name} – #{t(".title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [

--- a/app/views/programmes/cohorts/show.html.erb
+++ b/app/views/programmes/cohorts/show.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: @programme.name, href: programme_overview_path(@programme) },
                                           { text: t("programmes.cohorts.index.title"), href: programme_cohorts_path(@programme) },
                                         ]) %>
 <% end %>

--- a/app/views/programmes/cohorts/show.html.erb
+++ b/app/views/programmes/cohorts/show.html.erb
@@ -3,7 +3,7 @@
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
                                           { text: @programme.name, href: programme_path(@programme) },
-                                          { text: t("cohorts.index.title"), href: programme_cohorts_path(@programme) },
+                                          { text: t("programmes.cohorts.index.title"), href: programme_cohorts_path(@programme) },
                                         ]) %>
 <% end %>
 

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -18,7 +18,7 @@
         <% body.with_row do |row| %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Programme</span>
-            <%= link_to programme.name, programme_path(programme) %>
+            <%= link_to programme.name, programme_overview_path(programme) %>
           <% end %>
 
           <% row.with_cell do %>

--- a/app/views/programmes/overview/show.html.erb
+++ b/app/views/programmes/overview/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{@programme.name} – Overview" %>
+<% content_for :page_title, "#{@programme.name} – #{t(".title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [

--- a/app/views/programmes/patients/index.html.erb
+++ b/app/views/programmes/patients/index.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: @programme.name, href: programme_overview_path(@programme) },
                                         ]) %>
 <% end %>
 

--- a/app/views/programmes/patients/index.html.erb
+++ b/app/views/programmes/patients/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@programme.name} – #{t("patients.index.title")}" %>
+<%= content_for :page_title, "#{@programme.name} – #{t(".title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
@@ -20,7 +20,7 @@
   <div class="app-grid-column-filters">
     <%= render AppSearchComponent.new(
           form: @form,
-          url: patients_programme_path(@programme),
+          url: programme_patients_path(@programme),
           programme_statuses: Patient::VaccinationStatus.statuses.keys,
           consent_statuses: Patient::ConsentStatus.statuses.keys,
           triage_statuses: %w[required delay_vaccination do_not_vaccinate safe_to_vaccinate],

--- a/app/views/programmes/sessions/index.html.erb
+++ b/app/views/programmes/sessions/index.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: @programme.name, href: programme_overview_path(@programme) },
                                         ]) %>
 <% end %>
 

--- a/app/views/programmes/sessions/index.html.erb
+++ b/app/views/programmes/sessions/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@programme.name} – Sessions" %>
+<%= content_for :page_title, "#{@programme.name} – #{t(".title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [

--- a/app/views/programmes/show.html.erb
+++ b/app/views/programmes/show.html.erb
@@ -11,7 +11,7 @@
 
 <%= render AppProgrammeNavigationComponent.new(@programme, active: :overview) %>
 
-<%= govuk_button_to "Download vaccination report", programme_vaccination_reports_path(@programme), secondary: true, class: "nhsuk-u-margin-bottom-5" %>
+<%= govuk_button_to "Download vaccination report", programme_reports_path(@programme), secondary: true, class: "nhsuk-u-margin-bottom-5" %>
 
 <%= render AppProgrammeStatsComponent.new(programme: @programme) %>
 

--- a/app/views/programmes/vaccinations/index.html.erb
+++ b/app/views/programmes/vaccinations/index.html.erb
@@ -4,7 +4,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: @programme.name, href: programme_overview_path(@programme) },
                                         ]) %>
 <% end %>
 

--- a/app/views/programmes/vaccinations/index.html.erb
+++ b/app/views/programmes/vaccinations/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{@programme.name} – #{t("vaccination_records.index.title")}" %>
+<% content_for :page_title, "#{@programme.name} – #{t(".title")}" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
@@ -10,11 +10,10 @@
 
 <h1 class="nhsuk-heading-l"><%= @programme.name %></h1>
 
-<%= render AppProgrammeNavigationComponent.new(@programme, active: :vaccination_records) %>
+<%= render AppProgrammeNavigationComponent.new(@programme, active: :vaccinations) %>
 
 <%= govuk_button_link_to "Import vaccination records", new_immunisation_import_path, secondary: true, class: "nhsuk-u-margin-bottom-0" %>
 
 <%= render AppVaccinationRecordTableComponent.new(@vaccination_records, current_user:, count: @pagy.count) %>
 
 <%= govuk_pagination(pagy: @pagy) %>
-

--- a/app/views/vaccination_records/destroy.html.erb
+++ b/app/views/vaccination_records/destroy.html.erb
@@ -11,7 +11,7 @@
   <%= page_title %>
 <% end %>
 
-<%= form_with url: programme_vaccination_record_path, method: :delete do |f| %>
+<%= form_with url: vaccination_record_path, method: :delete do |f| %>
   <%= f.hidden_field :return_to, value: @return_to %>
   <div class="app-button-group">
     <%= f.govuk_submit "Yes, delete this vaccination record", warning: true %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -2,7 +2,7 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: @programme.name, href: programme_overview_path(@programme) },
                                           { text: t("programmes.vaccinations.index.title"), href: programme_vaccinations_path(@programme) },
                                         ]) %>
 <% end %>

--- a/app/views/vaccination_records/show.html.erb
+++ b/app/views/vaccination_records/show.html.erb
@@ -2,8 +2,8 @@
   <%= render AppBreadcrumbComponent.new(items: [
                                           { text: t("dashboard.index.title"), href: dashboard_path },
                                           { text: t("programmes.index.title"), href: programmes_path },
-                                          { text: @programme.name, href: programme_vaccination_records_path(@programme) },
-                                          { text: t("vaccination_records.index.title"), href: programme_vaccination_records_path(@programme) },
+                                          { text: @programme.name, href: programme_path(@programme) },
+                                          { text: t("programmes.vaccinations.index.title"), href: programme_vaccinations_path(@programme) },
                                         ]) %>
 <% end %>
 
@@ -18,13 +18,13 @@
   <div class="app-button-group">
     <% if policy(@vaccination_record).edit? %>
       <%= govuk_button_to "Edit vaccination record",
-                          programme_vaccination_record_path(@programme, @vaccination_record),
+                          vaccination_record_path(@vaccination_record),
                           method: :put, secondary: true %>
     <% end %>
 
     <% if policy(@vaccination_record).destroy? %>
       <%= govuk_link_to "Delete vaccination record",
-                        destroy_programme_vaccination_record_path(@programme, @vaccination_record) %>
+                        destroy_vaccination_record_path(@vaccination_record) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/vaccination_reports/dates.html.erb
+++ b/app/views/vaccination_reports/dates.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(programme_path(@programme), name: @programme.name) %>
+  <%= render AppBacklinkComponent.new(programme_overview_path(@programme), name: @programme.name) %>
 <% end %>
 
 <%= form_with model: @vaccination_report, url: wizard_path, method: :put do |f| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,6 +586,9 @@ en:
         title: Cohorts
     index:
       title: Programmes
+    overview:
+      show:
+        title: Overview
     patients:
       index:
         title: Children

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -490,9 +490,6 @@ en:
     zero: No children
     one: 1 child
     other: "%{count} children"
-  cohorts:
-    index:
-      title: Cohorts
   consent_forms:
     index:
       title: Unmatched consent responses
@@ -584,6 +581,9 @@ en:
     index:
       title: Children
   programmes:
+    cohorts:
+      index:
+        title: Cohorts
     index:
       title: Programmes
     sessions:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -586,6 +586,9 @@ en:
         title: Cohorts
     index:
       title: Programmes
+    patients:
+      index:
+        title: Children
     sessions:
       table_headings:
         completed: All sessions completed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,6 +591,9 @@ en:
         completed: All sessions completed
         scheduled: Sessions scheduled
         unscheduled: No sessions scheduled
+    vaccinations:
+      index:
+        title: Vaccinations
   school_moves:
     index:
       title: School moves
@@ -633,9 +636,6 @@ en:
   organisations:
     show:
       title: Your organisation
-  vaccination_records:
-    index:
-      title: Vaccinations
   vaccines:
     index:
       title: Vaccines

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -590,10 +590,8 @@ en:
       index:
         title: Children
     sessions:
-      table_headings:
-        completed: All sessions completed
-        scheduled: Sessions scheduled
-        unscheduled: No sessions scheduled
+      index:
+        title: Sessions
     vaccinations:
       index:
         title: Vaccinations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,12 +168,12 @@ Rails.application.routes.draw do
   resources :programmes, only: %i[index show], param: :type do
     member do
       get "sessions"
-      get "patients"
 
       get "consent-form", action: "consent_form"
     end
 
     resources :cohorts, only: %i[index show], controller: "programmes/cohorts"
+    resources :patients, only: :index, controller: "programmes/patients"
     resources :reports, only: :create, controller: "programmes/reports"
     resources :vaccinations, only: :index, controller: "programmes/vaccinations"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,10 +165,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :programmes, only: %i[index show], param: :type do
+  resources :programmes, only: :index, param: :type do
     get "consent-form", on: :member
 
     scope module: :programmes do
+      resource :overview, path: "", only: :show, controller: :overview
       resources :cohorts, only: %i[index show]
       resources :patients, only: :index
       resources :reports, only: :create

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,16 +166,15 @@ Rails.application.routes.draw do
   end
 
   resources :programmes, only: %i[index show], param: :type do
-    member do
-      get "sessions"
+    get "consent-form", on: :member
 
-      get "consent-form", action: "consent_form"
+    scope module: :programmes do
+      resources :cohorts, only: %i[index show]
+      resources :patients, only: :index
+      resources :reports, only: :create
+      resources :sessions, only: :index
+      resources :vaccinations, only: :index
     end
-
-    resources :cohorts, only: %i[index show], controller: "programmes/cohorts"
-    resources :patients, only: :index, controller: "programmes/patients"
-    resources :reports, only: :create, controller: "programmes/reports"
-    resources :vaccinations, only: :index, controller: "programmes/vaccinations"
   end
 
   resources :school_moves, path: "school-moves", only: %i[index show update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,12 +124,6 @@ Rails.application.routes.draw do
            only: %i[show update],
            path: "draft-vaccination-record/:id"
 
-  resource :vaccination_report,
-           only: %i[show update],
-           path: "draft-vaccination-report/:id" do
-    get "download", on: :member
-  end
-
   resources :immunisation_imports,
             path: "immunisation-imports",
             except: %i[index destroy]
@@ -180,11 +174,8 @@ Rails.application.routes.draw do
     end
 
     resources :cohorts, only: %i[index show], controller: "programmes/cohorts"
+    resources :reports, only: :create, controller: "programmes/reports"
     resources :vaccinations, only: :index, controller: "programmes/vaccinations"
-
-    resources :vaccination_reports,
-              path: "vaccination-reports",
-              only: %i[create]
   end
 
   resources :school_moves, path: "school-moves", only: %i[index show update]
@@ -297,6 +288,12 @@ Rails.application.routes.draw do
             path: "vaccination-records",
             only: %i[show update destroy] do
     get "destroy", action: :confirm_destroy, on: :member, as: "destroy"
+  end
+
+  resource :vaccination_report,
+           only: %i[show update],
+           path: "vaccination-report/:id" do
+    get "download", on: :member
   end
 
   resources :vaccines, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -179,7 +179,7 @@ Rails.application.routes.draw do
       get "consent-form", action: "consent_form"
     end
 
-    resources :cohorts, only: %i[index show]
+    resources :cohorts, only: %i[index show], controller: "programmes/cohorts"
 
     resources :vaccination_records,
               path: "vaccination-records",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,12 +180,7 @@ Rails.application.routes.draw do
     end
 
     resources :cohorts, only: %i[index show], controller: "programmes/cohorts"
-
-    resources :vaccination_records,
-              path: "vaccination-records",
-              only: %i[index show update destroy] do
-      get "destroy", action: :confirm_destroy, on: :member, as: "destroy"
-    end
+    resources :vaccinations, only: :index, controller: "programmes/vaccinations"
 
     resources :vaccination_reports,
               path: "vaccination-reports",
@@ -297,6 +292,12 @@ Rails.application.routes.draw do
   end
 
   resource :organisation, only: %i[show]
+
+  resources :vaccination_records,
+            path: "vaccination-records",
+            only: %i[show update destroy] do
+    get "destroy", action: :confirm_destroy, on: :member, as: "destroy"
+  end
 
   resources :vaccines, only: %i[index show] do
     resources :batches, only: %i[create edit new update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,7 +166,7 @@ Rails.application.routes.draw do
   end
 
   resources :programmes, only: :index, param: :type do
-    get "consent-form", on: :member
+    get "consent-form", on: :member, action: :consent_form
 
     scope module: :programmes do
       resource :overview, path: "", only: :show, controller: :overview

--- a/spec/features/download_vaccination_reports_spec.rb
+++ b/spec/features/download_vaccination_reports_spec.rb
@@ -117,7 +117,7 @@ describe "Download vaccination reports" do
 
   def when_i_go_to_the_programme
     sign_in @organisation.users.first
-    visit programme_path(@programme)
+    visit programme_overview_path(@programme)
   end
 
   def and_i_click_on_download_vaccination_report


### PR DESCRIPTION
This refactors the various controllers responsible for rendering the various parts of the programmes pages to split up the single `ProgrammesController` in to separate controllers response for each time ([similar to what we did for patient sessions](https://github.com/nhsuk/manage-vaccinations-in-schools/pull/3658)).

This should hopefully make it easier to understand what these controllers are for and how they relate to the other controllers. At the moment they're all in the root module which can make it difficult to see that they're actually all part of the patient sessions section of the service.