### PR TITLE
Rename `Team` to `Subteam`

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ See the [releasing documentation](docs/releasing.md) for more information.
 
 - `access_log:for_patient[id]`
 - `access_log:for_user[id]`
-- `teams:create[ods_code,name,email,phone]`
+- `subteams:create[ods_code,name,email,phone]`
 - `users:create[email,password,given_name,family_name,organisation_ods_code]`
 - `vaccines:seed[type]`
 

--- a/app/controllers/api/testing/locations_controller.rb
+++ b/app/controllers/api/testing/locations_controller.rb
@@ -22,9 +22,9 @@ class API::Testing::LocationsController < API::Testing::BaseController
        ).present?
       @locations =
         if ActiveModel::Type::Boolean.new.cast(is_attached_to_organisation)
-          @locations.where.not(team_id: nil)
+          @locations.where.not(subteam_id: nil)
         else
-          @locations.where(team_id: nil)
+          @locations.where(subteam_id: nil)
         end
     end
 

--- a/app/controllers/api/testing/organisations_controller.rb
+++ b/app/controllers/api/testing/organisations_controller.rb
@@ -64,10 +64,10 @@ class API::Testing::OrganisationsController < API::Testing::BaseController
           log_destroy(SessionProgramme.where(session: sessions))
           log_destroy(sessions)
 
-          teams = Team.where(organisation:)
-          Location.where(team: teams).update_all(team_id: nil)
+          subteams = Subteam.where(organisation:)
+          Location.where(subteam: subteams).update_all(subteam_id: nil)
 
-          log_destroy(teams)
+          log_destroy(subteams)
           log_destroy(
             Location.generic_clinic.where(ods_code: organisation.ods_code)
           )

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -5,7 +5,7 @@ module ParentInterface
     skip_before_action :authenticate_user!
     skip_after_action :verify_policy_scoped
 
-    prepend_before_action :set_team
+    prepend_before_action :set_subteam
     prepend_before_action :set_programmes
     prepend_before_action :set_organisation
     prepend_before_action :set_session
@@ -48,12 +48,12 @@ module ParentInterface
         end
     end
 
-    def set_team
-      @team =
+    def set_subteam
+      @subteam =
         if @consent_form.present?
-          @consent_form.team
+          @consent_form.subteam
         elsif @session.present?
-          @session.team
+          @session.subteam
         end
     end
 

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -39,7 +39,7 @@ class EmailDeliveryJob < NotifyDeliveryJob
 
     if (
          email_reply_to_id =
-           personalisation.team&.reply_to_id ||
+           personalisation.subteam&.reply_to_id ||
              personalisation.organisation.reply_to_id
        )
       args[:email_reply_to_id] = email_reply_to_id

--- a/app/lib/generic_clinic_factory.rb
+++ b/app/lib/generic_clinic_factory.rb
@@ -23,9 +23,9 @@ class GenericClinicFactory
 
   delegate :programmes, to: :organisation
 
-  def team
+  def subteam
     organisation
-      .teams
+      .subteams
       .create_with(
         email: organisation.email,
         phone: organisation.phone,
@@ -42,7 +42,7 @@ class GenericClinicFactory
       Location.create!(
         name: "Community clinic",
         ods_code: organisation.ods_code,
-        team:,
+        subteam:,
         type: :generic_clinic
       )
   end

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -31,7 +31,8 @@ class GovukNotifyPersonalisation
     @organisation =
       session&.organisation || consent_form&.organisation ||
         consent&.organisation || vaccination_record&.organisation
-    @team = session&.team || consent_form&.team || vaccination_record&.team
+    @subteam =
+      session&.subteam || consent_form&.subteam || vaccination_record&.subteam
     @vaccination_record = vaccination_record
   end
 
@@ -64,11 +65,14 @@ class GovukNotifyPersonalisation
       short_patient_name_apos:,
       show_additional_instructions:,
       subsequent_session_dates_offered_message:,
+      subteam_email:,
+      subteam_name:,
+      subteam_phone:,
       survey_deadline_date:,
       talk_to_your_child_message:,
-      team_email:,
-      team_name:,
-      team_phone:,
+      team_email: subteam_email,
+      team_name: subteam_name,
+      team_phone: subteam_phone,
       today_or_date_of_vaccination:,
       vaccination:,
       vaccination_and_method:,
@@ -88,7 +92,7 @@ class GovukNotifyPersonalisation
               :patient,
               :programmes,
               :session,
-              :team,
+              :subteam,
               :organisation,
               :vaccination_record
 
@@ -275,6 +279,18 @@ class GovukNotifyPersonalisation
     }."
   end
 
+  def subteam_email
+    (subteam || organisation).email
+  end
+
+  def subteam_name
+    (subteam || organisation).name
+  end
+
+  def subteam_phone
+    format_phone_with_instructions(subteam || organisation)
+  end
+
   def survey_deadline_date
     recorded_at = consent_form&.recorded_at || consent&.created_at
     return if recorded_at.nil?
@@ -294,18 +310,6 @@ class GovukNotifyPersonalisation
         "have the right to consent to vaccinations themselves. " \
         "Our team may assess Gillick competence during vaccination sessions."
     ].join("\n\n")
-  end
-
-  def team_email
-    (team || organisation).email
-  end
-
-  def team_name
-    (team || organisation).name
-  end
-
-  def team_phone
-    format_phone_with_instructions(team || organisation)
   end
 
   def today_or_date_of_vaccination

--- a/app/lib/mavis_cli/clinics/add_to_organisation.rb
+++ b/app/lib/mavis_cli/clinics/add_to_organisation.rb
@@ -8,13 +8,13 @@ module MavisCLI
       argument :organisation_ods_code,
                required: true,
                desc: "The ODS code of the organisation"
-      argument :team, required: true, desc: "The team of the organisation"
+      argument :subteam, required: true, desc: "The subteam of the organisation"
       argument :clinic_ods_codes,
                type: :array,
                required: true,
                desc: "The ODS codes of the clinics"
 
-      def call(organisation_ods_code:, team:, clinic_ods_codes:, **)
+      def call(organisation_ods_code:, subteam:, clinic_ods_codes:, **)
         MavisCLI.load_rails
 
         organisation = Organisation.find_by(ods_code: organisation_ods_code)
@@ -24,10 +24,10 @@ module MavisCLI
           return
         end
 
-        team = organisation.teams.find_by(name: team)
+        subteam = organisation.subteams.find_by(name: subteam)
 
-        if team.nil?
-          warn "Could not find team."
+        if subteam.nil?
+          warn "Could not find subteam."
           return
         end
 
@@ -40,11 +40,11 @@ module MavisCLI
               next
             end
 
-            if !location.team_id.nil? && location.team_id != team.id
-              warn "#{ods_code} previously belonged to #{location.team.name}"
+            if !location.subteam_id.nil? && location.subteam_id != subteam.id
+              warn "#{ods_code} previously belonged to #{location.subteam.name}"
             end
 
-            location.update!(team:)
+            location.update!(subteam:)
           end
         end
       end

--- a/app/lib/mavis_cli/gias/check_import.rb
+++ b/app/lib/mavis_cli/gias/check_import.rb
@@ -23,7 +23,8 @@ module MavisCLI
               .pluck(:urn)
           )
         existing_schools = Set.new(Location.school.pluck(:urn))
