### PR TITLE
Enable SystmOne file format for flu

### DIFF
--- a/app/models/vaccination_report.rb
+++ b/app/models/vaccination_report.rb
@@ -9,7 +9,9 @@ class VaccinationReport
   end
 
   def self.file_formats(programme)
-    %w[careplus mavis].tap { it << "systm_one" if programme.hpv? }
+    %w[careplus mavis].tap do
+      it << "systm_one" if programme.hpv? || programme.flu?
+    end
   end
 
   attribute :date_from, :date

--- a/spec/models/vaccination_report_spec.rb
+++ b/spec/models/vaccination_report_spec.rb
@@ -15,5 +15,11 @@ describe VaccinationReport do
 
       it { should eq(%w[careplus mavis]) }
     end
+
+    context "when programme is flu" do
+      let(:programme) { create(:programme, :flu) }
+
+      it { should eq(%w[careplus mavis systm_one]) }
+    end
   end
 end


### PR DESCRIPTION
The general mappings for flu have been added so it is safe to enable the S1 file format for the flu programme.