### PR TITLE
Don't check patient pending changes on vaccination record

### DIFF
--- a/app/controllers/imports/issues_controller.rb
+++ b/app/controllers/imports/issues_controller.rb
@@ -27,7 +27,7 @@ class Imports::IssuesController < ApplicationController
 
   def set_import_issues
     @vaccination_records =
-      policy_scope(VaccinationRecord).with_pending_changes.distinct.includes(
+      policy_scope(VaccinationRecord).with_pending_changes.includes(
         :batch,
         :location,
         :performed_by_user,
@@ -37,11 +37,12 @@ class Imports::IssuesController < ApplicationController
       )
 
     @patients =
-      policy_scope(Patient)
-        .with_pending_changes
-        .distinct
-        .eager_load(:gp_practice, :school)
-        .preload(:school_moves, :pending_sessions)
+      policy_scope(Patient).with_pending_changes.includes(
+        :gp_practice,
+        :pending_sessions,
+        :school,
+        :school_moves
+      )
 
     @import_issues =
       (@vaccination_records + @patients).uniq do |record|
@@ -51,13 +52,11 @@ class Imports::IssuesController < ApplicationController
 
   def set_record
     @record =
-      (
-        if params[:type] == "vaccination-record"
-          @vaccination_records.find(params[:id])
-        else
-          @patients.find(params[:id])
-        end
-      )
+      if params[:type] == "vaccination-record"
+        @vaccination_records.find(params[:id])
+      else
+        @patients.find(params[:id])
+      end
   end
 
   def set_vaccination_record

--- a/app/models/concerns/pending_changes_concern.rb
+++ b/app/models/concerns/pending_changes_concern.rb
@@ -3,7 +3,11 @@
 module PendingChangesConcern
   extend ActiveSupport::Concern
 
-  included { attribute :pending_changes, :jsonb, default: {} }
+  included do
+    attribute :pending_changes, :jsonb, default: {}
+
+    scope :with_pending_changes, -> { where.not(pending_changes: {}) }
+  end
 
   def stage_changes(attributes)
     attributes.each do |attr, new_value|

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -160,8 +160,6 @@ class Patient < ApplicationRecord
           )
         end
 
-  scope :with_pending_changes, -> { where.not(pending_changes: {}) }
-
   scope :search_by_name,
         ->(query) do
           # Trigram matching requires at least 3 characters

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -106,13 +106,6 @@ class VaccinationRecord < ApplicationRecord
 
   scope :recorded_in_service, -> { where.not(session_id: nil) }
 
-  scope :with_pending_changes,
-        -> do
-          joins(:patient).where(
-            "patients.pending_changes != '{}' OR vaccination_records.pending_changes != '{}'"
-          )
-        end
-
   enum :protocol, { pgd: 0, psd: 1 }, validate: { allow_nil: true }
 
   enum :delivery_method,


### PR DESCRIPTION
The current scope on vaccination records means that if a patient has import issues, we end up seeing a row saying the vaccination record itself has an import issue, which is not correct, it should instead be just the patient.

This scope was introduced in 12ea88fa927133cd42778730bda9a2617f2713ff and the logic around imports has changed significantly since then. Specifically, we now doesn't apply pending changes to patients when importing vaccination records which was the reason for this scope in the first place.

Instead, the import issues controller combines issues across vaccination records and patients at a higher level.

The same tests pass before and after demonstrating that we're not losing any functionality from this change.