### PR TITLE
Hide "Get a new consent response" button

### DIFF
--- a/app/components/app_patient_session_consent_component.html.erb
+++ b/app/components/app_patient_session_consent_component.html.erb
@@ -28,11 +28,13 @@
                             secondary: true %>
       <% end %>
 
-      <%= govuk_button_to "Record a new consent response",
-                          session_patient_programme_consents_path(
-                            session, patient, programme
-                          ),
-                          secondary: true %>
+      <% if can_record_new_response? %>
+        <%= govuk_button_to "Record a new consent response",
+                            session_patient_programme_consents_path(
+                              session, patient, programme
+                            ),
+                            secondary: true %>
+      <% end %>
     </div>
 
     <%= render AppGillickAssessmentComponent.new(patient_session:, programme:) %>

--- a/app/components/app_patient_session_consent_component.rb
+++ b/app/components/app_patient_session_consent_component.rb
@@ -41,6 +41,14 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
         .order(created_at: :desc)
   end
 
+  def gillick_assessment
+    @gillick_assessment ||=
+      patient_session
+        .gillick_assessments
+        .order(created_at: :desc)
+        .find_by(programme:)
+  end
+
   def consent_status
     @consent_status ||= patient.consent_status(programme:)
   end
@@ -52,6 +60,10 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
   def can_send_consent_request?
     consent_status.no_response? && patient.send_notifications? &&
       session.open_for_consent? && patient.parents.any?
+  end
+
+  def can_record_new_response?
+    !consent_status.given? || gillick_assessment&.gillick_competent?
   end
 
   def grouped_consents

--- a/spec/components/app_patient_session_consent_component_spec.rb
+++ b/spec/components/app_patient_session_consent_component_spec.rb
@@ -58,5 +58,12 @@ describe AppPatientSessionConsentComponent do
 
     it { should have_css(".app-card--aqua-green", text: "Consent given") }
     it { should_not have_css("a", text: "Contact #{consent.parent.full_name}") }
+    it { should_not have_css("button", text: "Record a new consent response") }
+
+    context "when patient is Gillick competent" do
+      before { create(:gillick_assessment, :competent, patient_session:) }
+
+      it { should have_css("button", text: "Record a new consent response") }
+    end
   end
 end


### PR DESCRIPTION
This ensures that the button is hidden if no consent response is needed for this patient to prevent nurses from accidentally recording a consent response when not needed.

Specifically this prevents a scenario that was found to be possible in testing, but wouldn't occur in reality where a patient already had consent from a parent and then the nurse could request consent from another parent which changed the status from consent given to consent conflicting.

[Jira Issue - MAV-1591](https://nhsd-jira.digital.nhs.uk/browse/MAV-1591)