### PR TITLE
Add error message when picking an invalid organisation

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -3,8 +3,6 @@
 module AuthenticationConcern
   extend ActiveSupport::Concern
 
-  CIS2_WORKGROUP = "schoolagedimmunisations"
-
   included do
     private
 
@@ -41,7 +39,7 @@ module AuthenticationConcern
 
     def selected_cis2_workgroup_is_valid?
       workgroups = session.dig("cis2_info", "selected_role", "workgroups")
-      workgroups.present? && CIS2_WORKGROUP.in?(workgroups)
+      workgroups.present? && User::CIS2_WORKGROUP.in?(workgroups)
     end
 
     def valid_cis2_roles = [User::CIS2_NURSE_ROLE, User::CIS2_ADMIN_ROLE]

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -44,9 +44,7 @@ module AuthenticationConcern
       workgroups.present? && CIS2_WORKGROUP.in?(workgroups)
     end
 
-    def valid_cis2_roles
-      %w[S8000:G8000:R8001 S8000:G8001:R8006]
-    end
+    def valid_cis2_roles = [User::CIS2_NURSE_ROLE, User::CIS2_ADMIN_ROLE]
 
     def selected_cis2_role_is_valid?
       session["cis2_info"]["selected_role"]["code"].in? valid_cis2_roles

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -5,28 +5,22 @@ class Users::OrganisationsController < ApplicationController
   skip_after_action :verify_policy_scoped
 
   before_action :redirect_to_dashboard_if_cis2_is_enabled
-  before_action :set_organisations
 
   layout "two_thirds"
 
   def new
+    @form = SelectOrganisationForm.new(current_user:)
   end
 
   def create
-    organisation = current_user.organisations.find(params[:organisation_id])
+    @form =
+      SelectOrganisationForm.new(
+        current_user:,
+        request_session: session,
+        organisation_id: params.dig(:select_organisation_form, :organisation_id)
+      )
 
-    if organisation.present?
-      session["cis2_info"] = {
-        "selected_org" => {
-          "name" => organisation.name,
-          "code" => organisation.ods_code
-        },
-        "selected_role" => {
-          "code" => valid_cis2_roles.first,
-          "workgroups" => [User::CIS2_WORKGROUP]
-        }
-      }
-
+    if @form.save
       redirect_to dashboard_path
     else
       render :new, status: :unprocessable_entity
@@ -37,9 +31,5 @@ class Users::OrganisationsController < ApplicationController
 
   def redirect_to_dashboard_if_cis2_is_enabled
     redirect_to dashboard_path if Settings.cis2.enabled
-  end
-
-  def set_organisations
-    @organisations = current_user.organisations
   end
 end

--- a/app/controllers/users/organisations_controller.rb
+++ b/app/controllers/users/organisations_controller.rb
@@ -23,7 +23,7 @@ class Users::OrganisationsController < ApplicationController
         },
         "selected_role" => {
           "code" => valid_cis2_roles.first,
-          "workgroups" => ["schoolagedimmunisations"]
+          "workgroups" => [User::CIS2_WORKGROUP]
         }
       }
 

--- a/app/forms/select_organisation_form.rb
+++ b/app/forms/select_organisation_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class SelectOrganisationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :current_user, :request_session
+
+  attribute :organisation_id, :integer
+
+  validates :organisation_id, inclusion: { in: :organisation_id_values }
+
+  def save
+    return false if invalid?
+
+    request_session["cis2_info"] = {
+      "selected_org" => {
+        "name" => organisation.name,
+        "code" => organisation.ods_code
+      },
+      "selected_role" => {
+        "code" => User::CIS2_NURSE_ROLE,
+        "workgroups" => [User::CIS2_WORKGROUP]
+      }
+    }
+
+    true
+  end
+
+  private
+
+  def organisation = current_user.organisations.find(organisation_id)
+
+  def organisation_id_values = current_user.organisations.pluck(:id)
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,9 @@
 class User < ApplicationRecord
   include FullNameConcern
 
+  CIS2_NURSE_ROLE = "S8000:G8000:R8001"
+  CIS2_ADMIN_ROLE = "S8000:G8001:R8006"
+
   attr_accessor :cis2_info
 
   if Settings.cis2.enabled

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,8 @@ class User < ApplicationRecord
   CIS2_NURSE_ROLE = "S8000:G8000:R8001"
   CIS2_ADMIN_ROLE = "S8000:G8001:R8006"
 
+  CIS2_WORKGROUP = "schoolagedimmunisations"
+
   attr_accessor :cis2_info
 
   if Settings.cis2.enabled

--- a/app/views/users/organisations/new.html.erb
+++ b/app/views/users/organisations/new.html.erb
@@ -2,9 +2,11 @@
 
 <% content_for :page_title, legend %>
 
-<%= form_with url: users_organisations_path, method: :post do |f| %>
+<%= form_with model: @form, url: users_organisations_path do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :organisation_id,
-                                       @organisations,
+                                       current_user.organisations,
                                        :id,
                                        :name,
                                        :ods_code,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,10 @@ en:
           attributes:
             action:
               inclusion: Choose whether to update the child’s record with this new information
+        select_organisation_form:
+          attributes:
+            organisation_id:
+              inclusion: Choose an organisation
         session_programmes_form:
           attributes:
             programme_ids:

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     transient do
       organisation { Organisation.first || create(:organisation) }
 
-      selected_role_code { "S8000:G8000:R8001" }
+      selected_role_code { User::CIS2_NURSE_ROLE }
       selected_role_name { "Nurse Access Role" }
       selected_role_workgroups { %w[schoolagedimmunisations] }
 

--- a/spec/forms/select_organisation_form_spec.rb
+++ b/spec/forms/select_organisation_form_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe SelectOrganisationForm do
+  subject(:form) { described_class.new(current_user:) }
+
+  let(:organisation) { create(:organisation) }
+  let(:current_user) { create(:user, organisations: [organisation]) }
+
+  before { create(:organisation) }
+
+  describe "validations" do
+    it do
+      expect(form).to validate_inclusion_of(:organisation_id).in_array(
+        [organisation.id]
+      )
+    end
+  end
+end

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -153,8 +153,8 @@ module CIS2AuthHelper
     end
 
     role_code ||= {
-      nurse: "S8000:G8000:R8001",
-      admin_staff: "S8000:G8001:R8006"
+      nurse: User::CIS2_NURSE_ROLE,
+      admin_staff: User::CIS2_ADMIN_ROLE
     }.fetch(role)
 
     nhsid_nrbac_role = raw_info["nhsid_nrbac_roles"][0]


### PR DESCRIPTION
This adds a new form which handles the select an organisation page, ensuring that we validate that the user has selected a valid organisation and showing an error message if not.

This fixes an issue where if you selected an invalid organisation or didn't select an organisation, then the user would be taken to an error page.

Users don't see this page yet as it's not enabled when using CIS2, but they will once users can be part of multiple teams.

## Screenshot

<img width="785" height="535" alt="Screenshot 2025-07-31 at 19 24 36" src="https://github.com/user-attachments/assets/d5b5fb39-e336-4c0e-a6fa-16ddc2f2f723" />
