### PR TITLE
Revert "Hide "Get a new consent response" button"

### DIFF
--- a/app/components/app_patient_session_consent_component.html.erb
+++ b/app/components/app_patient_session_consent_component.html.erb
@@ -28,13 +28,11 @@
                             secondary: true %>
       <% end %>
 
-      <% if can_record_new_response? %>
-        <%= govuk_button_to "Record a new consent response",
-                            session_patient_programme_consents_path(
-                              session, patient, programme
-                            ),
-                            secondary: true %>
-      <% end %>
+      <%= govuk_button_to "Record a new consent response",
+                          session_patient_programme_consents_path(
+                            session, patient, programme
+                          ),
+                          secondary: true %>
     </div>
 
     <%= render AppGillickAssessmentComponent.new(patient_session:, programme:) %>

--- a/app/components/app_patient_session_consent_component.rb
+++ b/app/components/app_patient_session_consent_component.rb
@@ -41,14 +41,6 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
         .order(created_at: :desc)
   end
 
-  def gillick_assessment
-    @gillick_assessment ||=
-      patient_session
-        .gillick_assessments
-        .order(created_at: :desc)
-        .find_by(programme:)
-  end
-
   def consent_status
     @consent_status ||= patient.consent_status(programme:)
   end
@@ -60,10 +52,6 @@ class AppPatientSessionConsentComponent < ViewComponent::Base
   def can_send_consent_request?
     consent_status.no_response? && patient.send_notifications? &&
       session.open_for_consent? && patient.parents.any?
-  end
-
-  def can_record_new_response?
-    !consent_status.given? || gillick_assessment&.gillick_competent?
   end
 
   def grouped_consents

--- a/spec/components/app_patient_session_consent_component_spec.rb
+++ b/spec/components/app_patient_session_consent_component_spec.rb
@@ -58,12 +58,5 @@ describe AppPatientSessionConsentComponent do
 
     it { should have_css(".app-card--aqua-green", text: "Consent given") }
     it { should_not have_css("a", text: "Contact #{consent.parent.full_name}") }
-    it { should_not have_css("button", text: "Record a new consent response") }
-
-    context "when patient is Gillick competent" do
-      before { create(:gillick_assessment, :competent, patient_session:) }
-
-      it { should have_css("button", text: "Record a new consent response") }
-    end
   end
 end


### PR DESCRIPTION
Reverts nhsuk/manage-vaccinations-in-schools#4009

On second thoughts we need this button to remain visible to parents can record a refusal after giving consent.