### PR TITLE
Include academic year in status models

### DIFF
--- a/app/components/app_patient_search_result_card_component.rb
+++ b/app/components/app_patient_search_result_card_component.rb
@@ -5,6 +5,7 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
     patient,
     link_to:,
     programme: nil,
+    academic_year: nil,
     triage_status: nil,
     show_parents: false,
     show_postcode: false,
@@ -16,6 +17,7 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
     @patient = patient
     @link_to = link_to
     @programme = programme
+    @academic_year = academic_year
     @triage_status = triage_status
 
     @show_parents = show_parents
@@ -61,7 +63,7 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
             row.with_value { helpers.patient_parents(@patient) }
           end
         end
-        if @programme
+        if @programme && @academic_year
           summary_list.with_row do |row|
             row.with_key { "Consent status" }
             row.with_value { consent_status_tag }
@@ -97,7 +99,11 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
 
   def render_status_tag(status_type, outcome)
     status_model =
-      @patient.public_send("#{status_type}_status", programme: @programme)
+      @patient.public_send(
+        "#{status_type}_status",
+        programme: @programme,
+        academic_year: @academic_year
+      )
 
     status_key =
       if status_type == :triage && status_model.vaccine_method.present? &&
@@ -116,6 +122,9 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
   def display_triage_status?
     return true if @triage_status.present?
 
-    @patient.triage_status(programme: @programme).required?
+    @patient.triage_status(
+      programme: @programme,
+      academic_year: @academic_year
+    ).required?
   end
 end

--- a/app/components/app_patient_session_consent_component.rb
+++ b/app/components/app_patient_session_consent_component.rb
@@ -29,6 +29,7 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
         .consent_notifications
         .request
         .has_programme(programme)
+        .for_academic_year(academic_year)
         .order(sent_at: :desc)
         .first
   end
@@ -38,16 +39,18 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
       patient
         .consents
         .where(programme:)
+        .for_academic_year(academic_year)
         .includes(:consent_form, :parent, :programme)
         .order(created_at: :desc)
   end
 
   def consent_status
-    @consent_status ||= patient.consent_status(programme:)
+    @consent_status ||= patient.consent_status(programme:, academic_year:)
   end
 
   def vaccination_status
-    @vaccination_status ||= patient.vaccination_status(programme:)
+    @vaccination_status ||=
+      patient.vaccination_status(programme:, academic_year:)
   end
 
   def can_send_consent_request?

--- a/app/components/app_patient_session_consent_component.rb
+++ b/app/components/app_patient_session_consent_component.rb
@@ -13,6 +13,7 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
   attr_reader :patient_session, :programme
 
   delegate :patient, :session, to: :patient_session
+  delegate :academic_year, to: :session
 
   def colour
     I18n.t(status, scope: %i[status consent colour])
@@ -55,7 +56,8 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
   end
 
   def grouped_consents
-    @grouped_consents ||= ConsentGrouper.call(consents, programme:)
+    @grouped_consents ||=
+      ConsentGrouper.call(consents, programme_id: programme.id, academic_year:)
   end
 
   def who_refused

--- a/app/components/app_patient_session_outcome_component.rb
+++ b/app/components/app_patient_session_outcome_component.rb
@@ -9,6 +9,7 @@ class AppPatientSessionOutcomeComponent < ViewComponent::Base
       <%= render AppPatientVaccinationTableComponent.new(
             patient,
             programme:,
+            academic_year:,
             show_caption: true
           ) %>
     <% end %>
@@ -22,14 +23,18 @@ class AppPatientSessionOutcomeComponent < ViewComponent::Base
   end
 
   def render?
-    patient.vaccination_records.exists?
+    patient
+      .vaccination_records
+      .includes(:programme)
+      .any? { it.show_in_academic_year?(academic_year) }
   end
 
   private
 
   attr_reader :patient_session, :programme
 
-  delegate :patient, to: :patient_session
+  delegate :patient, :session, to: :patient_session
+  delegate :academic_year, to: :session
 
   def colour
     I18n.t(status, scope: %i[status programme colour])

--- a/app/components/app_patient_session_outcome_component.rb
+++ b/app/components/app_patient_session_outcome_component.rb
@@ -46,7 +46,7 @@ class AppPatientSessionOutcomeComponent < ViewComponent::Base
 
   def vaccination_status
     @vaccination_status ||=
-      patient.vaccination_statuses.find_or_initialize_by(programme:)
+      patient.vaccination_status(programme:, academic_year:)
   end
 
   delegate :status, to: :vaccination_status

--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -18,7 +18,7 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
   end
 
   def render?
