### PR TITLE
Revert "Turn off preparation period in QA"

### DIFF
--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -14,7 +14,7 @@ enable_cis2                     = false
 enable_pds_enqueue_bulk_updates = false
 
 # Normally this is 31, but this gives us 2 weeks of additional testing.
-academic_year_number_of_preparation_days = 14
+academic_year_number_of_preparation_days = 45
 
 http_hosts = {
   MAVIS__HOST                        = "qa.mavistesting.com"


### PR DESCRIPTION
This reverts commit 38008089df0951a3ddfb7331e1210a66fb70891e.

We've finished testing QA with the preparation period off so we can re-enable it now.