### PR TITLE
Record already had vaccinations from consent response

### DIFF
--- a/app/jobs/patients_refused_consent_already_vaccinated_job.rb
+++ b/app/jobs/patients_refused_consent_already_vaccinated_job.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class PatientsRefusedConsentAlreadyVaccinatedJob < ApplicationJob
+  queue_as :patients
+
+  def perform
+    return unless should_perform?
+
+    Programme.find_each { |programme| handle_programme!(programme) }
+  end
+
+  private
+
+  def academic_year = AcademicYear.current
+
+  def should_perform? = AcademicYear.pending > academic_year
+
+  def handle_programme!(programme)
+    programme_id = programme.id
+
+    ActiveRecord::Base.transaction do
+      patients_with_consent_refused(programme).find_each do |patient|
+        consents =
+          ConsentGrouper.call(patient.consents, programme_id:, academic_year:)
+
+        if should_record_already_vaccinated?(consents:)
+          record_already_vaccinated!(patient, programme:, consents:)
+        end
+      end
+    end
+  end
+
+  def patients_with_consent_refused(programme)
+    Patient
+      .includes(parent_relationships: :parent)
+      .appear_in_programmes([programme], academic_year:)
+      .has_vaccination_status(
+        %w[none_yet could_not_vaccinate],
+        programme:,
+        academic_year:
+      )
+      .has_consent_status("refused", programme:, academic_year:)
+  end
+
+  def should_record_already_vaccinated?(consents:)
+    consents.all?(&:reason_for_refusal_already_vaccinated?)
+  end
+
+  def record_already_vaccinated!(patient, programme:, consents:)
+    names =
+      consents.map { |consent| "#{consent.name} (#{consent.who_responded})" }
+
+    notes = "Self-reported by #{names.to_sentence}"
+    performed_at = consents.map(&:submitted_at).min
+
+    VaccinationRecord.create!(
+      location_name: "Unknown",
+      notes:,
+      outcome: "already_had",
+      patient:,
+      performed_at:,
+      programme:
+    )
+
+    StatusUpdater.call(patient:)
+  end
+end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -107,7 +107,7 @@ class VaccinationRecord < ApplicationRecord
           )
         end
 
-  enum :protocol, { pgd: 0, psd: 1 }, validate: true
+  enum :protocol, { pgd: 0, psd: 1 }, validate: { allow_nil: true }
 
   enum :delivery_method,
        { intramuscular: 0, subcutaneous: 1, nasal_spray: 2 },
@@ -142,6 +142,11 @@ class VaccinationRecord < ApplicationRecord
 
   academic_year_attribute :performed_at
 
+  with_options if: :administered? do
+    validates :full_dose, inclusion: [true, false]
+    validates :protocol, presence: true
+  end
+
   validates :notes, length: { maximum: 1000 }
 
   validates :location_name,
@@ -158,8 +163,6 @@ class VaccinationRecord < ApplicationRecord
               less_than_or_equal_to: :maximum_dose_sequence,
               allow_nil: true
             }
