### PR TITLE
Don't add school patients to community clinic

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -30,6 +30,18 @@ class PatientsController < ApplicationController
     render layout: "full"
   end
 
+  def invite_to_clinic
+    session =
+      current_team.generic_clinic_session(academic_year: AcademicYear.pending)
+
+    PatientSession.find_or_create_by!(patient: @patient, session:)
+
+    redirect_to patient_path(@patient),
+                flash: {
+                  success: "#{@patient.full_name} invited to the clinic"
+                }
+  end
+
   private
 
   def set_patient

--- a/app/controllers/sessions/invite_to_clinic_controller.rb
+++ b/app/controllers/sessions/invite_to_clinic_controller.rb
@@ -3,6 +3,7 @@
 class Sessions::InviteToClinicController < ApplicationController
   before_action :set_session
   before_action :set_generic_clinic_session
+  before_action :set_patient_sessions_to_invite
   before_action :set_invitations_to_send
 
   skip_after_action :verify_policy_scoped
@@ -13,6 +14,11 @@ class Sessions::InviteToClinicController < ApplicationController
 
   def update
     if @session.school?
+      PatientSession.import!(
+        @patient_sessions_to_invite,
+        on_duplicate_key_ignore: true
+      )
+
       SendClinicInitialInvitationsJob.perform_later(
         @generic_clinic_session,
         school: @session.location,
@@ -44,36 +50,51 @@ class Sessions::InviteToClinicController < ApplicationController
 
   def set_generic_clinic_session
     @generic_clinic_session =
-      (
-        if @session.clinic?
-          @session
-        else
-          @session.team.generic_clinic_session(
-            academic_year: @session.academic_year
+      if @session.clinic?
+        @session
+      else
+        @session.team.generic_clinic_session(
+          academic_year: @session.academic_year
+        )
+      end
+  end
+
+  def set_patient_sessions_to_invite
+    session_date = @generic_clinic_session.next_date(include_today: true)
+
+    if @session.school?
+      patient_sessions_in_school = @session.patient_sessions.includes(:patient)
+
+      patient_sessions_in_clinic =
+        patient_sessions_in_school.map do |patient_session|
+          PatientSession.find_or_initialize_by(
+            patient: patient_session.patient,
+            session: @generic_clinic_session
           )
         end
-      )
+
+      programmes = @session.programmes.to_a
+
+      @patient_sessions_to_invite =
+        patient_sessions_in_clinic
+          .reject { it.session_notifications.any? }
+          .select do |patient_session|
+            SendClinicInitialInvitationsJob.new.should_send_notification?(
+              patient_session:,
+              programmes:,
+              session_date:
+            )
+          end
+    else
+      @patient_sessions_to_invite =
+        SendClinicSubsequentInvitationsJob.new.patient_sessions(
+          @session,
+          session_date:
+        )
+    end
   end
 
   def set_invitations_to_send
-    session_date = @generic_clinic_session.next_date(include_today: true)
-
-    @invitations_to_send =
-      if @session.school?
-        SendClinicInitialInvitationsJob
-          .new
-          .patient_sessions(
-            @generic_clinic_session,
-            school: @session.location,
-            programmes: @session.programmes.to_a,
-            session_date:
-          )
-          .length
-      else
-        SendClinicSubsequentInvitationsJob
-          .new
-          .patient_sessions(@session, session_date:)
-          .length
-      end
+    @invitations_to_send = @patient_sessions_to_invite.length
   end
 end

--- a/app/jobs/enqueue_clinic_session_invitations_job.rb
+++ b/app/jobs/enqueue_clinic_session_invitations_job.rb
@@ -4,20 +4,10 @@ class EnqueueClinicSessionInvitationsJob < ApplicationJob
   queue_as :notifications
 
   def perform
-    Session
-      .send_invitations
-      .includes(:programmes)
-      .joins(:location)
-      .merge(Location.clinic)
-      .find_each do |session|
-        # We're only inviting patients who don't have a school.
-        # Patients who have a school are sent invitations manually by the
-        # nurse when they're finished at a school.
-        SendClinicInitialInvitationsJob.perform_now(
-          session,
-          school: nil,
-          programmes: session.programmes
-        )
-      end
+    sessions = Session.send_invitations.joins(:location).merge(Location.clinic)
+
+    sessions.find_each do |session|
+      SendClinicInitialInvitationsJob.perform_later(session)
+    end
   end
 end

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -35,12 +35,8 @@ class SendClinicInitialInvitationsJob < ApplicationJob
       )
       .where(patient: { school: })
       .reject { it.session_notifications.any? }
-      .select do
-        should_send_notification?(
-          patient_session: it,
-          programmes:,
-          session_date:
-        )
+      .select do |patient_session|
+        should_send_notification?(patient_session:, programmes:, session_date:)
       end
   end
 end

--- a/app/jobs/send_clinic_initial_invitations_job.rb
+++ b/app/jobs/send_clinic_initial_invitations_job.rb
@@ -5,23 +5,20 @@ class SendClinicInitialInvitationsJob < ApplicationJob
 
   queue_as :notifications
 
-  def perform(session, school:, programmes:)
+  def perform(session)
     raise InvalidLocation unless session.clinic?
 
     session_date = session.next_date(include_today: true)
     raise NoSessionDates if session_date.nil?
 
-    patient_sessions(
-      session,
-      school:,
-      programmes:,
-      session_date:
-    ).each do |patient_session|
+    patient_sessions(session, session_date:).each do |patient_session|
       send_notification(patient_session:, session_date:)
     end
   end
 
-  def patient_sessions(session, school:, programmes:, session_date:)
+  def patient_sessions(session, session_date:)
+    programmes = session.programmes
+
     # We only send initial invitations to patients who haven't already
     # received an invitation.
 
@@ -33,7 +30,6 @@ class SendClinicInitialInvitationsJob < ApplicationJob
         :session_notifications,
         patient: %i[consents parents vaccination_records]
       )
