### PR TITLE
Ensure duplicate patients aren't shown on cohort pages

### DIFF
--- a/app/controllers/programmes/cohorts_controller.rb
+++ b/app/controllers/programmes/cohorts_controller.rb
@@ -25,6 +25,13 @@ class Programmes::CohortsController < Programmes::BaseController
 
     patients =
       patients_in_organisation
+        # This is needed because the scope has a `distinct` and therefore
+        # anything in the ORDER BY needs to appear in the SELECT.
+        .select(
+          "patients.*",
+          "LOWER(given_name) AS given_name",
+          "LOWER(family_name) AS family_name"
+        )
         .where(birth_academic_year: @birth_academic_year)
         .not_deceased
         .eager_load(:school)

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -45,7 +45,7 @@ class Organisation < ApplicationRecord
   has_many :community_clinics, through: :teams
   has_many :locations, through: :teams
   has_many :patient_sessions, through: :sessions
-  has_many :patients, through: :patient_sessions
+  has_many :patients, -> { distinct }, through: :patient_sessions
   has_many :programmes, through: :organisation_programmes
   has_many :schools, through: :teams
   has_many :vaccination_records, through: :sessions

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -33,10 +33,6 @@ class Programme < ApplicationRecord
   has_many :vaccination_records, -> { kept }
   has_many :vaccines
 
-  has_many :consent_notifications, through: :consent_notification_programmes
-  has_many :sessions, through: :session_programmes
-  has_many :patient_sessions, through: :sessions
-  has_many :patients, through: :patient_sessions
   has_many :organisations, through: :organisation_programmes
 
   has_many :active_vaccines, -> { active }, class_name: "Vaccine"

--- a/app/views/programmes/cohorts/show.html.erb
+++ b/app/views/programmes/cohorts/show.html.erb
@@ -7,7 +7,7 @@
                                         ]) %>
 <% end %>
 
-<%= h1 format_year_group(@birth_academic_year.to_year_group) %>
+<%= h1 format_year_group(@birth_academic_year.to_year_group(academic_year: @academic_year)) %>
 
 <%= render AppPatientTableComponent.new(@patients, current_user:, count: @pagy.count) %>
 

--- a/spec/features/cohorts_index_spec.rb
+++ b/spec/features/cohorts_index_spec.rb
@@ -21,7 +21,13 @@ describe "Cohorts index" do
     @academic_year = Date.current.academic_year
     @programme = create(:programme, :hpv)
     @organisation =
-      create(:organisation, :with_one_nurse, programmes: [@programme])
+      create(
+        :organisation,
+        :with_one_nurse,
+        :with_generic_clinic,
+        programmes: [@programme]
+      )
+
     sign_in @organisation.users.first
   end
 
@@ -32,6 +38,15 @@ describe "Cohorts index" do
     @patient1 = create(:patient, session:, year_group: 9)
     @patient2 = create(:patient, session:, year_group: 9)
     create(:patient, session:, year_group: 10)
+
+    # To make it realistic we'll also add patients to clinics.
+    Patient.find_each do |patient|
+      create(
+        :patient_session,
+        patient:,
+        session: @organisation.generic_clinic_session
+      )
+    end
   end
 
   def when_i_visit_the_cohorts_page


### PR DESCRIPTION
When viewing the cohorts of a programme, sometimes patients can appear multiple times, if they appear in multiple sessions. These pages are shortly going to be redesigned to link to the children page with filters which doesn't have this problem, but until then this fixes the immediate issue.