### PR TITLE
Revert "Bump the bundler group across 1 directory with 2 updates"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,9 +390,9 @@ GEM
       net-protocol
     nio4r (2.7.4)
     nkf (0.2.0)
-    nokogiri (1.18.9-arm64-darwin)
+    nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.18.8-x86_64-linux-gnu)
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
@@ -661,7 +661,7 @@ GEM
       rbs
       syntax_tree (>= 2.0.1)
     temple (0.10.0)
-    thor (1.4.0)
+    thor (1.3.2)
     thruster (0.1.14-arm64-darwin)
     thruster (0.1.14-x86_64-linux)
     tilt (2.6.0)


### PR DESCRIPTION
Reverts nhsuk/manage-vaccinations-in-schools#4023

This was accidentally merged in to `main` when it should have instead been merged in to `next`.