### PR TITLE
Simplify logic for next immunisations API action

### DIFF
--- a/app/lib/nhs/immunisations_api.rb
+++ b/app/lib/nhs/immunisations_api.rb
@@ -197,11 +197,9 @@ module NHS::ImmunisationsAPI
 
         return nil if last_synced_at >= sync_pending_at
 
-        if should_be_recorded && !is_recorded
-          :create
-        elsif should_be_recorded && is_recorded
+        if should_be_recorded
           :update
-        elsif is_recorded
+        else
           discarded_at = vaccination_record.discarded_at
           :delete if discarded_at.nil? || last_synced_at < discarded_at
         end


### PR DESCRIPTION
This logic was checking `is_recorded` inside a block where `is_recorded` is already `true`, and therefore it was unnecessary to make those checks. Instead this can be simplified while ensuring the same result is given before and after.