### PR TITLE
Show import issues count on header item

### DIFF
--- a/app/components/app_count_component.rb
+++ b/app/components/app_count_component.rb
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
 class AppCountComponent < ViewComponent::Base
-  erb_template <<-ERB
-    <span class="app-count">
-      <span class="nhsuk-u-visually-hidden">(</span>
-      <%= @count %>
-      <span class="nhsuk-u-visually-hidden">)</span>
-    </span>
-  ERB
-
-  def initialize(count:)
+  def initialize(count)
     super
 
     @count = count
+  end
+
+  def call
+    tag.span(class: "app-count") do
+      safe_join(
+        [
+          tag.span("(", class: "nhsuk-u-visually-hidden"),
+          @count.to_s,
+          tag.span(")", class: "nhsuk-u-visually-hidden")
+        ]
+      )
+    end
   end
 end

--- a/app/components/app_header_navigation_item_component.rb
+++ b/app/components/app_header_navigation_item_component.rb
@@ -18,7 +18,7 @@ class AppHeaderNavigationItemComponent < ViewComponent::Base
         aria: {
           current: current? ? "true" : nil
         }
-      ) { safe_join([@title, count_tag], "") }
+      ) { safe_join([@title, count_tag].compact, " ") }
     end
   end
 
@@ -39,11 +39,6 @@ class AppHeaderNavigationItemComponent < ViewComponent::Base
   end
 
   def count_tag
-    return "" unless show_count?
-
-    tag.span(class: "app-count") do
-      tag.span(" (", class: "nhsuk-u-visually-hidden") + @count.to_s +
-        tag.span(")", class: "nhsuk-u-visually-hidden")
-    end
+    render AppCountComponent.new(@count) if show_count?
   end
 end

--- a/app/components/app_imports_navigation_component.rb
+++ b/app/components/app_imports_navigation_component.rb
@@ -36,24 +36,18 @@ class AppImportsNavigationComponent < ViewComponent::Base
   attr_reader :active
 
   def issues_text
-    vaccination_records_with_issues =
-      helpers.policy_scope(VaccinationRecord).with_pending_changes.distinct
-
-    patients_with_issues = helpers.policy_scope(Patient).with_pending_changes
-
-    unique_import_issues =
-      (vaccination_records_with_issues + patients_with_issues).uniq do |record|
-        record.is_a?(VaccinationRecord) ? record.patient_id : record.id
-      end
-
-    count = unique_import_issues.count
-
-    safe_join(["Import issues", " ", render(AppCountComponent.new(count:))])
+    safe_join(
+      [
+        "Import issues",
+        " ",
+        render(AppCountComponent.new(helpers.import_issues_count))
+      ]
+    )
   end
 
   def notices_text
     count = helpers.policy_scope(Patient).with_notice.count
 
-    safe_join(["Important notices", " ", render(AppCountComponent.new(count:))])
+    safe_join(["Important notices", " ", render(AppCountComponent.new(count))])
   end
 end

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ImportsHelper
+  def import_issues_count
+    vaccination_records_with_issues =
+      policy_scope(VaccinationRecord).with_pending_changes.distinct
+
+    patients_with_issues = policy_scope(Patient).with_pending_changes
+
+    unique_import_issues =
+      (vaccination_records_with_issues + patients_with_issues).uniq do |record|
+        record.is_a?(VaccinationRecord) ? record.patient_id : record.id
+      end
+
+    unique_import_issues.count
+  end
+end

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -25,6 +25,7 @@ class VaccinationRecordPolicy < ApplicationPolicy
   class Scope < ApplicationPolicy::Scope
     def resolve
       organisation = user.selected_organisation
+      return scope.none if organisation.nil?
 
       scope
         .kept

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -67,7 +67,7 @@
               t("imports.index.title_short"),
               imports_path,
               request_path: request.path,
-              count: policy_scope(ClassImport).count + policy_scope(CohortImport).count + policy_scope(ImmunisationImport).count
+              count: import_issues_count
             ) %>
 
             <%= render AppHeaderNavigationItemComponent.new(t("organisations.show.title"), organisation_path, request_path: request.path) %>

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -260,6 +260,6 @@ describe "Import child records" do
 
   def then_i_should_see_import_issues_with_the_count
     expect(page).to have_link("Import issues")
-    expect(page).to have_selector(".app-count", text: "( 1 )")
+    expect(page).to have_selector(".app-count", text: "(1)").twice
   end
 end

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -251,11 +251,11 @@ describe "Child record imports duplicates" do
 
   def then_i_should_see_import_issues_with_the_count
     expect(page).to have_link("Import issues")
-    expect(page).to have_selector(".app-count", text: "( 1 )")
+    expect(page).to have_selector(".app-count", text: "(1)")
   end
 
   def then_i_should_see_no_import_issues_with_the_count
     expect(page).to have_link("Import issues")
-    expect(page).to have_selector(".app-count", text: "( 0 )")
+    expect(page).to have_selector(".app-count", text: "(0)")
   end
 end

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -255,11 +255,11 @@ describe "Immunisation imports duplicates" do
 
   def then_i_should_see_import_issues_with_the_count
     expect(page).to have_link("Import issues")
-    expect(page).to have_selector(".app-count", text: "( 1 )")
+    expect(page).to have_selector(".app-count", text: "(1)").twice
   end
 
   def then_i_should_see_no_import_issues_with_the_count
     expect(page).to have_link("Import issues")
-    expect(page).to have_selector(".app-count", text: "( 0 )")
+    expect(page).to have_selector(".app-count", text: "(0")
   end
 end

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -390,19 +390,19 @@ describe "Manage children" do
   end
 
   def then_i_see_the_notice_of_date_of_death
-    expect(page).to have_content("Important notices ( 1 )")
+    expect(page).to have_content("Important notices (1)")
     expect(page).to have_content(@deceased_patient.full_name)
     expect(page).to have_content("Record updated with child’s date of death")
   end
 
   def then_i_see_the_notice_of_invalid
-    expect(page).to have_content("Important notices ( 1 )")
+    expect(page).to have_content("Important notices (1)")
     expect(page).to have_content(@invalidated_patient.full_name)
     expect(page).to have_content("Record flagged as invalid")
   end
 
   def then_i_see_the_notice_of_sensitive
-    expect(page).to have_content("Important notices ( 1 )")
+    expect(page).to have_content("Important notices (1)")
     expect(page).to have_content(@restricted_patient.full_name)
     expect(page).to have_content("Record flagged as sensitive")
   end


### PR DESCRIPTION
This updates the "Import" header item to show the count of the number of import issues rather than the count of the number of imports. This was actually supposed to be the case originally but it was built incorrectly.

I've implemented this by using a helper method since we need this number to be accessible in both the import issues navigation item and the global header item. A helper means it's available to every page.

It's a little awkward to test the helper on its own as it relies on the use of `policy_scope`, so instead test coverage is provided by the feature tests.

[Jira Issue - MAV-1695](https://nhsd-jira.digital.nhs.uk/browse/MAV-1695)