### PR TITLE
Choose team when signing in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_user_location!
   before_action :authenticate_user!
-  before_action :set_selected_team
+  before_action :ensure_team_is_selected
   before_action :set_user_cis2_info
   before_action :set_disable_cache_headers
   before_action :set_header_path
@@ -35,18 +35,16 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  def current_organisation = current_user&.selected_organisation
+
   def current_team = current_user&.selected_team
 
-  helper_method :current_team
+  helper_method :current_organisation, :current_team
 
   private
 
-  def set_selected_team
-    return if Settings.cis2.enabled
-    return unless current_user
-    return if cis2_info.signed_in?
-
-    redirect_to new_users_teams_path
+  def ensure_team_is_selected
+    redirect_to new_users_teams_path if current_user && cis2_info.team.nil?
   end
 
   def set_header_path

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
   def set_selected_team
     return if Settings.cis2.enabled
     return unless current_user
-    return if session["cis2_info"].present?
+    return if cis2_info.signed_in?
 
     redirect_to new_users_teams_path
   end

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -12,11 +12,11 @@ module AuthenticationConcern
           store_location_for(:user, request.fullpath)
         end
 
-        if Settings.cis2.enabled || request.path != new_user_session_path
+        if cis2_enabled? || request.path != new_user_session_path
           flash[:info] = "You must be logged in to access this page."
           redirect_to start_path
         end
-      elsif cis2_session?
+      elsif cis2_enabled?
         if !selected_cis2_workgroup_is_valid?
           redirect_to users_workgroup_not_found_path
         elsif !selected_cis2_role_is_valid?
@@ -27,9 +27,9 @@ module AuthenticationConcern
       end
     end
 
-    def cis2_info = CIS2Info.new(request_session: session)
+    def cis2_enabled? = Settings.cis2.enabled
 
-    def cis2_session? = cis2_info.present?
+    def cis2_info = CIS2Info.new(request_session: session)
 
     def selected_cis2_org_is_registered?
       Organisation.exists?(ods_code: cis2_info.organisation_code)
@@ -76,7 +76,7 @@ module AuthenticationConcern
     end
 
     def user_signed_in?
-      super && (Settings.cis2.enabled ? cis2_session? : true)
+      super && (cis2_enabled? ? cis2_info.present? : true)
     end
 
     def set_user_cis2_info

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -22,7 +22,7 @@ module AuthenticationConcern
         elsif !selected_cis2_role_is_valid?
           redirect_to users_role_not_found_path
         elsif !selected_cis2_org_is_registered?
-          redirect_to users_team_not_found_path
+          redirect_to users_organisation_not_found_path
         end
       end
     end

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -17,12 +17,12 @@ module AuthenticationConcern
           redirect_to start_path
         end
       elsif cis2_enabled?
-        if !selected_cis2_workgroup_is_valid?
-          redirect_to users_workgroup_not_found_path
-        elsif !selected_cis2_role_is_valid?
+        if !selected_cis2_role_is_valid?
           redirect_to users_role_not_found_path
         elsif !selected_cis2_org_is_registered?
           redirect_to users_organisation_not_found_path
+        elsif !selected_cis2_workgroup_is_valid?
+          redirect_to users_workgroup_not_found_path
         end
       end
     end
@@ -36,7 +36,7 @@ module AuthenticationConcern
     end
 
     def selected_cis2_workgroup_is_valid?
-      cis2_info.has_workgroup?
+      cis2_info.has_valid_workgroup?
     end
 
     def selected_cis2_role_is_valid?

--- a/app/controllers/users/errors_controller.rb
+++ b/app/controllers/users/errors_controller.rb
@@ -7,7 +7,7 @@ class Users::ErrorsController < ::ApplicationController
 
   before_action :set_cis2_info
 
-  def team_not_found
+  def organisation_not_found
     if @cis2_info.present?
       render status: :not_found
     else

--- a/app/controllers/users/errors_controller.rb
+++ b/app/controllers/users/errors_controller.rb
@@ -5,9 +5,10 @@ class Users::ErrorsController < ::ApplicationController
   skip_before_action :authenticate_user!
   skip_after_action :verify_policy_scoped
 
+  before_action :set_cis2_info
+
   def team_not_found
-    if session.key? :cis2_info
-      @cis2_info = session[:cis2_info].with_indifferent_access
+    if @cis2_info.present?
       render status: :not_found
     else
       redirect_to root_path
@@ -15,8 +16,7 @@ class Users::ErrorsController < ::ApplicationController
   end
 
   def workgroup_not_found
-    if session.key? :cis2_info
-      @cis2_info = session[:cis2_info].with_indifferent_access
+    if @cis2_info.present?
       render status: :not_found
     else
       redirect_to root_path
@@ -24,11 +24,16 @@ class Users::ErrorsController < ::ApplicationController
   end
 
   def role_not_found
-    if session.key? :cis2_info
-      @cis2_info = session[:cis2_info].with_indifferent_access
+    if @cis2_info.present?
       render status: :not_found
     else
       redirect_to root_path
     end
+  end
+
+  private
+
+  def set_cis2_info
+    @cis2_info = CIS2Info.new(request_session: session)
   end
 end

--- a/app/controllers/users/errors_controller.rb
+++ b/app/controllers/users/errors_controller.rb
@@ -3,6 +3,7 @@
 class Users::ErrorsController < ::ApplicationController
   skip_before_action :store_user_location!
   skip_before_action :authenticate_user!
+  skip_before_action :ensure_team_is_selected
   skip_after_action :verify_policy_scoped
 
   before_action :set_cis2_info

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,6 +5,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   include CIS2LogoutConcern
 
   skip_before_action :authenticate_user!
+  skip_before_action :ensure_team_is_selected
   skip_after_action :verify_policy_scoped
   skip_before_action :verify_authenticity_token, only: [:cis2_logout]
   skip_before_action :authenticate_basic, only: [:cis2_logout]
@@ -21,7 +22,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     elsif !selected_cis2_org_is_registered?
       redirect_to users_organisation_not_found_path
     else
-      @user = User.find_or_create_from_cis2_oidc(user_cis2_info, teams)
+      @user = User.find_or_create_from_cis2_oidc(user_cis2_info, valid_teams)
 
       # Force is set to true because the `session_token` might have changed
       # even if the same user is logging in.
@@ -92,14 +93,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user_cis2_info["extra"]["raw_info"]
   end
 
