### PR TITLE
Improve rendering of session dates

### DIFF
--- a/app/components/app_session_card_component.rb
+++ b/app/components/app_session_card_component.rb
@@ -61,17 +61,19 @@ class AppSessionCardComponent < ViewComponent::Base
   end
 
   def dates_row
-    {
-      key: {
-        text: "Session dates"
-      },
-      value: {
-        text:
-          tag.ul(class: "nhsuk-list") do
-            safe_join(session.dates.map { tag.li(it.to_fs(:long_day_of_week)) })
-          end
-      }
-    }
+    dates = session.dates
+
+    text =
+      if dates.empty?
+        "No sessions scheduled"
+      elsif dates.length == 1
+        dates.min.to_fs(:long)
+      else
+        "#{dates.min.to_fs(:long)} – #{dates.max.to_fs(:long)} " \
+          "(#{dates.length} sessions)"
+      end
+
+    { key: { text: "Session dates" }, value: { text: } }
   end
 
   def consent_period_row

--- a/spec/components/app_session_card_component_spec.rb
+++ b/spec/components/app_session_card_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AppSessionCardComponent do
-  subject { render_inline(component) }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) do
     travel_to(today) { described_class.new(session, patient_count: 100) }
@@ -19,6 +19,31 @@ describe AppSessionCardComponent do
   it { should have_text("Cohort\n100 children") }
   it { should have_text("Programmes\nFlu") }
   it { should have_text("Status\nSessions scheduled") }
-  it { should have_text("Session dates\nMonday, 1 September 2025") }
+  it { should have_text("Session dates\n1 September 2025") }
   it { should have_text("Consent period\nOpens 11 August") }
+
+  context "with no dates" do
+    let(:session) do
+      create(:session, academic_year: 2025, date: nil, programmes: [programme])
+    end
+
+    it { should have_text("Session dates\nNo sessions scheduled") }
+  end
+
+  context "with multiple dates" do
+    let(:session) do
+      create(
+        :session,
+        academic_year: 2025,
+        dates: [date, date + 1.week, date + 2.weeks],
+        programmes: [programme]
+      )
+    end
+
+    it do
+      expect(rendered).to have_text(
+        "Session dates\n1 September 2025 – 15 September 2025 (3 sessions)"
+      )
+    end
+  end
 end


### PR DESCRIPTION
When displaying a session card, the dates should be shown on one line to match the designs in the prototype. Specifically, this means that if there are no dates some static content is shown, and otherwise the first and last date is shown with a hyphen between them.

## Screenshots

<img width="525" height="89" alt="Screenshot 2025-07-31 at 15 29 32" src="https://github.com/user-attachments/assets/58fa3069-cd30-4eba-9040-4e8f3f0c7338" />
<img width="630" height="123" alt="Screenshot 2025-07-31 at 15 29 28" src="https://github.com/user-attachments/assets/ea96a7f6-8b4d-4c9f-94bf-9c5800f4679b" />