-      .where(patient: { school: })
       .reject { it.session_notifications.any? }
       .select do |patient_session|
         should_send_notification?(patient_session:, programmes:, session_date:)

--- a/app/jobs/send_clinic_subsequent_invitations_job.rb
+++ b/app/jobs/send_clinic_subsequent_invitations_job.rb
@@ -24,8 +24,9 @@ class SendClinicSubsequentInvitationsJob < ApplicationJob
 
     session
       .patient_sessions
-      .eager_load(:patient)
-      .preload(
+      .joins(:patient)
+      .includes_programmes
+      .includes(
         :session_notifications,
         patient: %i[consents parents vaccination_records]
       )

--- a/app/lib/clinic_patient_sessions_factory.rb
+++ b/app/lib/clinic_patient_sessions_factory.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class ClinicPatientSessionsFactory
+  def initialize(school_session:, generic_clinic_session:)
+    @school_session = school_session
+    @generic_clinic_session = generic_clinic_session
+  end
+
+  def create_patient_sessions!
+    PatientSession.import!(
+      patient_sessions_to_create,
+      on_duplicate_key_ignore: true
+    )
+  end
+
+  def patient_sessions_to_create
+    patient_sessions_in_clinic =
+      patient_sessions_in_school.map do |patient_session|
+        PatientSession.includes(:session_notifications).find_or_initialize_by(
+          patient: patient_session.patient,
+          session: generic_clinic_session
+        )
+      end
+
+    patient_sessions_in_clinic.select do |patient_session|
+      SendClinicInitialInvitationsJob.new.should_send_notification?(
+        patient_session:,
+        programmes:,
+        session_date:
+      )
+    end
+  end
+
+  private
+
+  attr_reader :school_session, :generic_clinic_session
+
+  def programmes
+    @programmes ||= school_session.programmes.to_a
+  end
+
+  def session_date
+    @session_date ||= generic_clinic_session.next_date(include_today: true)
+  end
+
+  def patient_sessions_in_school
+    school_session.patient_sessions.includes(:patient)
+  end
+end

--- a/app/lib/location_sessions_factory.rb
+++ b/app/lib/location_sessions_factory.rb
@@ -53,7 +53,7 @@ class LocationSessionsFactory
   def patient_ids
     @patient_ids ||=
       if location.generic_clinic?
-        team.patients.pluck(:id)
+        team.patients.where(school: nil).pluck(:id)
       else
         team.patients.where(school: location).pluck(:id)
       end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -369,7 +369,11 @@ class ConsentForm < ApplicationRecord
       (location_is_clinic? && original_session) ||
         (
           school &&
-            school.sessions.has_programmes(programmes).includes(:session_dates).find_by(academic_year:)
+            school
+              .sessions
+              .has_programmes(programmes)
+              .includes(:session_dates)
+              .find_by(academic_year:)
         ) || team.generic_clinic_session(academic_year:)
   end
 

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -369,7 +369,7 @@ class ConsentForm < ApplicationRecord
       (location_is_clinic? && original_session) ||
         (
           school &&
-            school.sessions.includes(:session_dates).find_by(academic_year:)
+            school.sessions.has_programmes(programmes).includes(:session_dates).find_by(academic_year:)
         ) || team.generic_clinic_session(academic_year:)
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -367,6 +367,12 @@ class Patient < ApplicationRecord
     end
   end
 
+  def in_generic_clinic?(team:, academic_year: nil)
+    academic_year ||= AcademicYear.pending
+    session = team.generic_clinic_session(academic_year:)
+    patient_sessions.exists?(session:)
+  end
+
   def consent_status(programme:, academic_year:)
     patient_status(consent_statuses, programme:, academic_year:)
   end

--- a/app/models/school_move.rb
+++ b/app/models/school_move.rb
@@ -113,14 +113,7 @@ class SchoolMove < ApplicationRecord
           )
 
         if school