-    patient.consent_given_and_safe_to_vaccinate?(programme:) &&
+    patient.consent_given_and_safe_to_vaccinate?(programme:, academic_year:) &&
       (
         patient_session.registration_status&.attending? ||
           patient_session.registration_status&.completed? || false
@@ -29,7 +29,8 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
 
   attr_reader :patient_session, :programme, :vaccinate_form
 
-  delegate :patient, to: :patient_session
+  delegate :patient, :session, to: :patient_session
+  delegate :academic_year, to: :session
 
   def default_vaccinate_form
     pre_screening_confirmed = patient.pre_screenings.today.exists?(programme:)
@@ -40,7 +41,8 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
   def heading
     vaccination =
       if programme.has_multiple_vaccine_methods?
-        vaccine_method = patient.approved_vaccine_methods(programme:).first
+        vaccine_method =
+          patient.approved_vaccine_methods(programme:, academic_year:).first
         method_string =
           Vaccine.human_enum_name(:method, vaccine_method).downcase
         "vaccination with #{method_string}"

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -79,6 +79,8 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
 
   attr_reader :patient_session, :patient, :session, :context, :programmes
 
+  delegate :academic_year, to: :session
+
   def can_register_attendance?
     session_attendance =
       SessionAttendance.new(
@@ -124,8 +126,11 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
 
     vaccine_methods =
       programmes_to_check.flat_map do |programme|
-        if patient.consent_given_and_safe_to_vaccinate?(programme:)
-          patient.approved_vaccine_methods(programme:)
+        if patient.consent_given_and_safe_to_vaccinate?(
+             programme:,
+             academic_year:
+           )
+          patient.approved_vaccine_methods(programme:, academic_year:)
         else
           []
         end
@@ -157,7 +162,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
           render(
             AppProgrammeStatusTagsComponent.new(
               programmes.index_with do |programme|
-                patient.consent_status(programme:).slice(
+                patient.consent_status(programme:, academic_year:).slice(
                   :status,
                   :vaccine_methods
                 )
@@ -173,7 +178,10 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
           render(
             AppProgrammeStatusTagsComponent.new(
               programmes.index_with do |programme|
-                triage_status_tag(patient.triage_status(programme:), programme)
+                triage_status_tag(
+                  patient.triage_status(programme:, academic_year:),
+                  programme
+                )
               end,
               outcome: :triage
             )

--- a/app/components/app_patient_session_triage_component.rb
+++ b/app/components/app_patient_session_triage_component.rb
@@ -33,7 +33,7 @@ class AppPatientSessionTriageComponent < ViewComponent::Base
       patient
         .triage_statuses
         .includes(:consents, :programme, :vaccination_records)
-        .find_by(programme:)
+        .find_by(programme:, academic_year:)
   end
 
   def vaccination_method

--- a/app/components/app_patient_session_triage_component.rb
+++ b/app/components/app_patient_session_triage_component.rb
@@ -18,6 +18,7 @@ class AppPatientSessionTriageComponent < ViewComponent::Base
   attr_reader :patient_session, :programme, :triage_form
 
   delegate :patient, :session, to: :patient_session
+  delegate :academic_year, to: :session
 
   def colour
     I18n.t(status, scope: %i[status triage colour])
@@ -43,12 +44,11 @@ class AppPatientSessionTriageComponent < ViewComponent::Base
 
   def latest_triage
     @latest_triage ||=
-      patient
-        .triages
-        .not_invalidated
-        .includes(:performed_by)
-        .order(created_at: :desc)
-        .find_by(programme:)
+      TriageFinder.call(
+        patient.triages.includes(:performed_by),
+        programme_id: programme.id,
+        academic_year:
+      )
   end
 
   def default_triage_form = TriageForm.new(patient_session:, programme:)

--- a/app/components/app_patient_vaccination_table_component.rb
+++ b/app/components/app_patient_vaccination_table_component.rb
@@ -1,17 +1,18 @@
 # frozen_string_literal: true
 
 class AppPatientVaccinationTableComponent < ViewComponent::Base
-  def initialize(patient, programme: nil, show_caption: false)
+  def initialize(patient, academic_year:, programme: nil, show_caption: false)
     super
 
     @patient = patient
+    @academic_year = academic_year
     @programme = programme
     @show_caption = show_caption
   end
 
   private
 
-  attr_reader :patient, :programme, :show_caption
+  attr_reader :patient, :academic_year, :programme, :show_caption
 
   def show_programme = programme.nil?
 
@@ -21,6 +22,6 @@ class AppPatientVaccinationTableComponent < ViewComponent::Base
       .then { programme ? it.where(programme:) : it }
       .includes(:location, :programme)
       .order(performed_at: :desc)
-      .select(&:show_this_academic_year?)
+      .select { it.show_in_academic_year?(academic_year) }
   end
 end

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -20,9 +20,7 @@ class AppSessionActionsComponent < ViewComponent::Base
 
   attr_reader :session
 
-  delegate :patient_sessions, to: :session
-
-  delegate :programmes, to: :session
+  delegate :academic_year, :patient_sessions, :programmes, to: :session
 
   def rows
     @rows ||= [
@@ -120,7 +118,8 @@ class AppSessionActionsComponent < ViewComponent::Base
           )
           .count do |patient_session|
             patient_session.patient.consent_given_and_safe_to_vaccinate?(
-              programme:
+              programme:,
+              academic_year:
             )
           end
       end

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -13,13 +13,14 @@ class AppVaccinateFormComponent < ViewComponent::Base
 
   delegate :patient_session, :programme, to: :vaccinate_form
   delegate :patient, :session, to: :patient_session
+  delegate :academic_year, to: :session
 
   def url
     session_patient_programme_vaccinations_path(session, patient, programme)
   end
 
   def vaccine_methods
-    patient.approved_vaccine_methods(programme:)
+    patient.approved_vaccine_methods(programme:, academic_year:)
   end
 
   def dose_sequence

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -46,17 +46,26 @@ module TriageMailerConcern
 
   def vaccination_will_happen?(patient, programme, consent)
     consent.requires_triage? &&
-      patient.triage_status(programme:).safe_to_vaccinate?
+      patient.triage_status(
+        programme:,
+        academic_year: consent.academic_year
+      ).safe_to_vaccinate?
   end
 
   def vaccination_wont_happen?(patient, programme, consent)
     consent.requires_triage? &&
-      patient.triage_status(programme:).do_not_vaccinate?
+      patient.triage_status(
+        programme:,
+        academic_year: consent.academic_year
+      ).do_not_vaccinate?
   end
 
   def vaccination_at_clinic?(patient, programme, consent)
     consent.requires_triage? &&
-      patient.triage_status(programme:).delay_vaccination?
+      patient.triage_status(
+        programme:,
+        academic_year: consent.academic_year
+      ).delay_vaccination?
   end
 
   def resolve_email_template(template_name, organisation)

--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -3,7 +3,11 @@
 module TriageMailerConcern
   extend ActiveSupport::Concern
 
-  def send_triage_confirmation(patient_session, consent)
+  def send_triage_confirmation(patient_session, programme, consent)
+    if consent.programme_id != programme.id
+      raise "Consent is for a different programme."
+    end
+
     session = patient_session.session
     patient = patient_session.patient
     organisation = patient_session.organisation
@@ -13,11 +17,11 @@ module TriageMailerConcern
 
     params = { consent:, session:, sent_by: current_user }
 
-    if vaccination_will_happen?(patient, consent)
+    if vaccination_will_happen?(patient, programme, consent)
       EmailDeliveryJob.perform_later(:triage_vaccination_will_happen, **params)
-    elsif vaccination_wont_happen?(patient, consent)
+    elsif vaccination_wont_happen?(patient, programme, consent)
       EmailDeliveryJob.perform_later(:triage_vaccination_wont_happen, **params)
-    elsif vaccination_at_clinic?(patient, consent)
+    elsif vaccination_at_clinic?(patient, programme, consent)
       email_template =
         resolve_email_template(:triage_vaccination_at_clinic, organisation)
       EmailDeliveryJob.perform_later(email_template, **params)
@@ -40,22 +44,19 @@ module TriageMailerConcern
 
   private
 
-  def vaccination_will_happen?(patient, consent)
-    programme_id = consent.programme_id
+  def vaccination_will_happen?(patient, programme, consent)
     consent.requires_triage? &&
-      patient.triage_status(programme_id:).safe_to_vaccinate?
+      patient.triage_status(programme:).safe_to_vaccinate?
   end
 
-  def vaccination_wont_happen?(patient, consent)
-    programme_id = consent.programme_id
+  def vaccination_wont_happen?(patient, programme, consent)
     consent.requires_triage? &&
-      patient.triage_status(programme_id:).do_not_vaccinate?
+      patient.triage_status(programme:).do_not_vaccinate?
   end
 
-  def vaccination_at_clinic?(patient, consent)
-    programme_id = consent.programme_id
+  def vaccination_at_clinic?(patient, programme, consent)
     consent.requires_triage? &&
-      patient.triage_status(programme_id:).delay_vaccination?
+      patient.triage_status(programme:).delay_vaccination?
   end
 
   def resolve_email_template(template_name, organisation)

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -52,8 +52,11 @@ module VaccinationMailerConcern
     patient = vaccination_record.patient
     return [] unless patient.send_notifications?
 
-    programme = vaccination_record.programme
-    consents = ConsentGrouper.call(patient.consents, programme:)
+    programme_id = vaccination_record.programme_id
+    academic_year = vaccination_record.academic_year
+
+    consents =
+      ConsentGrouper.call(patient.consents, programme_id:, academic_year:)
 
     parents =
       if consents.any?(&:via_self_consent?)

--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -74,7 +74,7 @@ class DraftConsentsController < ApplicationController
 
     set_patient_session # reload with new statuses
 
-    send_triage_confirmation(@patient_session, @consent)
+    send_triage_confirmation(@patient_session, @programme, @consent)
 
     heading_link_href =
       session_patient_programme_path(@session, @patient, @programme)

--- a/app/controllers/patient_sessions/base_controller.rb
+++ b/app/controllers/patient_sessions/base_controller.rb
@@ -2,6 +2,7 @@
 
 class PatientSessions::BaseController < ApplicationController
   before_action :set_session
+  before_action :set_academic_year
   before_action :set_patient
   before_action :set_patient_session
   before_action :set_programme
@@ -16,6 +17,10 @@ class PatientSessions::BaseController < ApplicationController
       policy_scope(Session).includes(:location, :programmes).find_by!(
         slug: params.fetch(:session_slug, params[:slug])
       )
+  end
+
+  def set_academic_year
+    @academic_year = @session.academic_year
   end
 
   def set_patient

--- a/app/controllers/patient_sessions/consents_controller.rb
+++ b/app/controllers/patient_sessions/consents_controller.rb
@@ -24,7 +24,12 @@ class PatientSessions::ConsentsController < PatientSessions::BaseController
   end
 
   def send_request
-    return unless @patient.consent_status(programme: @programme).no_response?
+    unless @patient.consent_status(
+             programme: @programme,
+             academic_year: @academic_year
+           ).no_response?
+      return
+    end
 
     # For programmes that are administered together we should send the consent request together.
     programmes =

--- a/app/controllers/patient_sessions/triages_controller.rb
+++ b/app/controllers/patient_sessions/triages_controller.rb
@@ -38,7 +38,11 @@ class PatientSessions::TriagesController < PatientSessions::BaseController
       StatusUpdater.call(patient: @patient)
 
       ConsentGrouper
-        .call(@patient.reload.consents, programme: @programme)
+        .call(
+          @patient.reload.consents,
+          programme_id: @programme.id,
+          academic_year: @academic_year
+        )
         .each { send_triage_confirmation(@patient_session, @programme, it) }
 
       redirect_to redirect_path, flash: { success: "Triage outcome updated" }

--- a/app/controllers/patient_sessions/triages_controller.rb
+++ b/app/controllers/patient_sessions/triages_controller.rb
@@ -39,7 +39,7 @@ class PatientSessions::TriagesController < PatientSessions::BaseController
 
       ConsentGrouper
         .call(@patient.reload.consents, programme: @programme)
-        .each { send_triage_confirmation(@patient_session, it) }
+        .each { send_triage_confirmation(@patient_session, @programme, it) }
 
       redirect_to redirect_path, flash: { success: "Triage outcome updated" }
     else

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -73,11 +73,29 @@ class SearchForm
       scope.in_programmes(programmes, academic_year:) if programmes.present?
 
     if (statuses = consent_statuses).present?
-      scope = scope.has_consent_status(statuses, programme: programmes)
+      scope =
+        if session
+          scope.has_consent_status(statuses, programme: programmes)
+        else
+          scope.has_consent_status(
+            statuses,
+            programme: programmes,
+            academic_year:
+          )
+        end
     end
 
     if (status = programme_status&.to_sym).present?
-      scope = scope.has_vaccination_status(status, programme: programmes)
+      scope =
+        if session
+          scope.has_vaccination_status(status, programme: programmes)
+        else
+          scope.has_vaccination_status(
+            status,
+            programme: programmes,
+            academic_year:
+          )
+        end
     end
 
     if (status = session_status&.to_sym).present?
@@ -89,7 +107,12 @@ class SearchForm
     end
 
     if (status = triage_status&.to_sym).present?
-      scope = scope.has_triage_status(status, programme: programmes)
+      scope =
+        if session
+          scope.has_triage_status(status, programme: programmes)
+        else
+          scope.has_triage_status(status, programme: programmes, academic_year:)
+        end
     end
 
     if vaccine_method.present?

--- a/app/forms/triage_form.rb
+++ b/app/forms/triage_form.rb
@@ -61,12 +61,13 @@ class TriageForm
 
   private
 
-  delegate :organisation, :patient, to: :patient_session
+  delegate :organisation, :patient, :session, to: :patient_session
+  delegate :academic_year, to: :session
 
   def consented_vaccine_methods
     @consented_vaccine_methods ||=
       vaccine_methods.presence ||
-        patient.consent_status(programme:).vaccine_methods
+        patient.consent_status(programme:, academic_year:).vaccine_methods
   end
 
   def triage_attributes

--- a/app/jobs/concerns/send_clinic_invitations_concern.rb
+++ b/app/jobs/concerns/send_clinic_invitations_concern.rb
@@ -21,7 +21,7 @@ module SendClinicInvitationsConcern
 
     already_sent_notification =
       patient_session.session_notifications.any? do
-        _1.session_date == session_date
+        it.session_date == session_date
       end
 
     return false if already_sent_notification
@@ -30,9 +30,11 @@ module SendClinicInvitationsConcern
 
     return false if eligible_programmes.empty?
 
+    academic_year = session_date.academic_year
+
     eligible_programmes.any? do |programme|
-      !patient.vaccination_status(programme:).vaccinated? &&
-        !patient.consent_status(programme:).refused?
+      !patient.vaccination_status(programme:, academic_year:).vaccinated? &&
+        !patient.consent_status(programme:, academic_year:).refused?
     end
   end
 

--- a/app/jobs/send_school_consent_reminders_job.rb
+++ b/app/jobs/send_school_consent_reminders_job.rb
@@ -42,10 +42,12 @@ class SendSchoolConsentRemindersJob < ApplicationJob
 
     return false unless patient.send_notifications?
 
+    academic_year = patient_session.academic_year
+
     suitable_programmes =
       programmes.select do |programme|
-        patient.consent_status(programme:).no_response? &&
-          patient.vaccination_status(programme:).none_yet?
+        patient.consent_status(programme:, academic_year:).no_response? &&
+          patient.vaccination_status(programme:, academic_year:).none_yet?
       end
 
     return false if suitable_programmes.empty?

--- a/app/jobs/send_school_consent_requests_job.rb
+++ b/app/jobs/send_school_consent_requests_job.rb
@@ -31,15 +31,15 @@ class SendSchoolConsentRequestsJob < ApplicationJob
   def should_send_notification?(patient:, programmes:)
     return false unless patient.send_notifications?
 
-    has_consent_or_vaccinated =
-      programmes.all? do |programme|
-        patient.consents.any? { it.programme_id == programme.id } ||
-          patient.vaccination_records.any? { it.programme_id == programme.id }
+    suitable_programmes =
+      programmes.select do |programme|
+        patient.consent_status(programme:).no_response? &&
+          patient.vaccination_status(programme:).none_yet?
       end
 
-    return false if has_consent_or_vaccinated
+    return false if suitable_programmes.empty?
 
-    programmes.any? do |programme|
+    suitable_programmes.any? do |programme|
       patient.consent_notifications.none? do
         it.request? && it.programmes.include?(programme)
       end

--- a/app/jobs/send_school_session_reminders_job.rb
+++ b/app/jobs/send_school_session_reminders_job.rb
@@ -33,16 +33,17 @@ class SendSchoolSessionRemindersJob < ApplicationJob
     return false unless patient.send_notifications?
 
     programmes = patient_session.programmes
+    academic_year = patient_session.academic_year
 
     all_vaccinated =
       programmes.all? do |programme|
-        patient.vaccination_status(programme:).vaccinated?
+        patient.vaccination_status(programme:, academic_year:).vaccinated?
       end
 
     return false if all_vaccinated
 
     programmes.any? do |programme|
-      patient.consent_given_and_safe_to_vaccinate?(programme:)
+      patient.consent_given_and_safe_to_vaccinate?(programme:, academic_year:)
     end
   end
 end

--- a/app/lib/consent_grouper.rb
+++ b/app/lib/consent_grouper.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 class ConsentGrouper
-  def initialize(consents, programme: nil, programme_id: nil)
+  def initialize(consents, programme_id:, academic_year:)
     @consents = consents
-    @programme_id = programme_id || programme&.id
-
-    raise "Provide a programme or programme id." if @programme_id.nil?
+    @programme_id = programme_id
+    @academic_year = academic_year
   end
 
   def call
     if consents.is_a?(Array) || consents.loaded?
       consents
         .select { it.programme_id == programme_id }
+        .select { it.academic_year == academic_year }
         .reject(&:invalidated?)
         .select(&:response_provided?)
         .group_by(&:name)
@@ -19,6 +19,7 @@ class ConsentGrouper
     else
       consents
         .where(programme_id:)
+        .for_academic_year(academic_year)
         .not_invalidated
         .response_provided
         .includes(:parent)
@@ -33,5 +34,5 @@ class ConsentGrouper
 
   private
 
-  attr_reader :consents, :programme_id
+  attr_reader :consents, :programme_id, :academic_year
 end

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -15,6 +15,9 @@ class GovukNotifyPersonalisation
     session: nil,
     vaccination_record: nil
   )
+    @academic_year =
+      consent&.academic_year || consent_form&.academic_year ||
+        session&.academic_year || vaccination_record&.academic_year
     @consent = consent
     @consent_form = consent_form
     @parent = parent || consent&.parent
@@ -78,7 +81,8 @@ class GovukNotifyPersonalisation
     }.compact
   end
 
-  attr_reader :consent,
+  attr_reader :academic_year,
+              :consent,
               :consent_form,
               :parent,
               :patient,
@@ -354,7 +358,10 @@ class GovukNotifyPersonalisation
             # We pick the first method as it's the one most likely to be used
             # to vaccinate the patient. For example, in the case of Flu, the
             # parents will approve nasal (and then optionally injection).
-            patient.approved_vaccine_methods(programme:).first == method
+            patient.approved_vaccine_methods(
+              programme:,
+              academic_year:
+            ).first == method
           end
         else
           Vaccine.where(programme: programmes, method:).exists?
@@ -374,7 +381,8 @@ class GovukNotifyPersonalisation
             # We pick the first method as it's the one most likely to be used
             # to vaccinate the patient. For example, in the case of Flu, the
             # parents will approve nasal (and then optionally injection).
-            method = patient.approved_vaccine_methods(programme:).first
+            method =
+              patient.approved_vaccine_methods(programme:, academic_year:).first
             Vaccine.where(programme:, method:).flat_map(&:side_effects)
           end
         else
@@ -410,7 +418,7 @@ class GovukNotifyPersonalisation
                 vaccination_record.delivery_method
               )
             elsif patient
-              patient.approved_vaccine_methods(programme:).first
+              patient.approved_vaccine_methods(programme:, academic_year:).first
             end
 
           method_prefix =

--- a/app/lib/reports/careplus_exporter.rb
+++ b/app/lib/reports/careplus_exporter.rb
@@ -1,9 +1,16 @@
 # frozen_string_literal: true
 
 class Reports::CareplusExporter
-  def initialize(organisation:, programme:, start_date:, end_date:)
+  def initialize(
+    organisation:,
+    programme:,
+    academic_year:,
+    start_date:,
+    end_date:
+  )
     @organisation = organisation
     @programme = programme
+    @academic_year = academic_year
     @start_date = start_date
     @end_date = end_date
   end
@@ -24,7 +31,7 @@ class Reports::CareplusExporter
 
   private
 
-  attr_reader :organisation, :programme, :start_date, :end_date
+  attr_reader :organisation, :programme, :academic_year, :start_date, :end_date
 
   def headers
     [
@@ -69,6 +76,7 @@ class Reports::CareplusExporter
       VaccinationRecord
         .kept
         .where(session: { organisation: }, programme:)
+        .for_academic_year(academic_year)
         .administered
         .order(:performed_at)
         .includes(:batch, :patient, :vaccine, session: :location)
@@ -107,6 +115,7 @@ class Reports::CareplusExporter
       Consent
         .select("DISTINCT ON (patient_id) consents.*")
         .where(patient: vaccination_records.select(:patient_id), programme:)
+        .for_academic_year(academic_year)
         .not_invalidated
         .response_given
         .order(:patient_id, created_at: :desc)

--- a/app/lib/reports/export_formatters.rb
+++ b/app/lib/reports/export_formatters.rb
@@ -25,8 +25,8 @@ module Reports::ExportFormatters
     location.school? ? "" : vaccination_record.location_name
   end
 
-  def consent_status(patient:, programme:)
-    consent_status = patient.consent_status(programme:)
+  def consent_status(patient:, programme:, academic_year:)
+    consent_status = patient.consent_status(programme:, academic_year:)
     if consent_status.given?
       "Consent given"
     elsif consent_status.refused?

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -195,9 +195,10 @@ class Reports::OfflineSessionExporter
 
   def rows(patient_session:)
     patient = patient_session.patient
+    academic_year = patient_session.academic_year
 
     patient_session.programmes.flat_map do |programme|
-      consent_status = patient.consent_status(programme:)
+      consent_status = patient.consent_status(programme:, academic_year:)
 
       bg_color =
         if consent_status.refused?
@@ -240,11 +241,13 @@ class Reports::OfflineSessionExporter
 
   def add_patient_cells(row, patient_session:, programme:)
     patient = patient_session.patient
+    session = patient_session.session
 
     grouped_consents = consents.dig(patient.id, programme.id) || []
     gillick_assessment =
       gillick_assessments.dig(patient_session.id, programme.id)
     triage = triages.dig(patient.id, programme.id)
+    academic_year = session.academic_year
 
     row[:organisation_code] = organisation.ods_code
     row[:person_forename] = patient.given_name
@@ -262,7 +265,7 @@ class Reports::OfflineSessionExporter
       patient.address_postcode unless patient.restricted?
     )
     row[:nhs_number] = patient.nhs_number
-    row[:consent_status] = consent_status(patient:, programme:)
+    row[:consent_status] = consent_status(patient:, programme:, academic_year:)
     row[:consent_details] = consent_details(consents: grouped_consents)
     row[:health_question_answers] = Cell.new(
       health_question_answers(consents: grouped_consents),

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -34,7 +34,7 @@ class Reports::OfflineSessionExporter
 
   attr_reader :session
 
-  delegate :location, :organisation, to: :session
+  delegate :academic_year, :location, :organisation, to: :session
 
   def add_vaccinations_sheet(package)
     workbook = package.workbook
@@ -151,11 +151,15 @@ class Reports::OfflineSessionExporter
         .not_invalidated
         .includes(:parent, patient: { parent_relationships: :parent })
         .group_by(&:patient_id)
-        .transform_values do
-          it
+        .transform_values do |consents_for_patient|
+          consents_for_patient
             .group_by(&:programme_id)
             .each_with_object({}) do |(programme_id, consents), hash|
-              hash[programme_id] = ConsentGrouper.call(consents, programme_id:)
+              hash[programme_id] = ConsentGrouper.call(
+                consents,
+                programme_id:,
+                academic_year:
+              )
             end
         end
   end

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -3,9 +3,16 @@
 class Reports::ProgrammeVaccinationsExporter
   include Reports::ExportFormatters
 
-  def initialize(organisation:, programme:, start_date:, end_date:)
+  def initialize(
+    organisation:,
+    programme:,
+    academic_year:,
+    start_date:,
+    end_date:
+  )
     @organisation = organisation
     @programme = programme
+    @academic_year = academic_year
     @start_date = start_date
     @end_date = end_date
   end
@@ -24,7 +31,7 @@ class Reports::ProgrammeVaccinationsExporter
 
   private
 
-  attr_reader :organisation, :programme, :start_date, :end_date
+  attr_reader :organisation, :programme, :academic_year, :start_date, :end_date
 
   def headers
     %w[
@@ -85,6 +92,7 @@ class Reports::ProgrammeVaccinationsExporter
       organisation
         .vaccination_records
         .where(programme:)
+        .for_academic_year(academic_year)
         .includes(
           :batch,
           :location,
@@ -129,8 +137,12 @@ class Reports::ProgrammeVaccinationsExporter
         .not_invalidated
         .includes(:parent, :patient)
         .group_by(&:patient_id)
-        .transform_values do
-          ConsentGrouper.call(it, programme_id: programme.id)
+        .transform_values do |consents_for_patient|
+          ConsentGrouper.call(
+            consents_for_patient,
+            programme_id: programme.id,
+            academic_year:
+          )
         end
   end
 
@@ -148,6 +160,7 @@ class Reports::ProgrammeVaccinationsExporter
           },
           programme:
         )
+        .for_academic_year(academic_year)
         .order(:patient_session_id, created_at: :desc)
         .includes(:performed_by)
         .group_by(&:patient_id)
@@ -161,6 +174,7 @@ class Reports::ProgrammeVaccinationsExporter
       Triage
         .select("DISTINCT ON (patient_id) triage.*")
         .where(patient_id: vaccination_records.select(:patient_id), programme:)
+        .for_academic_year(academic_year)
         .not_invalidated
         .order(:patient_id, created_at: :desc)
         .includes(:performed_by)

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -191,6 +191,7 @@ class Reports::ProgrammeVaccinationsExporter
     grouped_consents = consents.fetch(patient.id, [])
     triage = triages[patient.id]
     gillick_assessment = gillick_assessments.dig(patient.id, session.id)
+    academic_year = session.academic_year
 
     [
       organisation.ods_code,
@@ -210,7 +211,7 @@ class Reports::ProgrammeVaccinationsExporter
       nhs_number_status_code(patient:),
       patient.gp_practice&.ods_code || "",
       patient.gp_practice&.name || "",
-      consent_status(patient:, programme:),
+      consent_status(patient:, programme:, academic_year:),
       consent_details(consents: grouped_consents),
       health_question_answers(consents: grouped_consents),
       triage&.status&.humanize || "",

--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -32,9 +32,16 @@ class Reports::SystmOneExporter
     nasal_spray: "Nasal"
   }.with_indifferent_access.freeze
 
-  def initialize(organisation:, programme:, start_date:, end_date:)
+  def initialize(
+    organisation:,
+    programme:,
+    academic_year:,
+    start_date:,
+    end_date:
+  )
     @organisation = organisation
     @programme = programme
+    @academic_year = academic_year
     @start_date = start_date
     @end_date = end_date
   end
@@ -53,7 +60,7 @@ class Reports::SystmOneExporter
 
   private
 
-  attr_reader :organisation, :programme, :start_date, :end_date
+  attr_reader :organisation, :programme, :academic_year, :start_date, :end_date
 
   def headers
     [
@@ -87,6 +94,7 @@ class Reports::SystmOneExporter
         .vaccination_records
         .administered
         .where(programme:)
+        .for_academic_year(academic_year)
         .includes(:batch, :location, :vaccine, :patient)
 
     if start_date.present?

--- a/app/lib/status_updater.rb
+++ b/app/lib/status_updater.rb
@@ -86,7 +86,13 @@ class StatusUpdater
 
     PatientSession::SessionStatus
       .where(patient_session_id: patient_sessions.select(:id))
-      .includes(:consents, :triages, :vaccination_records, :session_attendance)
+      .includes(
+        :consents,
+        :session,
+        :triages,
+        :vaccination_records,
+        :session_attendance
+      )
       .find_in_batches(batch_size: 10_000) do |batch|
         batch.each(&:assign_status)
 

--- a/app/lib/triage_finder.rb
+++ b/app/lib/triage_finder.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class TriageFinder
+  def initialize(triages, programme_id:, academic_year:)
+    @triages = triages
+    @programme_id = programme_id
+    @academic_year = academic_year
+  end
+
+  def call
+    if triages.is_a?(Array) || triages.loaded?
+      triages
+        .select { it.programme_id == programme_id }
+        .select { it.academic_year == academic_year }
+        .reject(&:invalidated?)
+        .max_by(&:created_at)
+    else
+      triages
+        .where(programme_id:)
+        .for_academic_year(academic_year)
+        .not_invalidated
+        .order(created_at: :desc)
+        .first
+    end
+  end
+
+  def self.call(...) = new(...).call
+
+  private_class_method :new
+
+  private
+
+  attr_reader :triages, :programme_id, :academic_year
+end

--- a/app/lib/vaccinated_criteria.rb
+++ b/app/lib/vaccinated_criteria.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class VaccinatedCriteria
-  def initialize(programme:, patient:, vaccination_records:)
+  def initialize(programme:, academic_year:, patient:, vaccination_records:)
     @programme = programme
+    @academic_year = academic_year
     @patient = patient
     @vaccination_records = vaccination_records
   end
@@ -13,8 +14,8 @@ class VaccinatedCriteria
 
     if programme.seasonal?
       vaccination_records_for_programme
-        .select { it.administered? || it.already_had? }
-        .any?(&:performed_this_academic_year?)
+        .select { it.academic_year == academic_year }
+        .any? { it.administered? || it.already_had? }
     else
       return true if vaccination_records_for_programme.any?(&:already_had?)
 
@@ -44,5 +45,5 @@ class VaccinatedCriteria
 
   private
 
-  attr_reader :programme, :patient, :vaccination_records
+  attr_reader :programme, :academic_year, :patient, :vaccination_records
 end

--- a/app/models/concerns/belongs_to_academic_year.rb
+++ b/app/models/concerns/belongs_to_academic_year.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BelongsToAcademicYear
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def academic_year_attribute(name = nil)
+      @academic_year_attribute = name if name
+      @academic_year_attribute
+    end
+  end
+
+  included do
+    scope :for_academic_year,
+          ->(academic_year) do
+            where(
+              academic_year_attribute =>
+                academic_year.to_academic_year_date_range
+            )
+          end
+
+    def academic_year
+      __send__(self.class.academic_year_attribute).to_date.academic_year
+    end
+  end
+end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -112,6 +112,8 @@ class Consent < ApplicationRecord
     via_self_consent? ? patient.full_name : parent.label
   end
 
+  def academic_year = submitted_at.to_date.academic_year
+
   def response_provided? = !response_not_provided?
 
   def withdrawn?

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -41,6 +41,7 @@
 #
 
 class Consent < ApplicationRecord
+  include BelongsToAcademicYear
   include Invalidatable
   include HasHealthAnswers
   include HasVaccineMethods
@@ -87,6 +88,8 @@ class Consent < ApplicationRecord
        }
 
   encrypts :notes
+
+  academic_year_attribute :submitted_at
 
   validates :notes,
             presence: {

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -319,6 +319,8 @@ class ConsentForm < ApplicationRecord
       ].compact
   end
 
+  def academic_year = created_at.to_date.academic_year
+
   def recorded? = recorded_at != nil
 
   def response_given? = consent_form_programmes.any?(&:response_given?)

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -59,6 +59,7 @@ class ConsentForm < ApplicationRecord
   include AddressConcern
   include AgeConcern
   include Archivable
+  include BelongsToAcademicYear
   include FullNameConcern
   include GelatineVaccinesConcern
   include HasHealthAnswers
@@ -191,6 +192,8 @@ class ConsentForm < ApplicationRecord
   validates :notes, presence: { if: :archived? }, length: { maximum: 1000 }
 
   normalizes :nhs_number, with: -> { _1.blank? ? nil : _1.gsub(/\s/, "") }
+
+  academic_year_attribute :created_at
 
   on_wizard_step :name do
     validates :given_name, presence: true
@@ -557,10 +560,6 @@ class ConsentForm < ApplicationRecord
 
   def via_self_consent?
     false
-  end
-
-  def academic_year
-    created_at.to_date.academic_year
   end
 
   def health_answers_valid?

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -72,6 +72,7 @@ class ConsentNotification < ApplicationRecord
       patient:,
       session:,
       type:,
+      sent_at: Time.current,
       sent_by: current_user
     )
 

--- a/app/models/consent_notification.rb
+++ b/app/models/consent_notification.rb
@@ -24,6 +24,7 @@
 #  fk_rails_...  (session_id => sessions.id)
 #
 class ConsentNotification < ApplicationRecord
+  include BelongsToAcademicYear
   include Sendable
 
   self.inheritance_column = :nil
@@ -47,6 +48,8 @@ class ConsentNotification < ApplicationRecord
         ->(programme) { joins(:programmes).where(programmes: programme) }
 
   scope :reminder, -> { initial_reminder.or(subsequent_reminder) }
+
+  academic_year_attribute :sent_at
 
   def reminder?
     initial_reminder? || subsequent_reminder?

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -244,7 +244,9 @@ class DraftVaccinationRecord
   def vaccine_method_matches_consent_and_triage?
     return true if delivery_method.blank? || !administered?
 
-    approved_methods = patient.approved_vaccine_methods(programme:)
+    academic_year = session&.academic_year || performed_at.academic_year
+    approved_methods =
+      patient.approved_vaccine_methods(programme:, academic_year:)
     vaccine_method = Vaccine.delivery_method_to_vaccine_method(delivery_method)
 
     approved_methods.include?(vaccine_method)

--- a/app/models/gillick_assessment.rb
+++ b/app/models/gillick_assessment.rb
@@ -30,6 +30,8 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class GillickAssessment < ApplicationRecord
+  include BelongsToAcademicYear
+
   audited associated_with: :patient_session
 
   belongs_to :patient_session
@@ -44,6 +46,8 @@ class GillickAssessment < ApplicationRecord
   has_one :location, through: :session
 
   encrypts :notes
+
+  academic_year_attribute :created_at
 
   validates :knows_consequences,
             :knows_delivery,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -168,33 +168,33 @@ class Patient < ApplicationRecord
   scope :search_by_nhs_number, ->(nhs_number) { where(nhs_number:) }
 
   scope :has_vaccination_status,
-        ->(status, programme:) do
+        ->(status, programme:, academic_year:) do
           where(
             Patient::VaccinationStatus
               .where("patient_id = patients.id")
-              .where(status:, programme:)
+              .where(status:, programme:, academic_year:)
               .arel
               .exists
           )
         end
 
   scope :has_consent_status,
-        ->(status, programme:) do
+        ->(status, programme:, academic_year:) do
           where(
             Patient::ConsentStatus
               .where("patient_id = patients.id")
-              .where(status:, programme:)
+              .where(status:, programme:, academic_year:)
               .arel
               .exists
           )
         end
 
   scope :has_triage_status,
-        ->(status, programme:) do
+        ->(status, programme:, academic_year:) do
           where(
             Patient::TriageStatus
               .where("patient_id = patients.id")
-              .where(status:, programme:)
+              .where(status:, programme:, academic_year:)
               .arel
               .exists
           )

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -314,10 +314,9 @@ class Patient < ApplicationRecord
       consent_statuses.build(programme:)
   end
 
-  def triage_status(programme: nil, programme_id: nil)
-    programme_id ||= programme.id
-    triage_statuses.find { it.programme_id == programme_id } ||
-      triage_statuses.build(programme_id:)
+  def triage_status(programme:)
+    triage_statuses.find { it.programme_id == programme.id } ||
+      triage_statuses.build(programme:)
   end
 
   def vaccination_status(programme:)

--- a/app/models/patient/consent_status.rb
+++ b/app/models/patient/consent_status.rb
@@ -5,6 +5,7 @@
 # Table name: patient_consent_statuses
 #
 #  id              :bigint           not null, primary key
+#  academic_year   :integer          not null
 #  status          :integer          default("no_response"), not null
 #  vaccine_methods :integer          default([]), not null, is an Array
 #  patient_id      :bigint           not null
@@ -12,8 +13,8 @@
 #
 # Indexes
 #
-#  index_patient_consent_statuses_on_patient_id_and_programme_id  (patient_id,programme_id) UNIQUE
-#  index_patient_consent_statuses_on_status                       (status)
+#  idx_on_patient_id_programme_id_academic_year_1d3170e398  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_consent_statuses_on_status                 (status)
 #
 # Foreign Keys
 #

--- a/app/models/patient/consent_status.rb
+++ b/app/models/patient/consent_status.rb
@@ -103,6 +103,7 @@ class Patient::ConsentStatus < ApplicationRecord
   end
 
   def latest_consents
-    @latest_consents ||= ConsentGrouper.call(consents, programme_id:)
+    @latest_consents ||=
+      ConsentGrouper.call(consents, programme_id:, academic_year:)
   end
 end

--- a/app/models/patient/triage_status.rb
+++ b/app/models/patient/triage_status.rb
@@ -5,6 +5,7 @@
 # Table name: patient_triage_statuses
 #
 #  id             :bigint           not null, primary key
+#  academic_year  :integer          not null
 #  status         :integer          default("not_required"), not null
 #  vaccine_method :integer
 #  patient_id     :bigint           not null
@@ -12,8 +13,8 @@
 #
 # Indexes
 #
-#  index_patient_triage_statuses_on_patient_id_and_programme_id  (patient_id,programme_id) UNIQUE
-#  index_patient_triage_statuses_on_status                       (status)
+#  idx_on_patient_id_programme_id_academic_year_6cf32349df  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_triage_statuses_on_status                  (status)
 #
 # Foreign Keys
 #

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -4,15 +4,16 @@
 #
 # Table name: patient_vaccination_statuses
 #
-#  id           :bigint           not null, primary key
-#  status       :integer          default("none_yet"), not null
-#  patient_id   :bigint           not null
-#  programme_id :bigint           not null
+#  id            :bigint           not null, primary key
+#  academic_year :integer          not null
+#  status        :integer          default("none_yet"), not null
+#  patient_id    :bigint           not null
+#  programme_id  :bigint           not null
 #
 # Indexes
 #
-#  idx_on_patient_id_programme_id_e876faade2     (patient_id,programme_id) UNIQUE
-#  index_patient_vaccination_statuses_on_status  (status)
+#  idx_on_patient_id_programme_id_academic_year_fc0b47b743  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_vaccination_statuses_on_status             (status)
 #
 # Foreign Keys
 #

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -55,14 +55,21 @@ class Patient::VaccinationStatus < ApplicationRecord
   private
 
   def status_should_be_vaccinated?
-    VaccinatedCriteria.call(programme:, patient:, vaccination_records:)
+    VaccinatedCriteria.call(
+      programme:,
+      academic_year:,
+      patient:,
+      vaccination_records:
+    )
   end
 
   def status_should_be_could_not_vaccinate?
-    if ConsentGrouper.call(consents, programme_id:).any?(&:response_refused?)
+    if ConsentGrouper.call(consents, programme_id:, academic_year:).any?(
+         &:response_refused?
+       )
       return true
     end
 
-    triages.select { it.programme_id == programme_id }.last&.do_not_vaccinate?
+    TriageFinder.call(triages, programme_id:, academic_year:)&.do_not_vaccinate?
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -192,10 +192,12 @@ class PatientSession < ApplicationRecord
         ->(programmes:, vaccine_method:) do
           select do |patient_session|
             patient = patient_session.patient
+            session = patient_session.session
 
             programmes.any? do |programme|
               patient.consent_given_and_safe_to_vaccinate?(
                 programme:,
+                academic_year: session.academic_year,
                 vaccine_method:
               )
             end
@@ -211,6 +213,8 @@ class PatientSession < ApplicationRecord
           ).find_each(&:destroy_if_safe!)
         end
 
+  delegate :academic_year, to: :session
+
   def safe_to_destroy?
     vaccination_records.empty? && gillick_assessments.empty? &&
       session_attendances.none?(&:attending?)
@@ -221,7 +225,8 @@ class PatientSession < ApplicationRecord
   end
 
   def can_record_as_already_vaccinated?(programme:)
-    !session.today? && patient.vaccination_status(programme:).none_yet?
+    !session.today? &&
+      patient.vaccination_status(programme:, academic_year:).none_yet?
   end
 
   def programmes = session.eligible_programmes_for(patient:)
@@ -240,13 +245,19 @@ class PatientSession < ApplicationRecord
   end
 
   def next_activity(programme:)
-    return nil if patient.vaccination_status(programme:).vaccinated?
+    if patient.vaccination_status(programme:, academic_year:).vaccinated?
+      return nil
+    end
 
-    return :record if patient.consent_given_and_safe_to_vaccinate?(programme:)
+    if patient.consent_given_and_safe_to_vaccinate?(programme:, academic_year:)
+      return :record
+    end
 
-    return :triage if patient.triage_status(programme:).required?
+    if patient.triage_status(programme:, academic_year:).required?
+      return :triage
+    end
 
-    consent_status = patient.consent_status(programme:)
+    consent_status = patient.consent_status(programme:, academic_year:)
 
     return :consent if consent_status.no_response? || consent_status.conflicts?
 
@@ -268,7 +279,7 @@ class PatientSession < ApplicationRecord
 
     programmes.select do |programme|
       session_status(programme:).none_yet? &&
-        patient.consent_given_and_safe_to_vaccinate?(programme:)
+        patient.consent_given_and_safe_to_vaccinate?(programme:, academic_year:)
     end
   end
 end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -120,9 +120,10 @@ class PatientSession < ApplicationRecord
 
   scope :has_consent_status,
         ->(status, programme:) do
-          where(
+          joins(:session).where(
             Patient::ConsentStatus
               .where("patient_id = patient_sessions.patient_id")
+              .where("academic_year = sessions.academic_year")
               .where(status:, programme:)
               .arel
               .exists
@@ -153,9 +154,10 @@ class PatientSession < ApplicationRecord
 
   scope :has_triage_status,
         ->(status, programme:) do
-          where(
+          joins(:session).where(
             Patient::TriageStatus
               .where("patient_id = patient_sessions.patient_id")
+              .where("academic_year = sessions.academic_year")
               .where(status:, programme:)
               .arel
               .exists
@@ -164,22 +166,25 @@ class PatientSession < ApplicationRecord
 
   scope :has_vaccine_method,
         ->(vaccine_method, programme:) do
-          where(
+          joins(:session).where(
             Patient::TriageStatus
               .where("patient_id = patient_sessions.patient_id")
+              .where("academic_year = sessions.academic_year")
               .where(vaccine_method:, programme:)
               .arel
               .exists
           ).or(
-            where(
+            joins(:session).where(
               Patient::TriageStatus
                 .where("patient_id = patient_sessions.patient_id")
+                .where("academic_year = sessions.academic_year")
                 .where(status: "not_required", programme:)
                 .arel
                 .exists
             ).where(
               Patient::ConsentStatus
                 .where("patient_id = patient_sessions.patient_id")
+                .where("academic_year = sessions.academic_year")
                 .where(programme:)
                 .has_vaccine_method(vaccine_method)
                 .arel

--- a/app/models/patient_session/registration_status.rb
+++ b/app/models/patient_session/registration_status.rb
@@ -52,6 +52,8 @@ class PatientSession::RegistrationStatus < ApplicationRecord
 
   private
 
+  delegate :academic_year, to: :session
+
   def status_should_be_completed?
     patient_session.programmes.all? do |programme|
       vaccination_records.any? do

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -53,11 +53,13 @@ class SessionNotification < ApplicationRecord
     patient = patient_session.patient
     session = patient_session.session
 
+    academic_year = session.academic_year
+
     parents =
       if type == :school_reminder
         patient_session.programmes.flat_map do |programme|
           ConsentGrouper
-            .call(patient.consents, programme:)
+            .call(patient.consents, programme_id: programme.id, academic_year:)
             .select(&:response_given?)
             .filter_map(&:parent)
         end

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -85,10 +85,15 @@ class SessionNotification < ApplicationRecord
       sent_by: current_user
     )
 
+    academic_year = session_date.academic_year
+
     programmes =
       if type == :school_reminder
         patient_session.programmes.select do |programme|
-          patient.consent_given_and_safe_to_vaccinate?(programme:)
+          patient.consent_given_and_safe_to_vaccinate?(
+            programme:,
+            academic_year:
+          )
         end
       else
         patient_session.programmes

--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -79,6 +79,7 @@ class SessionNotification < ApplicationRecord
       session:,
       session_date:,
       type:,
+      sent_at: Time.current,
       sent_by: current_user
     )
 

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -31,6 +31,7 @@
 #  fk_rails_...  (programme_id => programmes.id)
 #
 class Triage < ApplicationRecord
+  include BelongsToAcademicYear
   include Invalidatable
 
   self.table_name = "triage"
@@ -61,4 +62,6 @@ class Triage < ApplicationRecord
        }
 
   encrypts :notes
+
+  academic_year_attribute :created_at
 end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -56,6 +56,7 @@
 #  fk_rails_...  (vaccine_id => vaccines.id)
 #
 class VaccinationRecord < ApplicationRecord
+  include BelongsToAcademicYear
   include Discard::Model
   include HasDoseVolume
   include PendingChangesConcern
@@ -139,6 +140,8 @@ class VaccinationRecord < ApplicationRecord
 
   encrypts :notes
 
+  academic_year_attribute :performed_at
+
   validates :notes, length: { maximum: 1000 }
 
   validates :location_name,
@@ -178,10 +181,6 @@ class VaccinationRecord < ApplicationRecord
 
   def recorded_in_service?
     session_id != nil
-  end
-
-  def academic_year
-    performed_at.to_date.academic_year
   end
 
   def performed_this_academic_year?

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -183,12 +183,12 @@ class VaccinationRecord < ApplicationRecord
     session_id != nil
   end
 
-  def performed_this_academic_year?
-    academic_year == AcademicYear.current
-  end
-
-  def show_this_academic_year?
-    programme.seasonal? ? performed_this_academic_year? : true
+  def show_in_academic_year?(current_academic_year)
+    if programme.seasonal?
+      academic_year == current_academic_year
+    else
+      academic_year >= current_academic_year
+    end
   end
 
   def delivery_method_snomed_code

--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -46,6 +46,7 @@ class VaccinationReport
     exporter_class.call(
       organisation: @current_user.selected_organisation,
       programme:,
+      academic_year:,
       start_date: date_from,
       end_date: date_to
     )

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -53,7 +53,7 @@
           href: session_patient_programme_path(@session, @patient, programme, return_to: params[:return_to]),
           text: programme.name,
           selected: @programme == programme,
-          ticked: @patient.vaccination_status(programme:).vaccinated?,
+          ticked: @patient.vaccination_status(programme:, academic_year: @academic_year).vaccinated?,
         )
       end
     

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -30,5 +30,7 @@
 
 <%= render AppCardComponent.new(section: true) do |card| %>
   <% card.with_heading { "Vaccinations" } %>
-  <%= render AppPatientVaccinationTableComponent.new(@patient, show_caption: false) %>
+  <%= render AppPatientVaccinationTableComponent.new(
+        @patient, academic_year: AcademicYear.current, show_caption: false,
+      ) %>
 <% end %>

--- a/app/views/programmes/patients/index.html.erb
+++ b/app/views/programmes/patients/index.html.erb
@@ -35,6 +35,7 @@
               patient,
               link_to: patient_path(patient),
               programme: @programme,
+              academic_year: Date.current.academic_year,
               triage_status: @form.triage_status,
               show_year_group: true,
             ) %>

--- a/db/migrate/20250718090719_add_academic_year_to_patient_statuses.rb
+++ b/db/migrate/20250718090719_add_academic_year_to_patient_statuses.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddAcademicYearToPatientStatuses < ActiveRecord::Migration[8.0]
+  TABLES = %i[
+    patient_consent_statuses
+    patient_triage_statuses
+    patient_vaccination_statuses
+  ].freeze
+
+  def up
+    TABLES.each { |table| add_column table, :academic_year, :integer }
+
+    academic_year = Date.current.academic_year
+
+    Patient::ConsentStatus.update_all(academic_year:)
+    Patient::TriageStatus.update_all(academic_year:)
+    Patient::VaccinationStatus.update_all(academic_year:)
+
+    TABLES.each do |table|
+      change_table table, bulk: true do |t|
+        t.change_null :academic_year, false
+        t.remove_index %i[patient_id programme_id]
+        t.index %i[patient_id programme_id academic_year], unique: true
+      end
+    end
+  end
+
+  def down
+    TABLES.each { |table| remove_column table, :academic_year }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_16_151841) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_18_090719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -565,7 +565,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_16_151841) do
     t.bigint "programme_id", null: false
     t.integer "status", default: 0, null: false
     t.integer "vaccine_methods", default: [], null: false, array: true
-    t.index ["patient_id", "programme_id"], name: "index_patient_consent_statuses_on_patient_id_and_programme_id", unique: true
+    t.integer "academic_year", null: false
+    t.index ["patient_id", "programme_id", "academic_year"], name: "idx_on_patient_id_programme_id_academic_year_1d3170e398", unique: true
     t.index ["status"], name: "index_patient_consent_statuses_on_status"
   end
 
@@ -614,7 +615,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_16_151841) do
     t.bigint "programme_id", null: false
     t.integer "status", default: 0, null: false
     t.integer "vaccine_method"
-    t.index ["patient_id", "programme_id"], name: "index_patient_triage_statuses_on_patient_id_and_programme_id", unique: true
+    t.integer "academic_year", null: false
+    t.index ["patient_id", "programme_id", "academic_year"], name: "idx_on_patient_id_programme_id_academic_year_6cf32349df", unique: true
     t.index ["status"], name: "index_patient_triage_statuses_on_status"
   end
 
@@ -622,7 +624,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_16_151841) do
     t.bigint "patient_id", null: false
     t.bigint "programme_id", null: false
     t.integer "status", default: 0, null: false
-    t.index ["patient_id", "programme_id"], name: "idx_on_patient_id_programme_id_e876faade2", unique: true
+    t.integer "academic_year", null: false
+    t.index ["patient_id", "programme_id", "academic_year"], name: "idx_on_patient_id_programme_id_academic_year_fc0b47b743", unique: true
     t.index ["status"], name: "index_patient_vaccination_statuses_on_status"
   end
 

--- a/lib/generate/triages.rb
+++ b/lib/generate/triages.rb
@@ -27,12 +27,14 @@ module Generate
 
     private
 
+    def academic_year = Date.current.academic_year
+
     def patients
       (@session.presence || organisation)
         .patients
         .includes(:triage_statuses)
-        .in_programmes([programme], academic_year: AcademicYear.current)
-        .select { it.triage_status(programme:).required? }
+        .in_programmes([programme], academic_year:)
+        .select { it.triage_status(programme:, academic_year:).required? }
     end
 
     def random_patients(count)

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -95,7 +95,12 @@ module Generate
         )
         .in_programmes([programme], academic_year: AcademicYear.current)
         .has_consent_status("given", programme:)
