### PR TITLE
Show eligible programmes on patient page

### DIFF
--- a/app/components/app_patient_programmes_table_component.rb
+++ b/app/components/app_patient_programmes_table_component.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+class AppPatientProgrammesTableComponent < ViewComponent::Base
+  def initialize(patient, programmes:)
+    super
+
+    @patient = patient
+    @programmes = programmes
+  end
+
+  def call
+    govuk_table(
+      caption: CAPTION,
+      head: HEADERS,
+      rows:,
+      first_cell_is_header: true
+    )
+  end
+
+  private
+
+  attr_reader :patient, :programmes
+
+  CAPTION = "Vaccination programmes"
+
+  HEADERS = ["Programme name", "Status", "Notes"].freeze
+
+  def rows
+    programmes.flat_map { |programme| rows_for_programme(programme) }
+  end
+
+  def rows_for_programme(programme)
+    if programme.seasonal?
+      eligible_year_groups = eligible_year_groups_for(programme:)
+
+      AcademicYear.all.filter_map do |academic_year|
+        year_group = patient.year_group(academic_year:)
+        next unless year_group.in?(eligible_year_groups)
+
+        [
+          name_for_programme(programme, academic_year:),
+          status_for_programme(programme, academic_year:),
+          notes_for_programme(programme, academic_year:)
+        ]
+      end
+    else
+      [
+        [
+          name_for_programme(programme, academic_year: AcademicYear.current),
+          status_for_programme(programme, academic_year: AcademicYear.current),
+          notes_for_programme(programme, academic_year: AcademicYear.current)
+        ]
+      ]
+    end
+  end
+
+  def name_for_programme(programme, academic_year:)
+    if programme.seasonal?
+      "#{programme.name} (Winter #{academic_year})"
+    else
+      programme.name
+    end
+  end
+
+  def status_for_programme(programme, academic_year:)
+    if vaccinated?(programme:, academic_year:)
+      govuk_tag(text: "Vaccinated", colour: "green")
+    else
+      "—"
+    end
+  end
+
+  def notes_for_programme(programme, academic_year:)
+    if vaccinated?(programme:, academic_year:)
+      vaccination_record =
+        if programme.seasonal?
+          vaccination_records(programme:)
+            .select { it.academic_year == academic_year }
+            .first
+        else
+          vaccination_records(programme:).first
+        end
+
+      return "—" if vaccination_record.nil?
+
+      "Vaccinated #{vaccination_record.performed_at.to_date.to_fs(:long)}"
+    else
+      earliest_academic_year =
+        if programme.seasonal?
+          academic_year
+        elsif (earliest_year_group = eligible_year_groups_for(programme:).first)
+          patient.birth_academic_year + earliest_year_group +
+            Integer::AGE_CHILDREN_START_SCHOOL
+        end
+
+      return "—" if earliest_academic_year.nil?
+
+      eligibility_date =
+        earliest_academic_year.to_academic_year_date_range.begin
+
+      if eligibility_date.future?
+        "Eligibility starts #{eligibility_date.to_fs(:long)}"
+      else
+        "Eligibility started #{eligibility_date.to_fs(:long)}"
+      end
+    end
+  end
+
+  def vaccinated?(programme:, academic_year:)
+    patient.vaccination_statuses.vaccinated.exists?(programme:, academic_year:)
+  end
+
+  def vaccination_records(programme:)
+    @vaccination_records ||=
+      patient
+        .vaccination_records
+        .where(outcome: %w[administered already_had])
+        .order(:performed_at)
+
+    @vaccination_records.select { it.programme_id = programme.id }
+  end
+
+  def eligible_year_groups_for(programme:)
+    location_ids = patient.patient_sessions.joins(:session).select(:location_id)
+
+    Location::ProgrammeYearGroup
+      .where(location_id: location_ids)
+      .where(programme:)
+      .pluck_year_groups
+  end
+end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -94,8 +94,6 @@ class PatientSession < ApplicationRecord
 
   scope :appear_in_programmes,
         ->(programmes) do
-          age_children_start_school = 5
-
           # Is the patient eligible for any of those programmes by year group?
           location_programme_year_groups =
             LocationProgrammeYearGroup
@@ -104,7 +102,7 @@ class PatientSession < ApplicationRecord
               .where(
                 "year_group = sessions.academic_year " \
                   "- patients.birth_academic_year " \
-                  "- #{age_children_start_school}"
+                  "- #{Integer::AGE_CHILDREN_START_SCHOOL}"
               )
 
           # Are any of the programmes administered in the session?

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -22,6 +22,10 @@
 <% end %>
 
 <%= render AppCardComponent.new(section: true) do |card| %>
