### PR TITLE
Improve message for errors caused by directly visiting draft vaccination record confirmation screen

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -14,6 +14,7 @@ class DraftVaccinationRecordsController < ApplicationController
 
   include WizardControllerConcern
 
+  before_action :validate_patient_id, only: :show
   before_action :validate_params, only: :update
   before_action :set_batches, if: -> { current_step == :batch }
   before_action :set_locations, if: -> { current_step == :location }
@@ -56,6 +57,12 @@ class DraftVaccinationRecordsController < ApplicationController
   end
 
   private
+
+  def validate_patient_id
+    if current_step == :confirm && @draft_vaccination_record.patient_id.nil?
+      render 'errors/no_patient_with_draft_vaccination_record', status: :unprocessable_entity
+    end
+  end
 
   def validate_params
     if current_step == :date_and_time

--- a/app/views/errors/no_patient_with_draft_vaccination_record.html.erb
+++ b/app/views/errors/no_patient_with_draft_vaccination_record.html.erb
@@ -1,0 +1,22 @@
+<%= h1 "Error: page not available", size: "xl" %>
+
+<p class="nhsuk-body">
+  You do not have a vaccination record open, or it has timed out.
+</p>
+
+<p class="nhsuk-body">
+  To see a vaccination record, you can search for it in Mavis in either:
+</p>
+
+<ul>
+  <li> the Sessions area (through the relevant session)</li>
+  <li> the Children area</li>
+</ul>
+
+<p class="nhsuk-body">
+  You will need to know the child’s name.
+</p>
+
+<p class="nhsuk-body">
+  <a href="/dashboard">Go to the Mavis dashboard</a>
+</p>

--- a/spec/controllers/draft_vaccination_records_controller_error.rb
+++ b/spec/controllers/draft_vaccination_records_controller_error.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+feature "Draft vaccination controller errors", type: :feature do
+  scenario "Go to draft vaccination record confirm with no open draft vaccination" do
+    given_i_am_signed_in_with_flu_programme
+    when_i_visit_draft_vaccination_record_confirm_with_no_active_record
+    then_i_see_a_descriptive_error_message
+  end
+
+  def given_i_am_signed_in_with_flu_programme
+    @programme = create(:programme, :flu)
+    @organisation =
+      create(:organisation, :with_one_nurse, programmes: [@programme])
+    sign_in @organisation.users.first
+  end
+
+  def when_i_visit_draft_vaccination_record_confirm_with_no_active_record
+    visit "/draft-vaccination-record/confirm"
+  end
+
+  def then_i_see_a_descriptive_error_message
+    expect(page).to have_content("Error: page not available")
+    expect(page).to have_content("You do not have a vaccination record open, or it has timed out.")
+  end
+end


### PR DESCRIPTION
When a user logs in to Mavis and visits `/draft-vaccination-record/confirm` without a draft vaccination record in progress, they will now see a more informative error message. Previously a generic page appeared, indicating that there was an error but suggesting that trying again later would fix the issue.

[Jira issue - MAV-1592](https://nhsd-jira.digital.nhs.uk/browse/MAV-1592)

# Screenshots
The new error page looks like this:
<img width="1314" height="1104" alt="image" src="https://github.com/user-attachments/assets/e737fc0b-c9d8-42b0-b1a0-76838aec92bd" />

