### PR TITLE
Increase flu maximum dose sequence

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -103,10 +103,15 @@ class Programme < ApplicationRecord
     hpv? || flu? ? vaccinated_dose_sequence : nil
   end
 
+  MAXIMUM_DOSE_SEQUENCES = {
+    "flu" => 2,
+    "hpv" => 3,
+    "menacwy" => 3,
+    "td_ipv" => 5
+  }.freeze
+
   def maximum_dose_sequence
-    # HPV is given 3 times to patients with a weakened immune system.
-    # MenACWY is sometimes given more frequently.
-    hpv? || menacwy? ? 3 : vaccinated_dose_sequence
+    MAXIMUM_DOSE_SEQUENCES.fetch(type)
   end
 
   IMPORT_NAMES = {

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -57,7 +57,7 @@ describe Programme do
   describe "#seasonal?" do
     subject { programme.seasonal? }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
       it { should be(true) }
@@ -113,7 +113,7 @@ describe Programme do
   describe "#vaccine_methods" do
     subject { programme.vaccine_methods }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
       it { should contain_exactly("injection", "nasal") }
@@ -129,7 +129,7 @@ describe Programme do
   describe "#vaccine_may_contain_gelatine?" do
     subject { programme.vaccine_may_contain_gelatine? }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
       it { should be(true) }
@@ -157,7 +157,7 @@ describe Programme do
   describe "#vaccinated_dose_sequence" do
     subject { programme.vaccinated_dose_sequence }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
       it { should eq(1) }
@@ -185,7 +185,7 @@ describe Programme do
   describe "#default_dose_sequence" do
     subject(:default_dose_sequence) { programme.default_dose_sequence }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
       it { should eq(1) }
@@ -213,10 +213,10 @@ describe Programme do
   describe "#maximum_dose_sequence" do
     subject(:maximum_dose_sequence) { programme.maximum_dose_sequence }
 
-    context "with a Flu programme" do
+    context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }
 
-      it { should eq(1) }
+      it { should eq(2) }
     end
 
     context "with an HPV programme" do


### PR DESCRIPTION
Some patients will receive a second flu dose and therefore we need to increase the maximum dose sequence for the programme to allow that.

[Jira Issue - MAV-1666](https://nhsd-jira.digital.nhs.uk/browse/MAV-1666)