### PR TITLE
Don't add deceased patients to sessions

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -39,6 +39,8 @@ class PatientImportRow
   end
 
   def to_school_move(patient)
+    return if patient.deceased?
+
     if patient.new_record? || patient.school != school ||
          patient.home_educated != home_educated || patient.not_in_team?
       school_move =

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -131,6 +131,24 @@ describe ClassImportRow do
     end
   end
 
+  describe "#to_school_move" do
+    subject { class_import_row.to_school_move(patient) }
+
+    let(:data) { valid_data }
+
+    let(:patient) { class_import_row.to_patient }
+
+    context "without a date of death" do
+      it { should_not be_nil }
+    end
+
+    context "with a date of death" do
+      before { patient.update!(date_of_death: today) }
+
+      it { should be_nil }
+    end
+  end
+
   describe "#to_parents" do
     subject(:parents) { class_import_row.to_parents }
 

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -561,6 +561,12 @@ describe CohortImportRow do
 
     it { should_not be_nil }
 
+    context "with a date of death" do
+      before { patient.update!(date_of_death: today) }
+
+      it { should be_nil }
+    end
+
     describe "#school" do
       subject(:school) { school_move.school }
 


### PR DESCRIPTION
This ensures that when a patient has a date of death, they are not added to any upcoming sessions.

[Jira Issue - MAV-1228](https://nhsd-jira.digital.nhs.uk/browse/MAV-1228)