+  <%= render AppPatientProgrammesTableComponent.new(@patient, programmes: policy_scope(Programme)) %>
+<% end %>
+
+<%= render AppCardComponent.new(section: true) do |card| %>
   <% card.with_heading { "Sessions" } %>
   <%= render AppPatientSessionTableComponent.new(@patient_sessions) %>
 <% end %>

--- a/lib/core_ext/integer/year_group.rb
+++ b/lib/core_ext/integer/year_group.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class Integer
-  def to_year_group(academic_year:)
-    # Children normally start school the September after their 4th birthday.
-    # https://www.gov.uk/schools-admissions/school-starting-age
+  AGE_CHILDREN_START_SCHOOL = 5
 
-    (academic_year || Date.current.academic_year) - self - 5
+  def to_year_group(academic_year: nil)
+    (academic_year || Date.current.academic_year) - self -
+      AGE_CHILDREN_START_SCHOOL
   end
 
   alias_method :to_birth_academic_year, :to_year_group

--- a/spec/components/app_patient_programmes_table_component_spec.rb
+++ b/spec/components/app_patient_programmes_table_component_spec.rb
@@ -18,7 +18,7 @@ describe AppPatientProgrammesTableComponent do
     it { should have_content("Vaccination programmes") }
     it { should have_content("Flu (Winter 2025)") }
     it { should_not have_content("Vaccinated") }
-    it { should have_content("Eligibility started 1 September 2025") }
+    it { should have_content("Selected for the Year 2025 to 2026 Flu cohort") }
 
     context "when vaccinated" do
       let(:patient) { create(:patient, :vaccinated, session:) }
@@ -57,7 +57,7 @@ describe AppPatientProgrammesTableComponent do
     it { should have_content("HPV") }
     it { should have_content("Td/IPV") }
     it { should have_content("MenACWY") }
-    it { should have_content("Eligibility started 1 September 2025").once }
+    it { should have_content("Selected for the Year 2025 to 2026 HPV cohort").once }
     it { should have_content("Eligibility starts 1 September 2026").twice }
 
     context "when vaccinated" do

--- a/spec/components/app_patient_programmes_table_component_spec.rb
+++ b/spec/components/app_patient_programmes_table_component_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+describe AppPatientProgrammesTableComponent do
+  subject { render_inline(component) }
+
+  let(:component) { described_class.new(patient, programmes:) }
+  let(:team) { create(:team, programmes:) }
+  let(:session) { create(:session, team:, programmes:) }
+
+  let(:today) { Date.new(2025, 9, 1) }
+
+  around { |example| travel_to(today) { example.run } }
+
+  context "for seasonal programmes" do
+    let(:patient) { create(:patient, session:) }
+    let(:programmes) { create_list(:programme, 1, :flu) }
+
+    it { should have_content("Vaccination programmes") }
+    it { should have_content("Flu (Winter 2025)") }
+    it { should_not have_content("Vaccinated") }
+    it { should have_content("Eligibility started 1 September 2025") }
+
+    context "when vaccinated" do
+      let(:patient) { create(:patient, :vaccinated, session:) }
+
+      it { should have_content("Vaccinated") }
+    end
+
+    context "when vaccinated last year" do
+      let(:patient) { create(:patient, session:) }
+
+      before do
+        create(
+          :vaccination_record,
+          patient:,
+          programme: programmes.first,
+          performed_at: Time.zone.local(2024, 9, 1)
+        )
+        StatusUpdater.call(patient:)
+      end
+
+      it { should_not have_content("Vaccinated") }
+    end
+  end
+
+  context "for non-seasonal programmes" do
+    let(:patient) { create(:patient, session:, year_group: 8) }
+    let(:programmes) do
+      [
+        create(:programme, :hpv),
+        create(:programme, :menacwy),
+        create(:programme, :td_ipv)
+      ]
+    end
+
+    it { should have_content("Vaccination programmes") }
+    it { should have_content("HPV") }
+    it { should have_content("Td/IPV") }
+    it { should have_content("MenACWY") }
+    it { should have_content("Eligibility started 1 September 2025").once }
+    it { should have_content("Eligibility starts 1 September 2026").twice }
+
+    context "when vaccinated" do
+      let(:patient) { create(:patient, :vaccinated, session:) }
+
+      it { should have_content("Vaccinated") }
+    end
+
+    context "when vaccinated last year" do
+      let(:patient) { create(:patient, session:) }
+
+      before do
+        create(
+          :vaccination_record,
+          patient:,
+          programme: programmes.first,
+          performed_at: Time.zone.local(2024, 9, 1)
+        )
+        StatusUpdater.call(patient:)
+      end
+
+      it { should have_content("Vaccinated") }
+    end
+  end
+end

