### PR TITLE
Create previous years sessions when onboarding

### DIFF
--- a/app/controllers/api/testing/onboard_controller.rb
+++ b/app/controllers/api/testing/onboard_controller.rb
@@ -7,7 +7,7 @@ class API::Testing::OnboardController < API::Testing::BaseController
     if onboarding.invalid?
       render json: onboarding.errors, status: :unprocessable_entity
     else
-      onboarding.save!
+      onboarding.save!(create_sessions_for_previous_academic_year: true)
       render status: :created
     end
   end

--- a/app/models/onboarding.rb
+++ b/app/models/onboarding.rb
@@ -122,7 +122,7 @@ class Onboarding
     end
   end
 
-  def save!
+  def save!(create_sessions_for_previous_academic_year: false)
     ActiveRecord::Base.transaction do
       models.each(&:save!)
 
@@ -132,6 +132,13 @@ class Onboarding
       @users.each { |user| user.organisations << organisation }
 
       OrganisationSessionsFactory.call(organisation, academic_year:)
+
+      if create_sessions_for_previous_academic_year
+        OrganisationSessionsFactory.call(
+          organisation,
+          academic_year: academic_year - 1
+        )
+      end
     end
   end
 

--- a/spec/requests/api/testing/onboard_spec.rb
+++ b/spec/requests/api/testing/onboard_spec.rb
@@ -35,6 +35,14 @@ describe "/api/testing/onboard" do
         request
         expect(Organisation.count).to eq(1)
       end
+
+      it "creates sessions for the current and previous academic years" do
+        request
+        expect(Session.count).to eq(10)
+        expect(Session.order(:academic_year).pluck(:academic_year).uniq).to eq(
+          [AcademicYear.pending - 1, AcademicYear.pending]
+        )
+      end
     end
 
     context "with an invalid configuration file" do


### PR DESCRIPTION
When onboarding a test for use in the regression tests, we should create sessions for the pending academic year, plus the previous academic year.

This ensures that during the preparation period, we have sessions that are valid for the current academic year (so vaccinations can be tested) and for the pending academic year.