-        organisation_schools = Set.new(Location.school.joins(:team).pluck(:urn))
+        organisation_schools =
+          Set.new(Location.school.joins(:subteam).pluck(:urn))
 
         closed_schools_with_future_sessions = Set.new
         closing_schools_with_future_sessions = Set.new

--- a/app/lib/mavis_cli/schools/add_to_organisation.rb
+++ b/app/lib/mavis_cli/schools/add_to_organisation.rb
@@ -8,7 +8,7 @@ module MavisCLI
       argument :ods_code,
                required: true,
                desc: "The ODS code of the organisation"
-      argument :team, required: true, desc: "The team of the organisation"
+      argument :subteam, required: true, desc: "The subteam of the organisation"
       argument :urns,
                type: :array,
                required: true,
@@ -18,7 +18,7 @@ module MavisCLI
              type: :array,
              desc: "The programmes administered at the school"
 
-      def call(ods_code:, team:, urns:, programmes: [], **)
+      def call(ods_code:, subteam:, urns:, programmes: [], **)
         MavisCLI.load_rails
 
         organisation = Organisation.find_by(ods_code:)
@@ -28,10 +28,10 @@ module MavisCLI
           return
         end
 
-        team = organisation.teams.find_by(name: team)
+        subteam = organisation.subteams.find_by(name: subteam)
 
-        if team.nil?
-          warn "Could not find team."
+        if subteam.nil?
+          warn "Could not find subteam."
           return
         end
 
@@ -53,11 +53,11 @@ module MavisCLI
               next
             end
 
-            if !location.team_id.nil? && location.team_id != team.id
-              warn "#{urn} previously belonged to #{location.team.name}"
+            if !location.subteam_id.nil? && location.subteam_id != subteam.id
+              warn "#{urn} previously belonged to #{location.subteam.name}"
             end
 
-            location.update!(team:)
+            location.update!(subteam:)
             location.create_default_programme_year_groups!(programmes)
 
             LocationSessionsFactory.call(location, academic_year:)

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -427,8 +427,8 @@ class Reports::OfflineSessionExporter
     @clinic_name_values ||=
       Location
         .community_clinic
-        .joins(:team)
-        .where(team: { organisation: })
+        .joins(:subteam)
+        .where(subteam: { organisation: })
         .pluck(:name)
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -105,7 +105,7 @@ class ConsentForm < ApplicationRecord
            through: :refused_consent_form_programmes,
            source: :programme
 
-  has_one :team, through: :location
+  has_one :subteam, through: :location
 
   has_many :eligible_schools, through: :organisation, source: :schools
   has_many :vaccines, through: :programmes

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -20,17 +20,17 @@
 #  year_groups               :integer          default([]), not null, is an Array
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  team_id                   :bigint
+#  subteam_id                :bigint
 #
 # Indexes
 #
-#  index_locations_on_ods_code  (ods_code) UNIQUE
-#  index_locations_on_team_id   (team_id)
-#  index_locations_on_urn       (urn) UNIQUE
+#  index_locations_on_ods_code    (ods_code) UNIQUE
+#  index_locations_on_subteam_id  (subteam_id)
+#  index_locations_on_urn         (urn) UNIQUE
 #
 # Foreign Keys
 #
-#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (subteam_id => subteams.id)
 #
 class Location < ApplicationRecord
   include AddressConcern
@@ -38,17 +38,17 @@ class Location < ApplicationRecord
 
   self.inheritance_column = :nil
 
-  audited associated_with: :team
+  audited associated_with: :subteam
   has_associated_audits
 
-  belongs_to :team, optional: true
+  belongs_to :subteam, optional: true
 
   has_many :consent_forms
   has_many :patients, foreign_key: :school_id
   has_many :programme_year_groups
   has_many :sessions
 
-  has_one :organisation, through: :team
+  has_one :organisation, through: :subteam
   has_many :programmes,
            -> { distinct.order(:type) },
            through: :programme_year_groups
@@ -73,7 +73,7 @@ class Location < ApplicationRecord
 
   with_options if: :generic_clinic? do
     validates :ods_code, inclusion: { in: :organisation_ods_code }
-    validates :team, presence: true
+    validates :subteam, presence: true
   end
 
   with_options if: :gp_practice? do
@@ -97,8 +97,8 @@ class Location < ApplicationRecord
   end
 
   def as_json
-    super.except("created_at", "updated_at", "team_id").merge(
-      "is_attached_to_organisation" => !team_id.nil?
+    super.except("created_at", "updated_at", "subteam_id").merge(
+      "is_attached_to_organisation" => !subteam_id.nil?
     )
   end
 
@@ -121,7 +121,7 @@ class Location < ApplicationRecord
 
   private
 
-  def organisation_ods_code = [team&.organisation&.ods_code].compact
+  def organisation_ods_code = [subteam&.organisation&.ods_code].compact
 
   def fhir_mapper
     @fhir_mapper ||= FHIRMapper::Location.new(self)

--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -29,7 +29,13 @@ class Onboarding
     reply_to_id
   ].freeze
 
