### PR TITLE
Hide patients vaccinated by the same organisation but different team

### DIFF
--- a/app/policies/patient_policy.rb
+++ b/app/policies/patient_policy.rb
@@ -27,14 +27,17 @@ class PatientPolicy < ApplicationPolicy
           .arel
           .exists
 
+      vaccination_records_for_patients =
+        VaccinationRecord.where("vaccination_records.patient_id = patients.id")
+
       vaccination_record_exists =
-        VaccinationRecord
-          .where("vaccination_records.patient_id = patients.id")
+        vaccination_records_for_patients
           .where(session: team.sessions)
           .or(
-            VaccinationRecord.where(
-              "vaccination_records.patient_id = patients.id"
-            ).where(performed_ods_code: organisation.ods_code)
+            vaccination_records_for_patients.where(
+              performed_ods_code: organisation.ods_code,
+              session_id: nil
+            )
           )
           .arel
           .exists

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -32,7 +32,12 @@ class VaccinationRecordPolicy < ApplicationPolicy
         .kept
         .where(patient: team.patients)
         .or(scope.kept.where(session: team.sessions))
-        .or(scope.kept.where(performed_ods_code: organisation.ods_code))
+        .or(
+          scope.kept.where(
+            performed_ods_code: organisation.ods_code,
+            session_id: nil
+          )
+        )
     end
   end
 end

--- a/spec/policies/vaccination_record_policy_spec.rb
+++ b/spec/policies/vaccination_record_policy_spec.rb
@@ -73,15 +73,21 @@ describe VaccinationRecordPolicy do
   end
 
   describe "Scope#resolve" do
-    subject(:resolve) do
+    subject(:scope) do
       VaccinationRecordPolicy::Scope.new(user, VaccinationRecord).resolve
     end
 
     let(:programme) { create(:programme) }
-    let(:team) { create(:team, programmes: [programme]) }
+    let(:organisation) { create(:organisation) }
+
+    let(:team) { create(:team, organisation:, programmes: [programme]) }
+    let(:other_team) { create(:team, organisation:, programmes: [programme]) }
     let(:user) { create(:user, team:) }
 
     let(:session) { create(:session, team:, programmes: [programme]) }
+    let(:other_session) do
+      create(:session, team: other_team, programmes: [programme])
+    end
 
     let(:kept_vaccination_record) do
       create(:vaccination_record, session:, programme:)
@@ -90,9 +96,18 @@ describe VaccinationRecordPolicy do
       create(:vaccination_record, :discarded, session:, programme:)
     end
     let(:non_team_kept_batch) { create(:vaccination_record, programme:) }
+    let(:vaccination_record_same_organisation_different_team) do
+      create(:vaccination_record, session: other_session, programme:)
+    end
 
     it { should include(kept_vaccination_record) }
     it { should_not include(discarded_vaccination_record) }
     it { should_not include(non_team_kept_batch) }
+
+    it do
+      expect(scope).not_to include(
+        vaccination_record_same_organisation_different_team
+      )
+    end
   end
 end


### PR DESCRIPTION
At the moment if a patient is vaccinated by one team, and there's another team in the same organisation, they will be shown the patient because it's vaccination record has the same ODS code.

Instead, for a non-historical vaccination, we shouldn't be looking at the ODS code, instead we should be looking at the team that's attached to the session.

[Jira Issue - MAV-1280](https://nhsd-jira.digital.nhs.uk/browse/MAV-1280)