### PR TITLE
Update Devise localisation strings

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -3,19 +3,19 @@
 en:
   devise:
     confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      confirmed: "Your email address has been successfully confirmed"
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes"
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes"
     failure:
-      already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
-      invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
-      last_attempt: "You have one more attempt before your account is locked."
-      not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
-      unconfirmed: "You have to confirm your email address before continuing."
+      already_authenticated: "You are already logged in"
+      inactive: "Your account is not activated yet"
+      invalid: "Invalid email or password"
+      locked: "Your account is locked"
+      last_attempt: "You have one more attempt before your account is locked"
+      not_found_in_database: "Invalid email or password"
+      timeout: "Your session has expired. Please log in again to continue"
+      unauthenticated: "You need to log in or register before continuing"
+      unconfirmed: "You have to confirm your email address before continuing"
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
@@ -24,39 +24,39 @@ en:
       unlock_instructions:
         subject: "Unlock instructions"
       email_changed:
-        subject: "Email Changed"
+        subject: "Email changed"
       password_change:
-        subject: "Password Changed"
+        subject: "Password changed"
     omniauth_callbacks:
-      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
-      success: "Successfully authenticated from %{kind} account."
+      failure: 'Could not authenticate you from %{kind} because "%{reason}"'
+      success: "Successfully authenticated from %{kind} account"
     passwords:
       no_token: "You can’t access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes"
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes"
+      updated: "Your password has been changed successfully. You are now logged in."
+      updated_not_active: "Your password has been changed successfully"
     registrations:
       destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up: "Welcome! You have registered successfully."
+      signed_up_but_inactive: "You have registered successfully. However, we could not log you in because your account is not yet activated."
+      signed_up_but_locked: "You have registered successfully. However, we could not log you in because your account is locked."
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
-      updated: "Your account has been updated successfully."
-      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
+      updated: "Your account has been updated successfully"
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to log in again"
     sessions:
       signed_in: ""
       signed_out: ""
       already_signed_in: ""
       already_signed_out: ""
     unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes"
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes"
+      unlocked: "Your account has been unlocked successfully. Please log in to continue."
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
+      already_confirmed: "was already confirmed, please try logging in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"
       not_found: "The email address is not in our records"


### PR DESCRIPTION
Mainly because the capitalisation and full stop in ‘Invalid Email or password.’ has been making my eyes twitch. Also replaces ‘sign in’ with ‘log in’ to be consistent with the wording we use throughout the service.

Very much 💅🤏