### PR TITLE
Fix missing styles for dev tools

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -5,6 +5,7 @@
 @forward "button";
 @forward "card";
 @forward "count";
+@forward "dev-tools";
 @forward "environment";
 @forward "filters";
 @forward "header";


### PR DESCRIPTION
Missed during the reorganisation of styles in #3974.