### PR TITLE
Add `theme-color` meta tag, adapt based on hosting environment

### DIFF
--- a/app/components/app_hosting_environment_component.rb
+++ b/app/components/app_hosting_environment_component.rb
@@ -14,17 +14,5 @@ class AppHostingEnvironmentComponent < ViewComponent::Base
 
   def render? = !Rails.env.production?
 
-  delegate :title, :title_in_sentence, to: :HostingEnvironment
-
-  ENVIRONMENT_COLOR = {
-    development: "white",
-    review: "purple",
-    test: "red",
-    qa: "orange",
-    preview: "yellow"
-  }.freeze
-
-  def colour
-    ENVIRONMENT_COLOR[HostingEnvironment.name.to_sym]
-  end
+  delegate :title, :title_in_sentence, :colour, to: :HostingEnvironment
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
   before_action :set_header_path
   before_action :set_service_name
+  before_action :set_theme_colour
   before_action :set_service_guide_url
   before_action :set_show_navigation
   before_action :set_privacy_policy_url
@@ -48,6 +49,10 @@ class ApplicationController < ActionController::Base
 
   def set_service_name
     @service_name = "Manage vaccinations in schools"
+  end
+
+  def set_theme_colour
+    @theme_colour = HostingEnvironment.theme_colour
   end
 
   def set_show_navigation

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,9 +1,35 @@
 # frozen_string_literal: true
 
 module HostingEnvironment
+  ENVIRONMENT_COLOUR = {
+    production: "blue",
+    development: "white",
+    review: "purple",
+    test: "red",
+    qa: "orange",
+    preview: "yellow"
+  }.freeze
+
+  ENVIRONMENT_THEME_COLOUR = {
+    production: "#005eb8",
+    development: "#fff",
+    review: "#d6cce3",
+    test: "#f7d4d1",
+    qa: "#ffdc8e",
+    preview: "#fff59d"
+  }.freeze
+
   class << self
     def name
       pull_request ? "review" : ENV.fetch("SENTRY_ENVIRONMENT", "development")
+    end
+
+    def colour
+      ENVIRONMENT_COLOUR[name.to_sym]
+    end
+
+    def theme_colour
+      ENVIRONMENT_THEME_COLOUR[name.to_sym]
     end
 
     def title

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, name: 'theme-color', content: @theme_colour %>
 
     <title><%= page_title(@service_name) %></title>
 

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -78,4 +78,56 @@ describe HostingEnvironment do
       it { should eq("development") }
     end
   end
+
+  describe "#colour" do
+    subject { described_class.colour }
+
+    context "when the environment variable is set" do
+      let(:hosting_environment) { "production" }
+
+      it { should eq("blue") }
+    end
+
+    context "when in the QA environment" do
+      let(:hosting_environment) { "qa" }
+
+      it { should eq("orange") }
+    end
+
+    context "when in a pull request environment" do
+      let(:hosting_environment) { "review" }
+
+      it { should eq("purple") }
+    end
+
+    context "when the environment variable isn't set" do
+      it { should eq("white") }
+    end
+  end
+
+  describe "#theme_colour" do
+    subject { described_class.theme_colour }
+
+    context "when the environment variable is set" do
+      let(:hosting_environment) { "production" }
+
+      it { should eq("#005eb8") }
+    end
+
+    context "when in the QA environment" do
+      let(:hosting_environment) { "qa" }
+
+      it { should eq("#ffdc8e") }
+    end
+
+    context "when in a pull request environment" do
+      let(:hosting_environment) { "review" }
+
+      it { should eq("#d6cce3") }
+    end
+
+    context "when the environment variable isn't set" do
+      it { should eq("#fff") }
+    end
+  end
 end


### PR DESCRIPTION
If I’ve got this right, this means that we can correctly set a `theme-color` of NHS brand blue (`#005eb8`) on the production environment, otherwise the `theme-color` will share that of the banner at the top of the page.