### PR TITLE
Remove "Vaccines administered" column

### DIFF
--- a/app/controllers/programmes_controller.rb
+++ b/app/controllers/programmes_controller.rb
@@ -4,8 +4,7 @@ class ProgrammesController < ApplicationController
   layout "full"
 
   def index
-    @programmes =
-      policy_scope(Programme).order(:type).includes(:active_vaccines)
+    @programmes = policy_scope(Programme).order(:type)
   end
 
   def consent_form

--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -35,8 +35,6 @@ class Programme < ApplicationRecord
 
   has_many :organisations, through: :organisation_programmes
 
-  has_many :active_vaccines, -> { active }, class_name: "Vaccine"
-
   enum :type,
        { flu: "flu", hpv: "hpv", menacwy: "menacwy", td_ipv: "td_ipv" },
        validate: true

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -8,7 +8,6 @@
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
           <% row.with_cell(text: "Programme") %>
-          <% row.with_cell(text: "Vaccines administered") %>
           <% row.with_cell(text: "Children") %>
           <% row.with_cell(text: "Vaccinations") %>
         <% end %>
@@ -20,11 +19,6 @@
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Programme</span>
               <%= link_to programme.name, programme_overview_path(programme, academic_year) %>
-            <% end %>
-
-            <% row.with_cell do %>
-              <span class="nhsuk-table-responsive__heading">Vaccines</span>
-              <%= programme.active_vaccines.map(&:brand).join("<br>").html_safe %>
             <% end %>
 
             <% row.with_cell do %>

--- a/spec/lib/fhir_mapper/vaccination_record_spec.rb
+++ b/spec/lib/fhir_mapper/vaccination_record_spec.rb
@@ -21,7 +21,7 @@ describe FHIRMapper::VaccinationRecord do
       patient:,
       programme:,
       session:,
-      vaccine: programme.active_vaccines.first,
+      vaccine: programme.vaccines.first,
       outcome: vaccination_outcome,
       nhs_immunisations_api_id:
     )


### PR DESCRIPTION
When viewing the list of programmes this removes the column displaying the vaccines administered in the programme to match the latest designs in the prototype.