### PR TITLE
Add address to school options in select dropdown

### DIFF
--- a/app/views/draft_class_imports/session.html.erb
+++ b/app/views/draft_class_imports/session.html.erb
@@ -15,7 +15,8 @@
     <% @session_options.each do |session| %>
       <%= tag.option session.location.name,
                      value: session.id,
-                     selected: session.id == @draft_class_import.session_id %>
+                     selected: session.id == @draft_class_import.session_id,
+                     data: { hint: format_address_single_line(session.location) } %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
Adds formatted address as a hint under school names on the class list import page, to help differentiate schools with identical names. This aims to prevent misselection, especially with increased number of schools on mavis for the flu programme.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1131

<img width="765" height="362" alt="image" src="https://github.com/user-attachments/assets/8d6eaae5-805e-4958-90cd-b69fbc68f58f" />