--- a/spec/features/vaccination_programmes_spec.rb
+++ b/spec/features/vaccination_programmes_spec.rb
@@ -28,6 +28,8 @@ describe "Vaccination programmes table" do
 
     then_the_table_has_a_row_showing_hpv_vaccinated
     and_the_table_has_a_row_showing_second_hpv_vaccinated
+
+    screenshot_and_save_page
   end
 
   scenario "patient has a seasonal vaccine" do
@@ -38,6 +40,8 @@ describe "Vaccination programmes table" do
     and_i_click_on_a_child
 
     then_the_table_has_two_rows_showing_flu_vaccinated
+
+    screenshot_and_save_page
   end
 
   scenario "patient has an outcome other than vaccinated" do
@@ -48,6 +52,8 @@ describe "Vaccination programmes table" do
     and_i_click_on_a_child
 
     then_the_table_displays_the_outcome
+
+    screenshot_and_save_page
   end
 
   def given_my_team_exists
@@ -125,7 +131,7 @@ describe "Vaccination programmes table" do
     ) do |row|
       expect(row).to have_selector(
         "td.nhsuk-table__cell",
-        text: "Eligibility started 1 September 2023"
+        text: "Selected for the Year 2023 to 2024 MenACWY cohort"
       )
     end
   end
@@ -143,7 +149,7 @@ describe "Vaccination programmes table" do
 
     expect(page).to have_selector(
       "table.nhsuk-table tbody tr",
-      text: "Flu (2nd dose, Winter 2024)"
+      text: "Flu (Winter 2024, 2nd dose)"
     ) do |row|
       expect(row).to have_selector(
         "td.nhsuk-table__cell",
@@ -157,6 +163,10 @@ describe "Vaccination programmes table" do
       "table.nhsuk-table tbody tr",
       text: "HPV"
     ) do |row|
+      expect(row).to have_selector(
+        "td.nhsuk-table__cell",
+        text: "Could not vaccinate"
+      )
       expect(row).to have_selector("td.nhsuk-table__cell", text: "Not well")
     end
   end

--- a/spec/features/vaccination_programmes_spec.rb
+++ b/spec/features/vaccination_programmes_spec.rb
@@ -14,6 +14,8 @@ describe "Vaccination programmes table" do
 
     then_the_table_has_a_row_showing_hpv_vaccinated
     and_the_table_shows_other_eligible_vaccinations
+
+    screenshot_and_save_page
   end
 
   scenario "patient has non-seasonal vaccine with more than one dose" do
@@ -26,6 +28,26 @@ describe "Vaccination programmes table" do
 
     then_the_table_has_a_row_showing_hpv_vaccinated
     and_the_table_has_a_row_showing_second_hpv_vaccinated
+  end
+
+  scenario "patient has a seasonal vaccine" do
+    given_patients_exist_in_year_eleven
+    and_the_patient_had_two_flu_doses_last_year
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+
+    then_the_table_has_two_rows_showing_flu_vaccinated
+  end
+
+  scenario "patient has an outcome other than vaccinated" do
+    given_patients_exist_in_year_eleven
+    and_the_patient_has_an_outcome_other_than_vaccinated
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+
+    then_the_table_displays_the_outcome
   end
 
   def given_my_team_exists
@@ -108,6 +130,37 @@ describe "Vaccination programmes table" do
     end
   end
 
+  def then_the_table_has_two_rows_showing_flu_vaccinated
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "Flu (Winter 2024)"
+    ) do |row|
+      expect(row).to have_selector(
+        "td.nhsuk-table__cell",
+        text: "Vaccinated 1 September 2024"
+      )
+    end
+
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "Flu (2nd dose, Winter 2024)"
+    ) do |row|
+      expect(row).to have_selector(
+        "td.nhsuk-table__cell",
+        text: "Vaccinated 1 March 2025"
+      )
+    end
+  end
+
+  def then_the_table_displays_the_outcome
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "HPV"
+    ) do |row|
+      expect(row).to have_selector("td.nhsuk-table__cell", text: "Not well")
+    end
+  end
+
   def and_the_patient_is_vaccinated_for_hpv
     create(
       :vaccination_record,
@@ -126,5 +179,35 @@ describe "Vaccination programmes table" do
       programme: @hpv_programme,
       session: @session
     )
