### PR TITLE
Fix "an team" typos

### DIFF
--- a/app/lib/mavis_cli/clinics/add_to_team.rb
+++ b/app/lib/mavis_cli/clinics/add_to_team.rb
@@ -3,7 +3,7 @@
 module MavisCLI
   module Clinics
     class AddToTeam < Dry::CLI::Command
-      desc "Add an existing clinic to an team"
+      desc "Add an existing clinic to a team"
 
       argument :team_ods_code, required: true, desc: "The ODS code of the team"
       argument :subteam, required: true, desc: "The subteam of the team"

--- a/app/lib/mavis_cli/schools/add_to_team.rb
+++ b/app/lib/mavis_cli/schools/add_to_team.rb
@@ -3,7 +3,7 @@
 module MavisCLI
   module Schools
     class AddToTeam < Dry::CLI::Command
-      desc "Add an existing school to an team"
+      desc "Add an existing school to a team"
 
       argument :ods_code, required: true, desc: "The ODS code of the team"
       argument :subteam, required: true, desc: "The subteam of the team"

--- a/app/lib/mavis_cli/teams/add_programme.rb
+++ b/app/lib/mavis_cli/teams/add_programme.rb
@@ -3,7 +3,7 @@
 module MavisCLI
   module Teams
     class AddProgramme < Dry::CLI::Command
-      desc "Adds a programme to an team"
+      desc "Adds a programme to a team"
 
       argument :ods_code, required: true, desc: "The ODS code of the team"
 

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -798,11 +798,11 @@ class ImmunisationImportRow
       if performed_ods_code.nil?
         errors.add(:base, "<code>ORGANISATION_CODE</code> is required")
       elsif performed_ods_code.blank?
-        errors.add(performed_ods_code.header, "Enter an team code.")
+        errors.add(performed_ods_code.header, "Enter a team code.")
       elsif performed_ods_code.to_s != team.ods_code
         errors.add(
           performed_ods_code.header,
-          "Enter an team code that matches the current team."
+          "Enter a team code that matches the current team."
         )
       end
     end

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -214,7 +214,7 @@ Start the web server:
 RAILS_ENV=staging rails s
 ```
 
-## Exporting an team
+## Exporting a team
 
 Generate an export and encrypt it:
 

--- a/docs/ops-tasks.md
+++ b/docs/ops-tasks.md
@@ -35,7 +35,7 @@ patient = Patient.find(...)
 SchoolMove.new(patient:, school: patient.school).confirm!
 ```
 
-## Add a location to an team and add patients to the session
+## Add a location to a team and add patients to the session
 
 Normally patients are added to a location on import. However, their may be cases when they need to be added to a location after they've been imported, for example if their school was not added to the team at the time the patients were imported. At the time of writing, re-importing the patients does not add them to the location's session or to the team's cohorts.
 

--- a/docs/rake-tasks.md
+++ b/docs/rake-tasks.md
@@ -33,7 +33,7 @@ Creates a school location suitable for smoke testing in production.
 
 If none of the arguments are provided (`rake teams:create`), the user will be prompted for responses.
 
-This creates a new team within an team.
+This creates a new team within a team.
 
 ## Users
 

--- a/lib/tasks/onboard.rake
+++ b/lib/tasks/onboard.rake
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-desc "Onboard an team from a configuration file."
+desc "Onboard a team from a configuration file."
 task :onboard, [:filename] => :environment do |_, args|
   config = YAML.safe_load(File.read(args[:filename]))
 

--- a/lib/tasks/subteams.rake
+++ b/lib/tasks/subteams.rake
@@ -4,7 +4,7 @@ require_relative "../task_helpers"
 
 namespace :subteams do
   desc <<-DESC
-    Create a new subteam within an team.
+    Create a new subteam within a team.
 
     Usage:
       rake subteams:create # Complete the prompts

--- a/lib/tasks/teams.rake
+++ b/lib/tasks/teams.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :teams do
-  desc "Add a programme to an team."
+  desc "Add a programme to a team."
   task :add_programme, %i[ods_code type] => :environment do |_task, args|
     team = Team.find_by!(ods_code: args[:ods_code])
     programme = Programme.find_by!(type: args[:type])

--- a/spec/lib/reports/school_moves_exporter_spec.rb
+++ b/spec/lib/reports/school_moves_exporter_spec.rb
@@ -112,7 +112,7 @@ describe Reports::SchoolMovesExporter do
       end
     end
 
-    context "when a patient moves out of an team" do
+    context "when a patient moves out of a team" do
       let(:team_a) { create(:team) }
       let(:team_b) { create(:team) }
 

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -197,7 +197,7 @@ describe Location do
       )
     end
 
-    context "when the location is not attached to an team" do
+    context "when the location is not attached to a team" do
       let(:location) { create(:school, subteam: nil) }
 
       it { should include("is_attached_to_team" => false) }


### PR DESCRIPTION
This fixes a number of typos where the phrase "an team" is used. This happened when team was renamed from organisation.