-        .select { it.patient.consent_given_and_safe_to_vaccinate?(programme:) }
+        .select do
+          it.patient.consent_given_and_safe_to_vaccinate?(
+            programme:,
+            academic_year: it.session.academic_year
+          )
+        end
     end
 
     def vaccine

--- a/spec/components/app_patient_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_search_result_card_component_spec.rb
@@ -16,6 +16,7 @@ describe AppPatientSearchResultCardComponent do
 
   let(:link_to) { "/patient" }
   let(:programme) { nil }
+  let(:academic_year) { nil }
   let(:triage_status) { "" }
   let(:show_postcode) { false }
   let(:show_school) { false }
@@ -25,6 +26,7 @@ describe AppPatientSearchResultCardComponent do
       patient,
       link_to:,
       programme:,
+      academic_year:,
       triage_status:,
       show_postcode:,
       show_school:
@@ -50,6 +52,7 @@ describe AppPatientSearchResultCardComponent do
 
   context "when given a programme" do
     let(:programme) { create(:programme, :flu) }
+    let(:academic_year) { Date.current.academic_year }
 
     it { should have_text("Programme outcome\nFluNo outcome yet") }
     it { should_not have_text("Triage status") }

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -128,12 +128,15 @@ describe AppPatientSessionSearchResultCardComponent do
 
     context "and the programme is flu" do
       let(:programme) { create(:programme, :flu) }
