### PR TITLE
Remove `vaccine_methods` assignment

### DIFF
--- a/app/controllers/patient_sessions/consents_controller.rb
+++ b/app/controllers/patient_sessions/consents_controller.rb
@@ -138,8 +138,7 @@ class PatientSessions::ConsentsController < PatientSessions::BaseController
     {
       patient_session: @patient_session,
       programme: @programme,
-      recorded_by: current_user,
-      vaccine_methods: %w[injection]
+      recorded_by: current_user
     }
   end
 


### PR DESCRIPTION
This was added in e63f3d0d4164e2f9616a8d2a1241b27de7127952 when we first started recording vaccine method on consent forms, and it was defaulted to `injection` as we didn't have support for nasal flu at the time.

Since then, the users are now asked which vaccine method they want to consent to, and we don't need to specify the vaccine method upfront. Either way, this was doing no harm as it was being [reset by the `reset_unused_attributes` method](https://github.com/nhsuk/manage-vaccinations-in-schools/blob/9883eaca6bd34f04f98dc2c8579c5b51e7ca40a0/app/models/draft_consent.rb#L463) anyway. However, I think it looks strange and could be potentially confusing.

The tests pass before and after demonstrating that it is not needed.