### PR TITLE
Show academic year next to year group 

### DIFF
--- a/app/components/app_child_summary_component.rb
+++ b/app/components/app_child_summary_component.rb
@@ -110,6 +110,8 @@ class AppChildSummaryComponent < ViewComponent::Base
 
   private
 
+  def academic_year = AcademicYear.current
+
   def format_nhs_number
     highlight_if(helpers.patient_nhs_number(@child), @child.nhs_number_changed?)
   end
@@ -162,7 +164,7 @@ class AppChildSummaryComponent < ViewComponent::Base
 
   def format_year_group
     highlight_if(
-      helpers.patient_year_group(@child),
+      helpers.patient_year_group(@child, academic_year:),
       @child.year_group_changed? || @child.registration_changed?
     )
   end

--- a/app/components/app_patient_search_result_card_component.rb
+++ b/app/components/app_patient_search_result_card_component.rb
@@ -42,7 +42,9 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
         if @show_year_group
           summary_list.with_row do |row|
             row.with_key { "Year group" }
-            row.with_value { helpers.patient_year_group(@patient) }
+            row.with_value do
+              helpers.patient_year_group(@patient, academic_year:)
+            end
           end
         end
         if @show_postcode && !@patient.restricted?
@@ -84,6 +86,8 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
   end
 
   private
+
+  def academic_year = AcademicYear.current
 
   def programme_outcome_tag
     render_status_tag(:vaccination, :programme)

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -13,7 +13,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
 
             summary_list.with_row do |row|
               row.with_key { "Year group" }
-              row.with_value { helpers.patient_year_group(patient) }
+              row.with_value { helpers.patient_year_group(patient, academic_year:) }
             end
 
             if action_required

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -34,12 +34,16 @@ module PatientsHelper
     end
   end
 
-  def patient_year_group(patient)
-    if (registration = patient.registration).present?
-      "#{format_year_group(patient.year_group)} (#{registration})"
-    else
-      format_year_group(patient.year_group)
-    end
+  def patient_year_group(patient, academic_year:)
+    parts = [
+      format_year_group(patient.year_group(academic_year:)),
+      ("(#{patient.registration})" if patient.registration.present?),
+      if academic_year != AcademicYear.current
+        "(#{format_academic_year(academic_year)} academic year)"
+      end
+    ]
+
+    parts.compact.join(" ")
   end
 
   def patient_parents(patient)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -37,5 +37,7 @@ class Note < ApplicationRecord
 
   private
 
-  def year_group = patient.year_group(now: created_at.to_date)
+  def academic_year = created_at.to_date.academic_year
+
+  def year_group = patient.year_group(academic_year:)
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -299,10 +299,9 @@ class Patient < ApplicationRecord
     results
   end
 
-  def year_group(now: nil)
-    birth_academic_year.to_year_group(
-      academic_year: (now || Date.current).academic_year
-    )
+  def year_group(academic_year: nil)
+    academic_year ||= AcademicYear.current
+    birth_academic_year.to_year_group(academic_year:)
   end
 
   def year_group_changed?

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -44,7 +44,7 @@
     <% if import.is_a?(ClassImport) %>
       <%= summary_list.with_row do |row| %>
         <%= row.with_key { "Year groups" } %>
-        <%= row.with_value { import.year_groups.map { format_year_group(_1) }.to_sentence } %>
+        <%= row.with_value { import.year_groups.map { format_year_group(it) }.to_sentence } %>
       <% end %>
     <% end %>
 

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -20,7 +20,7 @@
 </h1>
 
 <p class="nhsuk-caption-l nhsuk-u-margin-bottom-4">
-  <%= patient_year_group(@patient) %>
+  <%= patient_year_group(@patient, academic_year: @academic_year) %>
 </p>
 
 <ul class="app-action-list">

--- a/spec/helpers/cohorts_helper_spec.rb
+++ b/spec/helpers/cohorts_helper_spec.rb
@@ -2,7 +2,7 @@
 
 describe CohortsHelper do
   describe "#format_year_group" do
-    subject(:formatted_year_group) { helper.format_year_group(year_group) }
+    subject { helper.format_year_group(year_group) }
 
     context "when the year group is negative" do
       let(:year_group) { -1 }

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -81,21 +81,38 @@ describe PatientsHelper do
   end
 
   describe "#patient_year_group" do
-    subject(:patient_year_group) do
-      travel_to(today) { helper.patient_year_group(patient) }
+    subject do
+      travel_to(today) { helper.patient_year_group(patient, academic_year:) }
     end
 
     let(:patient) do
       create(:patient, date_of_birth: Date.new(2010, 1, 1), registration: nil)
     end
+
     let(:today) { Date.new(2024, 1, 1) }
 
-    it { should eq("Year 9") }
+    context "in the current academic year" do
+      let(:academic_year) { today.academic_year }
 
-    context "with a registration" do
-      before { patient.registration = "9AB" }
+      it { should eq("Year 9") }
 
-      it { should eq("Year 9 (9AB)") }
+      context "with a registration" do
+        before { patient.registration = "9AB" }
+
+        it { should eq("Year 9 (9AB)") }
+      end
+    end
+
+    context "in the next academic year" do
+      let(:academic_year) { today.academic_year + 1 }
+
+      it { should eq("Year 10 (2024 to 2025 academic year)") }
+
+      context "with a registration" do
+        before { patient.registration = "9AB" }
+
+        it { should eq("Year 10 (9AB) (2024 to 2025 academic year)") }
+      end
     end
   end
 end


### PR DESCRIPTION
When displaying the year group of a patient the academic year should be displayed if it is different to the current academic year. This only affects when viewing a patient in the context of a session where there is an associated academic year.