### PR TITLE
Log requests to immunisations API

### DIFF
--- a/app/jobs/sync_vaccination_record_to_nhs_job.rb
+++ b/app/jobs/sync_vaccination_record_to_nhs_job.rb
@@ -6,6 +6,11 @@ class SyncVaccinationRecordToNHSJob < ApplicationJob
   retry_on Faraday::ServerError, wait: :polynomially_longer
 
   def perform(vaccination_record)
-    NHS::ImmunisationsAPI.sync_immunisation(vaccination_record)
+    tx_id = SecureRandom.urlsafe_base64(16)
+    SemanticLogger.tagged(tx_id:, job_id: provider_job_id || job_id) do
+      Sentry.set_tags(tx_id:, job_id: provider_job_id || job_id)
+
+      NHS::ImmunisationsAPI.sync_immunisation(vaccination_record)
+    end
   end
 end

--- a/app/lib/nhs/immunisations_api.rb
+++ b/app/lib/nhs/immunisations_api.rb
@@ -30,6 +30,11 @@ module NHS::ImmunisationsAPI
 
       check_vaccination_record_for_create_or_update(vaccination_record)
 
+      Rails.logger.info(
+        "Recording vaccination record to immunisations API:" \
+          " #{vaccination_record.id}"
+      )
+
       response =
         NHS::API.connection.post(
           "/immunisation-fhir-api/FHIR/R4/Immunization",
@@ -78,6 +83,11 @@ module NHS::ImmunisationsAPI
       if vaccination_record.nhs_immunisations_api_etag.blank?
         raise "Vaccination record #{vaccination_record.id} missing ETag"
       end
+
+      Rails.logger.info(
+        "Updating vaccination record in immunisations API:" \
+          " #{vaccination_record.id}"
+      )
 
       nhs_id = vaccination_record.nhs_immunisations_api_id
       response =
@@ -132,6 +142,11 @@ module NHS::ImmunisationsAPI
       if vaccination_record.nhs_immunisations_api_id.blank?
         raise "Vaccination record #{vaccination_record.id} missing NHS Immunisation ID"
       end
+
+      Rails.logger.info(
+        "Deleting vaccination record from immunisations API:" \
+          " #{vaccination_record.id}"
+      )
 
       nhs_id = vaccination_record.nhs_immunisations_api_id
       response =


### PR DESCRIPTION
Adds log messages when we make a request to the immunisations API, and also adds job and transaction identifiers to the logs and Sentry payloads.

Jira-Issue: MAV-1719