### PR TITLE
Remove `Session#today` scope

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -74,8 +74,6 @@ class Session < ApplicationRecord
           )
         end
 
-  scope :today, -> { has_date(Date.current) }
-
   scope :for_current_academic_year,
         -> { where(academic_year: AcademicYear.current) }
 


### PR DESCRIPTION
This is not being used anywhere and in fact should have been removed in 44027aaa7a81efed1a513ba1aa9e69ceda2cfae4 so this can be safely removed.