### PR TITLE
Remove case sensitivity in validation check of clinic name

### DIFF
--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -355,6 +355,52 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "with clinic care setting" do
+      let(:valid_clinic_data) do
+        valid_data.merge(
+          "CARE_SETTING" => "2",
+          "DATE_OF_VACCINATION" => session.dates.first.strftime("%Y%m%d"),
+          "SESSION_ID" => session.id.to_s,
+          "ORGANISATION_CODE" => organisation.ods_code,
+          "PERFORMING_PROFESSIONAL_EMAIL" => create(:user).email
+        )
+      end
+
+      let(:session) { create(:session, organisation:, programmes:) }
+
+      before { create(:community_clinic, name: "A clinic", organisation:) }
+
+      context "with an existing community clinic" do
+        let(:data) { valid_clinic_data.merge("CLINIC_NAME" => "A clinic") }
+
+        it "is matching" do
+          expect(immunisation_import_row).to be_valid
+        end
+      end
+
+      context "with incorrect casing for an existing clinic" do
+        let(:data) { valid_clinic_data.merge("CLINIC_NAME" => "a cLinIC") }
+
+        it "is case insensitive" do
+          expect(immunisation_import_row).to be_valid
+        end
+      end
+
+      context "with a non-existent clinic" do
+        let(:data) do
+          valid_clinic_data.merge("CLINIC_NAME" => "A wrong clinic")
+        end
+
+        it "is invalid" do
+          expect(immunisation_import_row).to be_invalid
+
+          expect(
+            immunisation_import_row.errors["CLINIC_NAME"]
+          ).to contain_exactly("is not recognised")
+        end
+      end
+    end
+
     context "with more than two matching patients" do
       let(:data) do
         {


### PR DESCRIPTION
This ensures that the validation check on the clinic name is not case sensitive when importing vaccination records for community clinics.

This replaces #3664 as that was raised from a fork.

[Jira Issue - MAV-691](https://nhsd-jira.digital.nhs.uk/browse/MAV-691)