### PR TITLE
Order academic years most recent first

### DIFF
--- a/app/lib/academic_year.rb
+++ b/app/lib/academic_year.rb
@@ -2,7 +2,7 @@
 
 module AcademicYear
   class << self
-    def all = (first..last).to_a
+    def all = (first..last).to_a.reverse
 
     def current = Date.current.academic_year
 

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -19,13 +19,13 @@ describe AcademicYear do
     context "preparing for 2025" do
       let(:today) { Date.new(2025, 8, 1) }
 
-      it { should eq([2024, 2025]) }
+      it { should eq([2025, 2024]) }
     end
 
     context "first day of 2025" do
       let(:today) { Date.new(2025, 9, 1) }
 
-      it { should eq([2024, 2025]) }
+      it { should eq([2025, 2024]) }
     end
   end
 


### PR DESCRIPTION
This changes the order of academic years when displayed in a number of places to ensure that the most recent years are shown first.