### PR TITLE
Prevent changing the vaccination record administration date to a different academic year

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,6 @@ en:
               missing_month: Enter a month
               missing_year: Enter a year
               invalid: Enter a valid date and time
-              less_than_or_equal_to: Enter a time in the past
         health_answer:
           attributes:
             notes:

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -400,9 +400,11 @@ describe "Edit vaccination record" do
   end
 
   def when_i_fill_in_a_valid_date_and_time
-    fill_in "Year", with: "2024"
-    fill_in "Month", with: "9"
-    fill_in "Day", with: "1"
+    @valid_date = Date.current - 1.day
+
+    fill_in "Year", with: @valid_date.year.to_s
+    fill_in "Month", with: @valid_date.month.to_s
+    fill_in "Day", with: @valid_date.day.to_s
 
     fill_in "Hour", with: "12"
     fill_in "Minute", with: "00"
@@ -437,7 +439,9 @@ describe "Edit vaccination record" do
   end
 
   def and_i_should_see_the_updated_date_time
-    expect(page).to have_content("Date1 September 2024")
+    formatted_date = @valid_date.strftime("%-d %B %Y")
+
+    expect(page).to have_content("Date#{formatted_date}")
     expect(page).to have_content("Time12:00pm")
   end
 


### PR DESCRIPTION
This change adds a validation that the vaccination event administration date falls within the same academic year as the session it is attached to. This validation prevents editing vaccination records to be outside the given academic year.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1567

<img width="791" height="680" alt="image" src="https://github.com/user-attachments/assets/0f6ccbc3-33de-4bc8-977c-eacc5ace799d" />
