### PR TITLE
Add `AcademicYear#pending`

### DIFF
--- a/app/lib/academic_year.rb
+++ b/app/lib/academic_year.rb
@@ -2,20 +2,22 @@
 
 module AcademicYear
   class << self
-    def all = (first..last).to_a.reverse
-
     def current = Date.current.academic_year
 
-    # 2024 is the year we ran Mavis. We support earlier years only in the case
-    # where the service is running in an environment prior to 2024 (only used
-    # when changing the date in tests).
+    def pending = preparation? ? current + 1 : current
+
+    # 2024 is the year Mavis went into private beta. Earlier years are
+    # supported only in the case where the service is running in an
+    # environment prior to 2024 (only used when changing the date in tests).
     def first = [2024, current].min
 
-    def last = preparation? ? current + 1 : current
+    alias_method :last, :pending
 
-    def preparation? = Date.current >= preparation_start_date
+    def all = (first..last).to_a.reverse
 
     private
+
+    def preparation? = Date.current >= preparation_start_date
 
     def preparation_start_date
       start_date = (current + 1).to_academic_year_date_range.first

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -1,34 +1,6 @@
 # frozen_string_literal: true
 
 describe AcademicYear do
-  describe "#all" do
-    subject { travel_to(today) { described_class.all } }
-
-    context "first day of 2024" do
-      let(:today) { Date.new(2024, 9, 1) }
-
-      it { should eq([2024]) }
-    end
-
-    context "last day of only 2024" do
-      let(:today) { Date.new(2025, 7, 31) }
-
-      it { should eq([2024]) }
-    end
-
-    context "preparing for 2025" do
-      let(:today) { Date.new(2025, 8, 1) }
-
-      it { should eq([2025, 2024]) }
-    end
-
-    context "first day of 2025" do
-      let(:today) { Date.new(2025, 9, 1) }
-
-      it { should eq([2025, 2024]) }
-    end
-  end
-
   describe "#current" do
     subject { travel_to(today) { described_class.current } }
 
@@ -36,6 +8,34 @@ describe AcademicYear do
       let(:today) { Date.new(2024, 9, 1) }
 
       it { should eq(2024) }
+    end
+
+    context "first day of 2025" do
+      let(:today) { Date.new(2025, 9, 1) }
+
+      it { should eq(2025) }
+    end
+  end
+
+  describe "#pending" do
+    subject { travel_to(today) { described_class.pending } }
+
+    context "first day of 2024" do
+      let(:today) { Date.new(2024, 9, 1) }
+
+      it { should eq(2024) }
+    end
+
+    context "last day of only 2024" do
+      let(:today) { Date.new(2025, 7, 31) }
+
+      it { should eq(2024) }
+    end
+
+    context "preparing for 2025" do
+      let(:today) { Date.new(2025, 8, 1) }
+
+      it { should eq(2025) }
     end
 
     context "first day of 2025" do
@@ -95,31 +95,31 @@ describe AcademicYear do
     end
   end
 
-  describe "#preparation?" do
-    subject { travel_to(today) { described_class.preparation? } }
+  describe "#all" do
+    subject { travel_to(today) { described_class.all } }
 
     context "first day of 2024" do
       let(:today) { Date.new(2024, 9, 1) }
 
-      it { should be(false) }
+      it { should eq([2024]) }
     end
 
     context "last day of only 2024" do
       let(:today) { Date.new(2025, 7, 31) }
 
-      it { should be(false) }
+      it { should eq([2024]) }
     end
 
     context "preparing for 2025" do
       let(:today) { Date.new(2025, 8, 1) }
 
-      it { should be(true) }
+      it { should eq([2025, 2024]) }
     end
 
     context "first day of 2025" do
       let(:today) { Date.new(2025, 9, 1) }
 
-      it { should be(false) }
+      it { should eq([2025, 2024]) }
     end
   end
 end


### PR DESCRIPTION
This represents either the current academic year, or if during the preparation for the next academic year, the next academic year.

Pending was chosen as the word to use to try and explain how it's neither the `next` or the `current` academic year, and can be either at different times in the year.

Although this is not used yet, most of the changes related to rollover rely on this value so it would be good to get this change merged in to base off.