-          scope.where(team: school.team, location: school).or(
-            scope.where(
-              team: school.team,
-              locations: {
-                type: "generic_clinic"
-              }
-            )
-          )
+          scope.where(team: school.team, location: school)
         else
           scope.where(team:, locations: { type: "generic_clinic" })
         end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -85,7 +85,12 @@ class Team < ApplicationRecord
     location = locations.generic_clinic.first
 
     sessions
-      .includes(:location, :programmes, :session_dates)
+      .includes(
+        :location,
+        :location_programme_year_groups,
+        :programmes,
+        :session_dates
+      )
       .create_with(programmes:)
       .find_or_create_by!(academic_year:, location:)
   end

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -24,6 +24,10 @@
 <%= render AppCardComponent.new(section: true) do |card| %>
   <% card.with_heading { "Sessions" } %>
   <%= render AppPatientSessionTableComponent.new(@patient_sessions) %>
+
+  <% unless @patient.in_generic_clinic?(team: current_team) %>
+    <%= govuk_button_to "Invite to community clinic", invite_to_clinic_patient_path(@patient), secondary: true %>
+  <% end %>
 <% end %>
 
 <%= render AppCardComponent.new(section: true) do |card| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Rails.application.routes.draw do
 
     member do
       get "log"
+      post "invite-to-clinic"
 
       get "edit/nhs-number",
           controller: "patients/edit",

--- a/spec/controllers/api/testing/teams_controller_spec.rb
+++ b/spec/controllers/api/testing/teams_controller_spec.rb
@@ -45,10 +45,10 @@ describe API::Testing::TeamsController do
         end
       end
 
-      TeamSessionsFactory.call(team, academic_year: AcademicYear.current)
-
       create(:school, urn: "123456", team:, programmes:) # to match cohort_import/valid.csv
       create(:school, urn: "110158", team:, programmes:) # to match valid_hpv.csv
+
+      TeamSessionsFactory.call(team, academic_year: AcademicYear.current)
 
       cohort_import.process!
       immunisation_import.process!
@@ -79,7 +79,7 @@ describe API::Testing::TeamsController do
         change(Team, :count)
           .by(-1)
           .and(change(Subteam, :count).by(-1))
-          .and(change(Session, :count).by(-1))
+          .and(change(Session, :count).by(-3))
           .and(change(CohortImport, :count).by(-1))
           .and(change(ImmunisationImport, :count).by(-1))
           .and(change(NotifyLogEntry, :count).by(-3))

--- a/spec/features/access_log_spec.rb
+++ b/spec/features/access_log_spec.rb
@@ -33,7 +33,7 @@ describe "Access log" do
 
   def given_i_am_signed_in
     programmes = [create(:programme, :hpv)]
