### PR TITLE
Fix content of verbal consent labels

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,13 +1,5 @@
 en:
   activemodel:
-    attributes:
-      draft_consent:
-        responses:
-          given: Consent given
-          given_injection: Consent given
-          given_nasal: Consent given
-          not_provided: Not provided
-          refused: Consent refused
     errors:
       models:
         batch_form:
@@ -158,6 +150,8 @@ en:
           will_be_vaccinated_elsewhere: Vaccine will be given elsewhere
         responses:
           given: Consent given
+          given_injection: Consent given
+          given_nasal: Consent given
           not_provided: Not provided
           refused: Consent refused
         routes:

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -15,6 +15,19 @@ describe "Verbal consent" do
     and_i_can_see_the_consent_response_details
   end
 
+  scenario "Given flu injection" do
+    given_an_flu_programme_is_underway
+    and_i_am_signed_in
+
+    when_i_record_that_verbal_injection_consent_was_given
+    then_i_see_the_check_and_confirm_page
+    and_i_see_the_flu_injection_consent_given
+
+    when_i_confirm_the_consent_response
+    then_an_email_is_sent_to_the_parent_confirming_their_consent
+    and_a_text_is_sent_to_the_parent_confirming_their_consent
+  end
+
   scenario "Given flu nasal spray" do
     given_an_flu_programme_is_underway
     and_i_am_signed_in
@@ -68,6 +81,14 @@ describe "Verbal consent" do
     record_that_verbal_consent_was_given(
       consent_option: "Yes, they agree",
       number_of_health_questions: 4
+    )
+  end
+
+  def when_i_record_that_verbal_injection_consent_was_given
+    record_that_verbal_consent_was_given(
+      consent_option: "Yes, for the injected vaccine only",
+      number_of_health_questions: 4,
+      triage_option: "Yes, it’s safe to vaccinate with injected vaccine"
     )
   end
 
@@ -140,13 +161,17 @@ describe "Verbal consent" do
     expect(page).to have_content(["Method", "By phone"].join)
   end
 
+  def and_i_see_the_flu_injection_consent_given
+    expect(page).to have_content("Consent givenInjection")
+  end
+
   def and_i_see_the_flu_nasal_consent_given
-    expect(page).to have_content("Given nasalNasal spray")
+    expect(page).to have_content("Consent givenNasal spray")
     expect(page).to have_content("Consent also given for injected vaccine?No")
   end
 
   def and_i_see_the_flu_nasal_and_injection_consent_given
-    expect(page).to have_content("Given nasalNasal spray")
+    expect(page).to have_content("Consent givenNasal spray")
     expect(page).to have_content("Consent also given for injected vaccine?Yes")
   end
 


### PR DESCRIPTION
This fixes the confirmation labels shown as part of the verbal consent journey to match the designs in the prototype.

The original commit that attempted to fix this 8ba778e03405aedbdb8f8272eeed601c98c8b00c didn't work correctly.

[Jira Issue - MAV-1693](https://nhsd-jira.digital.nhs.uk/browse/MAV-1693)

## Screenshot

<img width="790" height="173" alt="Screenshot 2025-07-30 at 12 09 03" src="https://github.com/user-attachments/assets/34ad7bed-7a2c-4356-9fbe-f4bcb26ec460" />
