### PR TITLE
Show expired flu consents in activity log

### DIFF
--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -614,5 +614,50 @@ describe AppActivityLogComponent do
                        notes: "DOE, Sarah was not vaccinated.",
                        programme: "Flu"
     end
+
+    context "with vaccinated but seasonal programme" do
+      before do
+        create(
+          :consent,
+          :given,
+          programme: flu_programme,
+          patient:,
+          parent: mum,
+          academic_year: 2024,
+          submitted_at: Time.zone.parse("#2024-05-30 12:00")
+        )
+
+        create(
+          :triage,
+          :ready_to_vaccinate,
+          programme: flu_programme,
+          patient:,
+          academic_year: 2024,
+          created_at: Time.zone.parse("#2024-05-30 14:30"),
+          performed_by: user
+        )
+
+        create(
+          :patient_specific_direction,
+          programme: flu_programme,
+          patient:,
+          created_by: user,
+          academic_year: 2024,
+          created_at: Time.zone.parse("#2024-05-30 15:00")
+        )
+
+        patient.vaccination_status(
+          programme: flu_programme,
+          academic_year: 2024
+        ).vaccinated!
+      end
+
+      include_examples "card",
+                       title:
+                         "Consent, health information, triage outcome and PSD status expired",
+                       date: "31 August 2025 at 11:59pm",
+                       notes: "DOE, Sarah was vaccinated.",
+                       programme: "Flu"
+    end
   end
 end

--- a/spec/components/app_activity_log_component_spec.rb
+++ b/spec/components/app_activity_log_component_spec.rb
@@ -589,30 +589,15 @@ describe AppActivityLogComponent do
           created_at: Time.zone.parse("#2024-05-30 15:00")
         )
 
-        create(
-          :vaccination_record,
+        patient.vaccination_status(
           programme: hpv_programme,
-          patient:,
-          session:,
-          performed_at: Time.zone.parse("#2024-05-31 12:00"),
-          performed_by: user
-        )
-
-        create(
-          :patient_specific_direction,
-          programme: flu_programme,
-          patient:,
-          created_by: user,
-          academic_year: 2024,
-          created_at: Time.zone.parse("#2024-05-30 15:00")
-        )
+          academic_year: 2024
+        ).vaccinated!
       end
 
-      include_examples "card",
-                       title: "PSD status expired",
-                       date: "31 August 2025 at 11:59pm",
-                       notes: "DOE, Sarah was not vaccinated.",
-                       programme: "Flu"
+      it "does not render expired PSD card for vaccinated patient" do
+        expect(rendered).not_to have_content("expired")
+      end
     end
 
     context "with vaccinated but seasonal programme" do


### PR DESCRIPTION
This implements [MAV-1711](https://nhsd-jira.digital.nhs.uk/browse/MAV-1711) and follows up on [PR-4053]( https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4053)