### PR TITLE
Import patients in to pending year group

### DIFF
--- a/app/controllers/sessions/invite_to_clinic_controller.rb
+++ b/app/controllers/sessions/invite_to_clinic_controller.rb
@@ -44,7 +44,15 @@ class Sessions::InviteToClinicController < ApplicationController
 
   def set_generic_clinic_session
     @generic_clinic_session =
-      @session.clinic? ? @session : @session.organisation.generic_clinic_session
+      (
+        if @session.clinic?
+          @session
+        else
+          @session.organisation.generic_clinic_session(
+            academic_year: @session.academic_year
+          )
+        end
+      )
   end
 
   def set_invitations_to_send

--- a/app/forms/patient_search_form.rb
+++ b/app/forms/patient_search_form.rb
@@ -66,7 +66,11 @@ class PatientSearchForm < SearchForm
   end
 
   def filter_year_groups(scope)
-    year_groups.present? ? scope.search_by_year_groups(year_groups) : scope
+    if year_groups.present?
+      scope.search_by_year_groups(year_groups, academic_year:)
+    else
+      scope
+    end
   end
 
   def filter_date_of_birth_year(scope)

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -319,6 +319,8 @@ class ConsentForm < ApplicationRecord
       ].compact
   end
 
+  # TODO: For consent forms submitted during the preparation period, this
+  #  should be the next academic year.
   def academic_year = created_at.to_date.academic_year
 
   def recorded? = recorded_at != nil
@@ -372,12 +374,8 @@ class ConsentForm < ApplicationRecord
       (location_is_clinic? && original_session) ||
         (
           school &&
-            school
-              .sessions
-              .includes(:session_dates)
-              .for_current_academic_year
-              .first
-        ) || organisation.generic_clinic_session
+            school.sessions.includes(:session_dates).find_by(academic_year:)
+        ) || organisation.generic_clinic_session(academic_year:)
   end
 
   def find_or_create_parent_with_relationship_to!(patient:)

--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -139,7 +139,7 @@ class Onboarding
 
   attr_reader :organisation, :programmes, :subteams, :users, :schools, :clinics
 
-  def academic_year = AcademicYear.current
+  def academic_year = AcademicYear.pending
 
   def models
     [organisation] + programmes + subteams + users + schools + clinics

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -80,8 +80,7 @@ class Organisation < ApplicationRecord
     @year_groups ||= location_programme_year_groups.pluck_year_groups
   end
 
-  def generic_clinic_session
-    academic_year = AcademicYear.current
+  def generic_clinic_session(academic_year:)
     location = locations.generic_clinic.first
 
     sessions

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -144,8 +144,11 @@ class Patient < ApplicationRecord
         end
 
   scope :search_by_year_groups,
-        ->(year_groups) do
-          where(birth_academic_year: year_groups.map(&:to_birth_academic_year))
+        ->(year_groups, academic_year:) do
+          where(
+            birth_academic_year:
+              year_groups.map { it.to_birth_academic_year(academic_year:) }
+          )
         end
 
   scope :search_by_date_of_birth_year,

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -168,6 +168,8 @@ class PatientImportRow
 
   private
 