-  def organisation
-    @organisation ||=
-      Organisation.find_by(ods_code: selected_cis2_org["org_code"])
-  end
-
-  def teams
-    # TODO: Select the right team based on the user's workgroup.
-    organisation.teams
+  def valid_teams
+    Team.joins(:organisation).where(
+      workgroup: selected_cis2_nrbac_role["workgroups"],
+      organisation: {
+        ods_code: selected_cis2_org["org_code"]
+      }
+    )
   end
 
   def set_cis2_session_info

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -103,18 +103,14 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def set_cis2_session_info
-    session["cis2_info"] = {
-      "selected_org" => {
-        "name" => selected_cis2_org["org_name"],
-        "code" => selected_cis2_org["org_code"]
-      },
-      "selected_role" => {
-        "name" => selected_cis2_nrbac_role["role_name"],
-        "code" => selected_cis2_nrbac_role["role_code"],
-        "workgroups" => selected_cis2_nrbac_role["workgroups"]
-      },
-      "has_other_roles" => raw_cis2_info["nhsid_nrbac_roles"].length > 1
-    }
+    cis2_info.update!(
+      organisation_name: selected_cis2_org["org_name"],
+      organisation_code: selected_cis2_org["org_code"],
+      role_name: selected_cis2_nrbac_role["role_name"],
+      role_code: selected_cis2_nrbac_role["role_code"],
+      workgroups: selected_cis2_nrbac_role["workgroups"],
+      has_other_roles: raw_cis2_info["nhsid_nrbac_roles"].length > 1
+    )
   end
 
   def after_omniauth_failure_path_for(_scope)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -19,7 +19,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     elsif !selected_cis2_role_is_valid?
       redirect_to users_role_not_found_path
     elsif !selected_cis2_org_is_registered?
-      redirect_to users_team_not_found_path
+      redirect_to users_organisation_not_found_path
     else
       @user = User.find_or_create_from_cis2_oidc(user_cis2_info, teams)
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -15,12 +15,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def cis2
     set_cis2_session_info
 
-    if !selected_cis2_workgroup_is_valid?
-      redirect_to users_workgroup_not_found_path
-    elsif !selected_cis2_role_is_valid?
+    if !selected_cis2_role_is_valid?
       redirect_to users_role_not_found_path
     elsif !selected_cis2_org_is_registered?
       redirect_to users_organisation_not_found_path
+    elsif !selected_cis2_workgroup_is_valid?
+      redirect_to users_workgroup_not_found_path
     else
       @user = User.find_or_create_from_cis2_oidc(user_cis2_info, valid_teams)
 

--- a/app/controllers/users/teams_controller.rb
+++ b/app/controllers/users/teams_controller.rb
@@ -9,14 +9,14 @@ class Users::TeamsController < ApplicationController
   layout "two_thirds"
 
   def new
-    @form = SelectTeamForm.new(current_user:)
+    @form = SelectTeamForm.new(cis2_info:, current_user:)
   end
 
   def create
     @form =
       SelectTeamForm.new(
+        cis2_info:,
         current_user:,
-        request_session: session,
         team_id: params.dig(:select_team_form, :team_id)
       )
 

--- a/app/controllers/users/teams_controller.rb
+++ b/app/controllers/users/teams_controller.rb
@@ -9,6 +9,12 @@ class Users::TeamsController < ApplicationController
 
   def new
     @form = SelectTeamForm.new(cis2_info:, current_user:)
+
+    if @form.teams.count == 1
+      @form.team_id = @form.teams.first.id
+
+      redirect_to return_to_path if @form.save
+    end
   end
 
   def create
@@ -20,9 +26,15 @@ class Users::TeamsController < ApplicationController
       )
 
     if @form.save
-      redirect_to session[:user_return_to] || dashboard_path
+      redirect_to return_to_path
     else
       render :new, status: :unprocessable_content
     end
+  end
+
+  private
+
+  def return_to_path
+    session[:user_return_to] || dashboard_path
   end
 end

--- a/app/controllers/users/teams_controller.rb
+++ b/app/controllers/users/teams_controller.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 class Users::TeamsController < ApplicationController
-  skip_before_action :set_selected_team
+  skip_before_action :store_user_location!
+  skip_before_action :ensure_team_is_selected
   skip_after_action :verify_policy_scoped
-
-  before_action :redirect_to_dashboard_if_cis2_is_enabled
 
   layout "two_thirds"
 
@@ -21,15 +20,9 @@ class Users::TeamsController < ApplicationController
       )
 
     if @form.save
-      redirect_to dashboard_path
+      redirect_to session[:user_return_to] || dashboard_path
     else
       render :new, status: :unprocessable_content
     end
-  end
-
-  private
-
-  def redirect_to_dashboard_if_cis2_is_enabled
-    redirect_to dashboard_path if Settings.cis2.enabled
   end
 end

--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -21,7 +21,7 @@ class SelectTeamForm
       cis2_info.update!(
         organisation_code: team.organisation.ods_code,
         role_code: CIS2Info::NURSE_ROLE,
-        workgroups: [CIS2Info::WORKGROUP] + [team.workgroup]
+        workgroups: [team.workgroup]
       )
     end
 

--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -29,11 +29,12 @@ class SelectTeamForm
   end
 
   def teams
-    if Settings.cis2.enabled
-      cis2_info.organisation.teams.where(workgroup: cis2_info.workgroups)
-    else
-      current_user.teams
-    end
+    @teams ||=
+      if Settings.cis2.enabled
+        cis2_info.organisation.teams.where(workgroup: cis2_info.workgroups)
+      else
+        current_user.teams.includes(:organisation)
+      end
   end
 
   private

--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -4,7 +4,7 @@ class SelectTeamForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :current_user, :request_session
+  attr_accessor :cis2_info, :current_user
 
   attribute :team_id, :integer
 
@@ -13,16 +13,12 @@ class SelectTeamForm
   def save
     return false if invalid?
 
-    request_session["cis2_info"] = {
-      "selected_org" => {
-        "name" => team.name,
-        "code" => organisation.ods_code
-      },
-      "selected_role" => {
-        "code" => User::CIS2_NURSE_ROLE,
-        "workgroups" => [User::CIS2_WORKGROUP]
-      }
-    }
+    cis2_info.update!(
+      organisation_name: team.name,
+      organisation_code: organisation.ods_code,
+      role_code: CIS2Info::NURSE_ROLE,
+      workgroups: [CIS2Info::WORKGROUP]
+    )
 
     true
   end

--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -13,21 +13,30 @@ class SelectTeamForm
   def save
     return false if invalid?
 
-    cis2_info.update!(
-      organisation_name: team.name,
-      organisation_code: organisation.ods_code,
-      role_code: CIS2Info::NURSE_ROLE,
-      workgroups: [CIS2Info::WORKGROUP]
-    )
+    team = teams.find(team_id)
+
+    cis2_info.update!(team_workgroup: team.workgroup)
+
+    unless Settings.cis2.enabled
+      cis2_info.update!(
+        organisation_code: team.organisation.ods_code,
+        role_code: CIS2Info::NURSE_ROLE,
+        workgroups: [CIS2Info::WORKGROUP] + [team.workgroup]
+      )
+    end
 
     true
   end
 
+  def teams
+    if Settings.cis2.enabled
+      cis2_info.organisation.teams.where(workgroup: cis2_info.workgroups)
+    else
+      current_user.teams
+    end
+  end
+
   private
 
