### PR TITLE
Rename unprocessable_entity

### DIFF
--- a/app/controllers/api/testing/onboard_controller.rb
+++ b/app/controllers/api/testing/onboard_controller.rb
@@ -5,7 +5,7 @@ class API::Testing::OnboardController < API::Testing::BaseController
     onboarding = Onboarding.new(params.to_unsafe_h)
 
     if onboarding.invalid?
-      render json: onboarding.errors, status: :unprocessable_entity
+      render json: onboarding.errors, status: :unprocessable_content
     else
       onboarding.save!(create_sessions_for_previous_academic_year: true)
       render status: :created

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,7 +80,7 @@ class ApplicationController < ActionController::Base
   end
 
   def handle_unprocessable_entity
-    render "errors/unprocessable_entity", status: :unprocessable_entity
+    render "errors/unprocessable_entity", status: :unprocessable_content
   end
 
   def user_not_authorized

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -30,7 +30,7 @@ class BatchesController < ApplicationController
                   }
     else
       @form.expiry = expiry_validator.date_params_as_struct
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 
@@ -55,7 +55,7 @@ class BatchesController < ApplicationController
                   }
     else
       @form.expiry = expiry_validator.date_params_as_struct
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -25,7 +25,7 @@ class ClassImportsController < ApplicationController
 
     @class_import.load_data!
     if @class_import.invalid?
-      render :new, status: :unprocessable_entity and return
+      render :new, status: :unprocessable_content and return
     end
 
     @class_import.save!

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -23,7 +23,7 @@ class CohortImportsController < ApplicationController
 
     @cohort_import.load_data!
     if @cohort_import.invalid?
-      render :new, status: :unprocessable_entity and return
+      render :new, status: :unprocessable_content and return
     end
 
     @cohort_import.save!

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -68,7 +68,7 @@ class ConsentFormsController < ApplicationController
                       "Consent response from #{@consent_form.parent_full_name} archived"
                   }
     else
-      render :archive, status: :unprocessable_entity
+      render :archive, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -71,7 +71,7 @@ class DraftVaccinationRecordsController < ApplicationController
 
       unless validator.date_params_valid? && time_valid
         @draft_vaccination_record.errors.add(:performed_at, :invalid)
-        render_wizard nil, status: :unprocessable_entity
+        render_wizard nil, status: :unprocessable_content
       end
     end
   end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -16,7 +16,7 @@ class ErrorsController < ActionController::Base
   end
 
   def unprocessable_entity
-    render "unprocessable_entity", status: :unprocessable_entity
+    render "unprocessable_entity", status: :unprocessable_content
   end
 
   def too_many_requests

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -21,7 +21,7 @@ class ImmunisationImportsController < ApplicationController
 
     @immunisation_import.load_data!
     if @immunisation_import.invalid?
-      render :new, status: :unprocessable_entity and return
+      render :new, status: :unprocessable_content and return
     end
 
     @immunisation_import.save!

--- a/app/controllers/imports/issues_controller.rb
+++ b/app/controllers/imports/issues_controller.rb
@@ -19,7 +19,7 @@ class Imports::IssuesController < ApplicationController
     if @form.save
       redirect_to imports_issues_path, flash: { success: "Record updated" }
     else
-      render :show, status: :unprocessable_entity and return
+      render :show, status: :unprocessable_content and return
     end
   end
 

--- a/app/controllers/offline_passwords_controller.rb
+++ b/app/controllers/offline_passwords_controller.rb
@@ -14,7 +14,7 @@ class OfflinePasswordsController < ApplicationController
                     success: "Campaign saved, you can now go offline"
                   }
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/parent_interface/consent_forms/edit_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/edit_controller.rb
@@ -188,7 +188,7 @@ module ParentInterface
 
         unless validator.date_params_valid?
           @consent_form.date_of_birth = validator.date_params_as_struct
-          render_wizard nil, status: :unprocessable_entity
+          render_wizard nil, status: :unprocessable_content
         end
       end
     end

