### PR TITLE
Ensure `MavisCLI.load_rails` is called

### DIFF
--- a/app/lib/mavis_cli/clinics/add_to_organisation.rb
+++ b/app/lib/mavis_cli/clinics/add_to_organisation.rb
@@ -15,6 +15,8 @@ module MavisCLI
                desc: "The ODS codes of the clinics"
 
       def call(organisation_ods_code:, team:, clinic_ods_codes:, **)
+        MavisCLI.load_rails
+
         organisation = Organisation.find_by(ods_code: organisation_ods_code)
 
         if organisation.nil?

--- a/app/lib/mavis_cli/clinics/create.rb
+++ b/app/lib/mavis_cli/clinics/create.rb
@@ -23,6 +23,8 @@ module MavisCLI
         address_postcode:,
         **
       )
+        MavisCLI.load_rails
+
         Location.create!(
           type: :community_clinic,
           name:,

--- a/app/lib/mavis_cli/schools/add_programme_year_group.rb
+++ b/app/lib/mavis_cli/schools/add_programme_year_group.rb
@@ -15,6 +15,8 @@ module MavisCLI
                desc: "The year groups to add"
 
       def call(urn:, programme_type:, year_groups:, **)
+        MavisCLI.load_rails
+
         location = Location.school.find_by(urn:)
 
         if location.nil?

--- a/app/lib/mavis_cli/schools/add_to_organisation.rb
+++ b/app/lib/mavis_cli/schools/add_to_organisation.rb
@@ -19,6 +19,8 @@ module MavisCLI
              desc: "The programmes administered at the school"
 
       def call(ods_code:, team:, urns:, programmes: [], **)
+        MavisCLI.load_rails
+
         organisation = Organisation.find_by(ods_code:)
 
         if organisation.nil?

--- a/app/lib/mavis_cli/schools/remove_programme_year_group.rb
+++ b/app/lib/mavis_cli/schools/remove_programme_year_group.rb
@@ -15,6 +15,8 @@ module MavisCLI
                desc: "The year groups to remove"
 
       def call(urn:, programme_type:, year_groups:, **)
+        MavisCLI.load_rails
+
         location = Location.school.find_by(urn:)
 
         if location.nil?


### PR DESCRIPTION
A number of new CLI commands have been added recently, but I forgot to add `MavisCLI.load_rails` meaning when run in a deployment environment they don't have access to any of the models or other classes autoloaded by Rails.