### PR TITLE
Improve session ordering

### DIFF
--- a/app/forms/session_search_form.rb
+++ b/app/forms/session_search_form.rb
@@ -22,7 +22,7 @@ class SessionSearchForm < SearchForm
     scope = filter_type(scope)
     scope = filter_status(scope)
 
-    scope.sort
+    scope.order_by_earliest_date
   end
 
   private

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -67,10 +67,8 @@ class Location < ApplicationRecord
           if query.length < 3
             where("locations.name ILIKE :like_query", like_query: "#{query}%")
           else
-            where(
-              "SIMILARITY(locations.name, :query) > 0.3 OR " \
-                "SIMILARITY(locations.name, :query) > 0.3",
-              query:
+            where("SIMILARITY(locations.name, ?) > 0.3", query).order(
+              Arel.sql("SIMILARITY(locations.name, ?) DESC", query)
             )
           end
         end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -116,6 +116,46 @@ describe Session do
 
       it { should contain_exactly(completed_session) }
     end
+
+    describe "#order_by_earliest_date" do
+      subject(:scope) { described_class.order_by_earliest_date }
+
+      around { |example| travel_to(today) { example.run } }
+
+      let(:today) { Date.new(2025, 1, 1) }
+
+      let(:programmes) { create_list(:programme, 1, :hpv) }
+
+      let(:first_session_before_today) do
+        create(:session, date: Date.new(2024, 12, 1), programmes:)
+      end
+      let(:second_session_before_today) do
+        create(:session, date: Date.new(2024, 12, 2), programmes:)
+      end
+      let(:session_today) do
+        create(:session, date: Date.new(2025, 1, 1), programmes:)
+      end
+      let(:first_session_after_today) do
+        create(:session, date: Date.new(2025, 1, 2), programmes:)
+      end
+      let(:second_session_after_today) do
+        create(:session, date: Date.new(2025, 1, 3), programmes:)
+      end
+      let(:session_without_dates) { create(:session, date: nil, programmes:) }
+
+      it do
+        expect(scope).to eq(
+          [
+            session_today,
+            first_session_after_today,
+            second_session_after_today,
+            first_session_before_today,
+            second_session_before_today,
+            session_without_dates
+          ]
+        )
+      end
+    end
   end
 
   describe "#programmes" do


### PR DESCRIPTION
This improves the ordering of sessions on the new sessions page. Specifically, when you search for a location by name this ensures that the results are ordered by the closest match, and if not searching by name then the sessions are ordered by date with the next closest sessions appearing at the top of the results.

[Jira Issue - MAV-1703](https://nhsd-jira.digital.nhs.uk/browse/MAV-1703)