### PR TITLE
Rename feature flag used to enqueue for imms api

### DIFF
--- a/app/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern.rb
+++ b/app/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern.rb
@@ -13,7 +13,7 @@ module VaccinationRecordSyncToNHSImmunisationsAPIConcern
   end
 
   def sync_to_nhs_immunisations_api
-    return unless Flipper.enabled?(:sync_vaccination_records_to_nhs_on_create)
+    return unless Flipper.enabled?(:enqueue_sync_vaccination_records_to_nhs)
     return unless syncable_to_nhs_immunisations_api?
 
     # The immunisations api module checks if a sync is still pending using this

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -10,5 +10,5 @@ offline_working: Prototype support for using Mavis offline.
 immunisations_fhir_api_integration: Master switch to control communications with
   NHS Immunistaions FHIR API.
 
-sync_vaccination_records_to_nhs_on_create: Send new vaccinations recorded by
+enqueue_sync_vaccination_records_to_nhs: Send new vaccinations recorded by
   nurses to NHS Immunisations FHIR API.

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -18,7 +18,7 @@ describe "Delete vaccination record" do
 
   scenario "User deletes a record and checks activity log" do
     given_an_hpv_programme_is_underway
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
     and_an_administered_vaccination_record_exists
 
     when_i_sign_in_as_a_superuser
@@ -168,8 +168,8 @@ describe "Delete vaccination record" do
     @vaccination_record.update(confirmation_sent_at: Time.current)
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     uuid = Random.uuid

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -5,7 +5,7 @@ describe "Edit vaccination record" do
     given_i_am_signed_in
     and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
     when_i_go_to_the_vaccination_records_page
     then_i_should_see_the_vaccination_records
@@ -105,7 +105,7 @@ describe "Edit vaccination record" do
   scenario "Edit outcome to vaccinated" do
     given_i_am_signed_in
     and_an_hpv_programme_is_underway
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
     and_a_not_administered_vaccination_record_exists
     and_the_vaccination_confirmation_was_already_sent
 
@@ -141,7 +141,7 @@ describe "Edit vaccination record" do
   scenario "Edit outcome to not vaccinated" do
     given_i_am_signed_in
     and_an_hpv_programme_is_underway
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
     and_an_administered_vaccination_record_exists
     and_the_vaccination_confirmation_was_already_sent
 
@@ -298,8 +298,8 @@ describe "Edit vaccination record" do
     end
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     uuid = Random.uuid

--- a/spec/features/flu_vaccination_administered_spec.rb
+++ b/spec/features/flu_vaccination_administered_spec.rb
@@ -7,7 +7,7 @@ describe "Flu vaccination" do
     given_i_am_signed_in_with_flu_programme
     and_there_is_a_flu_session_today_with_patients_ready_to_vaccinate
     and_there_are_nasal_and_injection_batches
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
     when_i_go_to_the_nasal_only_patient
     then_i_see_the_vaccination_form_for_nasal_spray
@@ -157,8 +157,8 @@ describe "Flu vaccination" do
       )
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     @stubbed_post_request = stub_immunisations_api_post

--- a/spec/features/hpv_vaccination_administered_spec.rb
+++ b/spec/features/hpv_vaccination_administered_spec.rb
@@ -5,7 +5,7 @@ describe "HPV vaccination" do
 
   scenario "Administered with common delivery site" do
     given_i_am_signed_in
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_fill_in_pre_screening_questions
@@ -106,8 +106,8 @@ describe "HPV vaccination" do
     sign_in organisation.users.first
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     immunisation_uuid = Random.uuid

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -44,7 +44,7 @@ describe "HPV vaccination" do
 
   scenario "User uploads duplicates in an offline recording for a session" do
     given_an_hpv_programme_is_underway_with_a_single_patient
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
     when_i_choose_to_record_offline_from_a_school_session_page
     and_alter_an_existing_vaccination_record_to_create_a_duplicate
@@ -168,8 +168,8 @@ describe "HPV vaccination" do
     )
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     immunisation_uuid = Random.uuid

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -205,7 +205,7 @@ describe "Manage children" do
   end
 
   def and_sync_vaccination_records_to_nhs_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     immunisation_uuid = Random.uuid

--- a/spec/features/menacwy_vaccination_administered_spec.rb
+++ b/spec/features/menacwy_vaccination_administered_spec.rb
@@ -5,7 +5,7 @@ describe "MenACWY vaccination" do
 
   scenario "Administered" do
     given_i_am_signed_in
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_record_that_the_patient_has_been_vaccinated
@@ -84,8 +84,8 @@ describe "MenACWY vaccination" do
     sign_in organisation.users.first
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     @stubbed_post_request = stub_immunisations_api_post

--- a/spec/features/td_ipv_vaccination_administered_spec.rb
+++ b/spec/features/td_ipv_vaccination_administered_spec.rb
@@ -5,7 +5,7 @@ describe "Td/IPV vaccination" do
 
   scenario "Administered" do
     given_i_am_signed_in
-    and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
+    and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
     when_i_go_to_a_patient_that_is_ready_to_vaccinate
     and_i_record_that_the_patient_has_been_vaccinated
@@ -84,8 +84,8 @@ describe "Td/IPV vaccination" do
     sign_in organisation.users.first
   end
 
-  def and_sync_vaccination_records_to_nhs_on_create_feature_is_enabled
-    Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+  def and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
     Flipper.enable(:immunisations_fhir_api_integration)
 
     @stubbed_post_request = stub_immunisations_api_post

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -167,7 +167,7 @@ describe PatientMerger do
     end
 
     it "enqueues sync jobs for vaccination records" do
-      Flipper.enable(:sync_vaccination_records_to_nhs_on_create)
+      Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
       expect { call }.to have_enqueued_job(SyncVaccinationRecordToNHSJob).with(
         vaccination_record
       )

--- a/spec/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern_spec.rb
+++ b/spec/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern_spec.rb
@@ -9,7 +9,7 @@ describe VaccinationRecordSyncToNHSImmunisationsAPIConcern do
   let(:session) { create(:session, programmes: [programme]) }
 
   describe "#sync_to_nhs_immunisations_api" do
-    before { Flipper.enable(:sync_vaccination_records_to_nhs_on_create) }
+    before { Flipper.enable(:enqueue_sync_vaccination_records_to_nhs) }
 
     it "enqueues the job if the vaccination record is elligible to sync" do
       expect {
@@ -50,7 +50,7 @@ describe VaccinationRecordSyncToNHSImmunisationsAPIConcern do
     end
 
     context "when the feature flag is disabled" do
-      before { Flipper.disable(:sync_vaccination_records_to_nhs_on_create) }
+      before { Flipper.disable(:enqueue_sync_vaccination_records_to_nhs) }
 
       let(:vaccination_record) { create(:vaccination_record) }
 

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -333,7 +333,7 @@ describe ImmunisationImport do
       )
     end
 
-    before { Flipper.enable :sync_vaccination_records_to_nhs_on_create }
+    before { Flipper.enable :enqueue_sync_vaccination_records_to_nhs }
 
     let(:session) { create(:session, programmes:) }
     let(:vaccination_record) do


### PR DESCRIPTION
This name better describes what the flag is used for.

Once deployed we'll have to update the feature flag in `qa` manually.