### PR TITLE
Restrict which year groups are shown 

### DIFF
--- a/app/controllers/draft_class_imports_controller.rb
+++ b/app/controllers/draft_class_imports_controller.rb
@@ -52,8 +52,14 @@ class DraftClassImportsController < ApplicationController
   end
 
   def set_year_group_options
+    year_groups =
+      @location
+        .programme_year_groups
+        .where(programme: current_organisation.programmes)
+        .pluck_year_groups
+
     @year_group_options =
-      @location.year_groups.map do |year_group|
+      year_groups.map do |year_group|
         OpenStruct.new(
           value: year_group,
           label: helpers.format_year_group(year_group)

--- a/app/views/class_imports/new.html.erb
+++ b/app/views/class_imports/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :before_main do %>
-  <%= render AppBacklinkComponent.new(draft_class_import_path("session")) %>
+  <%= render AppBacklinkComponent.new(draft_class_import_path("location")) %>
 <% end %>
 
 <% title = "Import class list records" %>

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -43,12 +43,8 @@ describe "Import class lists" do
       create(:organisation, :with_generic_clinic, :with_one_nurse, programmes:)
 
     location =
-      create(
-        :school,
-        :secondary,
-        name: "Waterloo Road",
-        organisation: @organisation
-      )
+      create(:school, name: "Waterloo Road", organisation: @organisation)
+
     @user = @organisation.users.first
 
     @session =
@@ -75,6 +71,16 @@ describe "Import class lists" do
   end
 
   def and_i_select_the_year_groups
+    expect(page).not_to have_content("Nursery")
+    expect(page).not_to have_content("Reception")
+    # Not testing for "Year 1" because it's included in "Year 10" and "Year 11".
+    expect(page).not_to have_content("Year 2")
+    expect(page).not_to have_content("Year 3")
+    expect(page).not_to have_content("Year 4")
+    expect(page).not_to have_content("Year 5")
+    expect(page).not_to have_content("Year 6")
+    expect(page).not_to have_content("Year 7")
+
     check "Year 8"
     check "Year 9"
     check "Year 10"


### PR DESCRIPTION
This ensures that when displaying the class import for a school, we only include year groups where programmes are administered at the school. Specifically, this ensures that users won't see year groups that are taught at the school, but not administered by any programmes.