### PR TITLE
Improve formatting of year groups

### DIFF
--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -35,18 +35,18 @@ module PatientsHelper
   end
 
   def patient_year_group(patient, academic_year:)
-    parts = [
-      format_year_group(patient.year_group(academic_year:)),
-      if patient.registration_academic_year == academic_year &&
-           patient.registration.present?
-        "(#{patient.registration})"
-      end,
-      if academic_year != AcademicYear.current
-        "(#{format_academic_year(academic_year)} academic year)"
-      end
-    ]
+    str = format_year_group(patient.year_group(academic_year:))
 
-    parts.compact.join(" ")
+    if patient.registration_academic_year == academic_year &&
+         patient.registration.present?
+      str << " (#{patient.registration})"
+    end
+
+    if academic_year != AcademicYear.current
+      str << " (#{format_academic_year(academic_year)} academic year)"
+    end
+
+    str
   end
 
   def patient_parents(patient)

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -37,10 +37,13 @@ module PatientsHelper
   def patient_year_group(patient, academic_year:)
     str = format_year_group(patient.year_group(academic_year:))
 
-    if patient.registration_academic_year == academic_year &&
-         patient.registration.present?
-      str << " (#{patient.registration})"
-    end
+    include_registration =
+      patient.registration_academic_year == academic_year &&
+        patient.registration.present?
+
+    str = str.dup if include_registration
+
+    str << ", #{patient.registration}" if include_registration
 
     if academic_year != AcademicYear.current
       str << " (#{format_academic_year(academic_year)} academic year)"

--- a/app/helpers/patients_helper.rb
+++ b/app/helpers/patients_helper.rb
@@ -41,11 +41,15 @@ module PatientsHelper
       patient.registration_academic_year == academic_year &&
         patient.registration.present?
 
-    str = str.dup if include_registration
+    include_academic_year =
+      academic_year != AcademicYear.current ||
+        AcademicYear.current != AcademicYear.pending
+
+    str = str.dup if include_registration || include_academic_year
 
     str << ", #{patient.registration}" if include_registration
 
-    if academic_year != AcademicYear.current
+    if include_academic_year
       str << " (#{format_academic_year(academic_year)} academic year)"
     end
 

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -236,8 +236,8 @@ describe "Child record imports duplicates" do
     expect(page).to have_content("Full nameDOE, Mark")
     expect(page).to have_content("Date of birth3 January 2010 (aged 14)")
     expect(page).to have_content("Date of birth3 March 2013 (aged 11)")
-    expect(page).to have_content("Year groupYear 10 (")
-    expect(page).to have_content("Year groupYear 8 (")
+    expect(page).to have_content("Year groupYear 10, ")
+    expect(page).to have_content("Year groupYear 8, ")
   end
 
   def when_i_go_to_the_import_page

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -120,5 +120,21 @@ describe PatientsHelper do
         it { should eq("Year 10 (2024 to 2025 academic year)") }
       end
     end
+
+    context "during the preparation period" do
+      let(:today) { Date.new(2024, 8, 1) }
+      let(:academic_year) { today.academic_year }
+
+      it { should eq("Year 9 (2023 to 2024 academic year)") }
+
+      context "with a registration" do
+        before do
+          patient.registration = "9AB"
+          patient.registration_academic_year = today.academic_year
+        end
+
+        it { should eq("Year 9, 9AB (2023 to 2024 academic year)") }
+      end
+    end
   end
 end

--- a/spec/helpers/patients_helper_spec.rb
+++ b/spec/helpers/patients_helper_spec.rb
@@ -102,7 +102,7 @@ describe PatientsHelper do
           patient.registration_academic_year = today.academic_year
         end
 
-        it { should eq("Year 9 (9AB)") }
+        it { should eq("Year 9, 9AB") }
       end
     end
 


### PR DESCRIPTION
This makes a number of small changes to clarify the year groups when they're shown:

- The registration is displayed after a comma as per the prototype.
- The academic year is always show during the preparation period.