### PR TITLE
Fix the text in the "Select a default batch" header

### DIFF
--- a/app/views/sessions/record/batch.html.erb
+++ b/app/views/sessions/record/batch.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% programme_name_and_method = if @programme.has_multiple_vaccine_methods?
-       "#{@programme.name_in_sentence} #{Vaccine.human_enum_name(:vaccine_method, @vaccine_method)}.downcase"
+       "#{@programme.name_in_sentence} #{Vaccine.human_enum_name(:vaccine_method, @vaccine_method).downcase}"
      else
        "#{@programme.name_in_sentence}"
      end %>


### PR DESCRIPTION
It used to have `.downcase` as part of the text in the UI:

<img width="775" height="418" alt="image" src="https://github.com/user-attachments/assets/0e3dc690-5bae-46cf-9b43-8b121c680541" />
