### PR TITLE
Fix `create_default_programme_year_groups` task

### DIFF
--- a/lib/tasks/create_default_programme_year_groups.rake
+++ b/lib/tasks/create_default_programme_year_groups.rake
@@ -9,7 +9,7 @@ task create_default_programme_year_groups: :environment do
         organisation.programmes.flat_map(&:default_year_groups).uniq.sort
 
       organisation.locations.generic_clinic.find_each do |generic_clinic|
-        generic_clinic.update_all(year_groups:)
+        generic_clinic.update!(year_groups:)
         generic_clinic.create_default_programme_year_groups!(
           organisation.programmes
         )


### PR DESCRIPTION
We need to run this task after deploying 2.11 to production and it looks like a refactor since the task was initially created and run in the test environment has broken it. This fixes the Rake task to run correctly.

This task doesn't have any tests as it's a one off task that will be run after a deploy and then deleted, it's been run in test and QA successfully.