### PR TITLE
Refactor how distinct patients are determined

### DIFF
--- a/app/controllers/programmes/base_controller.rb
+++ b/app/controllers/programmes/base_controller.rb
@@ -21,10 +21,11 @@ class Programmes::BaseController < ApplicationController
   end
 
   def patients
+    # We do this instead of using `organisation.patients` as that has a
+    # `distinct` on it which means we cannot apply ordering or grouping.
     @patients ||=
-      current_organisation.patients.appear_in_programmes(
-        [@programme],
-        academic_year: @academic_year
-      )
+      Patient.where(
+        id: current_organisation.patient_sessions.select(:patient_id).distinct
+      ).appear_in_programmes([@programme], academic_year: @academic_year)
   end
 end

--- a/app/controllers/programmes/patients_controller.rb
+++ b/app/controllers/programmes/patients_controller.rb
@@ -11,14 +11,12 @@ class Programmes::PatientsController < Programmes::BaseController
         programme: @programme
       ).pluck_year_groups
 
-    # The select is needed because the association scope has a `distinct` and
-    # therefore anything in the ORDER BY needs to appear in the SELECT.
     scope =
-      patients.select(
-        "patients.*",
-        "LOWER(given_name)",
-        "LOWER(family_name)"
-      ).includes(:consent_statuses, :triage_statuses, :vaccination_statuses)
+      patients.includes(
+        :consent_statuses,
+        :triage_statuses,
+        :vaccination_statuses
+      )
 
     @form.programme_types = [@programme.type]
 

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -38,6 +38,9 @@ describe "Import child records" do
     when_i_click_on_the_cohort_for_hpv
     then_i_should_see_the_children_for_hpv
 
+    when_i_search_for_a_child
+    then_i_should_see_only_the_child
+
     when_i_visit_the_doubles_programme_page
     then_i_should_see_the_cohorts_for_doubles
 
@@ -149,6 +152,16 @@ describe "Import child records" do
     expect(page).to have_content("2 children")
     expect(page).to have_content("DOE, Mark")
     expect(page).to have_content("SMITH, Jimmy")
+  end
+
+  def when_i_search_for_a_child
+    fill_in "Search", with: "DOE, Mark"
+    click_on "Search"
+  end
+
+  def then_i_should_see_only_the_child
+    expect(page).to have_content("1 child")
+    expect(page).to have_content("DOE, Mark")
   end
 
   def then_i_should_see_the_cohorts_for_doubles


### PR DESCRIPTION
In aebbe50364e78c826b410f4fb7f521d4853ff1b8 we attempted to fix the issue of duplicate patients being shown by using a `distinct` on the scope. This works, but it causes issues if we want to start ordering or grouping the patients.

Specifically, when using `DISTINCT` or `DISTINCT ON`, anything in the `ORDER BY` needs to be included, and this makes it tricky to use as you need to know before applying the ordering, what columns to select.

Instead, we can use a subquery to achieve the same result while avoiding the issues around using `DISTINCT`.

This also fixes a bug where you can't search for children on the programmes view.

[Sentry Issue](https://good-machine.sentry.io/issues/6782169105/)