--- a/app/controllers/parent_relationships_controller.rb
+++ b/app/controllers/parent_relationships_controller.rb
@@ -13,7 +13,7 @@ class ParentRelationshipsController < ApplicationController
     if @parent_relationship.update(parent_relationship_params)
       redirect_to edit_patient_path(@patient)
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patient_sessions/activities_controller.rb
+++ b/app/controllers/patient_sessions/activities_controller.rb
@@ -15,7 +15,7 @@ class PatientSessions::ActivitiesController < PatientSessions::BaseController
                     success: "Note added"
                   }
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patient_sessions/consents_controller.rb
+++ b/app/controllers/patient_sessions/consents_controller.rb
@@ -19,7 +19,7 @@ class PatientSessions::ConsentsController < PatientSessions::BaseController
     else
       render "patient_sessions/programmes/show",
              layout: "full",
-             status: :unprocessable_entity
+             status: :unprocessable_content
     end
   end
 
@@ -70,7 +70,7 @@ class PatientSessions::ConsentsController < PatientSessions::BaseController
 
       redirect_to session_patient_programme_consent_path
     else
-      render :withdraw, status: :unprocessable_entity
+      render :withdraw, status: :unprocessable_content
     end
   end
 
@@ -93,7 +93,7 @@ class PatientSessions::ConsentsController < PatientSessions::BaseController
                       "Consent response from #{@consent.name} marked as invalid"
                   }
     else
-      render :invalidate, status: :unprocessable_entity
+      render :invalidate, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patient_sessions/gillick_assessments_controller.rb
+++ b/app/controllers/patient_sessions/gillick_assessments_controller.rb
@@ -14,7 +14,7 @@ class PatientSessions::GillickAssessmentsController < PatientSessions::BaseContr
 
       redirect_to session_patient_programme_path(@session, @patient, @programme)
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patient_sessions/session_attendances_controller.rb
+++ b/app/controllers/patient_sessions/session_attendances_controller.rb
@@ -35,7 +35,7 @@ class PatientSessions::SessionAttendancesController < PatientSessions::BaseContr
                     @patient_session.programmes.first
                   )
     else
-      render :edit, status: :unprocessable_entity
+      render :edit, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patient_sessions/triages_controller.rb
+++ b/app/controllers/patient_sessions/triages_controller.rb
@@ -50,7 +50,7 @@ class PatientSessions::TriagesController < PatientSessions::BaseController
     else
       render "patient_sessions/programmes/show",
              layout: "full",
-             status: :unprocessable_entity
+             status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patient_sessions/vaccinations_controller.rb
+++ b/app/controllers/patient_sessions/vaccinations_controller.rb
@@ -47,7 +47,7 @@ class PatientSessions::VaccinationsController < PatientSessions::BaseController
     else
       render "patient_sessions/programmes/show",
              layout: "full",
-             status: :unprocessable_entity
+             status: :unprocessable_content
     end
   end
 

--- a/app/controllers/patients/edit_controller.rb
+++ b/app/controllers/patients/edit_controller.rb
@@ -21,7 +21,7 @@ class Patients::EditController < ApplicationController
 
       redirect_to edit_patient_path(@patient)
     else
-      render :nhs_number, status: :unprocessable_entity
+      render :nhs_number, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/school_moves_controller.rb
+++ b/app/controllers/school_moves_controller.rb
@@ -42,7 +42,7 @@ class SchoolMovesController < ApplicationController
 
       redirect_to school_moves_path, flash:
     else
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/session_dates_controller.rb
+++ b/app/controllers/session_dates_controller.rb
@@ -11,7 +11,7 @@ class SessionDatesController < ApplicationController
     @session.assign_attributes(remove_invalid_dates(session_params))
     @session.set_notification_dates
 
-    render :show, status: :unprocessable_entity and return if @session.invalid?
+    render :show, status: :unprocessable_content and return if @session.invalid?
 
     @session.save!
 