+      let(:academic_year) { Date.current.academic_year }
 
       it { should have_text("Vaccination method") }
       it { should have_text("Nasal") }
 
       context "and once vaccinated" do
-        before { patient.vaccination_status(programme:).vaccinated! }
+        before do
+          patient.vaccination_status(programme:, academic_year:).vaccinated!
+        end
 
         it { should_not have_text("Vaccination method") }
       end

--- a/spec/components/app_patient_vaccination_table_component_spec.rb
+++ b/spec/components/app_patient_vaccination_table_component_spec.rb
@@ -3,9 +3,12 @@
 describe AppPatientVaccinationTableComponent do
   subject { render_inline(component) }
 
-  let(:component) { described_class.new(patient, programme:, show_caption:) }
+  let(:component) do
+    described_class.new(patient, academic_year:, programme:, show_caption:)
+  end
 
   let(:patient) { create(:patient) }
+  let(:academic_year) { 2023 }
   let(:programme) { nil }
   let(:show_caption) { false }
 

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -26,11 +26,14 @@ describe AppVaccinateFormComponent do
 
   it { should have_css(".nhsuk-card") }
 
-  context "with a Flu programme and consent to nasal spray" do
+  context "with a flu programme and consent to nasal spray" do
     let(:programme) { create(:programme, :flu) }