-  def team = current_user.teams.includes(:organisation).find(team_id)
-
-  delegate :organisation, to: :team
-
-  def team_id_values = current_user.teams.pluck(:id)
+  def team_id_values = teams.pluck(:id)
 end

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -14,6 +14,7 @@ class CIS2Info
   attribute :role_name
   attribute :role_code
   attribute :workgroups, array: true
+  attribute :team_workgroup
   attribute :has_other_roles, :boolean
 
   def present? = attributes.compact_blank.present?
@@ -22,6 +23,14 @@ class CIS2Info
     @organisation ||=
       if (ods_code = organisation_code).present?
         Organisation.find_by(ods_code:)
+      end
+  end
+
+  def team
+    @team ||=
+      if (workgroup = team_workgroup).present? &&
+           workgroups&.include?(workgroup)
+        Team.find_by(organisation:, workgroup:)
       end
   end
 

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -6,7 +6,6 @@ class CIS2Info
   NURSE_ROLE = "S8000:G8000:R8001"
   ADMIN_ROLE = "S8000:G8001:R8006"
 
-  WORKGROUP = "schoolagedimmunisations"
   SUPERUSER_WORKGROUP = "mavissuperusers"
 
   attribute :organisation_name
@@ -34,7 +33,8 @@ class CIS2Info
       end
   end
 
-  def has_workgroup? = workgroups&.include?(WORKGROUP) || false
+  def has_valid_workgroup? =
+    organisation&.teams&.exists?(workgroup: workgroups) || false
 
   def is_admin? = role_code == ADMIN_ROLE
 

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class CIS2Info
+  include RequestSessionPersistable
+
+  NURSE_ROLE = "S8000:G8000:R8001"
+  ADMIN_ROLE = "S8000:G8001:R8006"
+
+  WORKGROUP = "schoolagedimmunisations"
+  SUPERUSER_WORKGROUP = "mavissuperusers"
+
+  attribute :organisation_name
+  attribute :organisation_code
+  attribute :role_name
+  attribute :role_code
+  attribute :workgroups, array: true
+  attribute :has_other_roles, :boolean
+
+  def present? = attributes.compact_blank.present?
+
+  def organisation
+    @organisation ||=
+      if (ods_code = organisation_code).present?
+        Organisation.find_by(ods_code:)
+      end
+  end
+
+  def has_workgroup? = workgroups&.include?(WORKGROUP) || false
+
+  def is_admin? = role_code == ADMIN_ROLE
+
+  def is_nurse? = role_code == NURSE_ROLE
+
+  def is_superuser? = workgroups&.include?(SUPERUSER_WORKGROUP) || false
+
+  # TODO: How do we determine this from CIS2?
+  def is_healthcare_assistant? = false
+
+  private
+
+  def request_session_key = "cis2_info"
+
+  def reset_unused_fields
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,7 @@ class User < ApplicationRecord
   end
 
   has_and_belongs_to_many :teams
+  has_many :organisations, -> { distinct }, through: :teams
 
   has_many :programmes, through: :teams
 
@@ -101,13 +102,7 @@ class User < ApplicationRecord
 
   def selected_organisation = cis2_info.organisation
 
-  def selected_team
-    # TODO: Select the right team based on the user's workgroup.
-    @selected_team ||=
-      Team.includes(:location_programme_year_groups, :programmes).find_by(
-        organisation: selected_organisation
-      )
-  end
+  def selected_team = cis2_info.team
 
   def requires_email_and_password?
     provider.blank? || uid.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,11 +32,6 @@
 class User < ApplicationRecord
   include FullNameConcern
 
-  CIS2_NURSE_ROLE = "S8000:G8000:R8001"
-  CIS2_ADMIN_ROLE = "S8000:G8001:R8006"
-
-  CIS2_WORKGROUP = "schoolagedimmunisations"
-
   attr_accessor :cis2_info
 
   if Settings.cis2.enabled
@@ -104,12 +99,7 @@ class User < ApplicationRecord
     end
   end
 
-  def selected_organisation
-    @selected_organisation ||=
-      if cis2_info.present?
-        Organisation.find_by(ods_code: cis2_info.dig("selected_org", "code"))
-      end
-  end
+  def selected_organisation = cis2_info.organisation
 
   def selected_team
     # TODO: Select the right team based on the user's workgroup.
@@ -124,31 +114,27 @@ class User < ApplicationRecord
   end
 
   def is_admin?
-    if Settings.cis2.enabled
-      cis2_info.dig("selected_role", "code")&.ends_with?("R8006")
+    if cis2_enabled?
+      cis2_info.is_admin?
     else
       fallback_role_admin? || fallback_role_superuser?
     end
   end
 
   def is_nurse?
-    return fallback_role_nurse? unless Settings.cis2.enabled
-
-    cis2_info.dig("selected_role", "code")&.ends_with?("R8001")
+    cis2_enabled? ? cis2_info.is_nurse? : fallback_role_nurse?
   end
 
   def is_superuser?
-    return fallback_role_superuser? unless Settings.cis2.enabled
-
-    cis2_info.dig("selected_role", "workgroups")&.include?("mavissuperusers") ||
-      false
+    cis2_enabled? ? cis2_info.is_superuser? : fallback_role_superuser?
   end
 
   def is_healthcare_assistant?
-    # TODO: How do we determine this from CIS2?
-    return false if Settings.cis2.enabled
-
-    fallback_role_healthcare_assistant?
+    if cis2_enabled?
+      cis2_info.is_healthcare_assistant?
+    else
+      fallback_role_healthcare_assistant?
+    end
   end
 
   def role_description
@@ -173,6 +159,8 @@ class User < ApplicationRecord
   end
 
   private
+
+  def cis2_enabled? = Settings.cis2.enabled
 
   def fhir_mapper = @fhir_mapper ||= FHIRMapper::User.new(self)
 end

--- a/app/views/users/errors/organisation_not_found.html.erb
+++ b/app/views/users/errors/organisation_not_found.html.erb
@@ -1,7 +1,7 @@
-<%= h1 "Your team is not using this service yet" %>
+<%= h1 "Your organisation is not using this service yet" %>
 
 <p>
-  The following team is not currently set up to use Mavis:
+  The following organisation is not currently set up to use Mavis:
 </p>
 
 <%= govuk_inset_text do %>
@@ -9,7 +9,7 @@
   (<%= @cis2_info.organisation_code %>)
 <% end %>
 
-<p>You'll be able to use Mavis once your team has been onboarded.</p>
+<p>You'll be able to use Mavis once your organisation has been onboarded.</p>
 
 <% if @cis2_info.has_other_roles %>
   <%= govuk_button_to "Change role", user_cis2_omniauth_authorize_path, params: { change_role: true } %>

--- a/app/views/users/errors/role_not_found.html.erb
+++ b/app/views/users/errors/role_not_found.html.erb
@@ -1,6 +1,6 @@
 <%= h1 "You do not have permission to use this service" %>
 
