### PR TITLE
Show notice in session if any patients are missing NHS number

### DIFF
--- a/app/components/app_patient_summary_component.rb
+++ b/app/components/app_patient_summary_component.rb
@@ -24,7 +24,7 @@ class AppPatientSummaryComponent < ViewComponent::Base
   attr_reader :patient
 
   def rows
-    [date_of_birth_row, address_row]
+    [nhs_number_row, date_of_birth_row, address_row]
   end
 
   def classes
@@ -33,6 +33,25 @@ class AppPatientSummaryComponent < ViewComponent::Base
       app-summary-list--full-width
       nhsuk-u-margin-bottom-2
     ]
+  end
+
+  def nhs_number_row
+    {
+      key: {
+        text: "NHS number"
+      },
+      value: {
+        text:
+          if patient.nhs_number.present?
+            helpers.patient_nhs_number(patient)
+          else
+            helpers.link_to(
+              "Add the child's NHS number",
+              edit_nhs_number_patient_path(patient)
+            )
+          end
+      }
+    }
   end
 
   def date_of_birth_row

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -29,12 +29,20 @@ class AppSessionActionsComponent < ViewComponent::Base
 
   def rows
     @rows ||= [
+      no_nhs_number_row,
       no_consent_response_row,
       conflicting_consent_row,
       triage_required_row,
       (register_attendance_row if session.requires_registration?),
       ready_for_vaccinator_row
     ].compact
+  end
+
+  def no_nhs_number_row
+    count = patient_sessions.merge(Patient.without_nhs_number).count
+    href = session_consent_path(session, missing_nhs_number: true)
+
+    generate_row(:children_without_nhs_number, count:, href:)
   end
 
   def no_consent_response_row

--- a/app/components/app_session_actions_component.rb
+++ b/app/components/app_session_actions_component.rb
@@ -38,75 +38,38 @@ class AppSessionActionsComponent < ViewComponent::Base
   end
 
   def no_consent_response_row
-    consent_row("No consent response", status: "no_response")
+    status = "no_response"
+    count =
+      patient_sessions.has_consent_status(status, programme: programmes).count
+    href = session_consent_path(session, consent_statuses: [status])
+
+    generate_row(:children_with_no_consent_response, count:, href:)
   end
 
   def conflicting_consent_row
-    consent_row("Conflicting consent", status: "conflicts")
-  end
-
-  def consent_row(text, status:)
+    status = "conflicts"
     count =
       patient_sessions.has_consent_status(status, programme: programmes).count
-
-    return nil if count.zero?
-
     href = session_consent_path(session, consent_statuses: [status])
 
-    {
-      key: {
-        text: text
-      },
-      value: {
-        text: I18n.t("children", count:)
-      },
-      actions: [{ text: "Review", visually_hidden_text: text.downcase, href: }]
-    }
+    generate_row(:children_with_conflicting_consent_response, count:, href:)
   end
 
   def triage_required_row
     status = "required"
-
     count =
       patient_sessions.has_triage_status(status, programme: programmes).count
-
-    return nil if count.zero?
-
     href = session_triage_path(session, triage_status: status)
 
-    {
-      key: {
-        text: "Triage needed"
-      },
-      value: {
-        text: I18n.t("children", count:)
-      },
-      actions: [
-        { text: "Review", visually_hidden_text: "triage needed", href: }
-      ]
-    }
+    generate_row(:children_requiring_triage, count:, href:)
   end
 
   def register_attendance_row
     status = "unknown"
-
     count = patient_sessions.has_registration_status(status).count
-
-    return nil if count.zero?
-
     href = session_register_path(session, register_status: status)
 
-    {
-      key: {
-        text: "Register attendance"
-      },
-      value: {
-        text: I18n.t("children", count:)
-      },
-      actions: [
-        { text: "Review", visually_hidden_text: "register attendance", href: }
-      ]
-    }
+    generate_row(:children_to_register, count:, href:)
   end
 
   def ready_for_vaccinator_row
@@ -130,11 +93,31 @@ class AppSessionActionsComponent < ViewComponent::Base
     return nil if counts_by_programme.values.all?(&:zero?)
 
     texts =
