### PR TITLE
Default session form academic year to pending

### DIFF
--- a/app/forms/session_search_form.rb
+++ b/app/forms/session_search_form.rb
@@ -8,7 +8,7 @@ class SessionSearchForm < SearchForm
   attribute :type, :string
 
   def academic_year
-    super || AcademicYear.current
+    super || AcademicYear.pending
   end
 
   def programmes=(values)

--- a/spec/features/td_ipv_already_had_spec.rb
+++ b/spec/features/td_ipv_already_had_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Td/IPV" do
+  around { |example| travel_to(Date.new(2025, 7, 1)) { example.run } }
+
   scenario "record a patient as already vaccinated outside the school session" do
     given_a_td_ipv_programme_with_a_session(clinic: false)
     and_a_patient_is_in_the_session

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Triage" do
+  around { |example| travel_to(Date.new(2025, 7, 1)) { example.run } }
+
   scenario "delay vaccination" do
     given_a_programme_with_a_running_session
     and_i_am_signed_in

--- a/spec/forms/session_search_form_spec.rb
+++ b/spec/forms/session_search_form_spec.rb
@@ -5,6 +5,8 @@ describe SessionSearchForm do
     described_class.new(request_session:, request_path:, **params)
   end
 
+  around { |example| travel_to(Date.new(2025, 7, 1)) { example.run } }
+
   let(:request_session) { {} }
   let(:request_path) { "/sessions" }
   let(:params) { {} }


### PR DESCRIPTION
When viewing the sessions during the preparation period, we should default to the upcoming sessions rather than the current ones.