### PR TITLE
Fix issue with incorrect patients appearing in programmes

### DIFF
--- a/app/forms/patient_search_form.rb
+++ b/app/forms/patient_search_form.rb
@@ -96,7 +96,7 @@ class PatientSearchForm < SearchForm
   def filter_programmes(scope)
     if programmes.present?
       if @session
-        scope.appear_in_programmes(programmes)
+        scope.joins(:patient, :session).appear_in_programmes(programmes)
       else
         scope.appear_in_programmes(programmes, academic_year:)
       end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -103,7 +103,7 @@ class PatientSession < ApplicationRecord
               )
 
           # Are any of the programmes administered in the session?
-          joins(:patient, :session).where(
+          where(
             SessionProgramme
               .where(programme: programmes)
               .where("session_programmes.session_id = sessions.id")

--- a/app/views/programmes/index.html.erb
+++ b/app/views/programmes/index.html.erb
@@ -23,7 +23,7 @@
 
             <% row.with_cell do %>
               <span class="nhsuk-table-responsive__heading">Children</span>
-              <%= policy_scope(Patient).appear_in_programmes([programme], academic_year:).count %>
+              <%= current_organisation.patients.appear_in_programmes([programme], academic_year:).count %>
             <% end %>
 
             <% row.with_cell do %>

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -33,10 +33,16 @@ describe "Import child records" do
     and_i_should_see_the_patients
 
     when_i_visit_the_hpv_programme_page
-    then_i_should_see_the_cohorts
+    then_i_should_see_the_cohorts_for_hpv
 
-    when_i_click_on_the_cohort
-    then_i_should_see_the_children
+    when_i_click_on_the_cohort_for_hpv
+    then_i_should_see_the_children_for_hpv
+
+    when_i_visit_the_doubles_programme_page
+    then_i_should_see_the_cohorts_for_doubles
+
+    when_i_click_on_the_cohort_for_doubles
+    then_i_should_see_the_children_for_doubles
 
     when_i_click_on_the_imports_page
     and_i_choose_to_import_child_records
@@ -50,14 +56,14 @@ describe "Import child records" do
   end
 
   def given_the_app_is_setup
-    programme = create(:programme, :hpv)
+    programmes = [
+      create(:programme, :hpv),
+      create(:programme, :menacwy),
+      create(:programme, :td_ipv)
+    ]
+
     @organisation =
-      create(
-        :organisation,
-        :with_generic_clinic,
-        :with_one_nurse,
-        programmes: [programme]
-      )
+      create(:organisation, :with_generic_clinic, :with_one_nurse, programmes:)
     create(:school, urn: "123456", organisation: @organisation)
     @user = @organisation.users.first
 
@@ -122,21 +128,47 @@ describe "Import child records" do
     click_on "HPV"
   end
 
-  def then_i_should_see_the_cohorts
+  def when_i_visit_the_doubles_programme_page
+    click_on "Programmes", match: :first
+    click_on "MenACWY"
+  end
+
+  def then_i_should_see_the_cohorts_for_hpv
+    expect(page).to have_content("Children\n3")
     expect(page).to have_content("Year 8\n2 children")
     expect(page).to have_content("Year 9\n1 child")
     expect(page).to have_content("Year 10\nNo children")
     expect(page).to have_content("Year 11\nNo children")
   end
 
-  def when_i_click_on_the_cohort
+  def when_i_click_on_the_cohort_for_hpv
     click_on "Year 8"
   end
 
-  def then_i_should_see_the_children
+  def then_i_should_see_the_children_for_hpv
     expect(page).to have_content("2 children")
     expect(page).to have_content("DOE, Mark")
     expect(page).to have_content("SMITH, Jimmy")
+  end
+
+  def then_i_should_see_the_cohorts_for_doubles
+    expect(page).to have_content("Children\n1")
+    expect(page).not_to have_content("Year 8")
+    expect(page).to have_content("Year 9\n1 child")
+    expect(page).to have_content("Year 10\nNo children")
+    expect(page).to have_content("Year 11\nNo children")
+  end
+
+  def when_i_click_on_the_cohort_for_doubles
+    within all(".nhsuk-card")[0] do
+      click_on "Children"
+    end
+  end
+
+  def then_i_should_see_the_children_for_doubles
+    expect(page).not_to have_content("Year 8")
+    expect(page).to have_content("1 child")
+    expect(page).to have_content("CLARKE, Jennifer")
   end
 
   def when_i_continue_without_uploading_a_file

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -42,7 +42,11 @@ describe PatientSession do
 
   describe "scopes" do
     describe "#appear_in_programmes" do
-      subject(:scope) { described_class.appear_in_programmes(programmes) }
+      subject(:scope) do
+        described_class.joins(:patient, :session).appear_in_programmes(
+          programmes
+        )
+      end
 
       let(:programmes) { create_list(:programme, 1, :td_ipv) }
       let(:session) { create(:session, programmes:) }

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -99,6 +99,56 @@ describe Patient do
 
         it { should_not include(patient) }
       end
+
+      context "in multiple sessions with the right year group for one programme" do
+        let(:flu_programme) { create(:programme, :flu) }
+        let(:hpv_programme) { create(:programme, :hpv) }
+
+        let(:location) do
+          create(:school, programmes: [flu_programme, hpv_programme])
+        end
+
+        # Year 4 is eligible for flu only.
+        let(:patient) { create(:patient, year_group: 4) }
+
+        # Year 9 is eligible for flu and HPV only.
+        let(:another_patient) { create(:patient, year_group: 9) }
+
+        let(:flu_session) do
+          create(:session, location:, programmes: [flu_programme])
+        end
+        let(:hpv_session) do
+          create(:session, location:, programmes: [hpv_programme])
+        end
+
+        before do
+          create(:patient_session, patient:, session: flu_session)
+          create(:patient_session, patient:, session: hpv_session)
+
+          create(
+            :patient_session,
+            patient: another_patient,
+            session: flu_session
+          )
+          create(
+            :patient_session,
+            patient: another_patient,
+            session: hpv_session
+          )
+        end
+
+        context "for the right programme" do
+          let(:programmes) { [flu_programme] }
+
+          it { should include(patient) }
+        end
+
+        context "for the wrong programme" do
+          let(:programmes) { [hpv_programme] }
+
+          it { should_not include(patient) }
+        end
+      end
     end
 
     describe "#search_by_name" do


### PR DESCRIPTION
This fixes a bug where patients would appear in the wrong programmes for their year groups. The reason this was happening is because the resulting SQL query generated was incorrect:

- `PatientSession#appear_in_programmes` scope joined on the patients.
- `Patient#appear_in_programmes` scope used the scope on `PatientSession` but it also did a `where("patient_id = patients.id")`.
- Due to these to facts, in the resulting SQL, the `patient_id` was referring to `patient_sessions.id` and so was `patients.id` (due to the join), meaning it would also be `true`.

Therefore, this scope would only work if there was only 1 patient. If not, any patient sessions for any other patients would be caught in the `EXISTS`.

To fix this I've taken the joins out of the `appear_in_programmes` scope and it's expected that any users of this scope would specify the joins as needed.

This only affected the programmes views, not the sessions views where we wouldn't be using the `Patient#appear_in_programmes` scope.

I've added a unit test for the scope to cover this scenario and added more to the feature test to ensure we don't regress.

[Jira Issue - MAV-1293](https://nhsd-jira.digital.nhs.uk/browse/MAV-1293)