### PR TITLE
Ignore delivery site if there's only one

### DIFF
--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -46,6 +46,19 @@ class VaccinateForm
     super(value.presence)
   end
 
+  def delivery_site
+    if vaccine_method.present?
+      available_delivery_sites =
+        Vaccine::AVAILABLE_DELIVERY_SITES.fetch(vaccine_method)
+
+      if available_delivery_sites.length == 1
+        return available_delivery_sites.first
+      end
+    end
+
+    super
+  end
+
   def save(draft_vaccination_record:)
     return nil if invalid?
 

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -48,7 +48,9 @@ describe "Flu vaccination" do
     then_i_see_the_vaccination_form_for_nasal_spray
     and_i_see_the_option_to_administer_injection
 
-    when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+    when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray(
+      check_injection_first: true
+    )
     then_i_see_the_check_and_confirm_page_for_nasal_spray
     and_i_get_confirmation_after_recording
 
@@ -217,9 +219,19 @@ describe "Flu vaccination" do
     )
   end
 
-  def when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray
+  def when_i_record_that_the_patient_has_been_vaccinated_with_nasal_spray(
+    check_injection_first: false
+  )
     within all("section")[0] do
       check "I have checked that the above statements are true"
+    end
+
+    # Check that I can change my mind injection to nasal.
+    if check_injection_first
+      within all("section")[1] do
+        choose "No — but they can have the injected flu instead"
+        choose "Left arm (upper position)"
+      end
     end
 
     within all("section")[1] do


### PR DESCRIPTION
If a delivery site is selected, but the vaccine method means that there's only one possible delivery site, we can ignore the provided value.

This fixes a bug where if the user were to select injection and then select a delivery site, but then go back and select nasal spray, the delivery site for injection would still come through and it would be invalid for nasal spray.

[Jira Issue - MAV-1656](https://nhsd-jira.digital.nhs.uk/browse/MAV-1656)