### PR TITLE
Revert "Delay preparation period in QA"

### DIFF
--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -13,8 +13,8 @@ rails_master_key_path = "/copilot/mavis/secrets/STAGING_RAILS_MASTER_KEY"
 enable_cis2                     = false
 enable_pds_enqueue_bulk_updates = false
 
-# TODO: Revert back to 45 once regression tests working during preparation period.
-academic_year_number_of_preparation_days = 14
+# Normally this is 31, but this gives us 2 weeks of additional testing.
+academic_year_number_of_preparation_days = 45
 
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"


### PR DESCRIPTION
Reverts nhsuk/manage-vaccinations-in-schools#4127

We can enable the regression tests in QA after https://nhsd-jira.digital.nhs.uk/browse/MAV-1700 is built.