+    let(:academic_year) { Date.current.academic_year }
 
     before do
-      patient.consent_status(programme:).update!(vaccine_methods: %w[nasal])
+      patient.consent_status(programme:, academic_year:).update!(
+        vaccine_methods: %w[nasal]
+      )
     end
 
     it { should have_content("Has Hari confirmed their identity?") }
@@ -64,14 +67,15 @@ describe AppVaccinateFormComponent do
     it { should have_field("Other") }
   end
 
-  context "with a Flu programme, consent to nasal spray, but triaged for injection" do
+  context "with a flu programme, consent to nasal spray, but triaged for injection" do
     let(:programme) { create(:programme, :flu) }
+    let(:academic_year) { Date.current.academic_year }
 
     before do
-      patient.consent_status(programme:).update!(
+      patient.consent_status(programme:, academic_year:).update!(
         vaccine_methods: %w[nasal injection]
       )
-      patient.triage_status(programme:).update!(
+      patient.triage_status(programme:, academic_year:).update!(
         status: "safe_to_vaccinate",
         vaccine_method: "injection"
       )

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -19,14 +19,15 @@ describe TriageMailerConcern do
   let(:current_user) { create(:user) }
 
   let(:programme) { create(:programme) }
+  let(:programmes) { [programme] }
   let(:patient) { patient_session.patient }
 
   describe "#send_triage_confirmation" do
     subject(:send_triage_confirmation) do
-      sample.send_triage_confirmation(patient_session, consent)
+      sample.send_triage_confirmation(patient_session, programme, consent)
     end
 
-    let(:session) { create(:session, programmes: [programme]) }
+    let(:session) { create(:session, programmes:) }
     let(:consent) { patient.consents.first }
 
     context "when the parents agree, triage is required and it is safe to vaccinate" do
@@ -178,7 +179,14 @@ describe TriageMailerConcern do
     end
 
     context "if the patient is deceased" do
-      let(:patient) { create(:patient, :deceased) }
+      let(:patient) do
+        create(
+          :patient,
+          :consent_given_triage_not_needed,
+          :deceased,
+          programmes:
+        )
+      end
       let(:patient_session) { create(:patient_session, patient:, session:) }
 
       it "doesn't send an email" do
@@ -191,7 +199,14 @@ describe TriageMailerConcern do
     end
 
     context "if the patient is invalid" do
-      let(:patient) { create(:patient, :invalidated) }
+      let(:patient) do
+        create(
+          :patient,
+          :consent_given_triage_not_needed,
+          :invalidated,
+          programmes:
+        )
+      end
       let(:patient_session) { create(:patient_session, patient:, session:) }
 
       it "doesn't send an email" do
@@ -204,7 +219,14 @@ describe TriageMailerConcern do
     end
 
     context "if the patient is restricted" do
-      let(:patient) { create(:patient, :restricted) }
+      let(:patient) do
+        create(
+          :patient,
+          :consent_given_triage_not_needed,
+          :restricted,
+          programmes:
+        )
+      end
       let(:patient_session) { create(:patient_session, patient:, session:) }
 
       it "doesn't send an email" do

--- a/spec/factories/patient_consent_statuses.rb
+++ b/spec/factories/patient_consent_statuses.rb
@@ -5,6 +5,7 @@
 # Table name: patient_consent_statuses
 #
 #  id              :bigint           not null, primary key
+#  academic_year   :integer          not null
 #  status          :integer          default("no_response"), not null
 #  vaccine_methods :integer          default([]), not null, is an Array
 #  patient_id      :bigint           not null
@@ -12,8 +13,8 @@
 #
 # Indexes
 #
-#  index_patient_consent_statuses_on_patient_id_and_programme_id  (patient_id,programme_id) UNIQUE
-#  index_patient_consent_statuses_on_status                       (status)
+#  idx_on_patient_id_programme_id_academic_year_1d3170e398  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_consent_statuses_on_status                 (status)
 #
 # Foreign Keys
 #

--- a/spec/factories/patient_consent_statuses.rb
+++ b/spec/factories/patient_consent_statuses.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
   factory :patient_consent_status, class: "Patient::ConsentStatus" do
     patient
     programme
+    academic_year { Date.current.academic_year }
 
     traits_for_enum :status
 

--- a/spec/factories/patient_triage_statuses.rb
+++ b/spec/factories/patient_triage_statuses.rb
@@ -5,6 +5,7 @@
 # Table name: patient_triage_statuses
 #
 #  id             :bigint           not null, primary key
+#  academic_year  :integer          not null
 #  status         :integer          default("not_required"), not null
 #  vaccine_method :integer
 #  patient_id     :bigint           not null
@@ -12,8 +13,8 @@
 #
 # Indexes
 #
-#  index_patient_triage_statuses_on_patient_id_and_programme_id  (patient_id,programme_id) UNIQUE
-#  index_patient_triage_statuses_on_status                       (status)
+#  idx_on_patient_id_programme_id_academic_year_6cf32349df  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_triage_statuses_on_status                  (status)
 #
 # Foreign Keys
 #

--- a/spec/factories/patient_triage_statuses.rb
+++ b/spec/factories/patient_triage_statuses.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
   factory :patient_triage_status, class: "Patient::TriageStatus" do
     patient
     programme
+    academic_year { Date.current.academic_year }
 
     traits_for_enum :status
 

--- a/spec/factories/patient_vaccination_statuses.rb
+++ b/spec/factories/patient_vaccination_statuses.rb
@@ -4,15 +4,16 @@
 #
 # Table name: patient_vaccination_statuses
 #
-#  id           :bigint           not null, primary key
-#  status       :integer          default("none_yet"), not null
-#  patient_id   :bigint           not null
-#  programme_id :bigint           not null
+#  id            :bigint           not null, primary key
+#  academic_year :integer          not null
+#  status        :integer          default("none_yet"), not null
+#  patient_id    :bigint           not null
+#  programme_id  :bigint           not null
 #
 # Indexes
 #
-#  idx_on_patient_id_programme_id_e876faade2     (patient_id,programme_id) UNIQUE
-#  index_patient_vaccination_statuses_on_status  (status)
+#  idx_on_patient_id_programme_id_academic_year_fc0b47b743  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_vaccination_statuses_on_status             (status)
 #
 # Foreign Keys
 #

--- a/spec/factories/patient_vaccination_statuses.rb
+++ b/spec/factories/patient_vaccination_statuses.rb
@@ -24,6 +24,7 @@ FactoryBot.define do
   factory :patient_vaccination_status, class: "Patient::VaccinationStatus" do
     patient
     programme
+    academic_year { Date.current.academic_year }
 
     traits_for_enum :status
   end

--- a/spec/features/cli_generate_vaccination_records_spec.rb
+++ b/spec/features/cli_generate_vaccination_records_spec.rb
@@ -2,8 +2,8 @@
 
 require_relative "../../app/lib/mavis_cli"
 
-describe "mavis generate vaccination_records" do
-  it "generates consents" do
+describe "mavis generate vaccination-records" do
+  it "generates vaccination records" do
     given_an_organisation_exists
     and_there_is_a_patient_in_a_session
     when_i_run_the_generate_vaccination_records_command
@@ -64,7 +64,11 @@ describe "mavis generate vaccination_records" do
       @organisation
         .reload
         .patients
-        .has_vaccination_status(:vaccinated, programme: @programme)
+        .has_vaccination_status(
+          :vaccinated,
+          programme: @programme,
+          academic_year: AcademicYear.current
+        )
         .count
     ).to eq 1
   end

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -400,7 +400,7 @@ describe "Edit vaccination record" do
   end
 
   def when_i_fill_in_a_valid_date_and_time
-    fill_in "Year", with: "2023"
+    fill_in "Year", with: "2024"
     fill_in "Month", with: "9"
     fill_in "Day", with: "1"
 
@@ -437,7 +437,7 @@ describe "Edit vaccination record" do
   end
 
   def and_i_should_see_the_updated_date_time
-    expect(page).to have_content("Date1 September 2023")
+    expect(page).to have_content("Date1 September 2024")
     expect(page).to have_content("Time12:00pm")
   end
 

--- a/spec/features/todays_batch_spec.rb
+++ b/spec/features/todays_batch_spec.rb
@@ -76,9 +76,10 @@ describe "Today’s batch" do
         year_group: 8
       )
 
