### PR TITLE
Simplify search form query parameters

### DIFF
--- a/app/components/app_patient_search_form_component.rb
+++ b/app/components/app_patient_search_form_component.rb
@@ -2,12 +2,13 @@
 
 class AppPatientSearchFormComponent < ViewComponent::Base
   erb_template <<-ERB
-    <%= form_with model: form, url:, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with url:, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= render AppCardComponent.new(heading_level:, filters: true) do |card| %>
         <% card.with_heading { "Find children" } %>
 
         <div class="app-search-input" role="search">
           <%= f.govuk_text_field :q,
+                                 value: form.q,
                                  label: { text: "Search", class: "nhsuk-u-visually-hidden" },
                                  autocomplete: "off",
                                  class: "app-search-input__input" %>
@@ -23,7 +24,10 @@ class AppPatientSearchFormComponent < ViewComponent::Base
         <% if programmes.size > 1 %>
           <%= f.govuk_check_boxes_fieldset :programme_types, legend: { text: "Programme", size: "s" } do %>
             <% programmes.each do |programme| %>
-              <%= f.govuk_check_box :programme_types, programme.type, label: { text: programme.name } %>
+              <%= f.govuk_check_box :programme_types,
+                                    programme.type,
+                                    checked: form.programme_types&.include?(programme.type),
+                                    label: { text: programme.name } %>
             <% end %>
           <% end %>
         <% end %>
@@ -31,52 +35,72 @@ class AppPatientSearchFormComponent < ViewComponent::Base
         <% if consent_statuses.any? %>
           <%= f.govuk_check_boxes_fieldset :consent_statuses, legend: { text: "Consent status", size: "s" } do %>
             <% consent_statuses.each do |status| %>
-              <%= f.govuk_check_box :consent_statuses, status, label: { text: t(status, scope: %i[status consent label]) } %>
+              <%= f.govuk_check_box :consent_statuses,
+                                    status,
+                                    checked: form.consent_statuses&.include?(status),
+                                    label: { text: t(status, scope: %i[status consent label]) } %>
             <% end %>
           <% end %>
         <% end %>
 
         <% if triage_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :triage_status, legend: { text: "Triage status", size: "s" } do %>
-            <%= f.govuk_radio_button :triage_status, "", label: { text: "Any" } %>
+            <%= f.govuk_radio_button :triage_status, "", checked: form.triage_status.blank?, label: { text: "Any" } %>
             <% triage_statuses.each do |status| %>
-              <%= f.govuk_radio_button :triage_status, status, label: { text: t(status, scope: %i[status triage label]) } %>
+              <%= f.govuk_radio_button :triage_status,
+                                       status,
+                                       checked: form.triage_status == status,
+                                       label: { text: t(status, scope: %i[status triage label]) } %>
             <% end %>
           <% end %>
         <% end %>
 
         <% if register_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :register_status, legend: { text: "Registration status", size: "s" } do %>
-            <%= f.govuk_radio_button :register_status, "", label: { text: "Any" } %>
+            <%= f.govuk_radio_button :register_status, "", checked: form.register_status.blank?, label: { text: "Any" } %>
             <% register_statuses.each do |status| %>
-              <%= f.govuk_radio_button :register_status, status, label: { text: t(status, scope: %i[status register label]) } %>
+              <%= f.govuk_radio_button :register_status,
+                                       status,
+                                       checked: form.register_status == status,
+                                       label: { text: t(status, scope: %i[status register label]) } %>
             <% end %>
           <% end %>
         <% end %>
 
         <% if session_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :session_status, legend: { text: "Session outcome", size: "s" } do %>
-            <%= f.govuk_radio_button :session_status, "", label: { text: "Any" } %>
+            <%= f.govuk_radio_button :session_status, "", checked: form.session_status.blank?, label: { text: "Any" } %>
             <% session_statuses.each do |status| %>
-              <%= f.govuk_radio_button :session_status, status, label: { text: t(status, scope: %i[status session label]) } %>
+              <%= f.govuk_radio_button :session_status,
+                                       status,
+                                       checked: form.session_status == status,
+                                       label: { text: t(status, scope: %i[status session label]) } %>
             <% end %>
           <% end %>
         <% end %>
 
         <% if programme_statuses.any? %>
           <%= f.govuk_radio_buttons_fieldset :programme_status, legend: { text: "Programme outcome", size: "s" } do %>
