### PR TITLE
Continue to fix session cohort stats

### DIFF
--- a/app/components/app_programme_session_table_component.rb
+++ b/app/components/app_programme_session_table_component.rb
@@ -13,11 +13,11 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   attr_reader :sessions, :programme
 
   def cohort_count(session:)
-    format_number(patient_count(session:))
+    format_number(patient_sessions(session:).count)
   end
 
   def no_response_scope(session:)
-    session.patient_sessions.has_consent_status(:no_response, programme:)
+    patient_sessions(session:).has_consent_status(:no_response, programme:)
   end
 
   def no_response_count(session:)
@@ -27,18 +27,18 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   def no_response_percentage(session:)
     format_percentage(
       no_response_scope(session:).count,
-      patient_count(session:)
+      patient_sessions(session:).count
     )
   end
 
   def triage_needed_count(session:)
     format_number(
-      session.patient_sessions.has_triage_status(:required, programme:).count
+      patient_sessions(session:).has_triage_status(:required, programme:).count
     )
   end
 
   def vaccinated_scope(session:)
-    session.patient_sessions.has_session_status(:vaccinated, programme:)
+    patient_sessions(session:).has_session_status(:vaccinated, programme:)
   end
 
   def vaccinated_count(session:)
@@ -46,15 +46,17 @@ class AppProgrammeSessionTableComponent < ViewComponent::Base
   end
 
   def vaccinated_percentage(session:)
-    format_percentage(vaccinated_scope(session:).count, patient_count(session:))
+    format_percentage(
+      vaccinated_scope(session:).count,
+      patient_sessions(session:).count
+    )
   end
 
-  def patient_count(session:)
+  def patient_sessions(session:)
     session
       .patient_sessions
       .joins(:patient, :session)
       .appear_in_programmes([programme])
-      .count
   end
 
   def format_number(count) = count.to_s

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -12,15 +12,20 @@ class AppSessionActionsComponent < ViewComponent::Base
     @session = session
   end
 
-  def render?
-    rows.any?
-  end
+  def render? = rows.any?
 
   private
 
   attr_reader :session
 
-  delegate :academic_year, :patient_sessions, :programmes, to: :session
+  delegate :academic_year, :programmes, to: :session
+
+  def patient_sessions
+    session
+      .patient_sessions
+      .joins(:patient, :session)
+      .appear_in_programmes(programmes)
+  end
 
   def rows
     @rows ||= [

--- a/app/components/app_session_details_summary_component.rb
+++ b/app/components/app_session_details_summary_component.rb
@@ -15,16 +15,17 @@ class AppSessionDetailsSummaryComponent < ViewComponent::Base
 
   attr_reader :session
 
-  delegate :patient_sessions, to: :session
-
   delegate :programmes, to: :session
 
+  def patient_sessions
+    session
+      .patient_sessions
+      .joins(:patient, :session)
+      .appear_in_programmes(programmes)
+  end
+
   def cohort_row
-    count =
-      patient_sessions
-        .joins(:patient, :session)
-        .appear_in_programmes(programmes)
-        .count
+    count = patient_sessions.count
     href = import_session_path(session)
 
     {

--- a/spec/components/app_programme_session_table_component_spec.rb
+++ b/spec/components/app_programme_session_table_component_spec.rb
@@ -49,5 +49,7 @@ describe AppProgrammeSessionTableComponent do
     let(:patient) { create(:patient, session:, year_group: 7) }
 
     it { should have_content(/Cohort(\s+)4/) }
+    it { should have_content(/No response(\s+)4(\s+)100%/) }
+    it { should have_content(/Vaccinated(\s+)0(\s+)0%/) }
   end
 end

--- a/spec/components/app_session_actions_component_spec.rb
+++ b/spec/components/app_session_actions_component_spec.rb
@@ -8,32 +8,38 @@ describe AppSessionActionsComponent do
   let(:programmes) { [create(:programme, :hpv)] }
   let(:session) { create(:session, programmes:) }
 
+  let(:year_group) { 8 }
+
   before do
     create(
       :patient_session,
       :consent_no_response,
       :unknown_attendance,
-      session:
+      session:,
+      year_group:
     )
     create(
       :patient_session,
       :consent_conflicting,
       :unknown_attendance,
-      session:
+      session:,
+      year_group:
     )
     create(
       :patient_session,
       :consent_given_triage_needed,
       :unknown_attendance,
-      session:
+      session:,
+      year_group:
     )
     create(
       :patient_session,
       :consent_given_triage_not_needed,
       :in_attendance,
-      session:
+      session:,
+      year_group:
     )
-    create(:patient_session, :vaccinated, :in_attendance, session:)
+    create(:patient_session, :vaccinated, :in_attendance, session:, year_group:)
   end
 
   it { should have_text("No consent response\n1 child") }
@@ -52,5 +58,15 @@ describe AppSessionActionsComponent do
     let(:session) { create(:session, :requires_no_registration, programmes:) }
 
     it { should_not have_link("Review register attendance") }
+  end
+
+  context "when patients are not eligible for the programme" do
+    let(:year_group) { 7 }
+
+    it { should_not have_text("No consent response") }
+    it { should_not have_text("Conflicting consent") }
+    it { should_not have_text("Triage needed") }
+    it { should_not have_text("Register attendance") }
+    it { should_not have_text("Ready for vaccinator") }
   end
 end

--- a/spec/components/app_session_details_summary_component_spec.rb
+++ b/spec/components/app_session_details_summary_component_spec.rb
@@ -27,9 +27,15 @@ describe AppSessionDetailsSummaryComponent do
     it { should have_link("Review vaccinated") }
   end
 
-  context "when the patient is not eligible for the programme" do
-    before { create(:patient, session:, year_group: 7) }
+  context "when the patients are not eligible for the programme" do
+    before do
+      create(:patient_session, session:, year_group: 7)
+      create(:patient_session, :consent_refused, session:, year_group: 7)
+      create(:patient_session, :vaccinated, session:, year_group: 7)
+    end
 
-    it { should have_text("No children") }
+    it { should have_text("Cohort\nNo children") }
+    it { should have_text("Consent refused\nNo children") }
+    it { should have_text("Vaccinated\nNo vaccinations given") }
   end
 end


### PR DESCRIPTION
This follows on from 830467ea55b97b411669e25c5fb760b0494b21bf and applies the same filtering in a number of other places which were missed in the original commit.

Without this filtering we can end up with percentages higher than 100% which is incorrect.

[Jira Issue - MAV-1520](https://nhsd-jira.digital.nhs.uk/browse/MAV-1520)