-    @patient2.consent_status(programme: flu_programme).update!(
-      vaccine_methods: %w[nasal]
-    )
+    @patient2.consent_status(
+      programme: flu_programme,
+      academic_year: Date.current.academic_year
+    ).update!(vaccine_methods: %w[nasal])
 
     sign_in organisation.users.first
   end

--- a/spec/forms/search_form_spec.rb
+++ b/spec/forms/search_form_spec.rb
@@ -154,7 +154,7 @@ describe SearchForm do
 
       let(:programme) { create(:programme) }
 
-      it "filters on session status" do
+      it "filters on programme status" do
         patient = create(:patient, :vaccinated, programmes: [programme])
         session = create(:session, programmes: [programme])
         create(:patient_session, patient:, session:)
@@ -274,17 +274,14 @@ describe SearchForm do
       let(:year_groups) { nil }
 
       let(:programme) { create(:programme) }
+      let(:session) { create(:session, programmes: [programme]) }
 
       it "filters on consent status" do
         patient_session_given =
-          create(
-            :patient_session,
-            :consent_given_triage_not_needed,
-            programmes: [programme]
-          )
+          create(:patient_session, :consent_given_triage_not_needed, session:)
 
         patient_session_refused =
-          create(:patient_session, :consent_refused, programmes: [programme])
+          create(:patient_session, :consent_refused, session:)
 
         expect(form.apply(scope)).to contain_exactly(
           patient_session_given,
@@ -350,14 +347,12 @@ describe SearchForm do
       let(:year_groups) { nil }
 
       let(:programme) { create(:programme) }
+      let(:session) { create(:session, programmes: [programme]) }
 
       it "filters on triage status" do
         patient_session =
-          create(
-            :patient_session,
-            :consent_given_triage_needed,
-            programmes: [programme]
-          )
+          create(:patient_session, :consent_given_triage_needed, session:)
+
         expect(form.apply(scope)).to include(patient_session)
       end
     end

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -388,6 +388,7 @@ describe GovukNotifyPersonalisation do
           :patient_consent_status,
           :given,
           patient:,
+          academic_year: session.academic_year,
           programme: programmes.first
         )
       end
