### PR TITLE
Set `academic_year_today_override` to `nil`

### DIFF
--- a/app/lib/academic_year.rb
+++ b/app/lib/academic_year.rb
@@ -19,7 +19,8 @@ module AcademicYear
 
     def override_current_date
       @override_current_date ||=
-        if (value = Settings.academic_year_today_override).present?
+        if (value = Settings.academic_year_today_override).present? &&
+             value != "nil"
           Date.parse(value)
         end
     end

--- a/spec/lib/academic_year_spec.rb
+++ b/spec/lib/academic_year_spec.rb
@@ -29,10 +29,19 @@ describe AcademicYear do
     end
 
     context "when using the override setting" do
-      let(:today) { Date.current }
-      let(:academic_year_today_override) { "2023-09-01" }
+      let(:today) { Date.new(2024, 9, 1) }
 
-      it { should eq(2023) }
+      context "when set to nil" do
+        let(:academic_year_today_override) { "nil" }
+
+        it { should eq(2024) }
+      end
+
+      context "when set to a specific date" do
+        let(:academic_year_today_override) { "2023-09-01" }
+
+        it { should eq(2023) }
+      end
     end
   end
 

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -149,7 +149,7 @@ variable "enable_pds_enqueue_bulk_updates" {
 
 variable "academic_year_today_override" {
   type        = string
-  default     = ""
+  default     = "nil"
   description = "A date that can be used to override today's date when calculating the current academic year."
   nullable    = false
 }


### PR DESCRIPTION
It turns out a blank string is not a valid parameter store value, so we need to set it to a specific value which is understood to mean unset.

We can't remove this variable while it's unused because we need to be able to change it dynamically, and therefore it needs to exist.

Follows on from #4088 

```
│ Error: creating SSM Parameter (/qa/env/MAVIS__ACADEMIC_YEAR_TODAY_OVERRIDE): operation error SSM: PutParameter, https response error StatusCode: 400, RequestID: c71334cc-0527-4396-9083-457b61c60c83, api error ValidationException: 1 validation error detected: Value at 'value' failed to satisfy constraint: Member must have length greater than or equal to 1
```