### PR TITLE
Add URN/postcode to school options drop down

### DIFF
--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module LocationsHelper
+  def location_display_name(location, show_postcode: false, show_urn: false)
+    return location.name unless show_postcode || show_urn
+
+    identifier =
+      show_postcode ? location.address_postcode : "URN: #{location.urn}"
+    "#{location.name} (#{identifier})"
+  end
+end

--- a/app/views/draft_class_imports/session.html.erb
+++ b/app/views/draft_class_imports/session.html.erb
@@ -13,7 +13,8 @@
     <%= tag.option "", value: "" %>
 
     <% @session_options.each do |session| %>
-      <%= tag.option session.location.name,
+      <% is_duplicate = @session_options.count { |s| s.location.name == session.location.name } > 1 %>
+      <%= tag.option location_display_name(session.location, show_urn: is_duplicate),
                      value: session.id,
                      selected: session.id == @draft_class_import.session_id,
                      data: { hint: format_address_single_line(session.location) } %>

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -18,7 +18,8 @@
                      data: { module: "autocomplete" } do %>
         <%= tag.option "", value: "" %>
         <% @consent_form.eligible_schools.each do |school| %>
-          <%= tag.option(school.name,
+          <% is_duplicate = @consent_form.eligible_schools.count { |s| s.name == school.name } > 1 %>
+          <%= tag.option(location_display_name(school, show_postcode: is_duplicate),
                          value: school.id,
                          selected: school.id == @consent_form.school_id,
                          data: { hint: school.address_parts.join(", ") }) %>


### PR DESCRIPTION
When schools have the same name, the autocomplete controller only finds the first match with the name and renders all other options with the same name as a duplicate of the first. This means the user will not be able to see or select the other options. Making the option names uniqe (e.g. by adding the URN) ensures all the options render and can be selected. We only add the URN for SAIS view and postcode for parent view when schools have the same name, not for all schools.

<img width="907" height="232" alt="Screenshot 2025-07-30 111942" src="https://github.com/user-attachments/assets/df0310f7-c346-4c9e-b9f0-6d2c3c7b42fd" />
<img width="891" height="486" alt="Screenshot 2025-07-30 112243" src="https://github.com/user-attachments/assets/4047dacb-459a-40ae-897b-bdf6afa230b2" />

https://nhsd-jira.digital.nhs.uk/browse/MAV-1131