-
-  validates :full_dose, inclusion: [true, false], if: :administered?
 
   validates :performed_at,
             comparison: {

--- a/config/cron_jobs.rb
+++ b/config/cron_jobs.rb
@@ -18,6 +18,12 @@ CRON_JOBS = {
     description:
       "Clears the registration of patients for the previous academic year"
   },
+  patients_refused_consent_already_vaccinated: {
+    cron: "every day at 5:30",
+    class: "PatientsRefusedConsentAlreadyVaccinatedJob",
+    description:
+      "Record already vaccinated for patients who refused consent in the previous academic year for that reason"
+  },
   remove_import_csv: {
     cron: "every day at 1am",
     class: "RemoveImportCSVJob",

--- a/spec/jobs/patients_refused_consent_already_vaccinated_job_spec.rb
+++ b/spec/jobs/patients_refused_consent_already_vaccinated_job_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+describe PatientsRefusedConsentAlreadyVaccinatedJob do
+  subject(:perform_now) do
+    StatusUpdater.call
+    described_class.perform_now
+  end
+
+  around { |example| travel_to(today) { example.run } }
+
+  let(:programmes) { create_list(:programme, 1, :flu) }
+  let(:session) { create(:session, programmes:) }
+
+  context "during the preparation period" do
+    let(:today) { Date.new(2025, 8, 1) }
+
+    context "with a vaccinated patient" do
+      before { create(:patient, :vaccinated, session:, year_group: 7) }
+
+      it "does not create a vaccination record" do
+        expect { perform_now }.not_to change(VaccinationRecord, :count)
+      end
+    end
+
+    context "with an unvaccinated patient and no consent" do
+      before { create(:patient, session:, year_group: 7) }
+
+      it "does not create a vaccination record" do
+        expect { perform_now }.not_to change(VaccinationRecord, :count)
+      end
+    end
+
+    context "with an unvaccinated patient and consent given" do
+      before do
+        create(
+          :patient,
+          :consent_given_triage_not_needed,
+          session:,
+          year_group: 7
+        )
+      end
+
+      it "does not create a vaccination record" do
+        expect { perform_now }.not_to change(VaccinationRecord, :count)
+      end
+    end
+
+    context "with an unvaccinated patient and consent refused" do
+      let(:patient) do
+        create(:patient, :consent_refused, session:, year_group: 7)
+      end
+
+      let(:consent) { patient.consents.first }
+
+      context "when refused for personal reasons" do
+        before { consent.update!(reason_for_refusal: "personal_choice") }
+
+        it "does not create a vaccination record" do
+          expect { perform_now }.not_to change(VaccinationRecord, :count)
+        end
+      end
+
+      context "when refused because already vaccinated" do
+        before { consent.update!(reason_for_refusal: "already_vaccinated") }
+
+        it "creates a vaccination record" do
+          expect { perform_now }.to change(VaccinationRecord, :count)
+
+          vaccination_record = VaccinationRecord.last
+          expect(vaccination_record).to be_already_had
+          expect(vaccination_record.location_name).to eq("Unknown")
+          expect(vaccination_record.notes).to eq(
+            "Self-reported by #{consent.name} (Mum)"
+          )
+          expect(vaccination_record.patient).to eq(patient)
+          expect(vaccination_record.performed_at).to eq(consent.submitted_at)
+          expect(vaccination_record.programme).to eq(programmes.first)
+        end
+      end
+    end
+  end
+
+  context "outside the preparation period" do
+    let(:today) { Date.new(2025, 7, 31) }
+
+    context "with a vaccinated patient" do
+      before { create(:patient, :vaccinated, session:, year_group: 7) }
+
+      it "does not create a vaccination record" do
+        expect { perform_now }.not_to change(VaccinationRecord, :count)
+      end
+    end
+
+    context "with an unvaccinated patient and no consent" do
+      before { create(:patient, session:, year_group: 7) }
+
+      it "does not create a vaccination record" do
+        expect { perform_now }.not_to change(VaccinationRecord, :count)
+      end
+    end
+
+    context "with an unvaccinated patient and consent given" do
+      before do
+        create(
+          :patient,
+          :consent_given_triage_not_needed,
+          session:,
+          year_group: 7
+        )
+      end
+
+      it "does not create a vaccination record" do
+        expect { perform_now }.not_to change(VaccinationRecord, :count)
+      end
+    end
+
+    context "with an unvaccinated patient and consent refused" do
+      let(:patient) do
+        create(:patient, :consent_refused, session:, year_group: 7)
+      end
+
+      let(:consent) { patient.consents.first }
+
+      context "when refused for personal reasons" do
+        before { consent.update!(reason_for_refusal: "personal_choice") }
+
+        it "does not create a vaccination record" do
+          expect { perform_now }.not_to change(VaccinationRecord, :count)
+        end
+      end
+
+      context "when refused because already vaccinated" do
+        before { consent.update!(reason_for_refusal: "already_vaccinated") }
+
+        it "does not create a vaccination record" do
+          expect { perform_now }.not_to change(VaccinationRecord, :count)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -69,11 +69,19 @@ describe VaccinationRecord do
     it { should validate_inclusion_of(:protocol).in_array(%w[pgd psd]) }
 
     context "when administered" do
+      before { vaccination_record.outcome = "administered" }
+
       it { should allow_values(true, false).for(:full_dose) }
       it { should_not allow_values(nil).for(:full_dose) }
+
+      it { should validate_presence_of(:protocol) }
     end
 
     context "when not administered" do
+      before { vaccination_record.outcome = "already_had" }
+
+      it { should_not validate_presence_of(:protocol) }
+
       it { should_not validate_presence_of(:full_dose) }
     end
 


### PR DESCRIPTION
If the parents responded to consent during an academic year and indicated that the patient was already vaccinated, provided that the academic year has come to an end, we should be recording these as vaccination records to ensure that the patient doesn't get asked for consent again next year.

To implement this I've created a job which only runs during the preparation period before an academic year starts.

[Jira Issue - MAV-1517](https://nhsd-jira.digital.nhs.uk/browse/MAV-1517)