@@ -404,6 +405,7 @@ describe GovukNotifyPersonalisation do
           :given,
           patient:,
           programme: programmes.first,
+          academic_year: session.academic_year,
           vaccine_methods: %w[nasal injection]
         )
       end
@@ -420,13 +422,15 @@ describe GovukNotifyPersonalisation do
           :given,
           patient:,
           programme: programmes.first,
+          academic_year: session.academic_year,
           vaccine_methods: %w[nasal injection]
         )
         create(
           :patient_consent_status,
           :given,
           patient:,
-          programme: programmes.second
+          programme: programmes.second,
+          academic_year: session.academic_year
         )
       end
 
@@ -453,7 +457,8 @@ describe GovukNotifyPersonalisation do
           :safe_to_vaccinate,
           :injection,
           patient:,
-          programme: programmes.first
+          programme: programmes.first,
+          academic_year: session.academic_year
         )
       end
 

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -5,10 +5,13 @@ describe Reports::CareplusExporter do
     described_class.call(
       organisation:,
       programme:,
+      academic_year:,
       start_date: 1.month.ago.to_date,
       end_date: Date.current
     )
   end
+
+  let(:academic_year) { AcademicYear.current }
 
   shared_examples "generates a report" do
     let(:programmes) { [programme] }

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -2,8 +2,19 @@
 
 describe Reports::ProgrammeVaccinationsExporter do
   subject(:call) do
-    described_class.call(organisation:, programme:, start_date:, end_date:)
+    described_class.call(
+      organisation:,
+      programme:,
+      academic_year:,
+      start_date:,
+      end_date:
+    )
   end
+
+  let(:today) { Time.zone.local(2024, 4, 1) }
+  let(:academic_year) { today.to_date.academic_year }
+
+  around { |example| travel_to(today) { example.run } }
 
   shared_examples "generates a report" do
     let(:programmes) { [programme] }
@@ -85,8 +96,6 @@ describe Reports::ProgrammeVaccinationsExporter do
 
     describe "rows" do
       subject(:rows) { CSV.parse(call, headers: true) }
-
-      around { |example| freeze_time { example.run } }
 
       context "a school session" do
         let(:location) { create(:school, team:) }

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -9,11 +9,13 @@ describe Reports::SystmOneExporter do
     described_class.call(
       organisation:,
       programme:,
+      academic_year:,
       start_date: 1.month.ago.to_date,
       end_date: Date.current
     )
   end
   let(:programme) { create(:programme, :hpv, organisations: [organisation]) }
+  let(:academic_year) { AcademicYear.current }
   let(:organisation) { create(:organisation, ods_code: "ABC123") }
   let(:location) { create(:school) }
   let(:session) do

--- a/spec/lib/vaccinated_criteria_spec.rb
+++ b/spec/lib/vaccinated_criteria_spec.rb
@@ -2,8 +2,16 @@
 
 describe VaccinatedCriteria do
   describe "#call" do
-    subject { described_class.call(programme:, patient:, vaccination_records:) }
+    subject do
+      described_class.call(
+        programme:,
+        academic_year:,
+        patient:,
+        vaccination_records:
+      )
+    end
 
+    let(:academic_year) { AcademicYear.current }
     let(:patient) { create(:patient, date_of_birth: 15.years.ago.to_date) }
     let(:vaccination_records) { [] }
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -56,6 +56,10 @@
 #
 
 describe ConsentForm do
