### PR TITLE
Fix tests following independent merges

### DIFF
--- a/lib/generate/cohort_imports.rb
+++ b/lib/generate/cohort_imports.rb
@@ -41,14 +41,14 @@ module Generate
                 :progress_bar
 
     def initialize(
-      team_workgroup: "A9A5A",
+      ods_code: "A9A5A",
       programme: "hpv",
       urns: nil,
       school_year_groups: nil,
       patient_count: 10,
       progress_bar: nil
     )
-      @team = Team.find_by(workgroup: team_workgroup)
+      @team = Team.joins(:organisation).find_by(organisation: { ods_code: })
       @programme = Programme.find_by(type: programme)
       @urns =
         urns || @team.locations.select { it.urn.present? }.sample(3).pluck(:urn)

--- a/spec/lib/generate/cohort_imports_spec.rb
+++ b/spec/lib/generate/cohort_imports_spec.rb
@@ -2,7 +2,7 @@
 
 describe Generate::CohortImports do
   before do
-    team = create(:team, workgroup: "A9A5A")
+    team = create(:team, ods_code: "A9A5A")
     programme = create(:programme, :hpv)
     location =
       create(:school, :secondary, team:, name: "Test School", urn: "31337")


### PR DESCRIPTION
PR #4095 made a change to the `Generate::CohortImports` class, but it was merged in without rebasing, and therefore I wasn't aware that the change broke some tests that were subsequently added.