+  def academic_year = AcademicYear.pending
+
   def import_attributes
     @import_attributes ||= {
       address_line_1: address_line_1&.to_s,
@@ -318,7 +320,7 @@ class PatientImportRow
 
   def birth_academic_year_value
     if year_group.present?
-      year_group.to_i&.to_birth_academic_year
+      year_group.to_i&.to_birth_academic_year(academic_year:)
     else
       date_of_birth&.to_date&.academic_year
     end
@@ -345,7 +347,7 @@ class PatientImportRow
   end
 
   def registration_academic_year
-    AcademicYear.pending if registration.present?
+    academic_year if registration.present?
   end
 
   def validate_date_of_birth
@@ -467,7 +469,7 @@ class PatientImportRow
   def validate_year_group
     field = year_group.presence || date_of_birth
 
-    year_group_value = birth_academic_year_value&.to_year_group
+    year_group_value = birth_academic_year_value&.to_year_group(academic_year:)
 
     if year_group_value.nil?
       # We only need to add a validation error here is the file had an

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -117,8 +117,10 @@ class PatientSession < ApplicationRecord
         ->(name) { joins(:patient).merge(Patient.search_by_name(name)) }
 
   scope :search_by_year_groups,
-        ->(year_groups) do
-          joins(:patient).merge(Patient.search_by_year_groups(year_groups))
+        ->(year_groups, academic_year:) do
+          joins(:patient).merge(
+            Patient.search_by_year_groups(year_groups, academic_year:)
+          )
         end
 
   scope :search_by_date_of_birth_year,

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -63,7 +63,7 @@ class SchoolMove < ApplicationRecord
 
   private
 
-  def academic_year = AcademicYear.current
+  def academic_year = AcademicYear.pending
 
   def update_patient!
     patient.update!(home_educated:, school:)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -213,7 +213,9 @@ class Session < ApplicationRecord
       next_date(include_today: true) && !completed?
     else
       completed? &&
-        organisation.generic_clinic_session.next_date(include_today: true)
+        organisation.generic_clinic_session(academic_year:).next_date(
+          include_today: true
+        )
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -159,7 +159,8 @@ def create_session(
 end
 
 def setup_clinic(organisation)
-  clinic_session = organisation.generic_clinic_session
+  academic_year = AcademicYear.current
+  clinic_session = organisation.generic_clinic_session(academic_year:)
 
   clinic_session.session_dates.create!(value: Date.current)
   clinic_session.session_dates.create!(value: Date.current - 1.day)

--- a/lib/core_ext/integer/year_group.rb
+++ b/lib/core_ext/integer/year_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Integer
-  def to_year_group(academic_year: nil)
+  def to_year_group(academic_year:)
     # Children normally start school the September after their 4th birthday.
     # https://www.gov.uk/schools-admissions/school-starting-age
 

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -18,12 +18,15 @@ namespace :performance do
     VaccinationRecord.delete_all
     Patient.delete_all
 
+    academic_year = AcademicYear.current
+
     Organisation.find_each do |organisation|
       puts "For organisation: #{organisation.name}"
 
       sessions_by_school_id =
         organisation
           .sessions
+          .where(academic_year:)
           .joins(:location)
           .merge(Location.school)
           .index_by(&:location_id)
@@ -44,7 +47,8 @@ namespace :performance do
       Patient.import!(patients)
 
       puts "Building patient sessions..."
-      generic_clinic_session = organisation.generic_clinic_session
+      generic_clinic_session =
+        organisation.generic_clinic_session(academic_year:)
 
       patient_sessions =
         patients.flat_map do |patient|

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
 
   factory :patient do
     transient do
+      academic_year { AcademicYear.pending }
       parents { [] }
       performed_by { association(:user) }
       programmes { session&.programmes || [] }
@@ -91,17 +92,18 @@ FactoryBot.define do
 
     date_of_birth do
       if year_group
-        academic_year_start = Date.new(AcademicYear.current, 9, 1)
-        start_date = academic_year_start - (5 + year_group).years
-        end_date = start_date + 1.year - 1.day
-        Faker::Date.between(from: end_date, to: start_date)
+        date_range =
+          year_group.to_birth_academic_year(
+            academic_year:
+          ).to_academic_year_date_range
+        Faker::Date.between(from: date_range.begin, to: date_range.end)
       else
         Faker::Date.birthday(min_age: 7, max_age: 16)
       end
     end
     birth_academic_year do
       if year_group
-        year_group.to_birth_academic_year
+        year_group.to_birth_academic_year(academic_year:)
       else
         date_of_birth.academic_year
       end

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -76,7 +76,10 @@ describe "HPV vaccination" do
 
     if clinic
       [previous_date, Date.current].each do |date|
-        @organisation.generic_clinic_session.session_dates.create!(value: date)
+        @organisation
+          .generic_clinic_session(academic_year: AcademicYear.current)
+          .session_dates
+          .create!(value: date)
       end
 
       @physical_clinic_location =
@@ -108,7 +111,16 @@ describe "HPV vaccination" do
         :patient,
         2,
         :consent_given_triage_not_needed,
-        session: clinic ? @organisation.generic_clinic_session : @session,
+        session:
+          (
+            if clinic
+              @organisation.generic_clinic_session(
+                academic_year: AcademicYear.current
+              )
+            else
+              @session
+            end
+          ),
         school:,
         year_group: 8
       )
@@ -116,7 +128,16 @@ describe "HPV vaccination" do
       create(
         :patient,
         :vaccinated,
-        session: clinic ? @organisation.generic_clinic_session : @session,
+        session:
+          (
+            if clinic
+              @organisation.generic_clinic_session(
+                academic_year: AcademicYear.current
+              )
+            else
+              @session
+            end
+          ),
         school:,
         location_name: clinic ? @physical_clinic_location.name : nil,
         year_group: 8
@@ -131,7 +152,16 @@ describe "HPV vaccination" do
         :patient,
         :vaccinated,
         :restricted,
-        session: clinic ? @organisation.generic_clinic_session : @session,
+        session:
+          (
+            if clinic
+              @organisation.generic_clinic_session(
+                academic_year: AcademicYear.current
+              )
+            else
+              @session
+            end
+          ),
         school:,
         location_name: clinic ? @physical_clinic_location.name : nil,
         year_group: 8

--- a/spec/features/manage_clinic_sessions_spec.rb
+++ b/spec/features/manage_clinic_sessions_spec.rb
@@ -75,7 +75,8 @@ describe "Manage clinic sessions" do
         programmes: [@programme]
       )
 
-    @session = @organisation.generic_clinic_session
+    @session =
+      @organisation.generic_clinic_session(academic_year: AcademicYear.current)
 
     @parent = create(:parent)
 

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -96,14 +96,18 @@ describe "Manage school sessions" do
     @patient =
       create(:patient, year_group: 8, session: @session, parents: [@parent])
 
-    @organisation.generic_clinic_session.session_dates.create!(
-      value: 1.month.from_now.to_date
-    )
+    @organisation
+      .generic_clinic_session(academic_year: AcademicYear.current)
+      .session_dates
+      .create!(value: 1.month.from_now.to_date)
 
     create(
       :patient_session,
       patient: @patient,
-      session: @organisation.generic_clinic_session
+      session:
+        @organisation.generic_clinic_session(
+          academic_year: AcademicYear.current
+        )
     )
   end
 

--- a/spec/features/programme_cohorts_spec.rb
+++ b/spec/features/programme_cohorts_spec.rb
@@ -44,7 +44,10 @@ describe "Programme" do
       create(
         :patient_session,
         patient:,
-        session: @organisation.generic_clinic_session
+        session:
+          @organisation.generic_clinic_session(
+            academic_year: AcademicYear.current
+          )
       )
     end
   end

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -335,7 +335,11 @@ describe Reports::OfflineSessionExporter do
         end
 
         context "with a vaccinated patient outside the school session, but in a clinic" do
-          let(:clinic_session) { organisation.generic_clinic_session }
+          let(:clinic_session) do
+            organisation.generic_clinic_session(
+              academic_year: AcademicYear.current
+            )
+          end
 
           let!(:vaccination_record) do
             create(

--- a/spec/models/class_import_spec.rb
+++ b/spec/models/class_import_spec.rb
@@ -432,7 +432,11 @@ describe ClassImport do
       end
 
       it "doesn't propose a move if the patient is in a different year group" do
-        existing_patient.update!(birth_academic_year: 7.to_birth_academic_year)
+        academic_year = AcademicYear.pending
+
+        existing_patient.update!(
+          birth_academic_year: 7.to_birth_academic_year(academic_year:)
+        )
 
         expect { process! }.not_to(
           change { existing_patient.reload.school_moves.count }

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -402,7 +402,9 @@ describe CohortImport do
     end
 
     context "with a scheduled clinic session" do
-      let(:session) { organisation.generic_clinic_session }
+      let(:session) do
+        organisation.generic_clinic_session(academic_year: AcademicYear.current)
+      end
 
       it "adds all the patients to the session" do
         expect { process! }.to change(session.patients, :count).from(0).to(3)

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -56,7 +56,9 @@ describe SchoolMove do
     let(:organisation) do
       create(:organisation, :with_generic_clinic, programmes:)
     end
-    let(:generic_clinic_session) { organisation.generic_clinic_session }
+    let(:generic_clinic_session) do
+      organisation.generic_clinic_session(academic_year: AcademicYear.current)
+    end
 
     shared_examples "creates a log entry" do
       it "creates a log entry" do
@@ -317,7 +319,9 @@ describe SchoolMove do
             create(:organisation, :with_generic_clinic, programmes:)
           end
           let(:generic_clinic_session) do
-            new_organisation.generic_clinic_session
+            new_organisation.generic_clinic_session(
+              academic_year: AcademicYear.current
+            )
           end
 
           include_examples "creates a log entry"
@@ -435,7 +439,9 @@ describe SchoolMove do
             create(:organisation, :with_generic_clinic, programmes:)
           end
           let(:generic_clinic_session) do
-            new_organisation.generic_clinic_session
+            new_organisation.generic_clinic_session(
+              academic_year: AcademicYear.current
+            )
           end
 
           include_examples "creates a log entry"
@@ -552,14 +558,19 @@ describe SchoolMove do
             create(
               :patient,
               :home_educated,
-              session: organisation.generic_clinic_session
+              session:
+                organisation.generic_clinic_session(
+                  academic_year: AcademicYear.current
+                )
             )
           end
           let(:new_organisation) do
             create(:organisation, :with_generic_clinic, programmes:)
           end
           let(:generic_clinic_session) do
-            new_organisation.generic_clinic_session
+            new_organisation.generic_clinic_session(
+              academic_year: AcademicYear.current
+            )
           end
 
           it "keeps the patient as home-schooled" do
@@ -680,7 +691,10 @@ describe SchoolMove do
             create(
               :patient,
               :home_educated,
-              session: organisation.generic_clinic_session
+              session:
+                organisation.generic_clinic_session(
+                  academic_year: AcademicYear.current
+                )
             )
           end
           let(:new_organisation) do
@@ -801,14 +815,19 @@ describe SchoolMove do
             create(
               :patient,
               school: nil,
-              session: organisation.generic_clinic_session
+              session:
+                organisation.generic_clinic_session(
+                  academic_year: AcademicYear.current
+                )
             )
           end
           let(:new_organisation) do
             create(:organisation, :with_generic_clinic, programmes:)
           end
           let(:generic_clinic_session) do
-            new_organisation.generic_clinic_session
+            new_organisation.generic_clinic_session(
+              academic_year: AcademicYear.current
+            )
           end
 
           include_examples "creates a log entry"
@@ -924,7 +943,10 @@ describe SchoolMove do
             create(
               :patient,
               school: nil,
-              session: organisation.generic_clinic_session
+              session:
+                organisation.generic_clinic_session(
+                  academic_year: AcademicYear.current
+                )
             )
           end
           let(:new_organisation) do

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -97,7 +97,9 @@ describe VaccinationRecord do
       let(:organisation) do
         create(:organisation, :with_generic_clinic, programmes: [programme])
       end
-      let(:session) { organisation.generic_clinic_session }
+      let(:session) do
+        organisation.generic_clinic_session(academic_year: AcademicYear.current)
+      end
 
       it { should validate_presence_of(:location_name) }
     end


### PR DESCRIPTION
When importing patient records this ensures that the year group is determined using the pending academic year. This means that during the preparation period for the upcoming academic year, patients can be imported using the year group they will be rather than their current year group.

In making this change I've been able to make the `academic_year` argument on the `to_year_group` and `to_birth_academic_year` methods a required argument, ensuring we're more deliberate about which academic year we're using.