### PR TITLE
Revert "Pin mise version"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,5 @@ jobs:
       - run: tflint --chdir=terraform --init
       - uses: jdx/mise-action@v2
         with:
-          version: v2025.7.12
           install_args: hk pkl
       - run: hk check --all


### PR DESCRIPTION
This reverts commit ed98acd9a9c78ab9a8c99044efe90b5c6b8098bf.

The issue with downloading the latest version of mise seems to have been fixed.