### PR TITLE
Ensure all changes are staged when recording offline

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -116,33 +116,33 @@ class ImmunisationImportRow
       )
     end
 
+    attributes_to_stage_if_already_exists = {
+      batch_id: batch&.id,
+      delivery_method: delivery_method_value,
+      delivery_site: delivery_site_value,
+      notes: notes&.to_s,
+      vaccine_id: vaccine&.id
+    }
+
     vaccination_record =
       if uuid.present?
         VaccinationRecord
           .joins(:organisation)
           .find_by!(organisations: { id: organisation.id }, uuid: uuid.to_s)
-          .tap { _1.assign_attributes(attributes) }
+          .tap { it.stage_changes(attributes) }
       else
         VaccinationRecord.find_or_initialize_by(attributes)
       end
 
     if vaccination_record.persisted?
-      vaccination_record.stage_changes(
-        batch_id: batch&.id,
-        delivery_method: delivery_method_value,
-        delivery_site: delivery_site_value,
-        notes: notes&.to_s,
-        vaccine_id: vaccine&.id
-      )
+      vaccination_record.stage_changes(attributes_to_stage_if_already_exists)
     else
       # Postgres UUID generation is skipped in bulk import
       vaccination_record.uuid = SecureRandom.uuid
 
-      vaccination_record.batch = batch
-      vaccination_record.delivery_method = delivery_method_value
-      vaccination_record.delivery_site = delivery_site_value
-      vaccination_record.notes = notes&.to_s
-      vaccination_record.vaccine = vaccine
+      vaccination_record.assign_attributes(
+        attributes_to_stage_if_already_exists
+      )
     end
 
     vaccination_record

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -14,7 +14,7 @@ describe "HPV vaccination" do
 
     when_i_record_vaccination_outcomes_to_the_spreadsheet_and_export_it_to_csv
     and_i_upload_the_modified_csv_file
-    then_i_see_there_are_previously_imported_records
+    then_i_see_there_are_no_previously_imported_records
     when_i_navigate_to_the_session_page
     then_i_see_the_uploaded_vaccination_outcomes_reflected_in_the_session
 
@@ -32,7 +32,7 @@ describe "HPV vaccination" do
 
     when_i_record_vaccination_outcomes_to_the_spreadsheet_and_export_it_to_csv
     and_i_upload_the_modified_csv_file
-    then_i_see_there_are_previously_imported_records
+    then_i_see_there_are_no_previously_imported_records
     when_i_navigate_to_the_clinic_page
     then_i_see_the_uploaded_vaccination_outcomes_reflected_in_the_session
     and_the_clinic_location_is_displayed
@@ -50,6 +50,9 @@ describe "HPV vaccination" do
     and_alter_an_existing_vaccination_record
     and_i_upload_the_modified_csv_file
     then_i_see_a_duplicate_record_needs_review
+
+    when_i_review_the_duplicate_record
+    then_i_should_see_the_changes
 
     when_i_choose_to_keep_the_duplicate_record
     then_i_should_see_a_success_message
@@ -189,7 +192,7 @@ describe "HPV vaccination" do
     @sheet = @workbook["Vaccinations"]
     @headers = @sheet[0].cells.map(&:value)
 
-    array = @workbook[0].to_a[1..].map(&:cells).map { _1.map(&:value) }
+    array = @workbook[0].to_a[1..].map(&:cells).map { it.map(&:value) }
     csv_table =
       CSV::Table.new(
         array.map do |row|
@@ -204,8 +207,21 @@ describe "HPV vaccination" do
     File.write("tmp/modified.csv", csv_table.to_csv)
   end
 
-  def when_i_choose_to_keep_the_duplicate_record
+  def when_i_review_the_duplicate_record
     click_on "Review"
+  end
+
+  def then_i_should_see_the_changes
+    expect(page).to have_css(
+      ".app-highlight",
+      text: "Right arm (upper position)"
+    )
+    expect(page).to have_css(".app-highlight", text: "Second")
+    expect(page).to have_css(".app-highlight", text: "1 January 2024")
+    expect(page).to have_css(".app-highlight", text: "10:00am")
+  end
+
+  def when_i_choose_to_keep_the_duplicate_record
     choose "Use duplicate record"
     click_on "Resolve duplicate"
   end
@@ -240,7 +256,7 @@ describe "HPV vaccination" do
     #
     # ideally we could drive Excel here (or similar) but the code below is better than nothing
 
-    array = @workbook[0].to_a[1..].map(&:cells).map { _1.map(&:value) }
+    array = @workbook[0].to_a[1..].map(&:cells).map { it.map(&:value) }
     csv_table =
       CSV::Table.new(
         array.map do |row|
@@ -398,10 +414,10 @@ describe "HPV vaccination" do
     )
   end
 
-  def then_i_see_there_are_previously_imported_records
+  def then_i_see_there_are_no_previously_imported_records
     expect(page).to have_content("Completed")
     expect(page).not_to have_content("Invalid")
-    expect(page).to have_content("2 previously imported records were omitted")
+    expect(page).to have_content("0 previously imported records were omitted")
   end
 
   def then_i_see_a_duplicate_record_needs_review


### PR DESCRIPTION
When recording offline, if a user is editing an existing record from the spreadsheet, we should ensure that all changes to that record are staged and highlighted to the user. This is to prevent the confusing scenario where some of the changes are staged and some others are accepted automatically.

[Jira Issue - MAV-1597](https://nhsd-jira.digital.nhs.uk/browse/MAV-1597)