### PR TITLE
Use `patient_id` when staging vaccination record changes

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -100,7 +100,7 @@ class ImmunisationImportRow
       full_dose: true,
       location_name:,
       outcome:,
-      patient:,
+      patient_id: patient.id,
       performed_at:,
       performed_by_user:,
       performed_ods_code: performed_ods_code&.to_s,

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -241,7 +241,12 @@ describe "HPV vaccination" do
       )
 
     row_for_vaccinated_patient = csv_table[0]
-    # row_for_vaccinated_patient["TIME_OF_VACCINATION"] = "10:00:00"
+
+    # Change details for the patient
+    row_for_vaccinated_patient["NHS_NUMBER"] = ""
+    row_for_vaccinated_patient["PERSON_FORENAME"] = "New name"
+
+    # Change details for the vaccination record
     row_for_vaccinated_patient["DOSE_SEQUENCE"] = "2"
     row_for_vaccinated_patient["ANATOMICAL_SITE"] = "Right Upper Arm"
 


### PR DESCRIPTION
This updates the immunisation import process to ensure that when importing details for a vaccination record that already exists, we use the `patient_id` as the value rather than the `patient` object. This ensures that the resulting pending changes can be saved successfully as it contains a single value rather than a hash of the patient.

Although we anticipate this structure will change soon with the PDS improvements, we saw an unhandled error occur in the test environment so this puts in a fix for the issue.

[Sentry Issue](https://good-machine.sentry.io/issues/6784604544/)