-<% if @cis2_info[:has_other_roles] %>
+<% if @cis2_info.has_other_roles %>
   <%= govuk_button_to "Change role", user_cis2_omniauth_authorize_path, params: { change_role: true } %>
 <% end %>
 
@@ -12,8 +12,8 @@
 </p>
 
 <%= govuk_inset_text do %>
-  <%= @cis2_info[:selected_org][:name] %><br />
-  (<%= @cis2_info[:selected_org][:code] %>)
+  <%= @cis2_info.organisation_name %><br />
+  (<%= @cis2_info.organisation_code %>)
 <% end %>
 
 <p>

--- a/app/views/users/errors/team_not_found.html.erb
+++ b/app/views/users/errors/team_not_found.html.erb
@@ -5,12 +5,12 @@
 </p>
 
 <%= govuk_inset_text do %>
-  <%= @cis2_info[:selected_org][:name] %><br />
-  (<%= @cis2_info[:selected_org][:code] %>)
+  <%= @cis2_info.organisation_name %><br />
+  (<%= @cis2_info.organisation_code %>)
 <% end %>
 
 <p>You'll be able to use Mavis once your team has been onboarded.</p>
 
-<% if @cis2_info[:has_other_roles] %>
+<% if @cis2_info.has_other_roles %>
   <%= govuk_button_to "Change role", user_cis2_omniauth_authorize_path, params: { change_role: true } %>
 <% end %>

--- a/app/views/users/errors/workgroup_not_found.html.erb
+++ b/app/views/users/errors/workgroup_not_found.html.erb
@@ -3,7 +3,7 @@
 <h2 class="nhsuk-heading-m">Contact your registration authority</h2>
 
 <p>
-  You need to belong to ‘<em><%= CIS2Info::WORKGROUP %></em>’ to use Mavis. If you think you should be in this workgroup, ask your registration authority to add you.
+  You need to belong to a workgroup to use Mavis. If you think you should be in the workgroup, ask your registration authority to add you.
 </p>
 
 <% if @cis2_info.has_other_roles %>

--- a/app/views/users/errors/workgroup_not_found.html.erb
+++ b/app/views/users/errors/workgroup_not_found.html.erb
@@ -3,9 +3,9 @@
 <h2 class="nhsuk-heading-m">Contact your registration authority</h2>
 
 <p>
-  You need to belong to ‘<em>schoolagedimmunisations</em>’ to use Mavis. If you think you should be in this workgroup, ask your registration authority to add you.
+  You need to belong to ‘<em><%= CIS2Info::WORKGROUP %></em>’ to use Mavis. If you think you should be in this workgroup, ask your registration authority to add you.
 </p>
 
-<% if @cis2_info[:has_other_roles] %>
+<% if @cis2_info.has_other_roles %>
   <%= govuk_button_to "Change role", user_cis2_omniauth_authorize_path, params: { change_role: true } %>
 <% end %>

--- a/app/views/users/teams/new.html.erb
+++ b/app/views/users/teams/new.html.erb
@@ -6,10 +6,9 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :team_id,
-                                       current_user.teams.includes(:organisation),
+                                       @form.teams,
                                        :id,
                                        :name,
-                                       -> { _1.organisation.ods_code },
                                        legend: { text: legend, size: "xl", tag: "h1" } %>
 
   <%= f.govuk_submit %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -310,7 +310,7 @@ Rails.application.routes.draw do
   end
 
   namespace :users do
-    get "team-not-found", controller: :errors
+    get "organisation-not-found", controller: :errors
     get "workgroup-not-found", controller: :errors
     get "role-not-found", controller: :errors
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -40,17 +40,18 @@ FactoryBot.define do
             uploaded_by
           ] do
     transient do
-      team { Team.first || create(:team) }
+      team { Team.includes(:organisation).first || create(:team) }
 
       role_code { CIS2Info::NURSE_ROLE }
       role_workgroups { [CIS2Info::WORKGROUP] }
 
       cis2_info_hash do
         {
-          "organisation_name" => team.name,
           "organisation_code" => team.organisation.ods_code,
+          "organisation_name" => team.name,
           "role_code" => role_code,
-          "workgroups" => role_workgroups
+          "team_workgroup" => team.workgroup,
+          "workgroups" => (role_workgroups || []) + [team.workgroup]
         }
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -42,21 +42,15 @@ FactoryBot.define do
     transient do
       team { Team.first || create(:team) }
 
-      selected_role_code { User::CIS2_NURSE_ROLE }
-      selected_role_name { "Nurse Access Role" }
-      selected_role_workgroups { %w[schoolagedimmunisations] }
+      role_code { CIS2Info::NURSE_ROLE }
+      role_workgroups { [CIS2Info::WORKGROUP] }
 
       cis2_info_hash do
         {
-          "selected_org" => {
-            "name" => team.name,
-            "code" => team.organisation.ods_code
-          },
-          "selected_role" => {
-            "name" => selected_role_name,
-            "code" => selected_role_code,
-            "workgroups" => selected_role_workgroups
-          }
+          "organisation_name" => team.name,
+          "organisation_code" => team.organisation.ods_code,
+          "role_code" => role_code,
+          "workgroups" => role_workgroups
         }
       end
     end
@@ -73,18 +67,22 @@ FactoryBot.define do
     # password { "power overwhelming!" }
 
     provider { Settings.cis2.enabled ? "cis2" : nil }
-    sequence(:uid) { Settings.cis2.enabled ? _1.to_s : nil }
-    cis2_info { Settings.cis2.enabled ? cis2_info_hash : nil }
+    sequence(:uid) { Settings.cis2.enabled ? it.to_s : nil }
+
+    cis2_info do
+      if Settings.cis2.enabled
+        CIS2Info.new(request_session: { "cis2_info" => cis2_info_hash })
+      end
+    end
 
     trait :admin do
-      selected_role_code { "S8000:G8001:R8006" }
-      selected_role_name { "Medical Secretary Access Role" }
+      role_code { CIS2Info::ADMIN_ROLE }
       sequence(:email) { |n| "admin-#{n}@example.com" }
       fallback_role { :admin }
     end
 
     trait :superuser do
-      selected_role_workgroups { %w[schoolagedimmunisations mavissuperusers] }
+      role_workgroups { [CIS2Info::WORKGROUP, CIS2Info::SUPERUSER_WORKGROUP] }
       fallback_role { :superuser }
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
       team { Team.includes(:organisation).first || create(:team) }
 
       role_code { CIS2Info::NURSE_ROLE }