+  end
+
+  def and_the_patient_had_two_flu_doses_last_year
+    create(
+      :vaccination_record,
+      patient: @patient,
+      programme: @flu_programme,
+      session: @session,
+      performed_at: Time.zone.local(2024, 9, 1)
+    )
+    create(
+      :vaccination_record,
+      dose_sequence: 2,
+      patient: @patient,
+      programme: @flu_programme,
+      session: @session,
+      performed_at: Time.zone.local(2025, 3, 1)
+    )
+    StatusUpdater.call(patient: @patient)
+  end
+
+  def and_the_patient_has_an_outcome_other_than_vaccinated
+    create(
+      :vaccination_record,
+      :not_administered,
+      patient: @patient,
+      programme: @hpv_programme,
+      session: @session
+    )
+    StatusUpdater.call(patient: @patient)
   end
 end

--- a/spec/features/vaccination_programmes_spec.rb
+++ b/spec/features/vaccination_programmes_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+describe "Vaccination programmes table" do
+  around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
+  before { given_my_team_exists }
+
+  scenario "patient has non-seasonal vaccine" do
+    given_patients_exist_in_year_eleven
+    and_the_patient_is_vaccinated_for_hpv
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+
+    then_the_table_has_a_row_showing_hpv_vaccinated
+    and_the_table_shows_other_eligible_vaccinations
+  end
+
+  scenario "patient has non-seasonal vaccine with more than one dose" do
+    given_patients_exist_in_year_eleven
+    and_the_patient_is_vaccinated_for_hpv
+    and_the_patient_has_a_second_dose_of_hpv
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+
+    then_the_table_has_a_row_showing_hpv_vaccinated
+    and_the_table_has_a_row_showing_second_hpv_vaccinated
+  end
+
+  def given_my_team_exists
+    @programmes = [
+      @flu_programme = create(:programme, :flu),
+      @hpv_programme = create(:programme, :hpv),
+      @menacwy_programme = create(:programme, :menacwy),
+      @td_ipv_programme = create(:programme, :td_ipv)
+    ]
+
+    @team = create(:team, :with_one_nurse, programmes: @programmes)
+  end
+
+  def given_patients_exist_in_year_eleven
+    school = create(:school, team: @team)
+
+    @session =
+      create(:session, location: school, team: @team, programmes: @programmes)
+
+    @patient =
+      create(
+        :patient,
+        session: @session,
+        year_group: 10,
+        given_name: "John",
+        family_name: "Smith",
+        programmes: @programmes,
+        school:
+      )
+  end
+
+  def when_i_click_on_children
+    sign_in @team.users.first
+
+    visit "/dashboard"
+    click_on "Children", match: :first
+  end
+
+  def and_i_click_on_a_child
+    click_on "SMITH, John"
+  end
+
+  def then_the_table_has_a_row_showing_hpv_vaccinated
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "HPV"
+    ) do |row|
+      expect(row).to have_selector("td.nhsuk-table__cell", text: "Vaccinated")
+    end
+  end
+
+  def and_the_table_has_a_row_showing_second_hpv_vaccinated
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "HPV (2nd dose)"
+    ) do |row|
+      expect(row).to have_selector("td.nhsuk-table__cell", text: "Vaccinated")
+    end
+  end
+
+  def and_the_table_shows_other_eligible_vaccinations
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "Flu (Winter 2025)"
+    ) do |row|
+      expect(row).to have_selector(
+        "td.nhsuk-table__cell",
+        text: "Eligibility starts 1 September 2025"
+      )
+    end
+
+    expect(page).to have_selector(
+      "table.nhsuk-table tbody tr",
+      text: "MenACWY"
+    ) do |row|
+      expect(row).to have_selector(
+        "td.nhsuk-table__cell",
+        text: "Eligibility started 1 September 2023"
+      )
+    end
+  end
+
+  def and_the_patient_is_vaccinated_for_hpv
+    create(
+      :vaccination_record,
+      patient: @patient,
+      programme: @hpv_programme,
+      session: @session,
+      performed_at: 6.months.ago
+    )
+  end
+
+  def and_the_patient_has_a_second_dose_of_hpv
+    create(
+      :vaccination_record,
+      dose_sequence: 2,
+      patient: @patient,
+      programme: @hpv_programme,
+      session: @session
+    )
+  end
+end


### PR DESCRIPTION
This adds a new section to the patient page showing which programmes the patient is eligible for at which time. In the prototype, this card is supposed to replace the cohorts card, but since we haven't built the archive functionality that's designed to replace "Remove from cohort" I've left it in place.

[Jira Issue - MAV-1516](https://nhsd-jira.digital.nhs.uk/browse/MAV-1516)

## Screenshots

<img width="791" height="461" alt="Screenshot 2025-07-29 at 19 34 37" src="https://github.com/user-attachments/assets/0d29e599-9cbd-4608-af69-53380f20d63b" />
<img width="774" height="446" alt="Screenshot 2025-07-29 at 19 34 45" src="https://github.com/user-attachments/assets/48a567bb-60f5-4a43-83c2-e7a2861bc634" />
