### PR TITLE
Handle discarded vaccination records on merge

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -53,8 +53,9 @@ class PatientMerger
       )
       patient_to_destroy.triages.update_all(patient_id: patient_to_keep.id)
 
-      vaccination_record_ids = patient_to_destroy.vaccination_records.ids
-      patient_to_destroy.vaccination_records.update_all(
+      vaccination_record_ids =
+        patient_to_destroy.vaccination_records.with_discarded.ids
+      patient_to_destroy.vaccination_records.with_discarded.update_all(
         patient_id: patient_to_keep.id
       )
 

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -80,6 +80,15 @@ describe PatientMerger do
         programme:
       )
     end
+    let(:discarded_vaccination_record) do
+      create(
+        :vaccination_record,
+        :discarded,
+        patient: patient_to_destroy,
+        session:,
+        programme:
+      )
+    end
 
     it "destroys one of the patients" do
       expect { call }.to change(Patient, :count).by(-1)
@@ -165,6 +174,12 @@ describe PatientMerger do
       expect { call }.to change { vaccination_record.reload.patient }.to(
         patient_to_keep
       )
+    end
+
+    it "moves discarded vaccination records" do
+      expect { call }.to change {
+        discarded_vaccination_record.reload.patient
+      }.to(patient_to_keep)
     end
 
     it "enqueues sync jobs for vaccination records" do


### PR DESCRIPTION
When merging two patients we need to make sure that any discarded vaccination records are also merged correctly, without this the user sees an unhandled error.

[Jira Issue - MAV-1718](https://nhsd-jira.digital.nhs.uk/browse/MAV-1718)