-      role_workgroups { [CIS2Info::WORKGROUP] }
+      role_workgroups { [] }
 
       cis2_info_hash do
         {
@@ -83,7 +83,7 @@ FactoryBot.define do
     end
 
     trait :superuser do
-      role_workgroups { [CIS2Info::WORKGROUP, CIS2Info::SUPERUSER_WORKGROUP] }
+      role_workgroups { [CIS2Info::SUPERUSER_WORKGROUP] }
       fallback_role { :superuser }
     end
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -184,7 +184,7 @@ describe "End-to-end journey" do
   end
 
   def when_i_register_verbal_consent_and_triage
-    click_link "Sessions"
+    click_link "Sessions", match: :first
     click_link "Pilot School"
     click_link "Register"
     click_link "TABLES, Bobby"

--- a/spec/features/manage_clinic_sessions_spec.rb
+++ b/spec/features/manage_clinic_sessions_spec.rb
@@ -5,6 +5,7 @@ describe "Manage clinic sessions" do
 
   scenario "Adding dates to the session, sending reminders and closing consent" do
     given_my_team_is_running_an_hpv_vaccination_programme
+    and_i_am_signed_in
 
     when_i_go_to_todays_sessions_as_a_nurse
     then_i_see_no_sessions
@@ -59,6 +60,7 @@ describe "Manage clinic sessions" do
 
     when_the_deadline_has_passed
     then_they_can_no_longer_give_consent
+    and_i_am_signed_in
 
     when_i_go_to_todays_sessions_as_a_nurse
     and_i_go_to_completed_sessions
@@ -83,8 +85,11 @@ describe "Manage clinic sessions" do
       create(:patient, year_group: 8, session: @session, parents: [@parent])
   end
 
-  def when_i_go_to_todays_sessions_as_a_nurse
+  def and_i_am_signed_in
     sign_in @team.users.first
+  end
+
+  def when_i_go_to_todays_sessions_as_a_nurse
     visit "/dashboard"
 
     click_link "Sessions", match: :first

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -5,6 +5,7 @@ describe "Manage school sessions" do
 
   scenario "Adding a new session, closing consent, and closing the session" do
     given_my_team_is_running_an_hpv_vaccination_programme
+    and_i_am_signed_in
 
     when_i_go_to_todays_sessions_as_a_nurse
     then_i_see_no_sessions
@@ -57,6 +58,7 @@ describe "Manage school sessions" do
 
     when_the_deadline_has_passed
     then_they_can_no_longer_give_consent
+    and_i_am_signed_in
 
     when_i_go_to_todays_sessions_as_a_nurse
     and_i_go_to_completed_sessions
@@ -105,8 +107,11 @@ describe "Manage school sessions" do
     clinic_session.save!
   end
 
-  def when_i_go_to_todays_sessions_as_a_nurse
+  def and_i_am_signed_in
     sign_in @team.users.first
+  end
+
+  def when_i_go_to_todays_sessions_as_a_nurse
     visit "/dashboard"
 
     click_link "Sessions", match: :first

--- a/spec/features/parental_consent_spec.rb
+++ b/spec/features/parental_consent_spec.rb
@@ -7,6 +7,8 @@ describe "Parental consent" do
     stub_pds_search_to_return_no_patients
 
     given_an_hpv_programme_is_underway
+    and_i_am_signed_in
+
     when_a_nurse_checks_consent_responses
     then_there_should_be_no_consent_for_my_child
 
@@ -44,8 +46,11 @@ describe "Parental consent" do
     @child = create(:patient, :consent_no_response, session: @session)
   end
 
-  def when_a_nurse_checks_consent_responses
+  def and_i_am_signed_in
     sign_in @team.users.first
+  end
+
+  def when_a_nurse_checks_consent_responses
     visit "/dashboard"
 
     click_on "Programmes", match: :first
@@ -143,7 +148,6 @@ describe "Parental consent" do
   end
 
   def when_the_nurse_checks_the_consent_responses
-    sign_in @team.users.first
     visit "/dashboard"
 
     click_on "Programmes", match: :first

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -5,6 +5,7 @@ describe "Triage" do
     given_a_programme_with_a_running_session
     and_a_patient_who_needs_triage_exists
     and_a_patient_who_doesnt_need_triage_exists
+    and_i_am_signed_in
 
     when_i_go_to_the_session_triage_tab
     then_i_see_the_patient_who_needs_triage
@@ -33,6 +34,7 @@ describe "Triage" do
   scenario "nurse can triage patients for a flu programme with different consent types" do
     given_a_flu_programme_with_a_running_session
     and_patients_with_different_flu_consent_types_exist
+    and_i_am_signed_in
 
     when_i_go_to_the_session_triage_tab
     then_i_see_both_patients_who_need_triage
@@ -138,9 +140,12 @@ describe "Triage" do
       ).patient
   end
 
-  def when_i_go_to_the_session_triage_tab
+  def and_i_am_signed_in
     @user = @team.users.first
     sign_in @user
+  end
+
+  def when_i_go_to_the_session_triage_tab
     visit session_triage_path(@session)
   end
 

--- a/spec/features/user_cis2_authentication_from_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_from_redirect_spec.rb
@@ -7,7 +7,6 @@ describe "User CIS2 authentication" do
     then_i_am_on_the_start_page
 
     when_i_click_the_cis2_login_button
-    and_i_choose_my_team
     then_i_see_the_sessions_page
     and_i_am_logged_in
   end
@@ -36,11 +35,6 @@ describe "User CIS2 authentication" do
 
   def when_i_click_the_cis2_login_button
     click_button "Care Identity"
-  end
-
-  def and_i_choose_my_team
-    choose @team.name
-    click_button "Continue"
   end
 
   def then_i_see_the_sessions_page

--- a/spec/features/user_cis2_authentication_from_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_from_redirect_spec.rb
@@ -1,25 +1,28 @@
 # frozen_string_literal: true
 
 describe "User CIS2 authentication" do
-  scenario "with redirect" do
+  scenario "from redirect" do
     given_a_test_team_is_setup_in_mavis_and_cis2
     when_i_go_to_the_sessions_page
     then_i_am_on_the_start_page
 
     when_i_click_the_cis2_login_button
+    and_i_choose_my_team
     then_i_see_the_sessions_page
     and_i_am_logged_in
   end
 
   def given_a_test_team_is_setup_in_mavis_and_cis2
-    @team = create :team
+    @user = create(:user, uid: "123")
+    @team = create(:team, users: [@user])
 
     mock_cis2_auth(
       uid: "123",
       given_name: "Nurse",
       family_name: "Test",
       org_code: @team.organisation.ods_code,
-      org_name: @team.name
+      org_name: @team.name,
+      workgroups: [CIS2Info::WORKGROUP, @team.workgroup]
     )
   end
 
@@ -35,8 +38,13 @@ describe "User CIS2 authentication" do
     click_button "Care Identity"
   end
 
+  def and_i_choose_my_team
+    choose @team.name
+    click_button "Continue"
+  end
+
   def then_i_see_the_sessions_page
-    expect(page).to have_current_path sessions_path
+    expect(page).to have_current_path(sessions_path)
   end
 
   def and_i_am_logged_in

