### PR TITLE
Ensure gelatine is a refusal option

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -42,9 +42,10 @@
 
 class Consent < ApplicationRecord
   include BelongsToAcademicYear
-  include Invalidatable
+  include GelatineVaccinesConcern
   include HasHealthAnswers
   include HasVaccineMethods
+  include Invalidatable
 
   audited associated_with: :patient
 
@@ -58,6 +59,8 @@ class Consent < ApplicationRecord
              class_name: "User",
              optional: true,
              foreign_key: :recorded_by_user_id
+
+  has_many :vaccines, through: :programme
 
   scope :withdrawn, -> { where.not(withdrawn_at: nil) }
   scope :not_withdrawn, -> { where(withdrawn_at: nil) }

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -6,6 +6,7 @@ class DraftConsent
   include WizardStepConcern
 
   include ActiveRecord::AttributeMethods::Serialization
+  include GelatineVaccinesConcern
   include HasHealthAnswers
 
   attr_reader :new_or_existing_contact
@@ -411,6 +412,8 @@ class DraftConsent
       vaccine_methods
     ]
   end
+
+  def vaccines = programme.vaccines
 
   def notes_required?
     response_refused? && reason_for_refusal != "personal_choice"

--- a/app/views/draft_consents/reason.html.erb
+++ b/app/views/draft_consents/reason.html.erb
@@ -13,6 +13,11 @@
                                      legend: { size: "l",
                                                tag: "h1",
                                                text: title }) do %>
+    <% if @draft_consent.vaccine_may_contain_gelatine? %>
+      <%= f.govuk_radio_button :reason, "contains_gelatine",
+                               label: { text: "Vaccine contains gelatine from pigs" },
+                               link_errors: true %>
+    <% end %>
     <%= f.govuk_radio_button :reason_for_refusal, "already_vaccinated",
                              label: { text: "Vaccine already received" }, link_errors: true %>
     <%= f.govuk_radio_button :reason_for_refusal, "will_be_vaccinated_elsewhere",

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -16,7 +16,7 @@ describe "Verbal consent" do
   end
 
   scenario "Given flu injection" do
-    given_an_flu_programme_is_underway
+    given_a_flu_programme_is_underway
     and_i_am_signed_in
 
     when_i_record_that_verbal_injection_consent_was_given
@@ -29,7 +29,7 @@ describe "Verbal consent" do
   end
 
   scenario "Given flu nasal spray" do
-    given_an_flu_programme_is_underway
+    given_a_flu_programme_is_underway
     and_i_am_signed_in
 
     when_i_record_that_verbal_nasal_consent_was_given
@@ -43,7 +43,7 @@ describe "Verbal consent" do
   end
 
   scenario "Given flu nasal spray and injection" do
-    given_an_flu_programme_is_underway
+    given_a_flu_programme_is_underway
     and_i_am_signed_in
 
     when_i_record_that_verbal_nasal_and_injection_consent_was_given
@@ -59,7 +59,7 @@ describe "Verbal consent" do
     create_programme(:hpv)
   end
 
-  def given_an_flu_programme_is_underway
+  def given_a_flu_programme_is_underway
     create_programme(:flu)
   end
 


### PR DESCRIPTION
When a nurse records a consent response, if the parent is refusing a flu vaccine, one of the options needs to be because it contains gelatine.

This option already appears on the parent journey.

[Jira Issue - MAV-1696](https://nhsd-jira.digital.nhs.uk/browse/MAV-1696)