### PR TITLE
Add flu procedure codes

### DIFF
--- a/app/lib/fhir_mapper/programme.rb
+++ b/app/lib/fhir_mapper/programme.rb
@@ -4,8 +4,6 @@ module FHIRMapper
   class Programme
     delegate :snomed_target_disease_code,
              :snomed_target_disease_term,
-             :snomed_procedure_code,
-             :snomed_procedure_term,
              to: :@programme
 
     def initialize(programme)
@@ -19,18 +17,6 @@ module FHIRMapper
             system: "http://snomed.info/sct",
             code: snomed_target_disease_code,
             display: snomed_target_disease_term
-          )
-        ]
-      )
-    end
-
-    def fhir_procedure_coding
-      FHIR::CodeableConcept.new(
-        coding: [
-          FHIR::Coding.new(
-            system: "http://snomed.info/sct",
-            code: snomed_procedure_code,
-            display: snomed_procedure_term
           )
         ]
       )

--- a/app/lib/fhir_mapper/vaccination_record.rb
+++ b/app/lib/fhir_mapper/vaccination_record.rb
@@ -61,7 +61,7 @@ module FHIRMapper
       FHIR::Extension.new(
         url:
           "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-VaccinationProcedure",
-        valueCodeableConcept: programme.fhir_procedure_coding
+        valueCodeableConcept: vaccine.fhir_procedure_coding
       )
     end
 

--- a/app/lib/fhir_mapper/vaccination_record.rb
+++ b/app/lib/fhir_mapper/vaccination_record.rb
@@ -61,7 +61,7 @@ module FHIRMapper
       FHIR::Extension.new(
         url:
           "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-VaccinationProcedure",
-        valueCodeableConcept: vaccine.fhir_procedure_coding
+        valueCodeableConcept: vaccine.fhir_procedure_coding(dose_sequence:)
       )
     end
 
@@ -75,18 +75,6 @@ module FHIRMapper
       else
         raise ArgumentError, "Unknown outcome: #{outcome}"
       end
-    end
-
-    def fhir_vaccine_code
-      FHIR::CodeableConcept.new(
-        coding: [
-          FHIR::Coding.new(
-            system: "http://snomed.info/sct",
-            code: vaccine.snomed_product_code,
-            display: vaccine.snomed_product_term
-          )
-        ]
-      )
     end
 
     def fhir_site

--- a/app/lib/fhir_mapper/vaccine.rb
+++ b/app/lib/fhir_mapper/vaccine.rb
@@ -2,7 +2,9 @@
 
 module FHIRMapper
   class Vaccine
-    delegate :snomed_product_code,
+    delegate :snomed_procedure_code,
+             :snomed_procedure_term,
+             :snomed_product_code,
              :snomed_product_term,
              :manufacturer,
              to: :@vaccine
@@ -25,6 +27,18 @@ module FHIRMapper
 
     def fhir_manufacturer_reference
       FHIR::Reference.new(display: manufacturer)
+    end
+
+    def fhir_procedure_coding
+      FHIR::CodeableConcept.new(
+        coding: [
+          FHIR::Coding.new(
+            system: "http://snomed.info/sct",
+            code: snomed_procedure_code,
+            display: snomed_procedure_term
+          )
+        ]
+      )
     end
   end
 end

--- a/app/lib/fhir_mapper/vaccine.rb
+++ b/app/lib/fhir_mapper/vaccine.rb
@@ -29,12 +29,12 @@ module FHIRMapper
       FHIR::Reference.new(display: manufacturer)
     end
 