-  TEAM_ATTRIBUTES = %i[email name phone phone_instructions reply_to_id].freeze
+  SUBTEAM_ATTRIBUTES = %i[
+    email
+    name
+    phone
+    phone_instructions
+    reply_to_id
+  ].freeze
 
   USER_ATTRIBUTES = %i[
     email
@@ -41,7 +47,7 @@ class Onboarding
 
   validates :organisation, presence: true
   validates :programmes, presence: true
-  validates :teams, presence: true
+  validates :subteams, presence: true
   validates :schools, presence: true
   validates :clinics, presence: true
 
@@ -58,13 +64,13 @@ class Onboarding
         .fetch(:programmes, [])
         .map { |type| ExistingProgramme.new(type:, organisation:) }
 
-    teams_by_name =
+    subteams_by_name =
       config
-        .fetch(:teams, {})
-        .transform_values { it.slice(*TEAM_ATTRIBUTES) }
-        .transform_values { Team.new(**it, organisation:) }
+        .fetch(:subteams, {})
+        .transform_values { it.slice(*SUBTEAM_ATTRIBUTES) }
+        .transform_values { Subteam.new(**it, organisation:) }
 
-    @teams = teams_by_name.values
+    @subteams = subteams_by_name.values
 
     @users =
       config
@@ -80,18 +86,20 @@ class Onboarding
       config
         .fetch(:schools, {})
         .flat_map do |team_name, school_urns|
-          team = teams_by_name[team_name]
-          school_urns.map { |urn| ExistingSchool.new(urn:, team:, programmes:) }
+          subteam = subteams_by_name[team_name]
+          school_urns.map do |urn|
+            ExistingSchool.new(urn:, subteam:, programmes:)
+          end
         end
 
     @clinics =
       config
         .fetch(:clinics, {})
         .flat_map do |team_name, clinic_configs|
-          team = teams_by_name[team_name]
+          subteam = subteams_by_name[team_name]
           clinic_configs
             .map { it.slice(*CLINIC_ATTRIBUTES) }
-            .map { Location.new(**it, type: :community_clinic, team:) }
+            .map { Location.new(**it, type: :community_clinic, subteam:) }
         end
   end
 
@@ -107,7 +115,7 @@ class Onboarding
     super.tap do |errors|
       merge_errors_from([organisation], errors:, name: "organisation")
       merge_errors_from(programmes, errors:, name: "programme")
-      merge_errors_from(teams, errors:, name: "team")
+      merge_errors_from(subteams, errors:, name: "subteam")
       merge_errors_from(users, errors:, name: "user")
       merge_errors_from(schools, errors:, name: "school")
       merge_errors_from(clinics, errors:, name: "clinic")
@@ -129,12 +137,12 @@ class Onboarding
 
   private
 
-  attr_reader :organisation, :programmes, :teams, :users, :schools, :clinics
+  attr_reader :organisation, :programmes, :subteams, :users, :schools, :clinics
 
   def academic_year = AcademicYear.current
 
   def models
-    [organisation] + programmes + teams + users + schools + clinics
+    [organisation] + programmes + subteams + users + schools + clinics
   end
 
   def merge_errors_from(objects, errors:, name:)
@@ -171,11 +179,11 @@ class Onboarding
   class ExistingSchool
     include ActiveModel::Model
 
-    attr_accessor :urn, :team, :programmes
+    attr_accessor :urn, :subteam, :programmes
 
-    validates :existing_team, absence: true
+    validates :existing_subteam, absence: true
     validates :location, presence: true
-    validates :team, presence: true
+    validates :subteam, presence: true
     validates :status, inclusion: %w[open opening]
 
     def location
@@ -184,12 +192,12 @@ class Onboarding
 
     delegate :status, to: :location, allow_nil: true
 
-    def existing_team
-      location&.team
+    def existing_subteam
+      location&.subteam
     end
 
     def save!
-      location.update!(team:)
+      location.update!(subteam:)
       location.create_default_programme_year_groups!(
         programmes.map(&:programme)
       )

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -40,14 +40,14 @@ class Organisation < ApplicationRecord
   has_many :organisation_programmes,
            -> { joins(:programme).order(:"programmes.type") }
   has_many :sessions
-  has_many :teams
+  has_many :subteams
 
-  has_many :community_clinics, through: :teams
-  has_many :locations, through: :teams
+  has_many :community_clinics, through: :subteams
+  has_many :locations, through: :subteams
   has_many :patient_sessions, through: :sessions
   has_many :patients, -> { distinct }, through: :patient_sessions
   has_many :programmes, through: :organisation_programmes
-  has_many :schools, through: :teams
+  has_many :schools, through: :subteams
   has_many :vaccination_records, through: :sessions
   has_many :vaccines, through: :programmes
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -50,7 +50,7 @@ class PatientSession < ApplicationRecord
   has_one :registration_status
 
   has_one :location, through: :session
-  has_one :team, through: :session
+  has_one :subteam, through: :session
   has_one :organisation, through: :session
   has_many :session_attendances, dependent: :destroy
 

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -44,7 +44,7 @@ class Session < ApplicationRecord
 
   has_and_belongs_to_many :immunisation_imports
 
-  has_one :team, through: :location
+  has_one :subteam, through: :location
   has_many :programmes, through: :session_programmes
   has_many :gillick_assessments, through: :patient_sessions
   has_many :patients, through: :patient_sessions

--- a/app/models/subteam.rb
+++ b/app/models/subteam.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: teams
+# Table name: subteams
 #
 #  id                 :bigint           not null, primary key
 #  email              :string           not null
@@ -16,13 +16,13 @@
 #
 # Indexes
 #
-#  index_teams_on_organisation_id_and_name  (organisation_id,name) UNIQUE
+#  index_subteams_on_organisation_id_and_name  (organisation_id,name) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
 #
-class Team < ApplicationRecord
+class Subteam < ApplicationRecord
   audited associated_with: :organisation
   has_associated_audits
 

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -96,7 +96,7 @@ class VaccinationRecord < ApplicationRecord
   has_one :identity_check, autosave: true, dependent: :destroy
   has_one :location, through: :session
   has_one :organisation, through: :session
-  has_one :team, through: :session
+  has_one :subteam, through: :session
 
   scope :recorded_in_service, -> { where.not(session_id: nil) }
 

--- a/app/policies/location/programme_year_group_policy.rb
+++ b/app/policies/location/programme_year_group_policy.rb
@@ -3,8 +3,8 @@
 class Location::ProgrammeYearGroupPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.joins(location: :team).where(
-        teams: {
+      scope.joins(location: :subteam).where(
+        subteams: {
           organisation: user.selected_organisation
         }
       )

--- a/app/policies/location_policy.rb
+++ b/app/policies/location_policy.rb
@@ -3,8 +3,8 @@
 class LocationPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope.joins(:team).where(
-        team: {
+      scope.joins(:subteam).where(
+        subteam: {
           organisation: user.selected_organisation
         }
       )

--- a/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
@@ -14,5 +14,5 @@
 
 <p>
   If you have any questions, please contact the local health organisation by calling
-  <%= format_phone_with_instructions(@team) %>, or email <%= mail_to @team.email %>.
+  <%= format_phone_with_instructions(@subteam) %>, or email <%= mail_to @subteam.email %>.
 </p>

--- a/app/views/parent_interface/consent_forms/deadline_passed.html.erb
+++ b/app/views/parent_interface/consent_forms/deadline_passed.html.erb
@@ -5,5 +5,5 @@
 <h2 class="nhsuk-heading-m">You can still book a clinic appointment</h2>
 
 <p class="govuk-body">
-  Contact <%= link_to @team.email, "mailto:#{@team.email}" %> to book a clinic appointment.
+  Contact <%= link_to @subteam.email, "mailto:#{@subteam.email}" %> to book a clinic appointment.
 </p>

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -9,7 +9,7 @@
 
   <p>
     You can only use this service if your child&apos;s school is listed here.
-    If it&apos;s not, contact <%= mail_to @team.email %>.
+    If it&apos;s not, contact <%= mail_to @subteam.email %>.
     If you&apos;ve moved recently, it&apos;s important to mention this.
   </p>
 

--- a/config/onboarding/coventry-training.yaml
+++ b/config/onboarding/coventry-training.yaml
@@ -9,7 +9,7 @@ organisation:
 
 programmes: [hpv]
 
-teams:
+subteams:
   generic:
     name: Coventry and Warwickshire Partnership NHS Trust
     email: example@covwarkpt.nhs.uk

--- a/config/onboarding/hertfordshire-training.yaml
+++ b/config/onboarding/hertfordshire-training.yaml
@@ -9,7 +9,7 @@ organisation:
 
 programmes: [hpv]
 
-teams:
+subteams:
   cambridgeshire-and-peterborough:
     name: Cambridgeshire and Peterborough Community and School Age Immunisation Service
     email: hct.csaiscambspb@nhs.net

--- a/config/onboarding/leicestershire-training.yaml
+++ b/config/onboarding/leicestershire-training.yaml
@@ -10,7 +10,7 @@ organisation:
 
 programmes: [hpv]
 
-teams:
+subteams:
   generic:
     name: Leicestershire Partnership Trust School Aged Immunisation Service
     email: lpt.sais@nhs.net

--- a/config/onboarding/smoke-test.yml
+++ b/config/onboarding/smoke-test.yml
@@ -8,18 +8,18 @@ organisation:
 
 programmes: [hpv]
 
-teams:
-  team1:
+subteams:
+  subteam1:
     name: XXX SMOKE TEST XXX
     email: xxx.smoke.test.xxx@example.nhs.net
     phone: "03003112233"
 
 schools:
-  team1:
+  subteam1:
     - XXXXXX
 
 clinics:
-  team1:
+  subteam1:
     - name: Test Clinic
       address_line_1: 1 Clinic Test Street
       address_town: Clinic Test Town

--- a/db/migrate/20250722162319_rename_team_to_subteam.rb
+++ b/db/migrate/20250722162319_rename_team_to_subteam.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RenameTeamToSubteam < ActiveRecord::Migration[8.0]
+  def change
+    rename_table :teams, :subteams
+    rename_column :locations, :team_id, :subteam_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -457,12 +457,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_24_113511) do
     t.integer "type", null: false
     t.string "ods_code"
     t.integer "year_groups", default: [], null: false, array: true
-    t.bigint "team_id"
+    t.bigint "subteam_id"
     t.integer "gias_local_authority_code"
     t.integer "gias_establishment_number"
     t.integer "status", default: 0, null: false
     t.index ["ods_code"], name: "index_locations_on_ods_code", unique: true
-    t.index ["team_id"], name: "index_locations_on_team_id"
+    t.index ["subteam_id"], name: "index_locations_on_subteam_id"
     t.index ["urn"], name: "index_locations_on_urn", unique: true
   end
 
@@ -758,7 +758,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_24_113511) do
     t.index ["organisation_id", "location_id"], name: "index_sessions_on_organisation_id_and_location_id"
   end
 
-  create_table "teams", force: :cascade do |t|
+  create_table "subteams", force: :cascade do |t|
     t.bigint "organisation_id", null: false
     t.string "name", null: false
     t.string "email", null: false
@@ -767,7 +767,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_24_113511) do
     t.datetime "updated_at", null: false
     t.uuid "reply_to_id"
     t.string "phone_instructions"
-    t.index ["organisation_id", "name"], name: "index_teams_on_organisation_id_and_name", unique: true
+    t.index ["organisation_id", "name"], name: "index_subteams_on_organisation_id_and_name", unique: true
   end
 
   create_table "triage", force: :cascade do |t|
@@ -926,7 +926,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_24_113511) do
   add_foreign_key "immunisation_imports_vaccination_records", "vaccination_records"
   add_foreign_key "location_programme_year_groups", "locations", on_delete: :cascade
   add_foreign_key "location_programme_year_groups", "programmes", on_delete: :cascade
-  add_foreign_key "locations", "teams"
+  add_foreign_key "locations", "subteams"
   add_foreign_key "notes", "patients"
   add_foreign_key "notes", "sessions"
   add_foreign_key "notes", "users", column: "created_by_user_id"
@@ -973,7 +973,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_24_113511) do
   add_foreign_key "session_programmes", "programmes"
   add_foreign_key "session_programmes", "sessions"
   add_foreign_key "sessions", "organisations"
