### PR TITLE
Prevent invalidated patients' records from being sent to the Imms API

### DIFF
--- a/app/lib/nhs/immunisations_api.rb
+++ b/app/lib/nhs/immunisations_api.rb
@@ -189,7 +189,8 @@ module NHS::ImmunisationsAPI
         vaccination_record.administered? &&
         vaccination_record.programme.type.in?(PROGRAMME_TYPES) &&
         (ignore_nhs_number || vaccination_record.patient.nhs_number.present?) &&
-        vaccination_record.notify_parents
+        vaccination_record.notify_parents &&
+        vaccination_record.patient.not_invalidated?
     end
 
     private

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -536,8 +536,12 @@ class Patient < ApplicationRecord
 
   def fhir_mapper = @fhir_mapper ||= FHIRMapper::Patient.new(self)
 
+  def should_sync_vaccinations_to_nhs_immunisations_api?
+    nhs_number_previously_changed? || invalidated_at_previously_changed?
+  end
+
   def sync_vaccinations_to_nhs_immunisations_api
-    if nhs_number_previously_changed?
+    if should_sync_vaccinations_to_nhs_immunisations_api?
       vaccination_records.syncable_to_nhs_immunisations_api.find_each(
         &:sync_to_nhs_immunisations_api
       )

--- a/spec/features/patient_invalidation_spec.rb
+++ b/spec/features/patient_invalidation_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+describe "Patient invalidation deletes vaccination record from API" do
+  around { |example| travel_to(Date.new(2025, 8, 7)) { example.run } }
+
+  scenario "PDS check invalidates patient and deletes vaccination record from API" do
+    given_a_patient_has_a_vaccination_record_eligible_for_api
+    and_the_feature_flags_are_enabled
+    and_the_vaccination_record_has_been_sent_to_the_api
+
+    when_a_pds_check_is_completed_which_returns_that_the_patient_is_invalid
+
+    then_the_patient_has_been_invalidated
+    and_the_vaccination_record_is_deleted_from_the_api
+  end
+
+  def given_a_patient_has_a_vaccination_record_eligible_for_api
+    @programme = create(:programme, :hpv)
+    @team = create(:team, :with_one_nurse, programmes: [@programme])
+    @session =
+      create(:session, :scheduled, team: @team, programmes: [@programme])
+    @patient = create(:patient, session: @session, nhs_number: "9000000009")
+
+    @vaccination_record =
+      create(
+        :vaccination_record,
+        :administered,
+        patient: @patient,
+        programme: @programme,
+        session: @session,
+        notify_parents: true
+      )
+  end
+
+  def and_the_feature_flags_are_enabled
+    Flipper.enable(:enqueue_sync_vaccination_records_to_nhs)
+    Flipper.enable(:immunisations_fhir_api_integration)
+  end
+
+  def and_the_vaccination_record_has_been_sent_to_the_api
+    @immunisation_uuid = Random.uuid
+
+    @stubbed_post_request =
+      stub_immunisations_api_post(uuid: @immunisation_uuid)
+
+    @vaccination_record.sync_to_nhs_immunisations_api
+    perform_enqueued_jobs(only: SyncVaccinationRecordToNHSJob)
+
+    expect(@stubbed_post_request).to have_been_requested
+
+    @vaccination_record.reload
+    expect(@vaccination_record.nhs_immunisations_api_id).to be_present
+    expect(@vaccination_record.nhs_immunisations_api_synced_at).to be_present
+  end
+
+  def when_a_pds_check_is_completed_which_returns_that_the_patient_is_invalid
+    # Move time forward to ensure deletion sync happens after the initial sync
+    travel_to(1.hour.from_now)
+
+    stub_pds_get_nhs_number_to_return_an_invalidated_patient
+
+    PatientUpdateFromPDSJob.perform_now(@patient)
+  end
+
+  def then_the_patient_has_been_invalidated
+    @patient.reload
+    expect(@patient).to be_invalidated
+    expect(@patient.invalidated_at).to be_present
+  end
+
+  def and_the_vaccination_record_is_deleted_from_the_api
+    @stubbed_delete_request =
+      stub_immunisations_api_delete(uuid: @immunisation_uuid)
+
+    perform_enqueued_jobs(only: SyncVaccinationRecordToNHSJob)
+
+    expect(@stubbed_delete_request).to have_been_requested
+  end
+end

--- a/spec/lib/nhs/immunisations_api_spec.rb
+++ b/spec/lib/nhs/immunisations_api_spec.rb
@@ -551,6 +551,12 @@ describe NHS::ImmunisationsAPI do
 
       it { should be false }
     end
+
+    context "when the patient is invalidated" do
+      before { patient.update(invalidated_at: Time.current) }
+
+      it { should be false }
+    end
   end
 
   describe "next_sync_action" do

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -806,6 +806,43 @@ describe Patient do
     end
   end
 
+  describe "#should_sync_vaccinations_to_nhs_immunisations_api" do
+    subject(:should_sync_vaccinations_to_nhs_immunisations_api?) do
+      patient.send(:should_sync_vaccinations_to_nhs_immunisations_api?)
+    end
+
+    let(:patient) { create(:patient, nhs_number: "9449310475") }
+    let(:programme) { create(:programme, type: "hpv") }
+    let(:session) { create(:session, programmes: [programme]) }
+    let(:vaccination_record) do
+      create(:vaccination_record, patient:, programme:, session:)
+    end
+
+    context "when nhs_number changes" do
+      it "syncs vaccination records to NHS Immunisations API" do
+        patient.update!(nhs_number: "9449304130")
+
+        expect(should_sync_vaccinations_to_nhs_immunisations_api?).to be_truthy
+      end
+    end
+
+    context "when invalidated_at changes" do
+      it "syncs vaccination records to NHS Immunisations API" do
+        patient.update!(invalidated_at: Time.current)
+
+        expect(should_sync_vaccinations_to_nhs_immunisations_api?).to be_truthy
+      end
+    end
+
+    context "when other attributes change" do
+      it "does not sync vaccination records to NHS Immunisations API" do
+        patient.update!(given_name: "NewName")
+
+        expect(should_sync_vaccinations_to_nhs_immunisations_api?).to be_falsy
+      end
+    end
+  end
+
   describe "#stage_changes" do
     let(:patient) { create(:patient, given_name: "John", family_name: "Doe") }
 

--- a/spec/support/pds_helper.rb
+++ b/spec/support/pds_helper.rb
@@ -33,4 +33,17 @@ module PDSHelper
       }
     )
   end
+
+  def stub_pds_get_nhs_number_to_return_an_invalidated_patient
+    stub_request(
+      :get,
+      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient/#{@patient.nhs_number}"
+    ).to_return(
+      body: file_fixture("pds/invalid-patient-response.json"),
+      status: 404,
+      headers: {
+        "Content-Type" => "application/fhir+json"
+      }
+    )
+  end
 end


### PR DESCRIPTION
This will prevent the vaccination records from being sent in the first place, and also trigger a sync whenever `Patient.validated_at` is edited

[MAV-1720](https://nhsd-jira.digital.nhs.uk/browse/MAV-1720)