### PR TITLE
Rename "Community clinics"

### DIFF
--- a/app/lib/generic_clinic_factory.rb
+++ b/app/lib/generic_clinic_factory.rb
@@ -40,7 +40,7 @@ class GenericClinicFactory
       type: :generic_clinic
     ) ||
       Location.create!(
-        name: "Community clinics",
+        name: "Community clinic",
         ods_code: organisation.ods_code,
         team:,
         type: :generic_clinic

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -69,7 +69,7 @@ FactoryBot.define do
 
     factory :generic_clinic do
       type { :generic_clinic }
-      name { "Community clinics" }
+      name { "Community clinic" }
 
       year_groups { (0..11).to_a }
 

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -190,7 +190,7 @@ describe "HPV vaccination" do
     visit "/dashboard"
     click_link "Sessions", match: :first
     click_link "Scheduled"
-    click_on "Community clinics"
+    click_on "Community clinic"
     click_link "Record offline"
   end
 
@@ -357,7 +357,7 @@ describe "HPV vaccination" do
     visit "/dashboard"
     click_on "Sessions", match: :first
     click_on "Scheduled"
-    click_on "Community clinics"
+    click_on "Community clinic"
   end
 
   def then_i_see_the_uploaded_vaccination_outcomes_reflected_in_the_session

--- a/spec/features/manage_clinic_sessions_spec.rb
+++ b/spec/features/manage_clinic_sessions_spec.rb
@@ -108,11 +108,11 @@ describe "Manage clinic sessions" do
   end
 
   def when_i_click_on_the_community_clinic
-    click_link "Community clinics"
+    click_link "Community clinic"
   end
 
   def then_i_see_the_clinic_session
-    expect(page).to have_content("Community clinics")
+    expect(page).to have_content("Community clinic")
     expect(page).to have_content("No sessions scheduled")
     expect(page).to have_content("Schedule sessions")
   end
@@ -197,7 +197,7 @@ describe "Manage clinic sessions" do
   end
 
   def then_i_see_the_community_clinic
-    expect(page).to have_content("Community clinics")
+    expect(page).to have_content("Community clinic")
   end
 
   def when_the_patient_has_been_invited
@@ -211,7 +211,7 @@ describe "Manage clinic sessions" do
   end
 
   def and_i_click_on_the_community_clinic
-    click_on "Community clinics"
+    click_on "Community clinic"
   end
 
   def when_i_click_on_send_reminders

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -271,7 +271,7 @@ describe "Parental consent school" do
     if in_the_school
       click_on @school.name
     else
-      click_on "Community clinics"
+      click_on "Community clinic"
     end
 
     click_on "Session outcome"


### PR DESCRIPTION
In the prototype it's written as a singular, "Community clinic". Because of how the sessions are created, this won't affect any existing ones in production but it will for the next academic year.