### PR TITLE
Ensure patients are unarchived

### DIFF
--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -32,7 +32,8 @@ class PatientImport < ApplicationRecord
     @school_moves_to_save ||= Set.new
 
     if (school_move = row.to_school_move(patient))
-      if (patient.school.nil? && !patient.home_educated) || patient.not_in_team?
+      if (patient.school.nil? && !patient.home_educated) ||
+           patient.not_in_team? || patient.archived?(team:)
         @school_moves_to_confirm.add(school_move)
       else
         @school_moves_to_save.add(school_move)

--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -42,7 +42,8 @@ class PatientImportRow
     return if patient.deceased?
 
     if patient.new_record? || patient.school != school ||
-         patient.home_educated != home_educated || patient.not_in_team?
+         patient.home_educated != home_educated || patient.not_in_team? ||
+         patient.archived?(team:)
       school_move =
         if school
           SchoolMove.find_or_initialize_by(patient:, school:)

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -147,6 +147,37 @@ describe ClassImportRow do
 
       it { should be_nil }
     end
+
+    context "with an existing patient that was previously archived" do
+      subject(:school_move) do
+        class_import_row.to_school_move(existing_patient)
+      end
+
+      let(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "male",
+          given_name: "Jimmy",
+          nhs_number: "9990000018",
+          session:
+        )
+      end
+
+      let(:data) { valid_data }
+
+      before do
+        create(
+          :archive_reason,
+          :moved_out_of_area,
+          team:,
+          patient: existing_patient
+        )
+      end
+
+      it { should_not be_nil }
+    end
   end
 
   describe "#to_parents" do

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -633,6 +633,42 @@ describe CohortImportRow do
 
       it { should_not be_nil }
     end
+
+    context "with an existing patient that was previously archived" do
+      subject(:school_move) do
+        cohort_import_row.to_school_move(existing_patient)
+      end
+
+      let(:data) { valid_data }
+
+      let(:location) { Location.school.find_by!(urn: "123456") }
+      let(:session) do
+        create(:session, location:, team:, programmes: [programme])
+      end
+
+      let(:existing_patient) do
+        create(
+          :patient,
+          address_postcode: "SW1A 1AA",
+          family_name: "Smith",
+          gender_code: "male",
+          given_name: "Jimmy",
+          nhs_number: "9990000018",
+          session:
+        )
+      end
+
+      before do
+        create(
+          :archive_reason,
+          :moved_out_of_area,
+          team:,
+          patient: existing_patient
+        )
+      end
+
+      it { should_not be_nil }
+    end
   end
 
   describe "#to_parent_relationships" do


### PR DESCRIPTION
When an archived patient is re-imported, we should unarchive them. This was added in to the school moves in
b35cc281ea7e813f5525ee4d52f1a17049fab6ba however, we didn't handle the case where a school move wouldn't be created.

If a patient is archived, and they're being re-imported exactly as they were (same school, etc) we don't create a school move. This results in them not being unarchived.

Instead, we can ensure that a school move is created if the patient is already archived.

I haven't written a feature test for this scenario as it's being covered by the regression tests.

[Jira Issue - MAV-1506](https://nhsd-jira.digital.nhs.uk/browse/MAV-1506)