-    team = create(:team, :with_one_nurse, programmes:)
+    team = create(:team, :with_generic_clinic, :with_one_nurse, programmes:)
 
     @user = team.users.first
 

--- a/spec/features/archive_children_spec.rb
+++ b/spec/features/archive_children_spec.rb
@@ -111,7 +111,7 @@ describe "Archive children" do
 
   def given_an_team_exists
     programmes = [create(:programme, :flu)]
-    @team = create(:team, programmes:)
+    @team = create(:team, :with_generic_clinic, programmes:)
 
     @session = create(:session, team: @team, programmes:)
   end

--- a/spec/features/delete_vaccination_record_spec.rb
+++ b/spec/features/delete_vaccination_record_spec.rb
@@ -113,7 +113,7 @@ describe "Delete vaccination record" do
   end
 
   def given_an_hpv_programme_is_underway
-    @team = create(:team, :with_one_nurse)
+    @team = create(:team, :with_generic_clinic, :with_one_nurse)
     @programme = create(:programme, :hpv, teams: [@team])
 
     @session =

--- a/spec/features/edit_parent_spec.rb
+++ b/spec/features/edit_parent_spec.rb
@@ -38,10 +38,12 @@ describe "Edit parent" do
   end
 
   def given_a_patient_with_a_parent_exists
-    team = create(:team)
+    programmes = [create(:programme)]
+
+    team = create(:team, :with_generic_clinic, programmes:)
     @nurse = create(:nurse, team:)
 
-    session = create(:session, team:)
+    session = create(:session, team:, programmes:)
     @patient = create(:patient, session:)
 
     @parent = create(:parent)

--- a/spec/features/edit_vaccination_record_spec.rb
+++ b/spec/features/edit_vaccination_record_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 describe "Edit vaccination record" do
+  before { given_an_hpv_programme_is_underway }
+
   scenario "User edits a new vaccination record" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
 
@@ -47,7 +48,6 @@ describe "Edit vaccination record" do
 
   scenario "User edits a vaccination record that already received confirmation" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_the_vaccination_confirmation_was_already_sent
 
@@ -75,7 +75,6 @@ describe "Edit vaccination record" do
 
   scenario "User edits a vaccination record, not enough to trigger an email" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_the_vaccination_confirmation_was_already_sent
 
@@ -95,7 +94,6 @@ describe "Edit vaccination record" do
 
   scenario "Edit outcome to vaccinated" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
     and_a_not_administered_vaccination_record_exists
     and_the_vaccination_confirmation_was_already_sent
@@ -128,7 +126,6 @@ describe "Edit vaccination record" do
 
   scenario "Edit outcome to not vaccinated" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_enqueue_sync_vaccination_records_to_nhs_feature_is_enabled
     and_an_administered_vaccination_record_exists
     and_the_vaccination_confirmation_was_already_sent
@@ -152,7 +149,6 @@ describe "Edit vaccination record" do
 
   scenario "With an archived batch" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_the_original_batch_has_been_archived
 
@@ -170,7 +166,6 @@ describe "Edit vaccination record" do
 
   scenario "With an expired batch" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
     and_the_original_batch_has_expired
 
@@ -188,7 +183,6 @@ describe "Edit vaccination record" do
 
   scenario "Cannot as an admin" do
     given_i_am_signed_in_as_an_admin
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
 
     when_i_go_to_the_vaccination_record_for_the_patient
@@ -197,7 +191,6 @@ describe "Edit vaccination record" do
 
   scenario "Navigating back" do
     given_i_am_signed_in
-    and_an_hpv_programme_is_underway
     and_an_administered_vaccination_record_exists
 
     when_i_go_to_the_vaccination_record_for_the_patient
@@ -214,18 +207,17 @@ describe "Edit vaccination record" do
     then_i_should_see_the_vaccination_record
   end
 
-  def given_i_am_signed_in
-    @team = create(:team, :with_one_nurse, ods_code: "R1L")
-    sign_in @team.users.first
-  end
+  def given_an_hpv_programme_is_underway
+    @programme = create(:programme, :hpv)
 
