### PR TITLE
Readonly container filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,8 @@ USER 1000:1000
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
+VOLUME ["/rails/tmp", "rails/log", "/tmp", "/var/log", "/var/lib/amazon/ssm"]
+
 # Start web server by default, this can be overwritten by environment variable
 EXPOSE 4000
 ENV HTTP_PORT=4000

--- a/terraform/app/modules/ecs_service/main.tf
+++ b/terraform/app/modules/ecs_service/main.tf
@@ -79,9 +79,10 @@ resource "aws_ecs_task_definition" "this" {
   task_role_arn            = var.task_config.task_role_arn
   container_definitions = jsonencode([
     {
-      name      = var.container_name
-      image     = var.task_config.docker_image
-      essential = true
+      name                   = var.container_name
+      image                  = var.task_config.docker_image
+      essential              = true
+      readonlyRootFileSystem = true
       portMappings = [
         {
           containerPort = 4000


### PR DESCRIPTION
Making the ECS container filesystem readonly prevents unlimited write access in case a running container gets compromised.
Specific write-access is allowed to certain directories that are added as volumes in the Dockerfile. In addition to the rails directories, the SSM systems manager that gives CLI access on running containers also needs write access to certain directories