### PR TITLE
Hide navigation bar in parent consent journey

### DIFF
--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -15,6 +15,10 @@ module ParentInterface
 
     private
 
+    def set_show_navigation
+      @show_navigation = false
+    end
+
     def set_consent_form
       @consent_form =
         ConsentForm.includes(:programmes, :vaccines).find(


### PR DESCRIPTION
At the moment we decide whether to show the navigation bar based on whether the user is signed in or not. Normally, when a parent fills in the consent journey they're not signed in so they won't see the navigation bar. However, if a nurse clicks on the link to view the parent consent journey then the navigation bar is shown and it currently doesn't render correctly as it has some missing CSS.