-  def given_i_am_signed_in_as_an_admin
-    @team = create(:team, :with_one_admin, ods_code: "R1L")
-    sign_in @team.users.first, role: :admin_staff
-  end
-
-  def and_an_hpv_programme_is_underway
-    @programme = create(:programme, :hpv, teams: [@team])
+    @team =
+      create(
+        :team,
+        :with_generic_clinic,
+        :with_one_nurse,
+        ods_code: "R1L",
+        programmes: [@programme]
+      )
 
     @vaccine = @programme.vaccines.first
 
@@ -251,11 +243,16 @@ describe "Edit vaccination record" do
         given_name: "John",
         family_name: "Smith",
         team: @team,
-        programmes: [@programme]
+        session: @session
       )
+  end
 
-    @patient_session =
-      create(:patient_session, patient: @patient, session: @session)
+  def given_i_am_signed_in
+    sign_in @team.users.first
+  end
+
+  def given_i_am_signed_in_as_an_admin
+    sign_in @team.users.first, role: :admin_staff
   end
 
   def and_an_administered_vaccination_record_exists

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -78,6 +78,20 @@ describe "Manage children" do
     and_the_patient_is_no_longer_invalidated
   end
 
+  scenario "Inviting to community clinic" do
+    given_patients_exist
+
+    when_i_click_on_children
+    and_i_click_on_a_child
+    then_i_see_the_child
+    and_i_dont_see_a_community_clinic_session
+
+    when_i_click_on_invite_to_clinic
+    then_i_see_a_success_banner
+    and_i_see_a_community_clinic_session
+    and_i_dont_see_an_invite_to_clinic_session
+  end
+
   scenario "Removing an NHS number" do
     given_patients_exist
     and_sync_vaccination_records_to_nhs_feature_is_enabled
@@ -140,7 +154,13 @@ describe "Manage children" do
 
   def given_my_team_exists
     @programme = create(:programme, :hpv)
-    @team = create(:team, :with_one_nurse, programmes: [@programme])
+    @team =
+      create(
+        :team,
+        :with_generic_clinic,
+        :with_one_nurse,
+        programmes: [@programme]
+      )
   end
 
   def given_patients_exist
@@ -335,6 +355,26 @@ describe "Manage children" do
   def and_i_see_the_cohort
     expect(page).not_to have_content("No cohorts")
     expect(page).not_to have_content("No sessions")
+  end
+
+  def and_i_dont_see_a_community_clinic_session
+    expect(page).not_to have_content("Community clinic")
+  end
+
+  def when_i_click_on_invite_to_clinic
+    click_on "Invite to community clinic"
+  end
+
+  def then_i_see_a_success_banner
+    expect(page).to have_content("invited to the clinic")
+  end
+
+  def and_i_see_a_community_clinic_session
+    expect(page).to have_content("Community clinic")
+  end
+
+  def and_i_dont_see_an_invite_to_clinic_session
+    expect(page).not_to have_button("Invite to community clinic")
   end
 
   def when_i_go_to_the_dashboard

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -100,12 +100,6 @@ describe "Manage school sessions" do
       .generic_clinic_session(academic_year: AcademicYear.current)
       .session_dates
       .create!(value: 1.month.from_now.to_date)
-
-    create(
-      :patient_session,
-      patient: @patient,
-      session: @team.generic_clinic_session(academic_year: AcademicYear.current)
-    )
   end
 
   def when_i_go_to_todays_sessions_as_a_nurse

--- a/spec/features/parent_relationships_spec.rb
+++ b/spec/features/parent_relationships_spec.rb
@@ -19,10 +19,11 @@ describe "Parent relationships" do
   end
 
   def given_a_patient_with_a_parent_exists
-    team = create(:team)
+    programmes = [create(:programme)]
+    team = create(:team, :with_generic_clinic, programmes:)
     @nurse = create(:nurse, team:)
 
-    session = create(:session, team:)
+    session = create(:session, team:, programmes:)
     @patient = create(:patient, session:)
 
     @parent = create(:parent)

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -63,7 +63,7 @@ describe "Parental consent manual matching" do
   def given_the_app_is_setup
     programmes = [create(:programme, :hpv)]
 
