### PR TITLE
Clarify `in_programmes` scope on patients and patient sessions

### DIFF
--- a/app/components/app_programme_stats_component.rb
+++ b/app/components/app_programme_stats_component.rb
@@ -11,7 +11,7 @@ class AppProgrammeStatsComponent < ViewComponent::Base
   def patients_count
     helpers
       .policy_scope(Patient)
-      .in_programmes([@programme], academic_year:)
+      .appear_in_programmes([@programme], academic_year:)
       .count
   end
 

--- a/app/controllers/programmes/overview_controller.rb
+++ b/app/controllers/programmes/overview_controller.rb
@@ -3,7 +3,7 @@
 class Programmes::OverviewController < Programmes::BaseController
   def show
     patients =
-      policy_scope(Patient).in_programmes(
+      policy_scope(Patient).appear_in_programmes(
         [@programme],
         academic_year: @academic_year
       )

--- a/app/controllers/programmes/patients_controller.rb
+++ b/app/controllers/programmes/patients_controller.rb
@@ -13,10 +13,9 @@ class Programmes::PatientsController < Programmes::BaseController
       ).pluck_year_groups
 
     scope =
-      policy_scope(Patient).includes(:vaccination_statuses).in_programmes(
-        [@programme],
-        academic_year: @academic_year
-      )
+      policy_scope(Patient).includes(
+        :vaccination_statuses
+      ).appear_in_programmes([@programme], academic_year: @academic_year)
 
     @form.programme_types = [@programme.type]
 

--- a/app/forms/patient_search_form.rb
+++ b/app/forms/patient_search_form.rb
@@ -72,11 +72,14 @@ class PatientSearchForm
 
     scope = scope.search_by_nhs_number(nil) if missing_nhs_number.present?
 
-    scope =
-      scope.appear_in_programmes(
-        programmes,
-        academic_year:
-      ) if programmes.present?
+    if programmes.present?
+      scope =
+        if @session
+          scope.appear_in_programmes(programmes)
+        else
+          scope.appear_in_programmes(programmes, academic_year:)
+        end
+    end
 
     if (statuses = consent_statuses).present?
       scope =

--- a/app/forms/patient_search_form.rb
+++ b/app/forms/patient_search_form.rb
@@ -73,7 +73,10 @@ class PatientSearchForm
     scope = scope.search_by_nhs_number(nil) if missing_nhs_number.present?
 
     scope =
-      scope.in_programmes(programmes, academic_year:) if programmes.present?
+      scope.appear_in_programmes(
+        programmes,
+        academic_year:
+      ) if programmes.present?
 
     if (statuses = consent_statuses).present?
       scope =

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -33,7 +33,7 @@ class Note < ApplicationRecord
 
   validates :body, presence: true, length: { maximum: 1000 }
 
-  def programmes = session.eligible_programmes_for(year_group:)
+  def programmes = session.programmes_for(year_group:)
 
   private
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -104,7 +104,7 @@ class Patient < ApplicationRecord
 
   scope :with_notice, -> { deceased.or(restricted).or(invalidated) }
 
-  scope :in_programmes,
+  scope :appear_in_programmes,
         ->(programmes, academic_year:) do
           location_programme_year_groups =
             Location::ProgrammeYearGroup

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -106,21 +106,12 @@ class Patient < ApplicationRecord
 
   scope :appear_in_programmes,
         ->(programmes, academic_year:) do
-          location_programme_year_groups =
-            Location::ProgrammeYearGroup
-              .where("location_id = sessions.location_id")
-              .where("programme_id = session_programmes.programme_id")
-              .where(
-                "year_group = ? - patients.birth_academic_year - 5",
-                academic_year
-              )
-
           where(
             PatientSession
-              .joins(session: :session_programmes)
-              .where(session_programmes: { programme: programmes })
-              .where("patient_sessions.patient_id = patients.id")
-              .where(location_programme_year_groups.arel.exists)
+              .joins(:session)
+              .where(sessions: { academic_year: })
+              .where("patient_id = patients.id")
+              .appear_in_programmes(programmes)
               .arel
               .exists
           )

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -21,6 +21,22 @@
 #  fk_rails_...  (session_id => sessions.id)
 #
 
