### PR TITLE
Remove ingress and egress for default security group

### DIFF
--- a/terraform/app/network.tf
+++ b/terraform/app/network.tf
@@ -6,6 +6,10 @@ resource "aws_vpc" "application_vpc" {
   }
 }
 
+resource "aws_default_security_group" "this" {
+  vpc_id = aws_vpc.application_vpc.id
+}
+
 resource "aws_subnet" "public_subnet_a" {
   vpc_id            = aws_vpc.application_vpc.id
   cidr_block        = "10.0.0.0/24"


### PR DESCRIPTION
Adding the default security group to the terraform configuration will replace the existing default security group. This way, the ingress and egress of the existing one gets removed

Jira-Issue: MAV-1577