-    @team = create(:team, :with_one_nurse, programmes:)
+    @team = create(:team, :with_generic_clinic, :with_one_nurse, programmes:)
     @user = @team.users.first
     @school = create(:school, name: "Pilot School", team: @team)
     @session = create(:session, location: @school, team: @team, programmes:)

--- a/spec/jobs/enqueue_clinic_session_invitations_job_spec.rb
+++ b/spec/jobs/enqueue_clinic_session_invitations_job_spec.rb
@@ -16,110 +16,10 @@ describe EnqueueClinicSessionInvitationsJob do
     let(:session) { create(:session, programmes:, date:, location:, team:) }
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
-    it "sends a notification" do
-      expect(SessionNotification).to receive(:create_and_send!).once.with(
-        patient_session:,
-        session_date: date,
-        type: :clinic_initial_invitation
-      )
-      perform_now
-    end
-
-    context "when patient goes to a school" do
-      let(:patient) { create(:patient, parents:, school: create(:school)) }
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
-    end
-
-    context "when already sent for that date" do
-      before do
-        create(
-          :session_notification,
-          :clinic_initial_invitation,
-          session:,
-          patient:
-        )
-      end
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
-
-      context "with a second date a week later" do
-        before { session.session_dates.create!(value: date + 1.week) }
-
-        let(:today) { date + 1.day }
-
-        it "doesn't send any notifications" do
-          expect(SessionNotification).not_to receive(:create_and_send!)
-          perform_now
-        end
-      end
-    end
-
-    context "when already vaccinated" do
-      before do
-        create(
-          :vaccination_record,
-          patient:,
-          session:,
-          programme: programmes.first,
-          location_name: "A clinic."
-        )
-      end
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
-    end
-
-    context "when refused consent has been received" do
-      before do
-        create(
-          :consent,
-          :refused,
-          patient:,
-          programme: programmes.first,
-          parent: parents.first
-        )
-      end
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
-    end
-
-    context "if the patient is deceased" do
-      let(:patient) { create(:patient, :deceased, parents:) }
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
-    end
-
-    context "if the patient is invalid" do
-      let(:patient) { create(:patient, :invalidated, parents:) }
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
-    end
-
-    context "if the patient is restricted" do
-      let(:patient) { create(:patient, :restricted, parents:) }
-
-      it "doesn't send any notifications" do
-        expect(SessionNotification).not_to receive(:create_and_send!)
-        perform_now
-      end
+    it "queues a job for the session" do
+      expect { perform_now }.to have_enqueued_job(
+        SendClinicInitialInvitationsJob
+      ).with(session)
     end
   end
 
@@ -128,13 +28,10 @@ describe EnqueueClinicSessionInvitationsJob do
     let(:session) { create(:session, programmes:, date:, location:, team:) }
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
-    it "sends a notification" do
-      expect(SessionNotification).to receive(:create_and_send!).once.with(
-        patient_session:,
-        session_date: date,
-        type: :clinic_initial_invitation
-      )
-      perform_now
+    it "queues a job for the session" do
+      expect { perform_now }.to have_enqueued_job(
+        SendClinicInitialInvitationsJob
+      ).with(session)
     end
   end
 
@@ -143,9 +40,10 @@ describe EnqueueClinicSessionInvitationsJob do
     let(:session) { create(:session, programmes:, date:, location:, team:) }
     let(:patient_session) { create(:patient_session, patient:, session:) }
 
-    it "doesn't send any notifications" do
-      expect(SessionNotification).not_to receive(:create_and_send!)
-      perform_now
+    it "doesn't queue any jobs" do
+      expect { perform_now }.not_to have_enqueued_job(
+        SendClinicInitialInvitationsJob
+      )
     end
   end
 
@@ -163,9 +61,10 @@ describe EnqueueClinicSessionInvitationsJob do
       )
     end
 
-    it "doesn't send any notifications" do
-      expect(SessionNotification).not_to receive(:create_and_send!)
-      perform_now
+    it "doesn't queue any jobs" do
+      expect { perform_now }.not_to have_enqueued_job(
+        SendClinicInitialInvitationsJob
+      )
     end
   end
 
@@ -181,9 +80,10 @@ describe EnqueueClinicSessionInvitationsJob do
       )
     end
 
