### PR TITLE
Add after_save hook to sync vaccination

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -123,8 +123,6 @@ class DraftVaccinationRecordsController < ApplicationController
 
     send_vaccination_confirmation(@vaccination_record) if should_notify_parents
 
-    @vaccination_record.sync_to_nhs_immunisations_api
-
     # In case the user navigates back to try and edit the newly created
     # vaccination record.
     @draft_vaccination_record.update!(editing_id: @vaccination_record.id)

--- a/spec/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern_spec.rb
+++ b/spec/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern_spec.rb
@@ -2,7 +2,7 @@
 
 describe VaccinationRecordSyncToNHSImmunisationsAPIConcern do
   let(:vaccination_record) do
-    create(:vaccination_record, outcome:, programme:, session:)
+    build(:vaccination_record, outcome:, programme:, session:)
   end
   let(:outcome) { "administered" }
   let(:programme) { create(:programme, type: "flu") }

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -273,4 +273,83 @@ describe VaccinationRecord do
       end
     end
   end
+
+  describe "#changes_need_to_be_synced_to_nhs_immunisations_api?" do
+    subject do
+      vaccination_record.send(
+        :changes_need_to_be_synced_to_nhs_immunisations_api?
+      )
+    end
+
+    let(:vaccination_record) { create(:vaccination_record) }
+
+    context "when the update doesn't change any attributes" do
+      before { vaccination_record.update!(notes: vaccination_record.notes) }
+
+      it { should be_falsy }
+    end
+
+    context "when regular fields have been changed" do
+      before { vaccination_record.update!(notes: "Updated notes") }
+
+      it { should be_truthy }
+    end
+
+    context "when only nhs_immunisations_api_etag has been changed" do
+      before do
+        vaccination_record.update!(nhs_immunisations_api_etag: "new-etag")
+      end
+
+      it { should be_falsy }
+    end
+
+    context "when only nhs_immunisations_api_sync_pending_at has been changed" do
+      before do
+        vaccination_record.update!(
+          nhs_immunisations_api_sync_pending_at: Time.current
+        )
+      end
+
+      it { should be_falsy }
+    end
+
+    context "when only nhs_immunisations_api_synced_at has been changed" do
+      before do
+        vaccination_record.update!(
+          nhs_immunisations_api_synced_at: Time.current
+        )
+      end
+
+      it { should be_falsy }
+    end
+
+    context "when only nhs_immunisations_api_id has been changed" do
+      before { vaccination_record.update!(nhs_immunisations_api_id: "new-id") }
+
+      it { should be_falsy }
+    end
+
+    context "when both regular fields and nhs_immunisations_api fields have been changed" do
+      before do
+        vaccination_record.update!(
+          notes: "Updated notes",
+          nhs_immunisations_api_etag: "new-etag"
+        )
+      end
+
+      it { should be_falsy }
+    end
+
+    context "when a regular field and multiple nhs_immunisations_api fields have been changed" do
+      before do
+        vaccination_record.update!(
+          outcome: :refused,
+          nhs_immunisations_api_etag: "new-etag",
+          nhs_immunisations_api_sync_pending_at: Time.current
+        )
+      end
+
+      it { should be_falsy }
+    end
+  end
 end


### PR DESCRIPTION
This fixes the issue of updating a vaccination after the duplicate is merged, and replaces the manual sync that was added to the draft vaccinations controller to trigger when a vaccination is edited.

[MAV-1553](https://nhsd-jira.digital.nhs.uk/browse/MAV-1553)