### PR TITLE
Fix archive_moved_out_of_cohort_patients

### DIFF
--- a/lib/tasks/archive_moved_out_of_cohort_patients.rake
+++ b/lib/tasks/archive_moved_out_of_cohort_patients.rake
@@ -2,25 +2,32 @@
 
 desc "Migrate patients who were moved out of cohorts to ensure they're archived."
 task archive_moved_out_of_cohort_patients: :environment do
-  Team.find_each do |team|
-    user = OpenStruct.new(selected_team: team)
-
-    patients_in_cohort = team.patients
-    patients_associated_with_team =
-      PatientPolicy::Scope.new(user, Patient).resolve
-
-    patients_not_in_cohort = patients_associated_with_team - patients_in_cohort
-
-    archive_reasons =
-      patients_not_in_cohort.map do |patient|
-        ArchiveReason.new(
-          patient:,
-          team:,
-          type: "other",
-          other_details: "Unknown: before reasons added"
+  Team
+    .includes(:organisation)
+    .find_each do |team|
+      user =
+        OpenStruct.new(
+          selected_team: team,
+          selected_organisation: team.organisation
         )
-      end
 
-    ArchiveReason.import!(archive_reasons, on_duplicate_key_ignore: true)
-  end
+      patients_in_cohort = team.patients
+      patients_associated_with_team =
+        PatientPolicy::Scope.new(user, Patient).resolve
+
+      patients_not_in_cohort =
+        patients_associated_with_team - patients_in_cohort
+
+      archive_reasons =
+        patients_not_in_cohort.map do |patient|
+          ArchiveReason.new(
+            patient:,
+            team:,
+            type: "other",
+            other_details: "Unknown: before reasons added"
+          )
+        end
+
+      ArchiveReason.import!(archive_reasons, on_duplicate_key_ignore: true)
+    end
 end


### PR DESCRIPTION
This fixes an issue with the Rake task that was introduced as part of the introduction of the new `Organisation` model.