### PR TITLE
Show year group according to pending academic year

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -328,7 +328,8 @@ class Patient < ApplicationRecord
 
   def year_group_changed? = birth_academic_year_changed?
 
-  def show_year_group?(team:, academic_year: nil)
+  def show_year_group?(team:)
+    academic_year = AcademicYear.pending
     year_group = self.year_group(academic_year:)
     programme_year_groups =
       school&.programme_year_groups || team.programme_year_groups

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -519,28 +519,60 @@ describe Patient do
     let(:team) { create(:team, programmes:) }
     let(:school) { create(:school, team:) }
 
-    context "for a year 1" do
-      let(:patient) { create(:patient, school:, year_group: 1) }
+    context "outside the preparation period" do
+      around { |example| travel_to(Date.new(2025, 7, 31)) { example.run } }
 
-      it { should be(true) }
+      context "for a year 1" do
+        let(:patient) { create(:patient, school:, year_group: 1) }
+
+        it { should be(true) }
+      end
+
+      context "for a year 7" do
+        let(:patient) { create(:patient, school:, year_group: 7) }
+
+        it { should be(true) }
+      end
+
+      context "for a year 11" do
+        let(:patient) { create(:patient, school:, year_group: 11) }
+
+        it { should be(true) }
+      end
+
+      context "for a year 12" do
+        let(:patient) { create(:patient, school:, year_group: 12) }
+
+        it { should be(false) }
+      end
     end
 
-    context "for a year 7" do
-      let(:patient) { create(:patient, school:, year_group: 7) }
+    context "inside the preparation period" do
+      around { |example| travel_to(Date.new(2025, 8, 1)) { example.run } }
 
-      it { should be(true) }
-    end
+      context "for a year 1" do
+        let(:patient) { create(:patient, school:, year_group: 1) }
 
-    context "for a year 11" do
-      let(:patient) { create(:patient, school:, year_group: 11) }
+        it { should be(true) }
+      end
 
-      it { should be(true) }
-    end
+      context "for a year 7" do
+        let(:patient) { create(:patient, school:, year_group: 7) }
 
-    context "for a year 12" do
-      let(:patient) { create(:patient, school:, year_group: 12) }
+        it { should be(true) }
+      end
 
-      it { should be(false) }
+      context "for a year 11" do
+        let(:patient) { create(:patient, school:, year_group: 11) }
+
+        it { should be(false) }
+      end
+
+      context "for a year 12" do
+        let(:patient) { create(:patient, school:, year_group: 12) }
+
+        it { should be(false) }
+      end
     end
   end
 


### PR DESCRIPTION
In https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4175 we made it so that the year group is hidden for some patients. This was supposed to apply for the pending academic year, not the current one. The idea is that during the preparation period, you would be looking at patients who are due to age out at the start of next academic year, and for those patients the year group is hidden.

[Jira Issue - MAV-1512](https://nhsd-jira.digital.nhs.uk/browse/MAV-1512)