-  add_foreign_key "teams", "organisations"
+  add_foreign_key "subteams", "organisations"
   add_foreign_key "triage", "organisations"
   add_foreign_key "triage", "patients"
   add_foreign_key "triage", "programmes"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -62,14 +62,14 @@ end
 def attach_sample_of_schools_to(organisation)
   Location
     .school
-    .where(team_id: nil)
+    .where(subteam_id: nil)
     .order("RANDOM()")
     .limit(50)
-    .update_all(team_id: organisation.teams.first.id)
+    .update_all(subteam_id: organisation.subteams.first.id)
 end
 
 def attach_specific_school_to_organisation_if_present(organisation:, urn:)
-  Location.where(urn:).update_all(team_id: organisation.teams.first.id)
+  Location.where(urn:).update_all(subteam_id: organisation.subteams.first.id)
 end
 
 def create_session(

--- a/docs/managing-teams.md
+++ b/docs/managing-teams.md
@@ -21,18 +21,18 @@ organisation:
 
 programmes: [] # A list of programmes (flu, hpv, menacwy, td_ipv)
 
-teams:
-  team1: # Identifier to link team with school and links below, not used in app
+subteams:
+  subteam1: # Identifier to link team with school and links below, not used in app
     name: # Name of the team
     email: # Contact email address
     phone: # Contact phone number
     reply_to_id: # Optional GOV.UK Notify Reply-To UUID
 
 schools:
-  team1: [] # URNs managed by a particular team
+  subteam1: [] # URNs managed by a particular team
 
 clinics:
-  team1:
+  subteam1:
     - name: # Name of the clinic
       address_line_1: # First line of the address
       address_town: # Town of the address
@@ -63,17 +63,17 @@ Once a team has been onboarding, the YAML configuration file can be deleted as i
 The command `schools add-to-organisation` is provided to add new schools to an existing organisation.
 
 ```sh
-$ bin/mavis schools add-to-organisation ODS_CODE TEAM URNS
+$ bin/mavis schools add-to-organisation ODS_CODE SUBTEAM URNS
 ```
 
 - `ODS_CODE` refers to the ODS code of the organisation
-- `TEAM` refers to the name of the team in the organisation
+- `SUBTEAM` refers to the name of the subteam in the organisation
 - `URNS` are the URNs of the schools to add
 
 Optionally, it's also possible to customise which programmes are administered at a particular school:
 
 ```sh
-$ bin/mavis schools add-to-organisation ODS_CODE TEAM URNS --programmes VALUE1,VALUE2,...
+$ bin/mavis schools add-to-organisation ODS_CODE SUBTEAM URNS --programmes VALUE1,VALUE2,...
 ```
 
 ### Changing administered year groups of a school

--- a/lib/tasks/schools.rake
+++ b/lib/tasks/schools.rake
@@ -37,10 +37,10 @@ namespace :schools do
       raise "Some patient sessions at #{old_loc.urn} are not safe to destroy. Cannot complete transfer."
     end
 
-    if !new_loc.team_id.nil? && new_loc.team_id != old_loc.team_id
-      raise "#{new_loc.urn} belongs to #{new_loc.team.name}. Could not complete transfer."
+    if !new_loc.subteam_id.nil? && new_loc.subteam_id != old_loc.subteam_id
+      raise "#{new_loc.urn} belongs to #{new_loc.subteam.name}. Could not complete transfer."
     end
-    new_loc.update!(team: old_loc.team)
+    new_loc.update!(subteam: old_loc.subteam)
 
     Session.where(location_id: old_loc.id).update_all(location_id: new_loc.id)
     Patient.where(school_id: old_loc.id).update_all(school_id: new_loc.id)

--- a/lib/tasks/subteams.rake
+++ b/lib/tasks/subteams.rake
@@ -2,22 +2,22 @@
 
 require_relative "../task_helpers"
 
-namespace :teams do
+namespace :subteams do
   desc <<-DESC
-    Create a new team within an organisation.
+    Create a new subteam within an organisation.
 
     Usage:
-      rake team:create # Complete the prompts
-      rake team:create[ods_code,name,email,phone]
+      rake subteams:create # Complete the prompts
+      rake subteams:create[ods_code,name,email,phone]
   DESC
   task :create, %i[ods_code name email phone] => :environment do |_task, args|
     include TaskHelpers
 
     if args.to_a.empty? && $stdin.isatty && $stdout.isatty
       ods_code = prompt_user_for "Enter organisation ODS code:", required: true
-      name = prompt_user_for "Enter team name:", required: true
-      email = prompt_user_for "Enter team email:", required: true
-      phone = prompt_user_for "Enter team phone:", required: true
+      name = prompt_user_for "Enter subteam name:", required: true
+      email = prompt_user_for "Enter subteam email:", required: true
+      phone = prompt_user_for "Enter subteam phone:", required: true
     elsif args.to_a.size == 4
       ods_code = args[:ods_code]
       name = args[:name]
@@ -30,9 +30,9 @@ namespace :teams do
     ActiveRecord::Base.transaction do
       organisation = Organisation.find_by!(ods_code:)
 
-      organisation.teams.create!(name:, email:, phone:)
+      subteam = organisation.subteams.create!(name:, email:, phone:)
 
-      puts "New #{team.name} team with ID #{team.id} created."
+      puts "New #{subteam.name} subteam with ID #{subteam.id} created."
     end
   end
 end

--- a/script/organisation_export.rb
+++ b/script/organisation_export.rb
@@ -75,14 +75,14 @@ class OrganisationExport
 
   def patients
     Patient
-      .joins(school: { team: :organisation })
+      .joins(school: { subteam: :organisation })
       .where(teams: { organisation_id: @organisation.id })
       .includes(
         :consents,
         :triages,
         :cohort,
         patient_sessions: %i[gillick_assessment vaccination_records],
-        school: :team
+        school: :subteam
       )
   end
 

--- a/spec/controllers/api/testing/organisations_controller_spec.rb
+++ b/spec/controllers/api/testing/organisations_controller_spec.rb
@@ -73,7 +73,7 @@ describe API::Testing::OrganisationsController do
       expect { delete :destroy, params: { ods_code: "r1l" } }.to(
         change(Organisation, :count)
           .by(-1)
-          .and(change(Team, :count).by(-1))
+          .and(change(Subteam, :count).by(-1))
           .and(change(Session, :count).by(-1))
           .and(change(CohortImport, :count).by(-1))
           .and(change(ImmunisationImport, :count).by(-1))
@@ -94,7 +94,7 @@ describe API::Testing::OrganisationsController do
       it "deletes associated data" do
         expect { call }.to(
           not_change(Organisation, :count)
-            .and(not_change(Team, :count))
+            .and(not_change(Subteam, :count))
             .and(not_change(Session, :count))
             .and(change(CohortImport, :count).by(-1))
             .and(change(ImmunisationImport, :count).by(-1))

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -20,17 +20,17 @@
 #  year_groups               :integer          default([]), not null, is an Array
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  team_id                   :bigint
+#  subteam_id                :bigint
 #
 # Indexes
 #
-#  index_locations_on_ods_code  (ods_code) UNIQUE
-#  index_locations_on_team_id   (team_id)
-#  index_locations_on_urn       (urn) UNIQUE
+#  index_locations_on_ods_code    (ods_code) UNIQUE
+#  index_locations_on_subteam_id  (subteam_id)
+#  index_locations_on_urn         (urn) UNIQUE
 #
 # Foreign Keys
 #
-#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (subteam_id => subteams.id)
 #
 
 require_relative "../../lib/faker/address"
@@ -39,7 +39,7 @@ FactoryBot.define do
   factory :location do
     transient do
       organisation { nil }
-      programmes { team&.organisation&.programmes || [] }
+      programmes { subteam&.organisation&.programmes || [] }
     end
 
     address_line_1 { Faker::Address.street_address }
@@ -48,9 +48,9 @@ FactoryBot.define do
 
     url { Faker::Internet.url }
 
-    team do
+    subteam do
       if organisation
-        organisation.teams.first || association(:team, organisation:)
+        organisation.subteams.first || association(:subteam, organisation:)
       end
     end
 
@@ -73,7 +73,7 @@ FactoryBot.define do
 
       year_groups { (0..11).to_a }
 
-      ods_code { team&.organisation&.ods_code }
+      ods_code { subteam&.organisation&.ods_code }
     end
 
     factory :gp_practice do

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -4,31 +4,32 @@
 #
 # Table name: patients
 #
-#  id                        :bigint           not null, primary key
-#  address_line_1            :string
-#  address_line_2            :string
-#  address_postcode          :string
-#  address_town              :string
-#  birth_academic_year       :integer          not null
-#  date_of_birth             :date             not null
-#  date_of_death             :date
-#  date_of_death_recorded_at :datetime
-#  family_name               :string           not null
-#  gender_code               :integer          default("not_known"), not null
-#  given_name                :string           not null
-#  home_educated             :boolean
-#  invalidated_at            :datetime
-#  nhs_number                :string
-#  pending_changes           :jsonb            not null
-#  preferred_family_name     :string
-#  preferred_given_name      :string
-#  registration              :string
-#  restricted_at             :datetime
-#  updated_from_pds_at       :datetime
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  gp_practice_id            :bigint
-#  school_id                 :bigint
+#  id                         :bigint           not null, primary key
+#  address_line_1             :string
+#  address_line_2             :string
+#  address_postcode           :string
+#  address_town               :string
+#  birth_academic_year        :integer          not null
+#  date_of_birth              :date             not null
+#  date_of_death              :date
+#  date_of_death_recorded_at  :datetime
+#  family_name                :string           not null
+#  gender_code                :integer          default("not_known"), not null
+#  given_name                 :string           not null
+#  home_educated              :boolean
+#  invalidated_at             :datetime
+#  nhs_number                 :string
+#  pending_changes            :jsonb            not null
+#  preferred_family_name      :string
+#  preferred_given_name       :string
+#  registration               :string
+#  registration_academic_year :integer
+#  restricted_at              :datetime
+#  updated_from_pds_at        :datetime
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#  gp_practice_id             :bigint
+#  school_id                  :bigint
 #
 # Indexes
 #

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     transient do
       date { Date.current }
       dates { [] }
-      team { association(:team, organisation:) }
+      subteam { association(:subteam, organisation:) }
     end
 
     sequence(:slug) { |n| "session-#{n}" }
@@ -38,7 +38,7 @@ FactoryBot.define do
     academic_year { (date || Date.current).academic_year }
     programmes { [association(:programme)] }
     organisation { association(:organisation, programmes:) }
-    location { association(:school, team:, programmes:) }
+    location { association(:school, subteam:, programmes:) }
 
     days_before_consent_reminders do
       if date && !location.generic_clinic?

--- a/spec/factories/subteams.rb
+++ b/spec/factories/subteams.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: teams
+# Table name: subteams
 #
 #  id                 :bigint           not null, primary key
 #  email              :string           not null
@@ -16,20 +16,20 @@
 #
 # Indexes
 #
-#  index_teams_on_organisation_id_and_name  (organisation_id,name) UNIQUE
+#  index_subteams_on_organisation_id_and_name  (organisation_id,name) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
 #
 FactoryBot.define do
-  factory :team do
+  factory :subteam do
     transient { sequence(:identifier) }
 
     organisation
 
-    name { "SAIS Team #{identifier}" }
-    email { "sais-team-#{identifier}@example.com" }
+    name { "SAIS Subteam #{identifier}" }
+    email { "sais-subteam-#{identifier}@example.com" }
     phone { "01234 567890" }
   end
 end

--- a/spec/features/cli_clinics_add_to_organisation_spec.rb
+++ b/spec/features/cli_clinics_add_to_organisation_spec.rb
@@ -10,19 +10,19 @@ describe "mavis clinics add-to-organisation" do
     end
   end
 
-  context "when the team doesn't exist" do
+  context "when the subteam doesn't exist" do
     it "displays an error message" do
       given_the_organisation_exists
 
       when_i_run_the_command_expecting_an_error
-      then_a_team_not_found_error_message_is_displayed
+      then_a_subteam_not_found_error_message_is_displayed
     end
   end
 
   context "when the clinic doesn't exist" do
     it "displays an error message" do
       given_the_organisation_exists
-      and_the_team_exists
+      and_the_subteam_exists
 
       when_i_run_the_command_expecting_an_error
       then_a_clinic_not_found_error_message_is_displayed
@@ -32,7 +32,7 @@ describe "mavis clinics add-to-organisation" do
   context "when the clinic exists" do
     it "runs successfully" do
       given_the_organisation_exists
-      and_the_team_exists
+      and_the_subteam_exists
       and_the_clinic_exists
 
       when_i_run_the_command
@@ -52,8 +52,8 @@ describe "mavis clinics add-to-organisation" do
     @organisation = create(:organisation, ods_code: "ABC")
   end
 
-  def and_the_team_exists
-    @team = create(:team, name: "Team", organisation: @organisation)
+  def and_the_subteam_exists
+    @subteam = create(:subteam, name: "Team", organisation: @organisation)
   end
 
   def and_the_clinic_exists
@@ -72,8 +72,8 @@ describe "mavis clinics add-to-organisation" do
     expect(@output).to include("Could not find organisation.")
   end
 
-  def then_a_team_not_found_error_message_is_displayed
-    expect(@output).to include("Could not find team.")
+  def then_a_subteam_not_found_error_message_is_displayed
+    expect(@output).to include("Could not find subteam.")
   end
 
   def then_a_clinic_not_found_error_message_is_displayed

--- a/spec/features/cli_generate_vaccination_records_spec.rb
+++ b/spec/features/cli_generate_vaccination_records_spec.rb
@@ -16,8 +16,8 @@ describe "mavis generate vaccination-records" do
   end
 
   def and_there_is_a_patient_in_a_session
-    team = create(:team, organisation: @organisation)
-    location = create(:generic_clinic, team:)
+    subteam = create(:subteam, organisation: @organisation)
+    location = create(:generic_clinic, subteam:)
     @session =
       create(
         :session,

--- a/spec/features/cli_schools_add_to_organisation_spec.rb
+++ b/spec/features/cli_schools_add_to_organisation_spec.rb
@@ -10,19 +10,19 @@ describe "mavis schools add-to-organisation" do
     end
   end
 
-  context "when the team doesn't exist" do
+  context "when the subteam doesn't exist" do
     it "displays an error message" do
       given_the_organisation_exists
 
       when_i_run_the_command_expecting_an_error
-      then_a_team_not_found_error_message_is_displayed
+      then_a_subteam_not_found_error_message_is_displayed
     end
   end
 
   context "when the school doesn't exist" do
     it "displays an error message" do
       given_the_organisation_exists
-      and_the_team_exists
+      and_the_subteam_exists
 
       when_i_run_the_command_expecting_an_error
       then_a_school_not_found_error_message_is_displayed
@@ -32,7 +32,7 @@ describe "mavis schools add-to-organisation" do
   context "when the school exists" do
     it "runs successfully" do
       given_the_organisation_exists
-      and_the_team_exists
+      and_the_subteam_exists
       and_the_school_exists
 
       when_i_run_the_command
@@ -43,7 +43,7 @@ describe "mavis schools add-to-organisation" do
   context "when customising the programmes" do
     it "runs successfully" do
       given_the_organisation_exists
-      and_the_team_exists
+      and_the_subteam_exists
       and_the_school_exists
 
       when_i_run_the_command_with_flu_only
@@ -79,8 +79,8 @@ describe "mavis schools add-to-organisation" do
       create(:organisation, ods_code: "ABC", programmes: @programmes)
   end
 
-  def and_the_team_exists
-    @team = create(:team, name: "Team", organisation: @organisation)
+  def and_the_subteam_exists
+    @subteam = create(:subteam, name: "Team", organisation: @organisation)
   end
 
   def and_the_school_exists
@@ -103,8 +103,8 @@ describe "mavis schools add-to-organisation" do
     expect(@output).to include("Could not find organisation.")
   end
 
-  def then_a_team_not_found_error_message_is_displayed
-    expect(@output).to include("Could not find team.")
+  def then_a_subteam_not_found_error_message_is_displayed
+    expect(@output).to include("Could not find subteam.")
   end
 
   def then_a_school_not_found_error_message_is_displayed

--- a/spec/features/parental_consent_closed_spec.rb
+++ b/spec/features/parental_consent_closed_spec.rb
@@ -20,8 +20,8 @@ describe "Parental consent closed" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    @team = create(:team, organisation: @organisation)
-    location = create(:school, name: "Pilot School", team: @team)
+    @subteam = create(:subteam, organisation: @organisation)
+    location = create(:school, name: "Pilot School", subteam: @subteam)
     @session =
       create(
         :session,
@@ -36,8 +36,8 @@ describe "Parental consent closed" do
     @programme = create(:programme, :hpv)
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
-    @team = create(:team, organisation: @organisation)
-    location = create(:school, name: "Pilot School", team: @team)
+    @subteam = create(:subteam, organisation: @organisation)
+    location = create(:school, name: "Pilot School", subteam: @subteam)
     @session =
       create(
         :session,
@@ -114,7 +114,7 @@ describe "Parental consent closed" do
   def then_i_see_that_consent_is_closed
     expect(page).to have_content("The deadline for responding has passed")
     expect(page).to have_content(
-      "Contact #{@team.email} to book a clinic appointment."
+      "Contact #{@subteam.email} to book a clinic appointment."
     )
   end
 end

--- a/spec/features/parental_consent_school_session_completed_spec.rb
+++ b/spec/features/parental_consent_school_session_completed_spec.rb
@@ -22,10 +22,10 @@ describe "Parental consent" do
     @organisation =
       create(:organisation, :with_one_nurse, programmes: [@programme])
 
-    team = create(:team, organisation: @organisation)
+    subteam = create(:subteam, organisation: @organisation)
 
-    @scheduled_school = create(:school, :secondary, name: "School 1", team:)
-    @completed_school = create(:school, :secondary, name: "School 2", team:)
+    @scheduled_school = create(:school, :secondary, name: "School 1", subteam:)
+    @completed_school = create(:school, :secondary, name: "School 2", subteam:)
 
     @scheduled_session =
       create(

--- a/spec/fixtures/files/onboarding/invalid.yaml
+++ b/spec/fixtures/files/onboarding/invalid.yaml
@@ -1,10 +1,10 @@
 organisation:
   email: example@trust.nhs.uk
 
-teams:
-  team_1:
+subteams:
+  subteam_1:
     phone: 07700 900816
 
 schools:
-  unknown_team: [123456, 234567]
-  team_1: [567890]
+  unknown_subteam: [123456, 234567]
+  subteam_1: [567890]

--- a/spec/fixtures/files/onboarding/valid.yaml
+++ b/spec/fixtures/files/onboarding/valid.yaml
@@ -10,28 +10,28 @@ organisation:
 
 programmes: [hpv]
 
-teams:
-  team_1:
-    name: Team 1
-    email: team-1@trust.nhs.uk
+subteams:
+  subteam_1:
+    name: Subteam 1
+    email: subteam-1@trust.nhs.uk
     phone: 07700 900816
     phone_instructions: option 9
     reply_to_id: 24af66c3-d6bd-4b9f-8067-3844f49e08d0
-  team_2:
-    name: Team 2
-    email: team-2@trust.nhs.uk
+  subteam_2:
+    name: Subteam 2
+    email: subteam-2@trust.nhs.uk
     phone: 07700 900817
 
 schools:
-  team_1: [123456, 234567]
-  team_2: [345678, 456789]
+  subteam_1: [123456, 234567]
+  subteam_2: [345678, 456789]
 
 clinics:
-  team_1:
+  subteam_1:
     - name: 10 Downing Street
       address_postcode: SW1A 1AA
       # ods_code intentionally not provided
-  team_2:
+  subteam_2:
     - name: 11 Downing Street
       address_postcode: SW1A 1AA
       ods_code: SW1A11

--- a/spec/forms/patient_search_form_spec.rb
+++ b/spec/forms/patient_search_form_spec.rb
@@ -508,7 +508,7 @@ describe PatientSearchForm do
 
     let(:organisation) { create(:organisation) }
     let(:programme) { create(:programme, :flu) }
-    let(:team) { create(:team, organisation:) }
+    let(:subteam) { create(:subteam, organisation:) }
     let(:user) { create(:user, organisation:) }
     let(:patient) { create(:patient) }
     let(:scope) { PatientPolicy::Scope.new(user, Patient).resolve }
@@ -519,7 +519,7 @@ describe PatientSearchForm do
           :school_move,
           :to_school,
           patient:,
-          school: create(:school, team:)
+          school: create(:school, subteam:)
         )
       end
 

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -23,9 +23,9 @@ describe GovukNotifyPersonalisation do
       programmes:
     )
   end
-  let(:team) do
+  let(:subteam) do
     create(
-      :team,
+      :subteam,
       name: "Organisation",
       email: "organisation@example.com",
       phone: "01234 567890",
@@ -43,7 +43,7 @@ describe GovukNotifyPersonalisation do
       year_group: 8
     )
   end
-  let(:location) { create(:school, name: "Hogwarts", team:) }
+  let(:location) { create(:school, name: "Hogwarts", subteam:) }
   let(:session) do
     create(
       :session,
@@ -88,6 +88,9 @@ describe GovukNotifyPersonalisation do
         short_patient_name: "John",
         short_patient_name_apos: "John’s",
         subsequent_session_dates_offered_message: "",
+        subteam_email: "organisation@example.com",
+        subteam_name: "Organisation",
+        subteam_phone: "01234 567890 (option 1)",
         team_email: "organisation@example.com",
         team_name: "Organisation",
         team_phone: "01234 567890 (option 1)",

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -34,7 +34,7 @@ describe Reports::OfflineSessionExporter do
       create(:organisation, :with_generic_clinic, programmes: [programme])
     end
     let(:user) { create(:user, email: "nurse@example.com", organisation:) }
-    let(:team) { create(:team, organisation:) }
+    let(:subteam) { create(:subteam, organisation:) }
     let(:session) do
       create(:session, location:, organisation:, programmes: [programme])
     end
@@ -42,7 +42,7 @@ describe Reports::OfflineSessionExporter do
     context "a school session" do
       subject(:workbook) { RubyXL::Parser.parse_buffer(call) }
 
-      let(:location) { create(:school, team:) }
+      let(:location) { create(:school, subteam:) }
 
       it { should_not be_blank }
 

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -28,7 +28,7 @@ describe Reports::ProgrammeVaccinationsExporter do
         organisation:
       )
     end
-    let(:team) { create(:team, organisation:) }
+    let(:subteam) { create(:subteam, organisation:) }
     let(:session) { create(:session, location:, organisation:, programmes:) }
 
     let(:start_date) { nil }
@@ -98,7 +98,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       subject(:rows) { CSV.parse(call, headers: true) }
 
       context "a school session" do
-        let(:location) { create(:school, team:) }
+        let(:location) { create(:school, subteam:) }
 
         it { should be_empty }
 
@@ -250,7 +250,7 @@ describe Reports::ProgrammeVaccinationsExporter do
       end
 
       context "a clinic session" do
-        let(:location) { create(:generic_clinic, team:) }
+        let(:location) { create(:generic_clinic, subteam:) }
 
         it { should be_empty }
 

--- a/spec/lib/tasks/schools_rake_spec.rb
+++ b/spec/lib/tasks/schools_rake_spec.rb
@@ -6,9 +6,9 @@ describe "schools:move_patients" do
   end
 
   let(:organisation) { create(:organisation) }
-  let(:team) { create(:team, organisation:) }
-  let(:other_team) { create(:team, organisation:) }
-  let(:source_school) { create(:school, organisation: organisation, team:) }
+  let(:subteam) { create(:subteam, organisation:) }
+  let(:other_subteam) { create(:subteam, organisation:) }
+  let(:source_school) { create(:school, organisation: organisation, subteam:) }
   let(:target_school) { create(:school, organisation: organisation) }
   let(:programmes) { [create(:programme, :hpv)] }
   let!(:patient) { create(:patient, school: source_school) }
@@ -24,7 +24,7 @@ describe "schools:move_patients" do
       session:
     )
   end
-  let(:other_org_school) { create(:school, team: other_team) }
+  let(:other_org_school) { create(:school, subteam: other_subteam) }
 
   let(:source_urn) { source_school.urn.to_s }
   let(:target_urn) { target_school.urn.to_s }

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -20,17 +20,17 @@
 #  year_groups               :integer          default([]), not null, is an Array
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
-#  team_id                   :bigint
+#  subteam_id                :bigint
 #
 # Indexes
 #
-#  index_locations_on_ods_code  (ods_code) UNIQUE
-#  index_locations_on_team_id   (team_id)
-#  index_locations_on_urn       (urn) UNIQUE
+#  index_locations_on_ods_code    (ods_code) UNIQUE
+#  index_locations_on_subteam_id  (subteam_id)
+#  index_locations_on_urn         (urn) UNIQUE
 #
 # Foreign Keys
 #
-#  fk_rails_...  (team_id => teams.id)
+#  fk_rails_...  (subteam_id => subteams.id)
 #
 
 describe Location do
@@ -198,7 +198,7 @@ describe Location do
     end
 
     context "when the location is not attached to an organisation" do
-      let(:location) { create(:school, team: nil) }
+      let(:location) { create(:school, subteam: nil) }
 
       it { should include("is_attached_to_organisation" => false) }
     end

--- a/spec/models/onboarding_spec.rb
+++ b/spec/models/onboarding_spec.rb
@@ -38,30 +38,32 @@ describe Onboarding do
       expect(generic_clinic.year_groups).to eq([8, 9, 10, 11])
       expect(generic_clinic.programme_year_groups.count).to eq(4)
 
-      team1 = organisation.teams.includes(:schools).find_by!(name: "Team 1")
-      expect(team1.email).to eq("team-1@trust.nhs.uk")
-      expect(team1.phone).to eq("07700 900816")
-      expect(team1.phone_instructions).to eq("option 9")
-      expect(team1.reply_to_id).to eq("24af66c3-d6bd-4b9f-8067-3844f49e08d0")
+      subteam1 =
+        organisation.subteams.includes(:schools).find_by!(name: "Subteam 1")
+      expect(subteam1.email).to eq("subteam-1@trust.nhs.uk")
+      expect(subteam1.phone).to eq("07700 900816")
+      expect(subteam1.phone_instructions).to eq("option 9")
+      expect(subteam1.reply_to_id).to eq("24af66c3-d6bd-4b9f-8067-3844f49e08d0")
 
-      team2 = organisation.teams.includes(:schools).find_by!(name: "Team 2")
-      expect(team2.email).to eq("team-2@trust.nhs.uk")
-      expect(team2.phone).to eq("07700 900817")
-      expect(team2.reply_to_id).to be_nil
+      subteam2 =
+        organisation.subteams.includes(:schools).find_by!(name: "Subteam 2")
+      expect(subteam2.email).to eq("subteam-2@trust.nhs.uk")
+      expect(subteam2.phone).to eq("07700 900817")
+      expect(subteam2.reply_to_id).to be_nil
 
-      expect(team1.schools).to contain_exactly(school1, school2)
-      expect(team2.schools).to contain_exactly(school3, school4)
+      expect(subteam1.schools).to contain_exactly(school1, school2)
+      expect(subteam2.schools).to contain_exactly(school3, school4)
 
       expect(school1.programme_year_groups.count).to eq(4)
       expect(school2.programme_year_groups.count).to eq(4)
       expect(school3.programme_year_groups.count).to eq(4)
       expect(school4.programme_year_groups.count).to eq(4)
 
-      clinic1 = team1.community_clinics.find_by!(ods_code: nil)
+      clinic1 = subteam1.community_clinics.find_by!(ods_code: nil)
       expect(clinic1.name).to eq("10 Downing Street")
       expect(clinic1.address_postcode).to eq("SW1A 1AA")
 
-      clinic2 = team2.community_clinics.find_by!(ods_code: "SW1A11")
+      clinic2 = subteam2.community_clinics.find_by!(ods_code: "SW1A11")
       expect(clinic2.name).to eq("11 Downing Street")
       expect(clinic2.address_postcode).to eq("SW1A 1AA")
 
@@ -85,11 +87,11 @@ describe Onboarding do
           "organisation.phone": ["can't be blank", "is invalid"],
           "organisation.privacy_notice_url": ["can't be blank"],
           "organisation.privacy_policy_url": ["can't be blank"],
-          "school.0.team": ["can't be blank"],
-          "school.1.team": ["can't be blank"],
+          "school.0.subteam": ["can't be blank"],
+          "school.1.subteam": ["can't be blank"],
           "school.2.status": ["is not included in the list"],
-          "team.email": ["can't be blank"],
-          "team.name": ["can't be blank"],
+          "subteam.email": ["can't be blank"],
+          "subteam.name": ["can't be blank"],
           clinics: ["can't be blank"],
           programmes: ["can't be blank"]
         }

--- a/spec/models/subteam_spec.rb
+++ b/spec/models/subteam_spec.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: teams
+# Table name: subteams
 #
 #  id                 :bigint           not null, primary key
 #  email              :string           not null
@@ -16,15 +16,15 @@
 #
 # Indexes
 #
-#  index_teams_on_organisation_id_and_name  (organisation_id,name) UNIQUE
+#  index_subteams_on_organisation_id_and_name  (organisation_id,name) UNIQUE
 #
 # Foreign Keys
 #
 #  fk_rails_...  (organisation_id => organisations.id)
 #
 
-describe Team do
-  subject(:team) { build(:team) }
+describe Subteam do
+  subject(:subteam) { build(:subteam) }
 
   it_behaves_like "a model with a normalised email address"
   it_behaves_like "a model with a normalised phone number"

--- a/spec/requests/api/testing/locations_spec.rb
+++ b/spec/requests/api/testing/locations_spec.rb
@@ -4,22 +4,22 @@ describe "/api/testing/locations" do
   before { Flipper.enable(:testing_api) }
   after { Flipper.disable(:testing_api) }
 
-  let(:team) { create(:team) }
+  let(:subteam) { create(:subteam) }
 
   let!(:community_clinic) do
-    create(:community_clinic, :open, name: "Location A", team:)
+    create(:community_clinic, :open, name: "Location A", subteam:)
   end
   let!(:generic_clinic) do
-    create(:generic_clinic, :closed, name: "Location B", team:)
+    create(:generic_clinic, :closed, name: "Location B", subteam:)
   end
   let!(:gp_practice) do
-    create(:gp_practice, :closed, name: "Location C", team:)
+    create(:gp_practice, :closed, name: "Location C", subteam:)
   end
   let!(:primary_school) do
-    create(:school, :primary, :closed, name: "Location D", team: nil)
+    create(:school, :primary, :closed, name: "Location D", subteam: nil)
   end
   let!(:secondary_school) do
-    create(:school, :secondary, :closed, name: "Location E", team: nil)
+    create(:school, :secondary, :closed, name: "Location E", subteam: nil)
   end
 
   describe "GET" do

--- a/spec/requests/api/testing/onboard_spec.rb
+++ b/spec/requests/api/testing/onboard_spec.rb
@@ -59,14 +59,14 @@ describe "/api/testing/onboard" do
             "programmes" => ["can't be blank"],
             "school.0.location" => ["can't be blank"],
             "school.0.status" => ["is not included in the list"],
-            "school.0.team" => ["can't be blank"],
+            "school.0.subteam" => ["can't be blank"],
             "school.1.location" => ["can't be blank"],
             "school.1.status" => ["is not included in the list"],
-            "school.1.team" => ["can't be blank"],
+            "school.1.subteam" => ["can't be blank"],
             "school.2.location" => ["can't be blank"],
             "school.2.status" => ["is not included in the list"],
-            "team.email" => ["can't be blank"],
-            "team.name" => ["can't be blank"]
+            "subteam.email" => ["can't be blank"],
+            "subteam.name" => ["can't be blank"]
           }
         )
       end


### PR DESCRIPTION
This renames the team model, and all associated models and foreign keys to subteam. The functionality of the service before and after should be the same.

We're doing this because we're going to be restructuring organisations and teams in to three levels. What we currently call teams becomes subteams, organisations becomes teams and we'll be introducing a new top-level organisation to group teams together.

To support this change I've also added three new personalisation variables to use in GOV.UK Notify: `subteam_name`, `subteam_email` and `subteam_phone`. These are equivalent to the existing variables prefixed with `team_` and once the templates have been updated we can remove them.

[Jira Issue - MAV-1280](https://nhsd-jira.digital.nhs.uk/browse/MAV-1280)