+# The patient session model represents a patient who goes to the school or
+# clinic location represented by the session. This doesn't necessarily mean
+# that the patient is eligible for any of the programmes administered in any
+# particular session they belong to.
+#
+# This is designed to support programmes being dynamically added or removed to
+# sessions without needing to also create or destroy patient session
+# instances. While also adding support for patients becoming eligible if year
+# groups are added or removed to locations, again without needing to also
+# create or destroy patient session instances.
+#
+# It also supports the scenario where a patient belongs to a session but is
+# only eligible for one of many programmes administered in the session. In
+# that case, the list of programmes they appear in won't be the same as the
+# complete list of programmes administered in the session.
+
 class PatientSession < ApplicationRecord
   audited associated_with: :patient
   has_associated_audits
@@ -72,9 +88,28 @@ class PatientSession < ApplicationRecord
         end
 
   scope :appear_in_programmes,
-        ->(programmes, academic_year:) do
-          joins(:patient).merge(
-            Patient.appear_in_programmes(programmes, academic_year:)
+        ->(programmes) do
+          age_children_start_school = 5
+
+          # Is the patient eligible for any of those programmes by year group?
+          location_programme_year_groups =
+            Location::ProgrammeYearGroup
+              .where("programme_id = session_programmes.programme_id")
+              .where("location_id = sessions.location_id")
+              .where(
+                "year_group = sessions.academic_year " \
+                  "- patients.birth_academic_year " \
+                  "- #{age_children_start_school}"
+              )
+
+          # Are any of the programmes administered in the session?
+          joins(:patient, :session).where(
+            SessionProgramme
+              .where(programme: programmes)
+              .where("session_programmes.session_id = sessions.id")
+              .where(location_programme_year_groups.arel.exists)
+              .arel
+              .exists
           )
         end
 
@@ -234,7 +269,7 @@ class PatientSession < ApplicationRecord
       patient.vaccination_status(programme:, academic_year:).none_yet?
   end
 
-  def programmes = session.programmes_for(patient:)
+  def programmes = session.programmes_for(patient:, academic_year:)
 
   def session_status(programme:)
     session_statuses.find { it.programme_id == programme.id } ||

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -71,10 +71,10 @@ class PatientSession < ApplicationRecord
           )
         end
 
-  scope :in_programmes,
+  scope :appear_in_programmes,
         ->(programmes, academic_year:) do
           joins(:patient).merge(
-            Patient.in_programmes(programmes, academic_year:)
+            Patient.appear_in_programmes(programmes, academic_year:)
           )
         end
 
@@ -234,7 +234,7 @@ class PatientSession < ApplicationRecord
       patient.vaccination_status(programme:, academic_year:).none_yet?
   end
 
-  def programmes = session.eligible_programmes_for(patient:)
+  def programmes = session.programmes_for(patient:)
 
   def session_status(programme:)
     session_statuses.find { it.programme_id == programme.id } ||

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -182,7 +182,7 @@ class Session < ApplicationRecord
     programmes.flat_map(&:vaccine_methods).uniq.sort
   end
 
-  def eligible_programmes_for(patient: nil, year_group: nil)
+  def programmes_for(patient: nil, year_group: nil)
     year_group ||= patient.year_group
 
     programmes.select do |programme|

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -182,8 +182,8 @@ class Session < ApplicationRecord
     programmes.flat_map(&:vaccine_methods).uniq.sort
   end
 
