### PR TITLE
Put imms API sync status behind feature flag

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -237,7 +237,8 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
         end
       end
 
-      if @vaccination_record.respond_to?(:sync_status)
+      if @vaccination_record.respond_to?(:sync_status) &&
+           Flipper.enabled?(:immunisations_fhir_api_integration)
         summary_list.with_row do |row|
           row.with_key { "Synced with NHS England?" }
           row.with_value do


### PR DESCRIPTION
Before, the Imms API sync status was visible in production, which was confusing for users. Now it won't show until the feature flag is enabled.

[MAV-1709](https://nhsd-jira.digital.nhs.uk/browse/MAV-1709)