-    def fhir_procedure_coding
+    def fhir_procedure_coding(dose_sequence:)
       FHIR::CodeableConcept.new(
         coding: [
           FHIR::Coding.new(
             system: "http://snomed.info/sct",
-            code: snomed_procedure_code,
+            code: snomed_procedure_code(dose_sequence:),
             display: snomed_procedure_term
           )
         ]

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -224,7 +224,7 @@ class Reports::ProgrammeVaccinationsExporter
       vaccination_record.dose_volume_ml,
       reason_not_vaccinated(vaccination_record:),
       patient.id,
-      vaccine&.snomed_procedure_code,
+      vaccination_record.snomed_procedure_code,
       reason_for_inclusion(vaccination_record:),
       record_created_at(vaccination_record:),
       record_updated_at(vaccination_record:)

--- a/app/lib/reports/programme_vaccinations_exporter.rb
+++ b/app/lib/reports/programme_vaccinations_exporter.rb
@@ -172,6 +172,7 @@ class Reports::ProgrammeVaccinationsExporter
     location = vaccination_record.location
     patient = vaccination_record.patient
     session = vaccination_record.session
+    vaccine = vaccination_record.vaccine
 
     grouped_consents = consents.fetch(patient.id, [])
     triage = triages[patient.id]
@@ -211,7 +212,7 @@ class Reports::ProgrammeVaccinationsExporter
       vaccination_record.performed_at.to_date.iso8601,
       vaccination_record.performed_at.strftime("%H:%M:%S"),
       programme.name,
-      vaccination_record.vaccine&.nivs_name || "",
+      vaccine&.nivs_name || "",
       vaccination_record.performed_by_user&.email || "",
       vaccination_record.performed_by&.given_name || "",
       vaccination_record.performed_by&.family_name || "",
@@ -223,7 +224,7 @@ class Reports::ProgrammeVaccinationsExporter
       vaccination_record.dose_volume_ml,
       reason_not_vaccinated(vaccination_record:),
       patient.id,
-      programme.snomed_procedure_code,
+      vaccine&.snomed_procedure_code,
       reason_for_inclusion(vaccination_record:),
       record_created_at(vaccination_record:),
       record_updated_at(vaccination_record:)

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -45,7 +45,7 @@ class Programme < ApplicationRecord
        { flu: "flu", hpv: "hpv", menacwy: "menacwy", td_ipv: "td_ipv" },
        validate: true
 
-  delegate :fhir_target_disease_coding, :fhir_procedure_coding, to: :fhir_mapper
+  delegate :fhir_target_disease_coding, to: :fhir_mapper
 
   def to_param = type
 
@@ -118,35 +118,6 @@ class Programme < ApplicationRecord
 
   def import_names
     IMPORT_NAMES.fetch(type)
-  end
-
-  SNOMED_PROCEDURE_CODES = {
-    "flu" => "822851000000102",
-    "hpv" => "761841000",
-    "menacwy" => "871874000",
-    "td_ipv" => "866186002"
-  }.freeze
-
-  def snomed_procedure_code
-    SNOMED_PROCEDURE_CODES.fetch(type)
-  end
-
-  SNOMED_PROCEDURE_TERMS = {
-    "flu" => "Seasonal influenza vaccination (procedure)",
-    "hpv" =>
-      "Administration of vaccine product containing only Human " \
-        "papillomavirus antigen (procedure)",
-    "menacwy" =>
-      "Administration of vaccine product containing only Neisseria " \
-        "meningitidis serogroup A, C, W135 and Y antigens (procedure)",
-    "td_ipv" =>
-      "Administration of vaccine product containing only Clostridium " \
-        "tetani and Corynebacterium diphtheriae and Human poliovirus " \
-        "antigens (procedure)"
-  }.freeze
-
-  def snomed_procedure_term
-    SNOMED_PROCEDURE_TERMS.fetch(type)
   end
 
   SNOMED_TARGET_DISEASE_CODES = {

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -200,6 +200,10 @@ class VaccinationRecord < ApplicationRecord
     DELIVERY_METHOD_SNOMED_CODES_AND_TERMS.fetch(delivery_method).second
   end
 
+  def snomed_procedure_code = vaccine&.snomed_procedure_code(dose_sequence:)
+
+  delegate :snomed_procedure_term, to: :vaccine, allow_nil: true
+
   private
 
   def requires_location_name?

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -99,14 +99,24 @@ class Vaccine < ApplicationRecord
   end
 
   SNOMED_PROCEDURE_CODES = {
-    "flu" => "822851000000102",
-    "hpv" => "761841000",
-    "menacwy" => "871874000",
-    "td_ipv" => "866186002"
+    "flu" => {
+      "injection" => %w[985151000000100 985171000000109],
+      "nasal" => %w[884861000000100 884881000000109]
+    },
+    "hpv" => {
+      "injection" => "761841000"
+    },
+    "menacwy" => {
+      "injection" => "871874000"
+    },
+    "td_ipv" => {
+      "injection" => "866186002"
+    }
   }.freeze
 
-  def snomed_procedure_code
-    SNOMED_PROCEDURE_CODES.fetch(programme.type)
+  def snomed_procedure_code(dose_sequence:)
+    codes = SNOMED_PROCEDURE_CODES.fetch(programme.type).fetch(method)
+    codes.is_a?(Array) ? codes[dose_sequence - 1] : codes
   end
 
   SNOMED_PROCEDURE_TERMS = {

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -55,6 +55,7 @@ class Vaccine < ApplicationRecord
   delegate :first_health_question, to: :health_questions
   delegate :fhir_codeable_concept,
            :fhir_manufacturer_reference,
+           :fhir_procedure_coding,
            to: :fhir_mapper
 
   def active? = !discontinued
@@ -97,7 +98,38 @@ class Vaccine < ApplicationRecord
     suitable_delivery_methods.keys.first
   end
 
+  SNOMED_PROCEDURE_CODES = {
+    "flu" => "822851000000102",
+    "hpv" => "761841000",
+    "menacwy" => "871874000",
+    "td_ipv" => "866186002"
+  }.freeze
+
+  def snomed_procedure_code
+    SNOMED_PROCEDURE_CODES.fetch(programme.type)
+  end
+
+  SNOMED_PROCEDURE_TERMS = {
+    "flu" => "Seasonal influenza vaccination (procedure)",
+    "hpv" =>
+      "Administration of vaccine product containing only Human " \
+        "papillomavirus antigen (procedure)",
+    "menacwy" =>
+      "Administration of vaccine product containing only Neisseria " \
+        "meningitidis serogroup A, C, W135 and Y antigens (procedure)",
+    "td_ipv" =>
+      "Administration of vaccine product containing only Clostridium " \
+        "tetani and Corynebacterium diphtheriae and Human poliovirus " \
+        "antigens (procedure)"
+  }.freeze
+
+  def snomed_procedure_term
+    SNOMED_PROCEDURE_TERMS.fetch(programme.type)
+  end
+
   private
 
-  def fhir_mapper = @fhir_mapper ||= FHIRMapper::Vaccine.new(self)
+  def fhir_mapper
+    @fhir_mapper ||= FHIRMapper::Vaccine.new(self)
+  end
 end

--- a/spec/lib/fhir_mapper/programme_spec.rb
+++ b/spec/lib/fhir_mapper/programme_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe FHIRMapper::Programme do
+describe FHIRMapper::Programme do
   let(:programme) { create(:programme, :hpv) }
   let(:mapper) { described_class.new(programme) }
 
@@ -12,19 +12,6 @@ RSpec.describe FHIRMapper::Programme do
       expect(coding.system).to eq("http://snomed.info/sct")
       expect(coding.code).to eq("240532009")
       expect(coding.display).to eq("Human papillomavirus infection")
-    end
-  end
-
-  describe "#procedure_coding" do
-    subject(:procedure_coding) { mapper.fhir_procedure_coding }
-
-    it "returns a FHIR CodeableConcept with the correct coding" do
-      coding = procedure_coding.coding.first
-      expect(coding.system).to eq("http://snomed.info/sct")
-      expect(coding.code).to eq("761841000")
-      expect(coding.display).to eq(
-        "Administration of vaccine product containing only Human papillomavirus antigen (procedure)"
-      )
     end
   end
 end

--- a/spec/lib/fhir_mapper/vaccine_spec.rb
+++ b/spec/lib/fhir_mapper/vaccine_spec.rb
@@ -6,6 +6,7 @@ describe FHIRMapper::Vaccine do
   let(:vaccine) do
     create(
       :vaccine,
+      :injection,
       snomed_product_code: "183817183",
       snomed_product_term: "This is one great vaccine!!!",
       manufacturer: "Merck Sharp & Dohme",
@@ -35,7 +36,9 @@ describe FHIRMapper::Vaccine do
   end
 
   describe "#fhir_procedure_coding" do
-    subject(:fhir_procedure_coding) { fhir_mapper.fhir_procedure_coding }
+    subject(:fhir_procedure_coding) do
+      fhir_mapper.fhir_procedure_coding(dose_sequence: nil)
+    end
 
     it { should be_a(FHIR::CodeableConcept) }
 

--- a/spec/lib/fhir_mapper/vaccine_spec.rb
+++ b/spec/lib/fhir_mapper/vaccine_spec.rb
@@ -8,15 +8,18 @@ describe FHIRMapper::Vaccine do
       :vaccine,
       snomed_product_code: "183817183",
       snomed_product_term: "This is one great vaccine!!!",
-      manufacturer: "Merck Sharp & Dohme"
+      manufacturer: "Merck Sharp & Dohme",
+      programme: create(:programme, :hpv)
     )
   end
 
   describe "#fhir_codeable_concept" do
-    subject(:vaccine_codeable_concept) { fhir_mapper.fhir_codeable_concept }
+    subject(:fhir_codeable_concept) { fhir_mapper.fhir_codeable_concept }
+
+    it { should be_a(FHIR::CodeableConcept) }
 
     describe "it's coding" do
-      subject { vaccine_codeable_concept.coding.first }
+      subject { fhir_codeable_concept.coding.first }
 
       its(:code) { should eq "183817183" }
       its(:display) { should eq "This is one great vaccine!!!" }
@@ -29,5 +32,24 @@ describe FHIRMapper::Vaccine do
 
     it { should be_a FHIR::Reference }
     its(:display) { should eq "Merck Sharp & Dohme" }
+  end
+
+  describe "#fhir_procedure_coding" do
+    subject(:fhir_procedure_coding) { fhir_mapper.fhir_procedure_coding }
+
+    it { should be_a(FHIR::CodeableConcept) }
+
+    describe "it's coding" do
+      subject { fhir_procedure_coding.coding.first }
+
+      its(:system) { should eq("http://snomed.info/sct") }
+      its(:code) { should eq("761841000") }
+
+      its(:display) do
+        should eq(
+                 "Administration of vaccine product containing only Human papillomavirus antigen (procedure)"
+               )
+      end
+    end
   end
 end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -95,12 +95,9 @@ describe Reports::ProgrammeVaccinationsExporter do
 
         context "with a vaccinated patient" do
           let(:patient) { create(:patient, session:) }
+          let(:vaccine) { programme.vaccines.active.first }
           let(:batch) do
-            create(
-              :batch,
-              expiry: Date.new(2025, 12, 1),
-              vaccine: programme.vaccines.active.first
-            )
+            create(:batch, expiry: Date.new(2025, 12, 1), vaccine:)
           end
           let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
 
@@ -163,7 +160,7 @@ describe Reports::ProgrammeVaccinationsExporter do
                 "ROUTE_OF_VACCINATION" => "intramuscular",
                 "SCHOOL_NAME" => location.name,
                 "SCHOOL_URN" => location.urn,
-                "SNOMED_PROCEDURE_CODE" => programme.snomed_procedure_code,
+                "SNOMED_PROCEDURE_CODE" => vaccine.snomed_procedure_code,
                 "TIME_OF_VACCINATION" => "12:05:20",
                 "TRIAGED_BY" => "",
                 "TRIAGE_DATE" => "",
@@ -249,12 +246,9 @@ describe Reports::ProgrammeVaccinationsExporter do
 
         context "with a vaccinated patient" do
           let(:patient) { create(:patient, session:) }
+          let(:vaccine) { programmes.first.vaccines.active.first }
           let(:batch) do
-            create(
-              :batch,
-              expiry: Date.new(2025, 12, 1),
-              vaccine: programmes.first.vaccines.active.first
-            )
+            create(:batch, expiry: Date.new(2025, 12, 1), vaccine:)
           end
           let(:performed_at) { Time.zone.local(2024, 1, 1, 12, 5, 20) }
 
@@ -316,7 +310,7 @@ describe Reports::ProgrammeVaccinationsExporter do
                 "ROUTE_OF_VACCINATION" => "intramuscular",
                 "SCHOOL_NAME" => "",
                 "SCHOOL_URN" => "888888",
-                "SNOMED_PROCEDURE_CODE" => programme.snomed_procedure_code,
+                "SNOMED_PROCEDURE_CODE" => vaccine.snomed_procedure_code,
                 "TIME_OF_VACCINATION" => "12:05:20",
                 "TRIAGED_BY" => "",
                 "TRIAGE_DATE" => "",

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -160,7 +160,8 @@ describe Reports::ProgrammeVaccinationsExporter do
                 "ROUTE_OF_VACCINATION" => "intramuscular",
                 "SCHOOL_NAME" => location.name,
                 "SCHOOL_URN" => location.urn,
-                "SNOMED_PROCEDURE_CODE" => vaccine.snomed_procedure_code,
+                "SNOMED_PROCEDURE_CODE" =>
+                  vaccination_record.snomed_procedure_code,
                 "TIME_OF_VACCINATION" => "12:05:20",
                 "TRIAGED_BY" => "",
                 "TRIAGE_DATE" => "",
@@ -310,7 +311,8 @@ describe Reports::ProgrammeVaccinationsExporter do
                 "ROUTE_OF_VACCINATION" => "intramuscular",
                 "SCHOOL_NAME" => "",
                 "SCHOOL_URN" => "888888",
-                "SNOMED_PROCEDURE_CODE" => vaccine.snomed_procedure_code,
+                "SNOMED_PROCEDURE_CODE" =>
+                  vaccination_record.snomed_procedure_code,
                 "TIME_OF_VACCINATION" => "12:05:20",
                 "TRIAGED_BY" => "",
                 "TRIAGE_DATE" => "",

--- a/spec/models/vaccine_spec.rb
+++ b/spec/models/vaccine_spec.rb
@@ -73,4 +73,42 @@ describe Vaccine do
       it { should eq(%w[nasal_spray]) }
     end
   end
+
+  describe "#snomed_procedure_code" do
+    subject { vaccine.snomed_procedure_code(dose_sequence:) }
+
+    let(:dose_sequence) { nil }
+
+    context "with an injection flu vaccine" do
+      let(:vaccine) { build(:vaccine, :flu, :injection) }
+
+      context "and first dose" do
+        let(:dose_sequence) { 1 }
+
+        it { should eq("985151000000100") }
+      end
+
+      context "and second dose" do
+        let(:dose_sequence) { 2 }
+
+        it { should eq("985171000000109") }
+      end
+    end
+
+    context "with a nasal flu vaccine" do
+      let(:vaccine) { build(:vaccine, :flu, :nasal) }
+
+      context "and first dose" do
+        let(:dose_sequence) { 1 }
+
+        it { should eq("884861000000100") }
+      end
+
+      context "and second dose" do
+        let(:dose_sequence) { 2 }
+
+        it { should eq("884881000000109") }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Following on from #4047 this adds the procedure codes for the flu vaccines. These codes are different depending on the method of the vaccine and the dose sequence so we need to consider both of those when returning the code.

[Jira Issue - MAV-1112](https://nhsd-jira.digital.nhs.uk/browse/MAV-1112)