### PR TITLE
Add administering professional info to SystmOne export

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -95,7 +95,7 @@ class Reports::SystmOneExporter
         .administered
         .where(programme:)
         .for_academic_year(academic_year)
-        .includes(:batch, :location, :vaccine, :patient)
+        .includes(:batch, :location, :vaccine, :patient, :performed_by_user)
 
     if start_date.present?
       scope =
@@ -150,7 +150,7 @@ class Reports::SystmOneExporter
       reason(vaccination_record), # Reason (not specified)
       site(vaccination_record), # Site
       method(vaccination_record), # Method
-      vaccination_record.notes # Notes
+      notes(vaccination_record) # Notes
     ]
   end
 
@@ -195,6 +195,17 @@ class Reports::SystmOneExporter
     return if vaccination_record.not_administered?
 
     DELIVERY_SITE_MAPPINGS.fetch(vaccination_record.delivery_site)
+  end
+
+  def notes(vaccination_record)
+    notes = vaccination_record.notes.to_s
+    if vaccination_record.performed_by
+      notes += (notes.empty? ? "" : "\n ")
+      notes +=
+        "Administered by: #{vaccination_record.performed_by.given_name}" \
+          " #{vaccination_record.performed_by.family_name}"
+    end
+    notes
   end
 
   def method(vaccination_record)

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -58,7 +58,7 @@ describe Reports::SystmOneExporter do
         "Reason" => "Routine",
         "Site" => "Left deltoid",
         "Method" => "Intramuscular",
-        "Notes" => vaccination_record.notes
+        "Notes" => "Administered by: Test User"
       }
     )
   end


### PR DESCRIPTION
SystmOne templates do not have a dedicated field for storing the administering professional information, so LPT and HCT have been using the notes field to capture this information. 

https://nhsd-jira.digital.nhs.uk/browse/MAV-1082

