### PR TITLE
Display URN for all school options

### DIFF
--- a/app/views/draft_class_imports/location.html.erb
+++ b/app/views/draft_class_imports/location.html.erb
@@ -13,8 +13,7 @@
     <%= tag.option "", value: "" %>
 
     <% @location_options.each do |location| %>
-      <% is_duplicate = @location_options.count { it.name == location.name } > 1 %>
-      <%= tag.option location_display_name(location, show_urn: is_duplicate),
+      <%= tag.option location_display_name(location, show_urn: true),
                      value: location.id,
                      selected: location.id == @draft_class_import.location_id,
                      data: { hint: format_address_single_line(location) } %>


### PR DESCRIPTION
For consistency reasons, it was decided that displaying the URN for all school options (for class import flow) in the dropdown is better, rather than just for schools with the same name.
This also enables users to search by URN.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1131