### PR TITLE
Show `notify_parents_on_vaccination` on confirmation

### DIFF
--- a/app/components/app_consent_summary_component.rb
+++ b/app/components/app_consent_summary_component.rb
@@ -54,6 +54,22 @@ class AppConsentSummaryComponent < ViewComponent::Base
         end
       end
 
+      unless consent.notify_parents_on_vaccination.nil?
+        summary_list.with_row do |row|
+          row.with_key { "Confirmation of vaccination sent to parent?" }
+          row.with_value do
+            consent.notify_parents_on_vaccination ? "Yes" : "No"
+          end
+          if (href = change_links[:notify_parents_on_vaccination])
+            row.with_action(
+              text: "Change",
+              visually_hidden_text: "decision",
+              href:
+            )
+          end
+        end
+      end
+
       if consent.reason_for_refusal.present?
         summary_list.with_row do |row|
           row.with_key { "Reason for refusal" }
@@ -63,7 +79,7 @@ class AppConsentSummaryComponent < ViewComponent::Base
 
       unless consent.notify_parent_on_refusal.nil?
         summary_list.with_row do |row|
-          row.with_key { "Confirmation of decision sent to parent" }
+          row.with_key { "Confirmation of decision sent to parent?" }
           row.with_value { consent.notify_parent_on_refusal ? "Yes" : "No" }
         end
       end

--- a/app/views/draft_consents/confirm.html.erb
+++ b/app/views/draft_consents/confirm.html.erb
@@ -16,6 +16,7 @@
   <%= render AppConsentSummaryComponent.new(@draft_consent, change_links: {
                                                               response: wizard_path("agree"),
                                                               route: wizard_path(@draft_consent.via_self_consent? ? "who" : "route"),
+                                                              notify_parents_on_vaccination: wizard_path("notify-parents-on-vaccination"),
                                                             }) %>
 <% end %>
 

--- a/spec/components/app_consent_summary_component_spec.rb
+++ b/spec/components/app_consent_summary_component_spec.rb
@@ -35,6 +35,30 @@ describe AppConsentSummaryComponent do
     it { should have_content("Notes") }
   end
 
+  it { should_not have_content("Confirmation of vaccination sent to parent?") }
+
+  context "when the child doesn't want the parents to know about the vaccination" do
+    let(:consent) { create(:consent, :given, :self_consent) }
+
+    it do
+      expect(rendered).to have_content(
+        "Confirmation of vaccination sent to parent?\nNo"
+      )
+    end
+  end
+
+  context "when the child wants the parents to know about the vaccination" do
+    let(:consent) do
+      create(:consent, :given, :self_consent, :notify_parents_on_vaccination)
+    end
+
+    it do
+      expect(rendered).to have_content(
+        "Confirmation of vaccination sent to parent?\nYes"
+      )
+    end
+  end
+
   it { should_not have_content("Consent also given for injected vaccine?") }
 
   context "with the flu programme" do

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -246,6 +246,8 @@ describe "Self-consent" do
     choose "Child (Gillick competent)"
     5.times { click_on "Continue" }
 
+    expect(page).to have_content("Confirmation of vaccination sent to parent")
+
     click_on "Confirm"
 
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -159,6 +159,9 @@ describe "Verbal consent" do
   def then_i_see_the_check_and_confirm_page
     expect(page).to have_content("Check and confirm answers")
     expect(page).to have_content(["Method", "By phone"].join)
+    expect(page).not_to have_content(
+      "Confirmation of vaccination sent to parent"
+    )
   end
 
   def and_i_see_the_flu_injection_consent_given

--- a/spec/features/verbal_consent_refused_personal_choice_spec.rb
+++ b/spec/features/verbal_consent_refused_personal_choice_spec.rb
@@ -65,9 +65,11 @@ describe "Verbal consent" do
     expect(page).to have_content(["Name", @parent.full_name].join)
 
     if notify_parent
-      expect(page).to have_content("Confirmation of decision sent to parentYes")
+      expect(page).to have_content(
+        "Confirmation of decision sent to parent?Yes"
+      )
     else
-      expect(page).to have_content("Confirmation of decision sent to parentNo")
+      expect(page).to have_content("Confirmation of decision sent to parent?No")
     end
 
     click_button "Confirm"


### PR DESCRIPTION
If a child self-consents, we ask them if they would like their parents to receive confirmation of their vaccination. Until 4f87a86ece6fdc0155abb482ca49fbb6e7547232 we weren't able to show this as it wasn't being stored in the database, but we can now show this information to the users when they view a consent response.

[Jira Issue - MAV-1708](https://nhsd-jira.digital.nhs.uk/browse/MAV-1708)

## Screenshots

<img width="791" height="179" alt="Screenshot 2025-08-04 at 20 27 55" src="https://github.com/user-attachments/assets/cfcf2f64-e769-43bf-9c42-37ee29d8bc1a" />
<img width="785" height="171" alt="Screenshot 2025-08-04 at 20 27 47" src="https://github.com/user-attachments/assets/957a28be-d566-4cce-b5cc-bbbf1f2e46c9" />

