### PR TITLE
Ensure aged out patients are added to community clinic

### DIFF
--- a/app/jobs/patients_aged_out_of_school_job.rb
+++ b/app/jobs/patients_aged_out_of_school_job.rb
@@ -16,7 +16,13 @@ class PatientsAgedOutOfSchoolJob < ApplicationJob
         next if school.year_groups.include?(year_group)
 
         team = school.team
-        SchoolMove.new(patient:, home_educated: false, team:).confirm!
+
+        SchoolMove.new(
+          patient:,
+          home_educated: false,
+          team:,
+          academic_year:
+        ).confirm!
       end
   end
 end

--- a/spec/jobs/patients_aged_out_of_school_job_spec.rb
+++ b/spec/jobs/patients_aged_out_of_school_job_spec.rb
@@ -13,6 +13,9 @@ describe PatientsAgedOutOfSchoolJob do
   let(:date_of_birth) { Date.new(2008, 1, 1) }
 
   let!(:patient) { create(:patient, school:, date_of_birth:) }
+  let!(:clinic_session) do
+    team.generic_clinic_session(academic_year: AcademicYear.pending)
+  end
 
   context "on the last day of July" do
     let(:today) { Date.new(2024, 7, 31) }
@@ -27,6 +30,10 @@ describe PatientsAgedOutOfSchoolJob do
 
     it "doesn't move the patient to unknown school" do
       expect { perform }.not_to(change { patient.reload.school })
+    end
+
+    it "doesn't add the patient to the clinic session" do
+      expect { perform }.not_to(change { patient.sessions.count })
     end
   end
 
@@ -48,6 +55,11 @@ describe PatientsAgedOutOfSchoolJob do
 
     it "moves the patient to unknown school" do
       expect { perform }.to change { patient.reload.school }.to(nil)
+    end
+
+    it "adds the patient to the clinic session" do
+      expect { perform }.to change { patient.sessions.count }.by(1)
+      expect(patient.sessions).to include(clinic_session)
     end
   end
 end


### PR DESCRIPTION
This fixes a bug where patients who have aged out of their school aren't added to the community clinic when the nightly job runs, meaning they're left in a state where they exist but don't belong to any sessions, resulting in the patient being in a strange state.