### PR TITLE
Rename API feature flag

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,4 +1,4 @@
-api: Basic API useful for automated testing.
+testing_api: Basic API useful for automated testing.
 
 basic_auth: Require users to sign in with basic authentication before they
   can use the service.


### PR DESCRIPTION
This was missed in 86f1046d3dbbca53b0a67cf6aeee51c8b6e1ce4e and means the feature flag doesn't get created and doesn't have a description.

[Jira Issue - MAV-1692](https://nhsd-jira.digital.nhs.uk/browse/MAV-1692)