### PR TITLE
Set `academic_year_today_override` to an empty string

### DIFF
--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 describe AcademicYear do
+  before do
+    Settings.academic_year_today_override = academic_year_today_override
+    described_class.instance_variable_set(:@override_current_date, nil)
+  end
+
+  after do
+    Settings.academic_year_today_override = nil
+    described_class.instance_variable_set(:@override_current_date, nil)
+  end
+
+  let(:academic_year_today_override) { "" }
+
   describe "#current" do
     subject { travel_to(today) { described_class.current } }
 
@@ -18,16 +30,7 @@ describe AcademicYear do
 
     context "when using the override setting" do
       let(:today) { Date.current }
-
-      before do
-        Settings.academic_year_today_override = "2023-09-01"
-        described_class.instance_variable_set(:@override_current_date, nil)
-      end
-
-      after do
-        Settings.academic_year_today_override = nil
-        described_class.instance_variable_set(:@override_current_date, nil)
-      end
+      let(:academic_year_today_override) { "2023-09-01" }
 
       it { should eq(2023) }
     end

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -149,9 +149,9 @@ variable "enable_pds_enqueue_bulk_updates" {
 
 variable "academic_year_today_override" {
   type        = string
-  default     = null
+  default     = ""
   description = "A date that can be used to override today's date when calculating the current academic year."
-  nullable    = true
+  nullable    = false
 }
 
 variable "academic_year_number_of_preparation_days" {


### PR DESCRIPTION
Initially I set this to `null`, but this causes an error when running Terraform. Instead we can default this to an empty string, and the code will only try to parse the value if it's not blank.

Failed run: https://github.com/nhsuk/manage-vaccinations-in-schools/actions/runs/16564031087/job/46841865740

```
│ Error: Invalid combination of arguments
│ 
│   with aws_ssm_parameter.environment_config["MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE"],
│   on ssm_parameters.tf line 1, in resource "aws_ssm_parameter" "environment_config":
│    1: resource "aws_ssm_parameter" "environment_config" {
│ 
│ "value_wo": one of `insecure_value,value,value_wo` must be specified
╵
╷
│ Error: Invalid combination of arguments
│ 
│   with aws_ssm_parameter.environment_config["MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE"],
│   on ssm_parameters.tf line 1, in resource "aws_ssm_parameter" "environment_config":
│    1: resource "aws_ssm_parameter" "environment_config" {
│ 
│ "insecure_value": one of `insecure_value,value,value_wo` must be specified
╵
╷
│ Error: Invalid combination of arguments
│ 
│   with aws_ssm_parameter.environment_config["MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE"],
│   on ssm_parameters.tf line 6, in resource "aws_ssm_parameter" "environment_config":
│    6:   value = each.value
│ 
│ "value": one of `insecure_value,value,value_wo` must be specified
```