+  subject(:consent_form) { build(:consent_form) }
+
+  it_behaves_like "a model that belongs to an academic year", :created_at
+
   describe "validations" do
     subject(:consent_form) do
       create(

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -24,6 +24,10 @@
 #  fk_rails_...  (session_id => sessions.id)
 #
 describe ConsentNotification do
+  it_behaves_like "a model that belongs to an academic year", :sent_at do
+    subject { build(:consent_notification, :request) }
+  end
+
   describe "#create_and_send!" do
     subject(:create_and_send!) do
       travel_to(today) do

--- a/spec/models/consent_notification_spec.rb
+++ b/spec/models/consent_notification_spec.rb
@@ -65,7 +65,7 @@ describe ConsentNotification do
         expect(consent_notification).not_to be_reminder
         expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
-        expect(consent_notification.sent_at).to be_today
+        expect(consent_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent" do
@@ -168,7 +168,7 @@ describe ConsentNotification do
         expect(consent_notification).not_to be_reminder
         expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
-        expect(consent_notification.sent_at).to be_today
+        expect(consent_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent" do
@@ -236,7 +236,7 @@ describe ConsentNotification do
         expect(consent_notification).to be_reminder
         expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
-        expect(consent_notification.sent_at).to be_today
+        expect(consent_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent" do
@@ -338,7 +338,7 @@ describe ConsentNotification do
         expect(consent_notification).to be_reminder
         expect(consent_notification.programmes).to eq(programmes)
         expect(consent_notification.patient).to eq(patient)
-        expect(consent_notification.sent_at).to be_today
+        expect(consent_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent" do

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -41,6 +41,10 @@
 #
 
 describe Consent do
+  subject(:consent) { build(:consent) }
+
+  it_behaves_like "a model that belongs to an academic year", :submitted_at
+
   describe "validations" do
     it { should validate_length_of(:notes).is_at_most(1000) }
 

--- a/spec/models/gillick_assessment_spec.rb
+++ b/spec/models/gillick_assessment_spec.rb
@@ -32,6 +32,10 @@
 describe GillickAssessment do
   subject(:gillick_assessment) { build(:gillick_assessment) }
 
+  it_behaves_like "a model that belongs to an academic year", :created_at do
+    subject { build(:gillick_assessment, :competent) }
+  end
+
   describe "validations" do
     it { should allow_values(true, false).for(:knows_consequences) }
     it { should allow_values(true, false).for(:knows_delivery) }

--- a/spec/models/patient/consent_status_spec.rb
+++ b/spec/models/patient/consent_status_spec.rb
@@ -5,6 +5,7 @@
 # Table name: patient_consent_statuses
 #
 #  id              :bigint           not null, primary key
+#  academic_year   :integer          not null
 #  status          :integer          default("no_response"), not null
 #  vaccine_methods :integer          default([]), not null, is an Array
 #  patient_id      :bigint           not null
@@ -12,8 +13,8 @@
 #
 # Indexes
 #
-#  index_patient_consent_statuses_on_patient_id_and_programme_id  (patient_id,programme_id) UNIQUE
-#  index_patient_consent_statuses_on_status                       (status)
+#  idx_on_patient_id_programme_id_academic_year_1d3170e398  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_consent_statuses_on_status                 (status)
 #
 # Foreign Keys
 #

--- a/spec/models/patient/triage_status_spec.rb
+++ b/spec/models/patient/triage_status_spec.rb
@@ -5,6 +5,7 @@
 # Table name: patient_triage_statuses
 #
 #  id             :bigint           not null, primary key
+#  academic_year  :integer          not null
 #  status         :integer          default("not_required"), not null
 #  vaccine_method :integer
 #  patient_id     :bigint           not null
@@ -12,8 +13,8 @@
 #
 # Indexes
 #
-#  index_patient_triage_statuses_on_patient_id_and_programme_id  (patient_id,programme_id) UNIQUE
-#  index_patient_triage_statuses_on_status                       (status)
+#  idx_on_patient_id_programme_id_academic_year_6cf32349df  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_triage_statuses_on_status                  (status)
 #
 # Foreign Keys
 #

--- a/spec/models/patient/vaccination_status_spec.rb
+++ b/spec/models/patient/vaccination_status_spec.rb
@@ -4,15 +4,16 @@
 #
 # Table name: patient_vaccination_statuses
 #
-#  id           :bigint           not null, primary key
-#  status       :integer          default("none_yet"), not null
-#  patient_id   :bigint           not null
-#  programme_id :bigint           not null
+#  id            :bigint           not null, primary key
+#  academic_year :integer          not null
+#  status        :integer          default("none_yet"), not null
+#  patient_id    :bigint           not null
+#  programme_id  :bigint           not null
 #
 # Indexes
 #
-#  idx_on_patient_id_programme_id_e876faade2     (patient_id,programme_id) UNIQUE
-#  index_patient_vaccination_statuses_on_status  (status)
+#  idx_on_patient_id_programme_id_academic_year_fc0b47b743  (patient_id,programme_id,academic_year) UNIQUE
+#  index_patient_vaccination_statuses_on_status             (status)
 #
 # Foreign Keys
 #

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -50,6 +50,7 @@ describe PatientSession do
       end
 
       let(:programmes) { [create(:programme, :flu), create(:programme, :hpv)] }
+      let(:academic_year) { Date.current.academic_year }
       let(:vaccine_method) { nil }
 
       it { should be_empty }
@@ -81,7 +82,7 @@ describe PatientSession do
           before do
             patient_session
               .patient
-              .consent_status(programme: programmes.first)
+              .consent_status(programme: programmes.first, academic_year:)
               .update!(vaccine_methods: %w[nasal injection])
           end
 
@@ -91,7 +92,7 @@ describe PatientSession do
             before do
               patient_session
                 .patient
-                .vaccination_status(programme: programmes.first)
+                .vaccination_status(programme: programmes.first, academic_year:)
                 .vaccinated!
             end
 

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -323,11 +323,12 @@ describe Patient do
 
   describe "#approved_vaccine_methods" do
     subject(:approved_vaccine_methods) do
-      patient.approved_vaccine_methods(programme:)
+      patient.approved_vaccine_methods(programme:, academic_year:)
     end
 
     let(:patient) { create(:patient) }
     let(:programme) { create(:programme) }
+    let(:academic_year) { Date.current.academic_year }
 
     it { should be_empty }
 
@@ -361,7 +362,7 @@ describe Patient do
 
       context "and when triaged" do
         before do
-          patient.triage_status(programme:).update!(
+          patient.triage_status(programme:, academic_year:).update!(
             status: "safe_to_vaccinate",
             vaccine_method: "nasal"
           )

--- a/spec/models/session_notification_spec.rb
+++ b/spec/models/session_notification_spec.rb
@@ -69,7 +69,7 @@ describe SessionNotification do
         expect(session_notification).to be_school_reminder
         expect(session_notification.session).to eq(session)
         expect(session_notification.patient).to eq(patient)
-        expect(session_notification.sent_at).to be_today
+        expect(session_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent who gave consent" do
@@ -136,7 +136,7 @@ describe SessionNotification do
         expect(session_notification).to be_clinic_initial_invitation
         expect(session_notification.session).to eq(session)
         expect(session_notification.patient).to eq(patient)
-        expect(session_notification.sent_at).to be_today
+        expect(session_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent" do
@@ -234,7 +234,7 @@ describe SessionNotification do
         expect(session_notification).to be_clinic_subsequent_invitation
         expect(session_notification.session).to eq(session)
         expect(session_notification.patient).to eq(patient)
-        expect(session_notification.sent_at).to be_today
+        expect(session_notification.sent_at).to eq(today)
       end
 
       it "enqueues an email per parent" do

--- a/spec/models/triage_spec.rb
+++ b/spec/models/triage_spec.rb
@@ -34,6 +34,8 @@
 describe Triage do
   subject { build(:triage) }
 
+  it_behaves_like "a model that belongs to an academic year", :created_at
+
   describe "validations" do
     context "when safe to vaccinate" do
       subject(:triage) { build(:triage, :ready_to_vaccinate) }

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -59,6 +59,8 @@
 describe VaccinationRecord do
   subject(:vaccination_record) { build(:vaccination_record) }
 
+  it_behaves_like "a model that belongs to an academic year", :performed_at
+
   describe "associations" do
     it { should have_one(:identity_check).autosave(true).dependent(:destroy) }
   end

--- a/spec/support/shared_examples/a_model_that_belongs_to_an_academic_year.rb
+++ b/spec/support/shared_examples/a_model_that_belongs_to_an_academic_year.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+shared_examples_for "a model that belongs to an academic year" do |attribute|
+  describe "#academic_year" do
+    let(:examples) do
+      {
+        Date.new(2020, 9, 1) => 2020,
+        Date.new(2021, 8, 31) => 2020,
+        Date.new(2021, 9, 1) => 2021,
+        Date.new(2022, 8, 31) => 2021
+      }
+    end
+
+    examples.each do |date, academic_year|
+      context "with #{date}" do
+        before { subject[attribute] = date }
+
+        it { expect(subject.academic_year).to eq(academic_year) }
+      end
+    end
+  end
+
+  describe "#for_academic_year" do
+    before { subject.save! }
+
+    it "returns the correct records" do
+      academic_year = subject.academic_year
+
+      expect(described_class.for_academic_year(academic_year)).to include(
+        subject
+      )
+
+      expect(
+        described_class.for_academic_year(academic_year + 1)
+      ).not_to include(subject)
+    end
+  end
+end


### PR DESCRIPTION
This updates the three patient status models (consent, triage and vaccination) to consider the academic year when generating the status. Specifically, we now create distinct instances of these models per academic year, allowing for various views in the service to be tailored to a specific academic year. See individual commits for more details.

In terms of test coverage, most of this has been implemented by adding `academic_year` as a required argument in a number of places, and therefore the tests passing indicates that this is being taken in to account, however it's worth adding more test coverage in follow up PRs as we implement the various features of rollback that will be built upon this work.

We should be careful about any potential performance implications from this change, specifically the number of consent status, triage status and vaccination statuses will double each academic year. The migration which adds the new column also updates the index, and this is likely going to block the tables while it's running, so I would recommend that we run this out of hours.

[Jira Issue - MAV-267](https://nhsd-jira.digital.nhs.uk/browse/MAV-267)