-            <%= f.govuk_radio_button :programme_status, "", label: { text: "Any" } %>
+            <%= f.govuk_radio_button :programme_status, "", checked: form.programme_status.blank?, label: { text: "Any" } %>
+
             <% programme_statuses.each do |status| %>
-              <%= f.govuk_radio_button :programme_status, status, label: { text: t(status, scope: %i[status programme label]) } %>
+              <%= f.govuk_radio_button :programme_status,
+                                       status,
+                                       checked: form.programme_status == status,
+                                       label: { text: t(status, scope: %i[status programme label]) } %>
             <% end %>
           <% end %>
         <% end %>
 
         <% if vaccine_methods.any? %>
           <%= f.govuk_radio_buttons_fieldset :vaccine_method, legend: { text: "Vaccination method", size: "s" } do %>
-            <%= f.govuk_radio_button :vaccine_method, "", label: { text: "Any" } %>
+            <%= f.govuk_radio_button :vaccine_method, "", checked: form.vaccine_method.blank?, label: { text: "Any" } %>
+
             <% vaccine_methods.each do |vaccine_method| %>
-              <%= f.govuk_radio_button :vaccine_method, vaccine_method, label: { text: Vaccine.human_enum_name(:vaccine_method, vaccine_method) } %>
+              <%= f.govuk_radio_button :vaccine_method,
+                                       vaccine_method,
+                                       checked: form.vaccine_method == vaccine_method,
+                                       label: { text: Vaccine.human_enum_name(:vaccine_method, vaccine_method) } %>
             <% end %>
           <% end %>
         <% end %>
@@ -84,7 +108,10 @@ class AppPatientSearchFormComponent < ViewComponent::Base
         <% if year_groups.any? %>
           <%= f.govuk_check_boxes_fieldset :year_groups, legend: { text: "Year group", size: "s" } do %>
             <% year_groups.each do |year_group| %>
-              <%= f.govuk_check_box :year_groups, year_group, label: { text: helpers.format_year_group(year_group) } %>
+              <%= f.govuk_check_box :year_groups,
+                                    year_group,
+                                    checked: form.year_groups&.include?(year_group),
+                                    label: { text: helpers.format_year_group(year_group) } %>
             <% end %>
           <% end %>
         <% end %>
@@ -95,20 +122,34 @@ class AppPatientSearchFormComponent < ViewComponent::Base
               <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">Date of birth</legend>
               <div class="nhsuk-date-input">
                 <div class="nhsuk-date-input__item">
-                  <%= f.govuk_number_field :date_of_birth_day, label: { text: "Day" }, width: 2 %>
+                  <%= f.govuk_number_field :date_of_birth_day,
+                                           value: form.date_of_birth_day,
+                                           label: { text: "Day" },
+                                           width: 2 %>
                 </div>
                 <div class="nhsuk-date-input__item">
-                  <%= f.govuk_number_field :date_of_birth_month, label: { text: "Month" }, width: 2 %>
+                  <%= f.govuk_number_field :date_of_birth_month,
+                                           value: form.date_of_birth_month,
+                                           label: { text: "Month" },
+                                           width: 2 %>
                 </div>
                 <div class="nhsuk-date-input__item">
-                  <%= f.govuk_number_field :date_of_birth_year, label: { text: "Year" }, width: 4 %>
+                  <%= f.govuk_number_field :date_of_birth_year,
+                                           value: form.date_of_birth_year,
+                                           label: { text: "Year" },
+                                           width: 4 %>
                 </div>
               </div>
             </fieldset>
           </div>
 
           <%= f.govuk_check_boxes_fieldset :missing_nhs_number, multiple: false, legend: { text: "Options", size: "s" } do %>
-            <%= f.govuk_check_box :missing_nhs_number, 1, 0, multiple: false, link_errors: true, label: { text: "Missing NHS number" } %>
+            <%= f.govuk_check_box :missing_nhs_number,
+                                  1, 0,
+                                  checked: form.missing_nhs_number,
+                                  multiple: false,
+                                  link_errors: true,
+                                  label: { text: "Missing NHS number" } %>
           <% end %>
 
           <% if show_buttons_in_details? %>
@@ -185,5 +226,5 @@ class AppPatientSearchFormComponent < ViewComponent::Base
     )
   end
 
-  def clear_filters_path = "#{@url}?patient_search_form[_clear]=true"
+  def clear_filters_path = "#{@url}?_clear=true"
 end

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -47,8 +47,8 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
 
       <% if context == :register && can_register_attendance? %>
         <div class="app-button-group">
