### PR TITLE
Fix patient show page layout

### DIFF
--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -19,8 +19,8 @@
     <div class="app-button-group">
       <%= govuk_button_link_to "Edit child record", edit_patient_path(@patient), secondary: true %>
       <%= govuk_button_link_to "Archive child record", new_patient_archive_path(@patient), class: "app-button--secondary-warning" %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 <% end %>
 
 <%= render AppCardComponent.new(section: true) do |card| %>


### PR DESCRIPTION
This was accidentally rebased incorrectly and the tags ended up the wrong way around in the ERB leading to the patient page looking incorrect.

This wasn't spotted by any tests because the content was here, just visually it looked all wrong.