### PR TITLE
fix: use AcademicYear.current rather than Date.current

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -304,7 +304,7 @@ class AppActivityLogComponent < ViewComponent::Base
     all_programmes = Programme.all.to_a
 
     AcademicYear.all.filter_map do |academic_year|
-      next if Date.new(academic_year + 1, 8, 31) >= Date.current
+      next if academic_year >= AcademicYear.current
 
       vaccinated_programmes =
         all_programmes.select do |programme|

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -329,17 +329,14 @@ class AppActivityLogComponent < ViewComponent::Base
           .flat_map { programmes_for(it) }
           .reject { vaccinated_programmes.include?(it) }
 
-      unless programmes_with_expired_consents.any? ||
-               programmes_with_expired_triages.any? ||
-               programmes_with_expired_psds.any?
-        next
-      end
-
       expired_items = []
-      expired_items << "consent" if programmes_with_expired_consents.any?
-      expired_items << "health information"
+      if programmes_with_expired_consents.any?
+        expired_items += ["consent", "health information"]
+      end
       expired_items << "triage outcome" if programmes_with_expired_triages.any?
       expired_items << "PSD status" if programmes_with_expired_psds.any?
+
+      next if expired_items.empty?
 
       programmes_with_expired_items = [
         programmes_with_expired_consents,

--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -352,11 +352,9 @@ class AppActivityLogComponent < ViewComponent::Base
           words_connector: ", ",
           last_word_connector: " and "
         )
-      capitalised_expired_items =
-        expired_items_sentence[0].upcase + expired_items_sentence[1..]
 
       {
-        title: "#{capitalised_expired_items} expired",
+        title: "#{expired_items_sentence.upcase_first} expired",
         body: "#{@patient.full_name} was not vaccinated.",
         at: academic_year.to_academic_year_date_range.end.end_of_day - 1.second,
         programmes: programmes_with_expired_items

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -552,7 +552,7 @@ describe AppActivityLogComponent do
       end
 
       include_examples "card",
-                       title: "Health information and PSD status expired",
+                       title: "PSD status expired",
                        date: "31 August 2025 at 11:59pm",
                        notes: "DOE, Sarah was not vaccinated.",
                        programme: "HPV"
@@ -589,7 +589,7 @@ describe AppActivityLogComponent do
       end
 
       include_examples "card",
-                       title: "Health information and PSD status expired",
+                       title: "PSD status expired",
                        date: "31 August 2025 at 11:59pm",
                        notes: "DOE, Sarah was not vaccinated.",
                        programme: "Flu"


### PR DESCRIPTION
This achieves two things. First, the academic year rollover date should not be hard-coded so we get rid of that, second  it means that this now works with the date override which can be performed on AcademicYear.