### PR TITLE
Use aqua-green for registration attending status colour

### DIFF
--- a/app/components/app_register_status_tag_component.rb
+++ b/app/components/app_register_status_tag_component.rb
@@ -7,7 +7,7 @@ class AppRegisterStatusTagComponent < ViewComponent::Base
     @status = status
   end
 
-  def call = govuk_tag(text:, colour:)
+  def call = tag.strong(text, class: ["nhsuk-tag nhsuk-tag--#{colour}"])
 
   private
 

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -40,7 +40,7 @@ en:
         not_attending: Absent from session
         unknown: Not registered yet
       colour:
-        attending: blue
+        attending: aqua-green
         completed: green
         not_attending: red
         unknown: grey


### PR DESCRIPTION
Changing the registration attending status colour to aqua-green means that nurses can more easily see if a child is ready to vaccinate as all the status colours align: consent outcome, (triage outcome), (registration outcome) and soon (PSD outcome). Nurses often like to think that “green means good to go”.