--- a/spec/features/user_cis2_authentication_from_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_from_redirect_spec.rb
@@ -21,7 +21,7 @@ describe "User CIS2 authentication" do
       family_name: "Test",
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      workgroups: [CIS2Info::WORKGROUP, @team.workgroup]
+      workgroups: [@team.workgroup]
     )
   end
 

--- a/spec/features/user_cis2_authentication_from_start_page_spec.rb
+++ b/spec/features/user_cis2_authentication_from_start_page_spec.rb
@@ -28,7 +28,7 @@ describe "User CIS2 authentication", :cis2 do
       family_name: "Test",
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      workgroups: [CIS2Info::WORKGROUP, @team.workgroup]
+      workgroups: [@team.workgroup]
     )
   end
 

--- a/spec/features/user_cis2_authentication_from_start_page_spec.rb
+++ b/spec/features/user_cis2_authentication_from_start_page_spec.rb
@@ -7,7 +7,7 @@ describe "User CIS2 authentication", :cis2 do
     then_i_should_see_the_cis2_login_button
 
     when_i_click_the_cis2_login_button
-    then_i_see_the_dashboard
+    and_i_choose_my_team
     and_i_am_logged_in
     and_i_am_added_to_the_team
 
@@ -19,26 +19,17 @@ describe "User CIS2 authentication", :cis2 do
     and_i_am_logged_out
   end
 
-  scenario "going straight to the sessions page" do
-    given_a_test_team_is_setup_in_mavis_and_cis2
-    when_i_go_to_the_sessions_page
-    then_i_am_on_the_start_page
-
-    when_i_click_the_cis2_login_button
-    then_i_see_the_sessions_page
-    and_i_am_logged_in
-    and_i_am_added_to_the_team
-  end
-
   def given_a_test_team_is_setup_in_mavis_and_cis2
-    @team = create :team
+    @user = create(:user, uid: "123")
+    @team = create(:team, users: [@user])
 
     mock_cis2_auth(
       uid: "123",
       given_name: "Nurse",
       family_name: "Test",
       org_code: @team.organisation.ods_code,
-      org_name: @team.name
+      org_name: @team.name,
+      workgroups: [CIS2Info::WORKGROUP, @team.workgroup]
     )
   end
 
@@ -52,6 +43,11 @@ describe "User CIS2 authentication", :cis2 do
 
   def when_i_click_the_cis2_login_button
     click_button "Care Identity"
+  end
+
+  def and_i_choose_my_team
+    choose @team.name
+    click_button "Continue"
   end
 
   def then_i_see_the_dashboard
@@ -84,13 +80,5 @@ describe "User CIS2 authentication", :cis2 do
   def and_i_am_logged_out
     expect(page).not_to have_content("TEST, Nurse")
     expect(page).not_to have_button("Log out")
-  end
-
-  def when_i_go_to_the_sessions_page
-    visit sessions_path
-  end
-
-  def then_i_see_the_sessions_page
-    expect(page).to have_current_path sessions_path
   end
 end

--- a/spec/features/user_cis2_authentication_from_start_page_spec.rb
+++ b/spec/features/user_cis2_authentication_from_start_page_spec.rb
@@ -7,7 +7,6 @@ describe "User CIS2 authentication", :cis2 do
     then_i_should_see_the_cis2_login_button
 
     when_i_click_the_cis2_login_button
-    and_i_choose_my_team
     and_i_am_logged_in
     and_i_am_added_to_the_team
 
@@ -43,11 +42,6 @@ describe "User CIS2 authentication", :cis2 do
 
   def when_i_click_the_cis2_login_button
     click_button "Care Identity"
-  end
-
-  def and_i_choose_my_team
-    choose @team.name
-    click_button "Continue"
   end
 
   def then_i_see_the_dashboard

--- a/spec/features/user_cis2_authentication_select_team_spec.rb
+++ b/spec/features/user_cis2_authentication_select_team_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe "User CIS2 authentication", :cis2 do
+  scenario "select a team" do
+    given_an_organisation_exists_with_multiple_teams
+    and_i_belong_to_the_teams
+
+    when_i_sign_in
+    then_i_am_required_to_select_a_team
+
+    when_i_choose_a_team
+    then_i_am_logged_in
+  end
+
+  def given_an_organisation_exists_with_multiple_teams
+    @organisation = create(:organisation, ods_code: "ABC")
+    @teams = create_list(:team, 3, organisation: @organisation)
+  end
+
+  def and_i_belong_to_the_teams
+    @user = create(:nurse, teams: @teams)
+  end
+
+  def when_i_sign_in
+    sign_in @user
+  end
+
+  def then_i_am_required_to_select_a_team
+    expect(page).to have_content("Select a team")
+  end
+
+  def when_i_choose_a_team
+    choose @teams.sample.name
+    click_on "Continue"
+  end
+
+  def then_i_am_logged_in
+    expect(page).to have_content("USER, Test")
+    expect(page).to have_button("Log out")
+  end
+end

--- a/spec/features/user_cis2_authentication_with_empty_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_empty_role_spec.rb
@@ -6,11 +6,11 @@ describe "User CIS2 authentication", :cis2 do
     when_i_go_to_the_sessions_page
     then_i_am_on_the_start_page
     when_i_click_the_cis2_login_button
-    then_i_see_the_wrong_workgroup_error
+    then_i_see_the_wrong_role_error
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_an_empty_role
-    @team = create :team, ods_code: "AB12"
+    @team = create(:team, ods_code: "AB12")
 
     mock_cis2_auth(selected_roleid: "")
   end
@@ -20,7 +20,7 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def then_i_am_on_the_start_page
-    expect(page).to have_current_path start_path
+    expect(page).to have_current_path(start_path)
   end
 
   def when_i_go_to_the_sessions_page
@@ -28,12 +28,12 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def then_i_see_the_sessions_page
-    expect(page).to have_current_path sessions_path
+    expect(page).to have_current_path(sessions_path)
   end
 
-  def then_i_see_the_wrong_workgroup_error
-    expect(
-      page
-    ).to have_heading "You’re not in the right workgroup to use this service"
+  def then_i_see_the_wrong_role_error
+    expect(page).to have_heading(
+      "You do not have permission to use this service"
+    )
   end
 end

--- a/spec/features/user_cis2_authentication_with_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_with_redirect_spec.rb
@@ -44,16 +44,14 @@ describe "User CIS2 authentication" do
     expect(page).to have_button("Log out")
   end
 
-  def then_i_see_the_team_not_found_error
-    expect(page).to have_heading("Your team is not using this service yet")
-  end
-
   def when_i_click_the_change_role_button
     click_button "Change role"
   end
 
-  def then_i_see_the_team_not_found_error
-    expect(page).to have_heading "Your team is not using this service yet"
+  def then_i_see_the_organisation_not_found_error
+    expect(page).to have_heading(
+      "Your organisation is not using this service yet"
+    )
   end
 
   def and_there_is_no_change_role_button