-  def programmes_for(patient: nil, year_group: nil)
-    year_group ||= patient.year_group
+  def programmes_for(year_group: nil, patient: nil, academic_year: nil)
+    year_group ||= patient.year_group(academic_year:)
 
     programmes.select do |programme|
       location_programme_year_groups.any? do

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -29,7 +29,7 @@
 
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Children</span>
-              <%= policy_scope(Patient).in_programmes([programme], academic_year:).count %>
+              <%= policy_scope(Patient).appear_in_programmes([programme], academic_year:).count %>
             <% end %>
 
             <% row.with_cell do %>

--- a/lib/generate/triages.rb
+++ b/lib/generate/triages.rb
@@ -33,7 +33,7 @@ module Generate
       (@session.presence || organisation)
         .patients
         .includes(:triage_statuses)
-        .in_programmes([programme], academic_year:)
+        .appear_in_programmes([programme], academic_year:)
         .select { it.triage_status(programme:, academic_year:).required? }
     end
 

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -93,7 +93,7 @@ module Generate
           session: :session_dates,
           patient: %i[consent_statuses vaccination_statuses triage_statuses]
         )
-        .appear_in_programmes([programme], academic_year: AcademicYear.current)
+        .appear_in_programmes([programme])
         .has_consent_status("given", programme:)
         .select do
           it.patient.consent_given_and_safe_to_vaccinate?(

--- a/lib/generate/vaccination_records.rb
+++ b/lib/generate/vaccination_records.rb
@@ -93,7 +93,7 @@ module Generate
           session: :session_dates,
           patient: %i[consent_statuses vaccination_statuses triage_statuses]
         )
