### PR TITLE
Add ability to override today's date 

### DIFF
--- a/app/lib/academic_year.rb
+++ b/app/lib/academic_year.rb
@@ -31,7 +31,7 @@ module AcademicYear
     def preparation_start_date
       start_date = (current + 1).to_academic_year_date_range.first
       days_of_preparation =
-        Settings.number_of_preparation_days_before_academic_year_starts.to_i
+        Settings.academic_year_number_of_preparation_days.to_i
       start_date - days_of_preparation.days
     end
   end

--- a/app/lib/academic_year.rb
+++ b/app/lib/academic_year.rb
@@ -2,7 +2,7 @@
 
 module AcademicYear
   class << self
-    def current = Date.current.academic_year
+    def current = (override_current_date || Date.current).academic_year
 
     def pending = preparation? ? current + 1 : current
 
@@ -17,7 +17,16 @@ module AcademicYear
 
     private
 
-    def preparation? = Date.current >= preparation_start_date
+    def override_current_date
+      @override_current_date ||=
+        if (value = Settings.academic_year_today_override).present?
+          Date.parse(value)
+        end
+    end
+
+    def preparation?
+      (override_current_date || Date.current) >= preparation_start_date
+    end
 
     def preparation_start_date
       start_date = (current + 1).to_academic_year_date_range.first

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,7 +6,7 @@ disallow_database_seeding: true
 web_concurrency: 2
 
 # Preparation normally starts on the 1st August.
-number_of_preparation_days_before_academic_year_starts: 31
+academic_year_number_of_preparation_days: 31
 academic_year_today_override: null
 
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,7 @@ web_concurrency: 2
 
 # Preparation normally starts on the 1st August.
 number_of_preparation_days_before_academic_year_starts: 31
+academic_year_today_override: null
 
 # NHS Care Identity Service OIDC integration configuration, used by Omniauth via
 # Devise.

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -15,6 +15,22 @@ describe AcademicYear do
 
       it { should eq(2025) }
     end
+
+    context "when using the override setting" do
+      let(:today) { Date.current }
+
+      before do
+        Settings.academic_year_today_override = "2023-09-01"
+        described_class.instance_variable_set(:@override_current_date, nil)
+      end
+
+      after do
+        Settings.academic_year_today_override = nil
+        described_class.instance_variable_set(:@override_current_date, nil)
+      end
+
+      it { should eq(2023) }
+    end
   end
 
   describe "#pending" do

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -11,7 +11,7 @@ rails_env             = "production"
 rails_master_key_path = "/copilot/mavis/production/secrets/RAILS_MASTER_KEY"
 
 # TODO: Change this to the default value of 31 once rollover is built.
-number_of_preparation_days_before_academic_year_starts = 1
+academic_year_number_of_preparation_days = 1
 
 http_hosts = {
   MAVIS__HOST                        = "www.manage-vaccinations-in-schools.nhs.uk"

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -14,7 +14,7 @@ enable_cis2                     = false
 enable_pds_enqueue_bulk_updates = false
 
 # Normally this is 31, but this gives us 2 weeks of additional testing.
-number_of_preparation_days_before_academic_year_starts = 45
+academic_year_number_of_preparation_days = 45
 
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -11,7 +11,7 @@ rails_env             = "staging"
 rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 
 # Normally this is 31, but this gives us 2 weeks of additional testing.
-number_of_preparation_days_before_academic_year_starts = 45
+academic_year_number_of_preparation_days = 45
 
 http_hosts = {
   MAVIS__HOST                        = "test.mavistesting.com"

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -147,6 +147,13 @@ variable "enable_pds_enqueue_bulk_updates" {
   nullable    = false
 }
 
+variable "academic_year_today_override" {
+  type        = string
+  default     = null
+  description = "A date that can be used to override today's date when calculating the current academic year."
+  nullable    = true
+}
+
 variable "number_of_preparation_days_before_academic_year_starts" {
   type        = number
   default     = 31
@@ -173,6 +180,7 @@ locals {
   parameter_store_variables = tomap({
     MAVIS__PDS__ENQUEUE_BULK_UPDATES                              = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
     MAVIS__PDS__WAIT_BETWEEN_JOBS                                 = 0.5
+    MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE                           = var.academic_year_today_override
     MAVIS__NUMBER_OF_PREPARATION_DAYS_BEFORE_ACADEMIC_YEAR_STARTS = var.number_of_preparation_days_before_academic_year_starts
     GOOD_JOB_MAX_THREADS                                          = 5
   })

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -154,7 +154,7 @@ variable "academic_year_today_override" {
   nullable    = true
 }
 
-variable "number_of_preparation_days_before_academic_year_starts" {
+variable "academic_year_number_of_preparation_days" {
   type        = number
   default     = 31
   description = "How many days before the start of the academic year to start the preparation period."
@@ -178,11 +178,11 @@ variable "app_version" {
 locals {
   is_production = var.environment == "production"
   parameter_store_variables = tomap({
-    MAVIS__PDS__ENQUEUE_BULK_UPDATES                              = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
-    MAVIS__PDS__WAIT_BETWEEN_JOBS                                 = 0.5
-    MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE                           = var.academic_year_today_override
-    MAVIS__NUMBER_OF_PREPARATION_DAYS_BEFORE_ACADEMIC_YEAR_STARTS = var.number_of_preparation_days_before_academic_year_starts
-    GOOD_JOB_MAX_THREADS                                          = 5
+    MAVIS__PDS__ENQUEUE_BULK_UPDATES                = var.enable_pds_enqueue_bulk_updates ? "true" : "false"
+    MAVIS__PDS__WAIT_BETWEEN_JOBS                   = 0.5
+    MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE             = var.academic_year_today_override
+    MAVIS__ACADEMIC_YEAR_NUMBER_OF_PREPARATION_DAYS = var.academic_year_number_of_preparation_days
+    GOOD_JOB_MAX_THREADS                            = 5
   })
   parameter_store_config_list = [for key, value in local.parameter_store_variables : {
     name      = key


### PR DESCRIPTION
When calculating the current academic year, this adds a setting and an environment variable that can be used to customise today's date. This is useful for testing.

[Jira Issue - MAV-1563](https://nhsd-jira.digital.nhs.uk/browse/MAV-1563)