-          <%= helpers.govuk_button_to "Attending", create_session_register_path(session, patient, "present", patient_search_form: params[:patient_search_form]&.permit!), secondary: true, class: "app-button--small" %>
-          <%= helpers.govuk_button_to "Absent", create_session_register_path(session, patient, "absent", patient_search_form: params[:patient_search_form]&.permit!), class: "app-button--secondary-warning app-button--small" %>
+          <%= helpers.govuk_button_to "Attending", create_session_register_path(session, patient, "present"), secondary: true, class: "app-button--small" %>
+          <%= helpers.govuk_button_to "Absent", create_session_register_path(session, patient, "absent"), class: "app-button--secondary-warning app-button--small" %>
         </div>
       <% end %>
     <% end %>

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -46,13 +46,7 @@ class AppSessionActionsComponent < ViewComponent::Base
 
     return nil if count.zero?
 
-    href =
-      session_consent_path(
-        session,
-        patient_search_form: {
-          consent_statuses: [status]
-        }
-      )
+    href = session_consent_path(session, consent_statuses: [status])
 
     {
       key: {
@@ -73,13 +67,7 @@ class AppSessionActionsComponent < ViewComponent::Base
 
     return nil if count.zero?
 
-    href =
-      session_triage_path(
-        session,
-        patient_search_form: {
-          triage_status: status
-        }
-      )
+    href = session_triage_path(session, triage_status: status)
 
     {
       key: {
@@ -101,13 +89,7 @@ class AppSessionActionsComponent < ViewComponent::Base
 
     return nil if count.zero?
 
-    href =
-      session_register_path(
-        session,
-        patient_search_form: {
-          register_status: status
-        }
-      )
+    href = session_register_path(session, register_status: status)
 
     {
       key: {

--- a/app/components/app_session_details_summary_component.rb
+++ b/app/components/app_session_details_summary_component.rb
@@ -40,13 +40,7 @@ class AppSessionDetailsSummaryComponent < ViewComponent::Base
     count =
       patient_sessions.has_consent_status(status, programme: programmes).count
 
-    href =
-      session_consent_path(
-        session,
-        patient_search_form: {
-          consent_statuses: [status]
-        }
-      )
+    href = session_consent_path(session, consent_statuses: [status])
 
     {
       key: {
@@ -70,13 +64,7 @@ class AppSessionDetailsSummaryComponent < ViewComponent::Base
         "#{I18n.t("vaccinations_given", count:)} for #{programme.name_in_sentence}"
       end
 
-    href =
-      session_outcome_path(
-        session,
-        patient_search_form: {
-          session_status: "vaccinated"
-        }
-      )
+    href = session_outcome_path(session, session_status: "vaccinated")
 
     {
       key: {

--- a/app/controllers/concerns/patient_search_form_concern.rb
+++ b/app/controllers/concerns/patient_search_form_concern.rb
@@ -16,7 +16,7 @@ module PatientSearchFormConcern
   private
 
   def patient_search_form_params
-    params.fetch(:patient_search_form, {}).permit(
+    params.permit(
       :_clear,
       :date_of_birth_day,
       :date_of_birth_month,

--- a/app/controllers/sessions/register_controller.rb
+++ b/app/controllers/sessions/register_controller.rb
@@ -42,10 +42,7 @@ class Sessions::RegisterController < ApplicationController
       t("attendance_flash.absent", name:)
     end
 
-    redirect_to session_register_path(
-                  @session,
-                  **params.permit(patient_search_form: {})
-                )
+    redirect_to session_register_path(@session)
   end
 
   private


### PR DESCRIPTION
This simplifies the query parameters for the patient search form to avoid the `patient_search_form` prefix appearing for every parameter. This is something Rails does by default and is useful for POST requests, but with a GET request it can result in particularly long URLs which can be difficult to work with. For example, what we have currently:

```
/patients?patient_search_form[q]=Thomas
```

Will be replaced with:

```
/patients?q=Thomas
```

One of the reasons to make this change is that I was concerned about reaching the length limit of URLs, particularly on pages with lots of filters.

Initially I wanted to implement this change by setting the `scope` parameter to `form_with` to `nil`, however this results in it defaulting to the `param_key` of the model. I tried a version where the `model_name` was overridden to provide a custom `ActiveModel::Name` class with a `nil` `param_key`, but this resulted in problems in other areas where the model is used. Instead, the approach I've taken is to no longer pass the search form model to the builder.