--- a/app/controllers/sessions/edit_controller.rb
+++ b/app/controllers/sessions/edit_controller.rb
@@ -19,7 +19,7 @@ class Sessions::EditController < ApplicationController
     if @form.save
       redirect_to edit_session_path(@session)
     else
-      render :programmes, status: :unprocessable_entity
+      render :programmes, status: :unprocessable_content
     end
   end
 
@@ -31,9 +31,9 @@ class Sessions::EditController < ApplicationController
     if !send_consent_requests_at_validator.date_params_valid?
       @session.send_consent_requests_at =
         send_consent_requests_at_validator.date_params_as_struct
-      render :send_consent_requests_at, status: :unprocessable_entity
+      render :send_consent_requests_at, status: :unprocessable_content
     elsif !@session.update(send_consent_requests_at_params)
-      render :send_consent_requests_at, status: :unprocessable_entity
+      render :send_consent_requests_at, status: :unprocessable_content
     else
       redirect_to edit_session_path(@session)
     end
@@ -47,9 +47,9 @@ class Sessions::EditController < ApplicationController
     if !send_invitations_at_validator.date_params_valid?
       @session.send_invitations_at =
         send_invitations_at_validator.date_params_as_struct
-      render :send_invitations_at, status: :unprocessable_entity
+      render :send_invitations_at, status: :unprocessable_content
     elsif !@session.update(send_invitations_at_params)
-      render :send_invitations_at, status: :unprocessable_entity
+      render :send_invitations_at, status: :unprocessable_content
     else
       redirect_to edit_session_path(@session)
     end
@@ -63,7 +63,7 @@ class Sessions::EditController < ApplicationController
     if @session.update(weeks_before_consent_reminders_params)
       redirect_to edit_session_path(@session)
     else
-      render :weeks_before_consent_reminders, status: :unprocessable_entity
+      render :weeks_before_consent_reminders, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -59,7 +59,7 @@ class Sessions::RecordController < ApplicationController
       @todays_batch = Batch.new
       @todays_batch.errors.add(:id, "Select a default batch for this session")
 
-      render :batch, status: :unprocessable_entity
+      render :batch, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/users/teams_controller.rb
+++ b/app/controllers/users/teams_controller.rb
@@ -23,7 +23,7 @@ class Users::TeamsController < ApplicationController
     if @form.save
       redirect_to dashboard_path
     else
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -379,7 +379,7 @@ Devise.setup do |config|
   # apps is `200 OK` and `302 Found respectively`, but new apps are generated with
   # these new defaults that match Hotwire/Turbo behavior.
   # Note: These might become the new default in future versions of Devise.
-  config.responder.error_status = :unprocessable_entity
+  config.responder.error_status = :unprocessable_content
   config.responder.redirect_status = :see_other
 
   # ==> Configuration for :registerable

--- a/spec/requests/api/testing/onboard_spec.rb
+++ b/spec/requests/api/testing/onboard_spec.rb
@@ -51,7 +51,7 @@ describe "/api/testing/onboard" do
       it "responds with an error" do
         request
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
 
         errors = JSON.parse(response.body)
 

--- a/spec/requests/patient_sessions/activity_spec.rb
+++ b/spec/requests/patient_sessions/activity_spec.rb
@@ -32,13 +32,13 @@ describe "Patient sessions activity" do
 
     it "validates the body is present" do
       post path, params: { note: { body: "" } }
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include("Enter a note")
     end
 
     it "validates the body isn't too long" do
       post path, params: { note: { body: "a" * 2000 } }
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:unprocessable_content)
       expect(response.body).to include(
         "Enter a note that is less than 1000 characters long"
       )


### PR DESCRIPTION
In Rack 3.2, this has been renamed to unprocessable_content and using the old symbol is deprecated, which results in a warning message.

Although a future version of Rails will handle this for us (https://github.com/rails/rails/pull/53383) but we can also change the symbol we use in our codebase to reduce the number of warnings happening at the moment.