-        .in_programmes([programme], academic_year: AcademicYear.current)
+        .appear_in_programmes([programme], academic_year: AcademicYear.current)
         .has_consent_status("given", programme:)
         .select do
           it.patient.consent_given_and_safe_to_vaccinate?(

--- a/spec/controllers/api/organisations_controller_spec.rb
+++ b/spec/controllers/api/organisations_controller_spec.rb
@@ -37,7 +37,10 @@ describe API::OrganisationsController do
         end
       end
 
-      UnscheduledSessionsFactory.call
+      OrganisationSessionsFactory.call(
+        organisation,
+        academic_year: AcademicYear.current
+      )
 
       create(:school, urn: "123456", organisation:, programmes:) # to match cohort_import/valid.csv
       create(:school, urn: "110158", organisation:, programmes:) # to match valid_hpv.csv

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -61,7 +61,10 @@ describe "Import child records" do
     create(:school, urn: "123456", organisation: @organisation)
     @user = @organisation.users.first
 
-    UnscheduledSessionsFactory.call
+    OrganisationSessionsFactory.call(
+      @organisation,
+      academic_year: AcademicYear.current
+    )
   end
 
   def when_i_visit_the_cohort_page_for_the_hpv_programme

--- a/spec/forms/patient_search_form_spec.rb
+++ b/spec/forms/patient_search_form_spec.rb
@@ -215,6 +215,9 @@ describe PatientSearchForm do
   context "for patient sessions" do
     let(:scope) { PatientSession.all }
 
+    let(:session) { create(:session, programmes: [programme]) }
+    let(:programme) { create(:programme) }
+
     it "doesn't raise an error" do
       expect { form.apply(scope) }.not_to raise_error
     end
@@ -238,9 +241,7 @@ describe PatientSearchForm do
       context "with a patient session eligible for the programme" do
         let(:patient) { create(:patient, year_group: 9) }
 
-        let(:patient_session) do
-          create(:patient_session, patient:, programmes: [programme])
-        end
+        let(:patient_session) { create(:patient_session, patient:, session:) }
 
         it "is included" do
           expect(form.apply(scope)).to include(patient_session)
@@ -250,9 +251,7 @@ describe PatientSearchForm do
       context "with a patient session not eligible for the programme" do
         let(:patient) { create(:patient, year_group: 8) }
 
-        let(:patient_session) do
-          create(:patient_session, patient:, programmes: [programme])
-        end
+        let(:patient_session) { create(:patient_session, patient:, session:) }
 
         it "is not included" do
           expect(form.apply(scope)).not_to include(patient_session)
@@ -272,9 +271,6 @@ describe PatientSearchForm do
       let(:register_status) { nil }
       let(:triage_status) { nil }
       let(:year_groups) { nil }
-
-      let(:programme) { create(:programme) }
-      let(:session) { create(:session, programmes: [programme]) }
 
       it "filters on consent status" do
         patient_session_given =
@@ -304,11 +300,8 @@ describe PatientSearchForm do
       let(:triage_status) { nil }
       let(:year_groups) { nil }
 
-      let(:programme) { create(:programme) }
-
       it "filters on session status" do
-        patient_session =
-          create(:patient_session, :vaccinated, programmes: [programme])
+        patient_session = create(:patient_session, :vaccinated, session:)
         expect(form.apply(scope)).to include(patient_session)
       end
     end
@@ -327,7 +320,7 @@ describe PatientSearchForm do
       let(:year_groups) { nil }
 
       it "filters on register status" do
-        patient_session = create(:patient_session, :in_attendance)
+        patient_session = create(:patient_session, :in_attendance, session:)
         expect(form.apply(scope)).to include(patient_session)
       end
     end
@@ -345,9 +338,6 @@ describe PatientSearchForm do
       let(:session_status) { nil }
       let(:triage_status) { "required" }
       let(:year_groups) { nil }
-
-      let(:programme) { create(:programme) }
-      let(:session) { create(:session, programmes: [programme]) }
 
       it "filters on triage status" do
         patient_session =
@@ -375,11 +365,7 @@ describe PatientSearchForm do
 
       it "filters on vaccine method" do
         nasal_patient_session =
-          create(
-            :patient_session,
-            :consent_given_triage_not_needed,
-            programmes: [programme]
-          )
+          create(:patient_session, :consent_given_triage_not_needed, session:)
 
         nasal_patient_session.patient.consent_statuses.first.update!(
           vaccine_methods: %w[nasal injection]
@@ -393,18 +379,10 @@ describe PatientSearchForm do
           )
 
         _injection_only_patient =
-          create(
-            :patient_session,
-            :consent_given_triage_not_needed,
-            programmes: [programme]
-          )
+          create(:patient_session, :consent_given_triage_not_needed, session:)
 
         injection_primary_patient =
-          create(
-            :patient_session,
-            :consent_given_triage_not_needed,
-            programmes: [programme]
-          )
+          create(:patient_session, :consent_given_triage_not_needed, session:)
 
         injection_primary_patient.patient.consent_statuses.first.update!(
           vaccine_methods: %w[injection nasal]

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -44,7 +44,12 @@ describe CohortImport do
   # Ensure location URN matches the URN in our fixture files
   let!(:location) { create(:school, urn: "123456", organisation:) }
 
-  before { UnscheduledSessionsFactory.call }
+  before do
+    OrganisationSessionsFactory.call(
+      organisation,
+      academic_year: AcademicYear.current
+    )
+  end
 
   it_behaves_like "a CSVImportable model"
 

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -41,6 +41,51 @@ describe PatientSession do
   end
 
   describe "scopes" do
+    describe "#appear_in_programmes" do
+      subject(:scope) { described_class.appear_in_programmes(programmes) }
+
+      let(:programmes) { create_list(:programme, 1, :td_ipv) }
+      let(:session) { create(:session, programmes:) }
+
+      it { should be_empty }
+
+      context "in a session with the right year group" do
+        let(:patient_session) do
+          create(:patient_session, session:, year_group: 9)
+        end
+
+        it { should include(patient_session) }
+      end
+
+      context "in a session but the wrong year group" do
+        let(:patient_session) do
+          create(:patient_session, session:, year_group: 8)
+        end
+
+        it { should_not include(patient_session) }
+      end
+
+      context "in a session with the right year group for the programme but not the location" do
+        let(:location) { create(:school, :secondary) }
+        let(:session) { create(:session, location:, programmes:) }
+
+        let(:patient_session) { create(:patient, session:, year_group: 9) }
+
+        before do
+          programmes.each do |programme|
+            create(
+              :location_programme_year_group,
+              programme:,
+              location:,
+              year_group: 10
+            )
+          end
+        end
+
+        it { should_not include(patient_session) }
+      end
+    end
+
     describe "#consent_given_and_ready_to_vaccinate" do
       subject(:scope) do
         described_class.consent_given_and_ready_to_vaccinate(

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -48,6 +48,58 @@
 
 describe Patient do
   describe "scopes" do
+    describe "#appear_in_programmes" do
+      subject(:scope) do
+        described_class.appear_in_programmes(programmes, academic_year:)
+      end
+
+      let(:programmes) { create_list(:programme, 1, :td_ipv) }
+      let(:academic_year) { AcademicYear.current }
+
+      it { should be_empty }
+
+      context "with a patient in no sessions" do
+        before { create(:patient) }
+
+        it { should be_empty }
+      end
+
+      context "in a session with the right year group" do
+        let(:session) { create(:session, programmes:) }
+
+        let(:patient) { create(:patient, session:, year_group: 9) }
+
+        it { should include(patient) }
+      end
+
+      context "in a session but the wrong year group" do
+        let(:session) { create(:session, programmes:) }
+
+        let(:patient) { create(:patient, session:, year_group: 8) }
+
+        it { should_not include(patient) }
+      end
+
+      context "in a session with the right year group for the programme but not the location" do
+        let(:location) { create(:school, :secondary) }
+        let(:patient) { create(:patient, session:, year_group: 9) }
+        let(:session) { create(:session, location:, programmes:) }
+
+        before do
+          programmes.each do |programme|
+            create(
+              :location_programme_year_group,
+              programme:,
+              location:,
+              year_group: 10
+            )
+          end
+        end
+
+        it { should_not include(patient) }
+      end
+    end
+
     describe "#search_by_name" do
       subject(:scope) { described_class.search_by_name(query) }
 


### PR DESCRIPTION
This makes a number of improvements to the `in_programmes` scopes on the `Patient` and `PatientSession` models:

- The `PatientSession` scope no longer needs an academic year. This is because the academic year can come from the associated session. This prevents the scope being used for a different academic year to the session which could cause unusual bugs.
- The logic of the `PatientSession` scope has been fixed to ensure that patients who are eligible for a programme based on their year group, but not eligible in a particular session (perhaps because the year groups aren't administered at the location), don't appear in the query. This fixes the possibility of a patient appearing incorrectly if they go to a school, but aren't eligible for any of the programmes administered at the school. Specifically, this fixes an issue where now that multiple sessions can exist for the same location, if a patient was eligible in one of the sessions they were appearing in all of them regardless of programme.
- Both scopes have been updated to ensure that patients who aren't in any sessions for any particular academic year are excluded from the results, ensuring they don't appear in the wrong place. For example, at the moment, if a patient was eligible for a programme one year, they'll continue to show in all subsequent academic years even if they're no longer eligible or have moved out of the cohort.

The scope has also been renamed `appear_in_programmes` to make it clearer what this scope represents. Initially I was going to go with `eligible_in_programmes` but I wanted to avoid the word eligible as it's not quite correct.

For example, a patient may be eligible for a programme based on their year group, but only exist in sessions where that programme isn't administered at their year group, therefore they remain eligible, but wouldn't show in those sessions for that programme.

The method `Session#programmes_for` already worked like the scopes do after this change, but a mismatch between the scope and this method meant it was possible for a patient to appear in a session, but with no eligible programmes, leading to bugs such as this one:

https://good-machine.sentry.io/issues/6770236206/

[Jira Issue - MAV-1293](https://nhsd-jira.digital.nhs.uk/browse/MAV-1293)
[Jira Issue - MAV-1429](https://nhsd-jira.digital.nhs.uk/browse/MAV-1429)