### PR TITLE
Academic year preparation start date

### DIFF
--- a/app/lib/academic_year.rb
+++ b/app/lib/academic_year.rb
@@ -11,6 +11,17 @@ module AcademicYear
     # when changing the date in tests).
     def first = [2024, current].min
 
-    def last = current
+    def last = preparation? ? current + 1 : current
+
+    def preparation? = Date.current >= preparation_start_date
+
+    private
+
+    def preparation_start_date
+      start_date = (current + 1).to_academic_year_date_range.first
+      days_of_preparation =
+        Settings.number_of_preparation_days_before_academic_year_starts.to_i
+      start_date - days_of_preparation.days
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,9 @@ allow_dev_phone_numbers: false
 disallow_database_seeding: true
 web_concurrency: 2
 
+# Preparation normally starts on the 1st August.
+number_of_preparation_days_before_academic_year_starts: 31
+
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via
 # Devise.
 cis2:

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -4,13 +4,25 @@ describe AcademicYear do
   describe "#all" do
     subject { travel_to(today) { described_class.all } }
 
-    context "in 2024" do
+    context "first day of 2024" do
       let(:today) { Date.new(2024, 9, 1) }
 
       it { should eq([2024]) }
     end
 
-    context "in 2025" do
+    context "last day of only 2024" do
+      let(:today) { Date.new(2025, 7, 31) }
+
+      it { should eq([2024]) }
+    end
+
+    context "preparing for 2025" do
+      let(:today) { Date.new(2025, 8, 1) }
+
+      it { should eq([2024, 2025]) }
+    end
+
+    context "first day of 2025" do
       let(:today) { Date.new(2025, 9, 1) }
 
       it { should eq([2024, 2025]) }
@@ -20,13 +32,13 @@ describe AcademicYear do
   describe "#current" do
     subject { travel_to(today) { described_class.current } }
 
-    context "in 2024" do
+    context "first day of 2024" do
       let(:today) { Date.new(2024, 9, 1) }
 
       it { should eq(2024) }
     end
 
-    context "in 2025" do
+    context "first day of 2025" do
       let(:today) { Date.new(2025, 9, 1) }
 
       it { should eq(2025) }
@@ -36,19 +48,19 @@ describe AcademicYear do
   describe "#first" do
     subject { travel_to(today) { described_class.first } }
 
-    context "in 2023" do
+    context "first day of 2023" do
       let(:today) { Date.new(2023, 9, 1) }
 
       it { should eq(2023) }
     end
 
-    context "in 2024" do
+    context "first day of 2024" do
       let(:today) { Date.new(2024, 9, 1) }
 
       it { should eq(2024) }
     end
 
-    context "in 2025" do
+    context "first day of 2025" do
       let(:today) { Date.new(2025, 9, 1) }
 
       it { should eq(2024) }
@@ -58,16 +70,56 @@ describe AcademicYear do
   describe "#last" do
     subject { travel_to(today) { described_class.last } }
 
-    context "in 2024" do
+    context "first day of 2024" do
       let(:today) { Date.new(2024, 9, 1) }
 
       it { should eq(2024) }
     end
 
-    context "in 2025" do
+    context "last day of only 2024" do
+      let(:today) { Date.new(2025, 7, 31) }
+
+      it { should eq(2024) }
+    end
+
+    context "preparing for 2025" do
+      let(:today) { Date.new(2025, 8, 1) }
+
+      it { should eq(2025) }
+    end
+
+    context "first day of 2025" do
       let(:today) { Date.new(2025, 9, 1) }
 
       it { should eq(2025) }
+    end
+  end
+
+  describe "#preparation?" do
+    subject { travel_to(today) { described_class.preparation? } }
+
+    context "first day of 2024" do
+      let(:today) { Date.new(2024, 9, 1) }
+
+      it { should be(false) }
+    end
+
+    context "last day of only 2024" do
+      let(:today) { Date.new(2025, 7, 31) }
+
+      it { should be(false) }
+    end
+
+    context "preparing for 2025" do
+      let(:today) { Date.new(2025, 8, 1) }
+
+      it { should be(true) }
+    end
+
+    context "first day of 2025" do
+      let(:today) { Date.new(2025, 9, 1) }
+
+      it { should be(false) }
     end
   end
 end

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -164,9 +164,10 @@ variable "app_version" {
 locals {
   is_production = var.environment == "production"
   parameter_store_variables = tomap({
-    MAVIS__PDS__ENQUEUE_BULK_UPDATES = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
-    MAVIS__PDS__WAIT_BETWEEN_JOBS    = 0.5
-    GOOD_JOB_MAX_THREADS             = 5
+    MAVIS__PDS__ENQUEUE_BULK_UPDATES                              = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
+    MAVIS__PDS__WAIT_BETWEEN_JOBS                                 = 0.5
+    MAVIS__NUMBER_OF_PREPARATION_DAYS_BEFORE_ACADEMIC_YEAR_STARTS = 31
+    GOOD_JOB_MAX_THREADS                                          = 5
   })
   parameter_store_config_list = [for key, value in local.parameter_store_variables : {
     name      = key


### PR DESCRIPTION
This adds support for adding academic years to the service before their official start date through the introduce of a preparation period.

For now this has no impact on the service, but in the future this will change which programme years are displayed on the programmes page and which year groups patients are assigned to when importing records.

We're not quite ready yet to enable this in production on the 1st August, so once this variable is live we will edit the setting in production to ensure it's closer to the 1st September.

[Jira Issue - MAV-1505](https://nhsd-jira.digital.nhs.uk/browse/MAV-1505)