-      counts_by_programme.map do |programme, count|
-        "#{I18n.t("children", count:)} for #{programme.name_in_sentence}"
+      if counts_by_programme.values.all?(&:zero?)
+        ["No children"]
+      else
+        counts_by_programme.map do |programme, count|
+          text =
+            I18n.t(
+              :children_for_programme,
+              count:,
+              programme: programme.name_in_sentence
+            )
+          href =
+            session_record_path(
+              session,
+              search_form: {
+                programme_types: [programme.type]
+              }
+            )
+          count.positive? ? helpers.link_to(text, href) : text
+        end
       end
 
-    href = session_record_path(session)
+    actions =
+      unless counts_by_programme.values.all?(&:zero?)
+        [{ text: "Record", href: session_record_path(session) }]
+      end
 
     {
       key: {
@@ -143,9 +126,21 @@ class AppSessionActionsComponent < ViewComponent::Base
       value: {
         text: safe_join(texts, tag.br)
       },
-      actions: [
-        { text: "Review", visually_hidden_text: "ready for vaccinator", href: }
-      ]
+      actions: actions
+    }
+  end
+
+  def generate_row(key, count:, href: nil)
+    return nil if count.zero?
+
+    {
+      key: {
+        text: I18n.t(:title, scope: key)
+      },
+      value: {
+        text:
+          (href ? helpers.link_to(I18n.t(key, count:), href).html_safe : text)
+      }
     }
   end
 end

--- a/app/components/app_session_needs_review_warning_component.rb
+++ b/app/components/app_session_needs_review_warning_component.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class AppSessionNeedsReviewWarningComponent < ViewComponent::Base
+  def call
+    render AppWarningCalloutComponent.new(heading: "Needs review") do
+      tag.ul do
+        safe_join(
+          warning_counts.filter_map do |warning, _c|
+            tag.li { make_row_from_warning(warning) }
+          end
+        )
+      end
+    end
+  end
+
+  def initialize(session:)
+    super
+    @session = session
+  end
+
+  def render?
+    warning_counts.values.any?(&:positive?)
+  end
+
+  private
+
+  def warning_href
+    {
+      children_without_nhs_number:
+        session_consent_path(@session, missing_nhs_number: true)
+    }
+  end
+
+  def warning_counts
+    @warning_counts ||= {
+      children_without_nhs_number:
+        patient_sessions.merge(Patient.without_nhs_number).count
+    }
+  end
+
+  def make_row_from_warning(warning)
+    return if warning_counts[warning].zero?
+    link_to(t(warning, count: warning_counts[warning]), warning_href[warning])
+  end
+
+  def patient_sessions
+    @session
+      .patient_sessions
+      .joins(:patient, :session)
+      .appear_in_programmes(@session.programmes)
+  end
+end

--- a/app/views/sessions/consent/show.html.erb
+++ b/app/views/sessions/consent/show.html.erb
@@ -20,6 +20,7 @@
   </div>
 
   <div class="app-grid-column-results">
+    <%= render AppSessionNeedsReviewWarningComponent.new(session: @session) %>
     <%= render AppSearchResultsComponent.new(@pagy, label: "children") do %>
       <% @patient_sessions.each do |patient_session| %>
         <%= render AppPatientSessionSearchResultCardComponent.new(

--- a/app/views/sessions/patients/show.html.erb
+++ b/app/views/sessions/patients/show.html.erb
@@ -21,6 +21,7 @@
   </div>
 
   <div class="app-grid-column-results">
+    <%= render AppSessionNeedsReviewWarningComponent.new(session: @session) %>
     <%= render AppSearchResultsComponent.new(@pagy, label: "children") do %>
       <% @patient_sessions.each do |patient_session| %>
         <%= render AppPatientSessionSearchResultCardComponent.new(

--- a/app/views/sessions/record/show.html.erb
+++ b/app/views/sessions/record/show.html.erb
@@ -50,6 +50,7 @@
     </div>
 
     <div class="app-grid-column-results">
+      <%= render AppSessionNeedsReviewWarningComponent.new(session: @session) %>
       <%= render AppSearchResultsComponent.new(@pagy, label: "children") do %>
         <% @patient_sessions.each do |patient_session| %>
           <%= render AppPatientSessionSearchResultCardComponent.new(

--- a/app/views/sessions/register/show.html.erb
+++ b/app/views/sessions/register/show.html.erb
@@ -22,6 +22,7 @@
     </div>
 
     <div class="app-grid-column-results">
+      <%= render AppSessionNeedsReviewWarningComponent.new(session: @session) %>
       <%= render AppSearchResultsComponent.new(@pagy, label: "children") do %>
         <% @patient_sessions.each do |patient_session| %>
           <%= render AppPatientSessionSearchResultCardComponent.new(

--- a/app/views/sessions/triage/show.html.erb
+++ b/app/views/sessions/triage/show.html.erb
@@ -20,6 +20,7 @@
   </div>
 
   <div class="app-grid-column-results">
+    <%= render AppSessionNeedsReviewWarningComponent.new(session: @session) %>
     <%= render AppSearchResultsComponent.new(@pagy, label: "children") do %>
       <% @patient_sessions.each do |patient_session| %>
         <%= render AppPatientSessionSearchResultCardComponent.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,6 +519,30 @@ en:
     zero: No children
     one: 1 child
     other: "%{count} children"
+  children_with_no_consent_response:
+    title: No consent response
+    zero: No children with no response
+    one: 1 child with no response
+    other: "%{count} children with no response"
+  children_with_conflicting_consent_response:
+    title: Conflicting consent
+    zero: No children with conflicting responses
+    one: 1 child with conflicting response
+    other: "%{count} children with conflicting responses"
+  children_requiring_triage:
+    title: Triage needed
+    zero: No children requiring triage
+    one: 1 child requiring triage
+    other: "%{count} children requiring triage"
+  children_to_register:
+    title: Register attendance
+    zero: No children to register
+    one: 1 child to register
+    other: "%{count} children to register"
+  children_for_programme:
+    zero: "No children for %{programme}"
+    one: "1 child for %{programme}"
+    other: "%{count} children for %{programme}"
   consent_forms:
     index:
       title: Unmatched consent responses

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,6 +519,11 @@ en:
     zero: No children
     one: 1 child
     other: "%{count} children"
+  children_without_nhs_number:
+    title: No NHS number
+    zero: No children without an NHS number
+    one: 1 child without an NHS number
+    other: "%{count} children without an NHS number"
   children_with_no_consent_response:
     title: No consent response
     zero: No children with no response

--- a/spec/components/app_patient_summary_component_spec.rb
+++ b/spec/components/app_patient_summary_component_spec.rb
@@ -19,6 +19,21 @@ describe AppPatientSummaryComponent do
 
   it { should have_content("SELDON, Hari") }
 
+  it { should have_content("NHS number") }
+
+  context "when patient has an NHS number" do
+    before { patient.update(nhs_number: "9993425389") }
+
+    it { should have_content("999 342 5389") }
+    it { should_not have_link("Add the child's NHS number") }
+  end
+
+  context "when patient does not have an NHS number" do
+    before { patient.update(nhs_number: nil) }
+
+    it { should have_link("Add the child's NHS number") }
+  end
+
   it { should have_content("Date of birth") }
   it { should have_content("1 January 2000") }
 

--- a/spec/components/app_session_actions_component_spec.rb
+++ b/spec/components/app_session_actions_component_spec.rb
@@ -48,11 +48,11 @@ describe AppSessionActionsComponent do
   it { should have_text("Register attendance\n3 child") }
   it { should have_text("Ready for vaccinator\n1 child for HPV") }
 
-  it { should have_link("Review no consent response") }
-  it { should have_link("Review conflicting consent") }
-  it { should have_link("Review triage needed") }
-  it { should have_link("Review register attendance") }
-  it { should have_link("Review ready for vaccinator") }
+  it { should have_link("1 child with no response") }
+  it { should have_link("1 child with conflicting response") }
+  it { should have_link("1 child requiring triage") }
+  it { should have_link("3 children to register") }
+  it { should have_link("1 child for HPV") }
 
   context "session requires no registration" do
     let(:session) { create(:session, :requires_no_registration, programmes:) }

--- a/spec/components/app_session_actions_component_spec.rb
+++ b/spec/components/app_session_actions_component_spec.rb
@@ -10,6 +10,10 @@ describe AppSessionActionsComponent do
 
   let(:year_group) { 8 }
 
+  let(:patient_without_nhs_number) do
+    create(:patient, nhs_number: nil, year_group:)
+  end
+
   before do
     create(
       :patient_session,
@@ -40,14 +44,23 @@ describe AppSessionActionsComponent do
       year_group:
     )
     create(:patient_session, :vaccinated, :in_attendance, session:, year_group:)
+
+    create(
+      :patient_session,
+      patient: patient_without_nhs_number,
+      session:,
+      year_group:
+    )
   end
 
+  it { should have_text("No NHS number\n1 child") }
   it { should have_text("No consent response\n1 child") }
   it { should have_text("Conflicting consent\n1 child") }
   it { should have_text("Triage needed\n1 child") }
   it { should have_text("Register attendance\n3 child") }
   it { should have_text("Ready for vaccinator\n1 child for HPV") }
 
+  it { should have_link("1 child without an NHS number") }
   it { should have_link("1 child with no response") }
   it { should have_link("1 child with conflicting response") }
   it { should have_link("1 child requiring triage") }

--- a/spec/components/app_session_needs_review_warning_component_spec.rb
+++ b/spec/components/app_session_needs_review_warning_component_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+describe AppSessionNeedsReviewWarningComponent do
+  let(:component) { described_class.new(session:) }
+  let(:session) { create(:session) }
+
+  describe "#render?" do
+    subject { component.render? }
+
+    context "when session has no patients without NHS number" do
+      it { should be(false) }
+    end
+
+    context "when session has patients without NHS number" do
+      before { create(:patient, nhs_number: nil, session:) }
+
+      it { should be(true) }
+    end
+  end
+
+  describe "rendered content" do
+    subject(:rendered) { render_inline(component) }
+
+    context "when session has patients without NHS number" do
+      before do
+        create(
+          :patient,
+          nhs_number: nil,
+          patient_sessions: [build(:patient_session, session:)],
+          year_group: session.programmes.sample.default_year_groups.sample
+        )
+      end
+
+      it "shows the count of children without NHS number" do
+        expect(rendered).to have_text("1")
+      end
+
+      it "has a link to the consent page with missing_nhs_number parameter" do
+        expect(rendered).to have_link(href: /missing_nhs_number=true/)
+      end
+
+      it "uses the correct translation key for the link text" do
+        expect(rendered).to have_text(
+          I18n.t(:children_without_nhs_number, count: 1)
+        )
+      end
+    end
+
+    context "when session has multiple patients without NHS number" do
+      before { create_list(:patient, 3, nhs_number: nil, session:) }
+
+      it "shows the correct count of children without NHS number" do
+        expect(rendered).to have_text("3")
+      end
+    end
+  end
+end

--- a/spec/features/filter_state_persistence_spec.rb
+++ b/spec/features/filter_state_persistence_spec.rb
@@ -101,27 +101,34 @@ describe "Filter states" do
   end
 
   def and_i_click_the_no_consent_response_link
-    click_on "Review no consent response"
+    click_on "1 child with no response"
   end
 
   def and_i_click_the_conflicting_consent_link
-    click_on "Review conflicting consent"
+    click_on "1 child with conflicting response"
   end
 
   def and_i_click_the_triage_needed_link
-    click_on "Review triage needed"
+    click_on "1 child requiring triage"
   end
 
   def and_i_click_the_register_attendance_link
-    click_on "Review register attendance"
+    click_on "1 child to register"
   end
 
   def and_i_click_the_ready_for_vaccinator_link
-    click_on "Review ready for vaccinator"
+    click_on "1 child for #{@programme.name}"
   end
 
   def then_i_should_be_on_the_record_page
-    expect(page).to have_current_path(session_record_path(@session))
+    expect(page).to have_current_path(
+      session_record_path(
+        @session,
+        search_form: {
+          programme_types: [@programme.type]
+        }
+      )
+    )
   end
 
   def then_the_vaccinated_filter_is_applied


### PR DESCRIPTION
This is [MAV-1604](https://nhsd-jira.digital.nhs.uk/browse/MAV-1604). This warning is desired now as without NHS numbers, we cannot use the imms api to automatically check that the child has not already been vaccinated. The PR also resolves [MAV-1748](https://nhsd-jira.digital.nhs.uk/browse/MAV-1748) by updating the session overview page to be like in the prototype.

<img width="2504" height="3378" alt="image" src="https://github.com/user-attachments/assets/e62603e0-da37-495a-a875-a0532117bdf1" />

<img width="2200" height="3036" alt="image" src="https://github.com/user-attachments/assets/9beb1801-2f2e-454b-9ab4-fccd728fadee" />

<img width="566" height="890" alt="image" src="https://github.com/user-attachments/assets/858b3681-0d00-49c9-8f6e-f6063609897f" />