-    it "doesn't send any notifications" do
-      expect(SessionNotification).not_to receive(:create_and_send!)
-      perform_now
+    it "doesn't queue any jobs" do
+      expect { perform_now }.not_to have_enqueued_job(
+        SendClinicInitialInvitationsJob
+      )
     end
   end
 end

--- a/spec/jobs/send_clinic_initial_invitations_job_spec.rb
+++ b/spec/jobs/send_clinic_initial_invitations_job_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 describe SendClinicInitialInvitationsJob do
-  subject(:perform_now) do
-    described_class.perform_now(session, school: nil, programmes:)
-  end
+  subject(:perform_now) { described_class.perform_now(session) }
 
   let(:programmes) { [create(:programme, :hpv)] }
   let(:team) { create(:team, programmes:) }

--- a/spec/lib/location_sessions_factory_spec.rb
+++ b/spec/lib/location_sessions_factory_spec.rb
@@ -120,7 +120,7 @@ describe LocationSessionsFactory do
           session =
             team.sessions.includes(:patients).find_by(location:, academic_year:)
           expect(session.patients).to include(patient_at_location)
-          expect(session.patients).to include(patient_at_school_location)
+          expect(session.patients).not_to include(patient_at_school_location)
         end
       end
     end

--- a/spec/models/cohort_import_spec.rb
+++ b/spec/models/cohort_import_spec.rb
@@ -395,15 +395,5 @@ describe CohortImport do
         expect { process! }.to change(session.patients, :count).from(0).to(2)
       end
     end
-
-    context "with a scheduled clinic session" do
-      let(:session) do
-        team.generic_clinic_session(academic_year: AcademicYear.current)
-      end
-
-      it "adds all the patients to the session" do
-        expect { process! }.to change(session.patients, :count).from(0).to(3)
-      end
-    end
   end
 end

--- a/spec/models/school_move_spec.rb
+++ b/spec/models/school_move_spec.rb
@@ -547,7 +547,6 @@ describe SchoolMove do
 
             include_examples "creates a log entry"
             include_examples "sets the patient school"
-            include_examples "keeps the patient in the community clinic"
             include_examples "adds the patient to the new school sessions"
             include_examples "destroys the school move"
           end
@@ -571,7 +570,6 @@ describe SchoolMove do
 
             include_examples "creates a log entry"
             include_examples "sets the patient school"
-            include_examples "keeps the patient in the community clinic"
             include_examples "adds the patient to the new school sessions"
             include_examples "destroys the school move"
           end
@@ -795,7 +793,6 @@ describe SchoolMove do
 
             include_examples "creates a log entry"
             include_examples "sets the patient school"
-            include_examples "keeps the patient in the community clinic"
             include_examples "adds the patient to the new school sessions"
             include_examples "destroys the school move"
           end
@@ -819,7 +816,6 @@ describe SchoolMove do
 
             include_examples "creates a log entry"
             include_examples "sets the patient school"
-            include_examples "keeps the patient in the community clinic"
             include_examples "adds the patient to the new school sessions"
             include_examples "destroys the school move"
           end


### PR DESCRIPTION
This updates the logic around school moves to not add patients in to the community clinic if they're assigned to a school. This is to reduce the number of patients who will exist in the community clinic session, to make it more useable, especially when it comes to flu where the total number of patients is high.

At the same time a button has been added that allows patients to be added individually to community clinics.

[Jira Issue - MAV-278](https://nhsd-jira.digital.nhs.uk/browse/MAV-278)
[Jira Issue - MAV-1430](https://nhsd-jira.digital.nhs.uk/browse/MAV-1430)

## Screenshots

<img width="786" height="548" alt="Screenshot 2025-08-06 at 19 14 09" src="https://github.com/user-attachments/assets/f53ed752-6025-4320-bb58-2e70a6b402dc" />
<img width="1198" height="166" alt="Screenshot 2025-08-06 at 19 13 53" src="https://github.com/user-attachments/assets/2c7b74c1-d704-42b0-9382-285de75b7606" />
<img width="818" height="507" alt="Screenshot 2025-08-06 at 19 13 49" src="https://github.com/user-attachments/assets/573965b0-ce14-421d-ad26-8be76e15bdf3" />