--- a/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
@@ -11,7 +11,7 @@ describe "User CIS2 authentication" do
 
     given_my_team_has_been_setup_in_mavis
     when_i_click_the_change_role_button
-    then_i_see_the_team_selection_page
+    then_i_see_the_sessions_page
   end
 
   context "user has no other orgs to select" do
@@ -31,19 +31,19 @@ describe "User CIS2 authentication" do
   end
 
   def given_i_am_setup_in_cis2_but_not_mavis
-    mock_cis2_auth(org_code: "A9A5A", org_name: "SAIS Team")
+    mock_cis2_auth(
+      org_code: "A9A5A",
+      org_name: "SAIS Team",
+      workgroups: %w[a9a5a]
+    )
   end
 
   def given_my_team_has_been_setup_in_mavis
-    @team = create :team, ods_code: "A9A5A"
+    @team = create(:team, ods_code: "A9A5A", workgroup: "a9a5a")
   end
 
   def when_i_go_to_the_start_page
     visit "/start"
-  end
-
-  def when_i_click_the_cis2_login_button
-    click_button "Care Identity"
   end
 
   def when_i_click_the_cis2_login_button
@@ -58,8 +58,8 @@ describe "User CIS2 authentication" do
     visit sessions_path
   end
 
-  def then_i_see_the_team_selection_page
-    expect(page).to have_current_path(new_users_teams_path)
+  def then_i_see_the_sessions_page
+    expect(page).to have_current_path(sessions_path)
   end
 
   def given_i_am_setup_in_cis2_with_only_one_role

--- a/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe "User CIS2 authentication" do
-  scenario "user has wrong team selected" do
+  scenario "user has wrong organisation selected" do
     given_i_am_setup_in_cis2_but_not_mavis
     when_i_go_to_the_sessions_page
     then_i_am_on_the_start_page
@@ -11,11 +11,11 @@ describe "User CIS2 authentication" do
 
     given_my_team_has_been_setup_in_mavis
     when_i_click_the_change_role_button
-    then_i_see_the_sessions_page
+    then_i_see_the_team_selection_page
   end
 
   context "user has no other orgs to select" do
-    scenario "user has wrong team selected" do
+    scenario "user has wrong organisation selected" do
       given_i_am_setup_in_cis2_with_only_one_role
       when_i_go_to_the_start_page
       then_i_should_see_the_cis2_login_button
@@ -58,8 +58,8 @@ describe "User CIS2 authentication" do
     visit sessions_path
   end
 
-  def then_i_see_the_sessions_page
-    expect(page).to have_current_path sessions_path
+  def then_i_see_the_team_selection_page
+    expect(page).to have_current_path(new_users_teams_path)
   end
 
   def given_i_am_setup_in_cis2_with_only_one_role

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -9,7 +9,7 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_role_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_sessions_page
+    then_i_see_the_team_selection_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
@@ -30,14 +30,14 @@ describe "User CIS2 authentication", :cis2 do
     visit sessions_path
   end
 
-  def then_i_see_the_sessions_page
-    expect(page).to have_current_path sessions_path
+  def then_i_see_the_team_selection_page
+    expect(page).to have_current_path(new_users_teams_path)
   end
 
   def then_i_see_the_wrong_role_error
-    expect(
-      page
-    ).to have_heading "You do not have permission to use this service"
+    expect(page).to have_heading(
+      "You do not have permission to use this service"
+    )
   end
 
   def when_i_click_the_change_role_button_and_select_the_right_role

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -6,7 +6,7 @@ describe "User CIS2 authentication", :cis2 do
     when_i_go_to_the_sessions_page
     then_i_am_on_the_start_page
     when_i_click_the_cis2_login_button
-    then_i_see_the_team_not_found_error
+    then_i_see_the_wrong_role_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
     then_i_see_the_sessions_page
@@ -34,7 +34,7 @@ describe "User CIS2 authentication", :cis2 do
     expect(page).to have_current_path sessions_path
   end
 
-  def then_i_see_the_team_not_found_error
+  def then_i_see_the_wrong_role_error
     expect(
       page
     ).to have_heading "You do not have permission to use this service"

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -9,13 +9,13 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_role_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_team_selection_page
+    then_i_see_the_session_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
     @team = create(:team, ods_code: "AB12")
 
-    mock_cis2_auth(selected_roleid: "wrong-role")
+    mock_cis2_auth(selected_roleid: "wrong-role", workgroups: [@team.workgroup])
   end
 
   def when_i_click_the_cis2_login_button
@@ -30,8 +30,8 @@ describe "User CIS2 authentication", :cis2 do
     visit sessions_path
   end
 
-  def then_i_see_the_team_selection_page
-    expect(page).to have_current_path(new_users_teams_path)
+  def then_i_see_the_session_page
+    expect(page).to have_current_path(sessions_path)
   end
 
   def then_i_see_the_wrong_role_error
@@ -46,7 +46,8 @@ describe "User CIS2 authentication", :cis2 do
     mock_cis2_auth(
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      role: :nurse
+      role: :nurse,
+      workgroups: [@team.workgroup]
     )
     click_button "Change role"
   end

--- a/spec/features/user_cis2_authentication_with_wrong_team_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_team_spec.rb
@@ -7,7 +7,7 @@ describe "User CIS2 authentication" do
     then_i_am_on_the_start_page
 
     when_i_click_the_cis2_login_button
-    then_i_see_the_team_not_found_error
+    then_i_see_the_organisation_not_found_error
 
     given_my_team_has_been_setup_in_mavis
     when_i_click_the_change_role_button
@@ -21,7 +21,7 @@ describe "User CIS2 authentication" do
       then_i_should_see_the_cis2_login_button
 
       when_i_click_the_cis2_login_button
-      then_i_see_the_team_not_found_error
+      then_i_see_the_organisation_not_found_error
       and_there_is_no_change_role_button
     end
   end
@@ -73,8 +73,10 @@ describe "User CIS2 authentication" do
     )
   end
 
-  def then_i_see_the_team_not_found_error
-    expect(page).to have_heading "Your team is not using this service yet"
+  def then_i_see_the_organisation_not_found_error
+    expect(page).to have_heading(
+      "Your organisation is not using this service yet"
+    )
   end
 
   def when_i_click_the_change_role_button

--- a/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
@@ -9,13 +9,13 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_workgroup_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_team_selection_page
+    then_i_see_the_session_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
-    @team = create :team, ods_code: "A9A5A"
+    @team = create(:team, ods_code: "A9A5A")
 
-    mock_cis2_auth(selected_roleid: "wrong-workgroup")
+    mock_cis2_auth(workgroups: ["wrong-workgroup"])
   end
 
   def when_i_click_the_cis2_login_button
