### PR TITLE
Align terraform versions

### DIFF
--- a/terraform/data_replication/main.tf
+++ b/terraform/data_replication/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.95"
+      version = "~> 6.2"
     }
   }
 


### PR DESCRIPTION
The data replication module still required terraform major version 5 which made it incompatible with the other modules that require version 6.2