@@ -23,15 +23,15 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def then_i_am_on_the_start_page
-    expect(page).to have_current_path start_path
+    expect(page).to have_current_path(start_path)
   end
 
   def when_i_go_to_the_sessions_page
     visit sessions_path
   end
 
-  def then_i_see_the_team_selection_page
-    expect(page).to have_current_path(new_users_teams_path)
+  def then_i_see_the_session_page
+    expect(page).to have_current_path(sessions_path)
   end
 
   def then_i_see_the_wrong_workgroup_error
@@ -43,7 +43,11 @@ describe "User CIS2 authentication", :cis2 do
   def when_i_click_the_change_role_button_and_select_the_right_role
     # With don't actually get to select the right role directly in our test
     # setup so we change the cis2 response to simulate it.
-    mock_cis2_auth(org_code: @team.organisation.ods_code, org_name: @team.name)
+    mock_cis2_auth(
+      org_code: @team.organisation.ods_code,
+      org_name: @team.name,
+      workgroups: [@team.workgroup]
+    )
     click_button("Change role")
   end
 end

--- a/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
@@ -9,7 +9,7 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_workgroup_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_sessions_page
+    then_i_see_the_team_selection_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
@@ -30,20 +30,20 @@ describe "User CIS2 authentication", :cis2 do
     visit sessions_path
   end
 
-  def then_i_see_the_sessions_page
-    expect(page).to have_current_path sessions_path
+  def then_i_see_the_team_selection_page
+    expect(page).to have_current_path(new_users_teams_path)
   end
 
   def then_i_see_the_wrong_workgroup_error
-    expect(
-      page
-    ).to have_heading "You’re not in the right workgroup to use this service"
+    expect(page).to have_heading(
+      "You’re not in the right workgroup to use this service"
+    )
   end
 
   def when_i_click_the_change_role_button_and_select_the_right_role
     # With don't actually get to select the right role directly in our test
     # setup so we change the cis2 response to simulate it.
     mock_cis2_auth(org_code: @team.organisation.ods_code, org_name: @team.name)
-    click_button "Change role"
+    click_button("Change role")
   end
 end

--- a/spec/forms/select_team_form_spec.rb
+++ b/spec/forms/select_team_form_spec.rb
@@ -1,14 +1,27 @@
 # frozen_string_literal: true
 
 describe SelectTeamForm do
-  subject(:form) { described_class.new(current_user:) }
+  subject(:form) { described_class.new(cis2_info:) }
 
-  let(:team) { create(:team) }
-  let(:current_user) { create(:user, teams: [team]) }
+  let(:organisation) { create(:organisation) }
+  let(:cis2_info) { CIS2Info.new(request_session:) }
+  let(:request_session) do
+    {
+      "cis2_info" => {
+        "organisation_code" => organisation.ods_code,
+        "workgroups" => [allowed_team.workgroup]
+      }
+    }
+  end
+  let(:allowed_team) { create(:team, organisation:) }
 
-  before { create(:team) }
+  before { create(:team, organisation:) }
 
   describe "validations" do
-    it { expect(form).to validate_inclusion_of(:team_id).in_array([team.id]) }
+    it do
+      expect(form).to validate_inclusion_of(:team_id).in_array(
+        [allowed_team.id]
+      )
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -145,7 +145,7 @@ describe User do
         end
 
         context "without workgroups" do
-          let(:user) { build(:admin, selected_role_workgroups: nil) }
+          let(:user) { build(:admin, role_workgroups: nil) }
 
           it { should be false }
         end
@@ -163,7 +163,7 @@ describe User do
         end
 
         context "without workgroups" do
-          let(:user) { build(:nurse, selected_role_workgroups: nil) }
+          let(:user) { build(:nurse, role_workgroups: nil) }
 
           it { should be false }
         end

--- a/spec/requests/patient_sessions/activity_spec.rb
+++ b/spec/requests/patient_sessions/activity_spec.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 describe "Patient sessions activity" do
-  let(:team) { create(:team) }
+  let(:team) { create(:team, :with_one_nurse) }
   let(:session) { create(:session, team:) }
   let(:patient) { create(:patient, session:) }
-  let(:nurse) { create(:nurse, team:) }
+  let(:nurse) { team.users.first }
 
   describe "creating notes" do
     let(:path) { "/sessions/#{session.slug}/patients/#{patient.id}/activity" }
 
-    before { sign_in nurse }
+    before do
+      sign_in nurse
+      2.times { follow_redirect! }
+    end
 
     it "renders the add note form" do
       get path

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -36,7 +36,7 @@ module CIS2AuthHelper
               "role_code" => "S8000:G8000:R8001",
               "activities" => [],
               "activity_codes" => [],
-              "workgroups" => ["schoolagedimmunisations"],
+              "workgroups" => [],
               "workgroups_codes" => ["15025792819"]
             },
             {
@@ -48,7 +48,7 @@ module CIS2AuthHelper
               "role_code" => "S8000:G8000:R8003",
               "activities" => [],
               "activity_codes" => [],
-              "workgroups" => ["schoolagedimmunisations"],
+              "workgroups" => [],
               "workgroups_codes" => ["15025792819"]
             },
             {
@@ -72,7 +72,7 @@ module CIS2AuthHelper
               "role_code" => "S8000:G8000:R8001",
               "activities" => [],
               "activity_codes" => [],
-              "workgroups" => ["schoolagedimmunisations"],
+              "workgroups" => [],
               "workgroups_codes" => ["15025792819"]
             }
           ],
@@ -94,7 +94,6 @@ module CIS2AuthHelper
   end
 
   def cis2_sign_in(user, workgroups:, role:, ods_code:, superuser:)
-    workgroups.insert(0, "schoolagedimmunisations")
     workgroups << "mavissuperusers" if superuser
 
     mock_cis2_auth(

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -153,8 +153,8 @@ module CIS2AuthHelper
     end
 
     role_code ||= {
-      nurse: User::CIS2_NURSE_ROLE,
-      admin_staff: User::CIS2_ADMIN_ROLE
+      nurse: CIS2Info::NURSE_ROLE,
+      admin_staff: CIS2Info::ADMIN_ROLE
     }.fetch(role)
 
     nhsid_nrbac_role = raw_info["nhsid_nrbac_roles"][0]

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -26,8 +26,6 @@ test("Accessibility", async ({ page }) => {
     .getByLabel("Password", { exact: true })
     .fill("nurse.joy@example.com");
   await page.getByRole("button", { name: "Log in" }).click();
-  await page.getByRole("radio", { name: "SAIS Team 1" }).check();
-  await page.getByRole("button", { name: "Continue" }).click();
   await expect(page.locator("h1")).toContainText("Mavis");
   await checkAccessibility(page);
 


### PR DESCRIPTION
This is the final part of the teams/organisations restructuring, which requires users to select the team they want to sign in to when they sign in. This is necessary as a single organisation can be part of multiple teams.

[Jira Issue - MAV-1280](https://nhsd-jira.digital.nhs.uk/browse/MAV-1280)