### PR TITLE
Allow signing in without a team workgroup

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -17,12 +17,12 @@ module AuthenticationConcern
           redirect_to start_path
         end
       elsif cis2_enabled?
-        if !selected_cis2_role_is_valid?
+        if !selected_cis2_workgroup_is_valid?
+          redirect_to users_workgroup_not_found_path
+        elsif !selected_cis2_role_is_valid?
           redirect_to users_role_not_found_path
         elsif !selected_cis2_org_is_registered?
           redirect_to users_organisation_not_found_path
-        elsif !selected_cis2_workgroup_is_valid?
-          redirect_to users_workgroup_not_found_path
         end
       end
     end
@@ -36,7 +36,7 @@ module AuthenticationConcern
     end
 
     def selected_cis2_workgroup_is_valid?
-      cis2_info.has_valid_workgroup?
+      cis2_info.has_workgroup?
     end
 
     def selected_cis2_role_is_valid?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -109,7 +109,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       role_name: selected_cis2_nrbac_role["role_name"],
       role_code: selected_cis2_nrbac_role["role_code"],
       workgroups: selected_cis2_nrbac_role["workgroups"],
-      has_other_roles: raw_cis2_info["nhsid_nrbac_roles"].length > 1
+      has_other_roles: raw_cis2_info["nhsid_nrbac_roles"].length > 1,
+      team_workgroup: nil
     )
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -15,12 +15,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def cis2
     set_cis2_session_info
 
-    if !selected_cis2_role_is_valid?
+    if !selected_cis2_workgroup_is_valid?
+      redirect_to users_workgroup_not_found_path
+    elsif !selected_cis2_role_is_valid?
       redirect_to users_role_not_found_path
     elsif !selected_cis2_org_is_registered?
       redirect_to users_organisation_not_found_path
-    elsif !selected_cis2_workgroup_is_valid?
-      redirect_to users_workgroup_not_found_path
     else
       @user = User.find_or_create_from_cis2_oidc(user_cis2_info, valid_teams)
 

--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -21,7 +21,7 @@ class SelectTeamForm
       cis2_info.update!(
         organisation_code: team.organisation.ods_code,
         role_code: CIS2Info::NURSE_ROLE,
-        workgroups: [team.workgroup]
+        workgroups: [CIS2Info::WORKGROUP] + [team.workgroup]
       )
     end
 

--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -31,7 +31,7 @@ class SelectTeamForm
   def teams
     @teams ||=
       if Settings.cis2.enabled
-        cis2_info.organisation.teams.where(workgroup: cis2_info.workgroups)
+        cis2_info.organisation.teams
       else
         current_user.teams.includes(:organisation)
       end

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -6,6 +6,7 @@ class CIS2Info
   NURSE_ROLE = "S8000:G8000:R8001"
   ADMIN_ROLE = "S8000:G8001:R8006"
 
+  WORKGROUP = "schoolagedimmunisations"
   SUPERUSER_WORKGROUP = "mavissuperusers"
 
   attribute :organisation_name
@@ -33,8 +34,7 @@ class CIS2Info
       end
   end
 
-  def has_valid_workgroup? =
-    organisation&.teams&.exists?(workgroup: workgroups) || false
+  def has_workgroup? = workgroups&.include?(WORKGROUP) || false
 
   def is_admin? = role_code == ADMIN_ROLE
 

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -28,8 +28,7 @@ class CIS2Info
 
   def team
     @team ||=
-      if (workgroup = team_workgroup).present? &&
-           workgroups&.include?(workgroup)
+      if (workgroup = team_workgroup).present?
         Team.find_by(organisation:, workgroup:)
       end
   end

--- a/app/views/users/errors/workgroup_not_found.html.erb
+++ b/app/views/users/errors/workgroup_not_found.html.erb
@@ -3,7 +3,7 @@
 <h2 class="nhsuk-heading-m">Contact your registration authority</h2>
 
 <p>
-  You need to belong to a workgroup to use Mavis. If you think you should be in the workgroup, ask your registration authority to add you.
+  You need to belong to ‘<em><%= CIS2Info::WORKGROUP %></em>’ to use Mavis. If you think you should be in this workgroup, ask your registration authority to add you.
 </p>
 
 <% if @cis2_info.has_other_roles %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -43,7 +43,7 @@ FactoryBot.define do
       team { Team.includes(:organisation).first || create(:team) }
 
       role_code { CIS2Info::NURSE_ROLE }
-      role_workgroups { [] }
+      role_workgroups { [CIS2Info::WORKGROUP] }
 
       cis2_info_hash do
         {
@@ -83,7 +83,7 @@ FactoryBot.define do
     end
 
     trait :superuser do
-      role_workgroups { [CIS2Info::SUPERUSER_WORKGROUP] }
+      role_workgroups { [CIS2Info::WORKGROUP, CIS2Info::SUPERUSER_WORKGROUP] }
       fallback_role { :superuser }
     end
 

--- a/spec/features/user_cis2_authentication_from_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_from_redirect_spec.rb
@@ -21,7 +21,7 @@ describe "User CIS2 authentication" do
       family_name: "Test",
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      workgroups: [@team.workgroup]
+      workgroups: [CIS2Info::WORKGROUP, @team.workgroup]
     )
   end
 

--- a/spec/features/user_cis2_authentication_from_start_page_spec.rb
+++ b/spec/features/user_cis2_authentication_from_start_page_spec.rb
@@ -28,7 +28,7 @@ describe "User CIS2 authentication", :cis2 do
       family_name: "Test",
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      workgroups: [@team.workgroup]
+      workgroups: [CIS2Info::WORKGROUP, @team.workgroup]
     )
   end
 

--- a/spec/features/user_cis2_authentication_with_empty_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_empty_role_spec.rb
@@ -6,11 +6,11 @@ describe "User CIS2 authentication", :cis2 do
     when_i_go_to_the_sessions_page
     then_i_am_on_the_start_page
     when_i_click_the_cis2_login_button
-    then_i_see_the_wrong_role_error
+    then_i_see_the_wrong_workgroup_error
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_an_empty_role
-    @team = create(:team, ods_code: "AB12")
+    @team = create :team, ods_code: "AB12"
 
     mock_cis2_auth(selected_roleid: "")
   end
@@ -20,7 +20,7 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def then_i_am_on_the_start_page
-    expect(page).to have_current_path(start_path)
+    expect(page).to have_current_path start_path
   end
 
   def when_i_go_to_the_sessions_page
@@ -28,12 +28,12 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def then_i_see_the_sessions_page
-    expect(page).to have_current_path(sessions_path)
+    expect(page).to have_current_path sessions_path
   end
 
-  def then_i_see_the_wrong_role_error
-    expect(page).to have_heading(
-      "You do not have permission to use this service"
-    )
+  def then_i_see_the_wrong_workgroup_error
+    expect(
+      page
+    ).to have_heading "You’re not in the right workgroup to use this service"
   end
 end

--- a/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
@@ -11,7 +11,7 @@ describe "User CIS2 authentication" do
 
     given_my_team_has_been_setup_in_mavis
     when_i_click_the_change_role_button
-    then_i_see_the_sessions_page
+    then_i_see_the_team_selection_page
   end
 
   context "user has no other orgs to select" do
@@ -31,19 +31,19 @@ describe "User CIS2 authentication" do
   end
 
   def given_i_am_setup_in_cis2_but_not_mavis
-    mock_cis2_auth(
-      org_code: "A9A5A",
-      org_name: "SAIS Team",
-      workgroups: %w[a9a5a]
-    )
+    mock_cis2_auth(org_code: "A9A5A", org_name: "SAIS Team")
   end
 
   def given_my_team_has_been_setup_in_mavis
-    @team = create(:team, ods_code: "A9A5A", workgroup: "a9a5a")
+    @team = create :team, ods_code: "A9A5A"
   end
 
   def when_i_go_to_the_start_page
     visit "/start"
+  end
+
+  def when_i_click_the_cis2_login_button
+    click_button "Care Identity"
   end
 
   def when_i_click_the_cis2_login_button
@@ -58,8 +58,8 @@ describe "User CIS2 authentication" do
     visit sessions_path
   end
 
-  def then_i_see_the_sessions_page
-    expect(page).to have_current_path(sessions_path)
+  def then_i_see_the_team_selection_page
+    expect(page).to have_current_path(new_users_teams_path)
   end
 
   def given_i_am_setup_in_cis2_with_only_one_role

--- a/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
@@ -11,7 +11,7 @@ describe "User CIS2 authentication" do
 
     given_my_team_has_been_setup_in_mavis
     when_i_click_the_change_role_button
-    then_i_see_the_team_selection_page
+    then_i_see_the_sessions_page
   end
 
   context "user has no other orgs to select" do
@@ -35,15 +35,11 @@ describe "User CIS2 authentication" do
   end
 
   def given_my_team_has_been_setup_in_mavis
-    @team = create :team, ods_code: "A9A5A"
+    @team = create(:team, ods_code: "A9A5A")
   end
 
   def when_i_go_to_the_start_page
     visit "/start"
-  end
-
-  def when_i_click_the_cis2_login_button
-    click_button "Care Identity"
   end
 
   def when_i_click_the_cis2_login_button
@@ -58,8 +54,8 @@ describe "User CIS2 authentication" do
     visit sessions_path
   end
 
-  def then_i_see_the_team_selection_page
-    expect(page).to have_current_path(new_users_teams_path)
+  def then_i_see_the_sessions_page
+    expect(page).to have_current_path(sessions_path)
   end
 
   def given_i_am_setup_in_cis2_with_only_one_role

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -9,13 +9,13 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_role_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_session_page
+    then_i_see_the_team_selection_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
     @team = create(:team, ods_code: "AB12")
 
-    mock_cis2_auth(selected_roleid: "wrong-role", workgroups: [@team.workgroup])
+    mock_cis2_auth(selected_roleid: "wrong-role")
   end
 
   def when_i_click_the_cis2_login_button
@@ -30,8 +30,8 @@ describe "User CIS2 authentication", :cis2 do
     visit sessions_path
   end
 
-  def then_i_see_the_session_page
-    expect(page).to have_current_path(sessions_path)
+  def then_i_see_the_team_selection_page
+    expect(page).to have_current_path(new_users_teams_path)
   end
 
   def then_i_see_the_wrong_role_error
@@ -46,8 +46,7 @@ describe "User CIS2 authentication", :cis2 do
     mock_cis2_auth(
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      role: :nurse,
-      workgroups: [@team.workgroup]
+      role: :nurse
     )
     click_button "Change role"
   end

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -9,7 +9,7 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_role_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_team_selection_page
+    then_i_see_the_sessions_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
@@ -30,8 +30,8 @@ describe "User CIS2 authentication", :cis2 do
     visit sessions_path
   end
 
-  def then_i_see_the_team_selection_page
-    expect(page).to have_current_path(new_users_teams_path)
+  def then_i_see_the_sessions_page
+    expect(page).to have_current_path(sessions_path)
   end
 
   def then_i_see_the_wrong_role_error

--- a/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
@@ -9,13 +9,13 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_workgroup_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_session_page
+    then_i_see_the_team_selection_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
-    @team = create(:team, ods_code: "A9A5A")
+    @team = create :team, ods_code: "A9A5A"
 
-    mock_cis2_auth(workgroups: ["wrong-workgroup"])
+    mock_cis2_auth(selected_roleid: "wrong-workgroup")
   end
 
   def when_i_click_the_cis2_login_button
@@ -23,15 +23,15 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def then_i_am_on_the_start_page
-    expect(page).to have_current_path(start_path)
+    expect(page).to have_current_path start_path
   end
 
   def when_i_go_to_the_sessions_page
     visit sessions_path
   end
 
-  def then_i_see_the_session_page
-    expect(page).to have_current_path(sessions_path)
+  def then_i_see_the_team_selection_page
+    expect(page).to have_current_path(new_users_teams_path)
   end
 
   def then_i_see_the_wrong_workgroup_error
@@ -43,11 +43,7 @@ describe "User CIS2 authentication", :cis2 do
   def when_i_click_the_change_role_button_and_select_the_right_role
     # With don't actually get to select the right role directly in our test
     # setup so we change the cis2 response to simulate it.
-    mock_cis2_auth(
-      org_code: @team.organisation.ods_code,
-      org_name: @team.name,
-      workgroups: [@team.workgroup]
-    )
+    mock_cis2_auth(org_code: @team.organisation.ods_code, org_name: @team.name)
     click_button("Change role")
   end
 end

--- a/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_workgroup_spec.rb
@@ -9,7 +9,7 @@ describe "User CIS2 authentication", :cis2 do
     then_i_see_the_wrong_workgroup_error
 
     when_i_click_the_change_role_button_and_select_the_right_role
-    then_i_see_the_team_selection_page
+    then_i_see_the_sessions_page
   end
 
   def given_i_am_setup_in_mavis_and_cis2_but_with_the_wrong_role
@@ -30,8 +30,8 @@ describe "User CIS2 authentication", :cis2 do
     visit sessions_path
   end
 
-  def then_i_see_the_team_selection_page
-    expect(page).to have_current_path(new_users_teams_path)
+  def then_i_see_the_sessions_page
+    expect(page).to have_current_path(sessions_path)
   end
 
   def then_i_see_the_wrong_workgroup_error

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -36,7 +36,7 @@ module CIS2AuthHelper
               "role_code" => "S8000:G8000:R8001",
               "activities" => [],
               "activity_codes" => [],
-              "workgroups" => [],
+              "workgroups" => ["schoolagedimmunisations"],
               "workgroups_codes" => ["15025792819"]
             },
             {
@@ -48,7 +48,7 @@ module CIS2AuthHelper
               "role_code" => "S8000:G8000:R8003",
               "activities" => [],
               "activity_codes" => [],
-              "workgroups" => [],
+              "workgroups" => ["schoolagedimmunisations"],
               "workgroups_codes" => ["15025792819"]
             },
             {
@@ -72,7 +72,7 @@ module CIS2AuthHelper
               "role_code" => "S8000:G8000:R8001",
               "activities" => [],
               "activity_codes" => [],
-              "workgroups" => [],
+              "workgroups" => ["schoolagedimmunisations"],
               "workgroups_codes" => ["15025792819"]
             }
           ],
@@ -94,6 +94,7 @@ module CIS2AuthHelper
   end
 
   def cis2_sign_in(user, workgroups:, role:, ods_code:, superuser:)
+    workgroups.insert(0, "schoolagedimmunisations")
     workgroups << "mavissuperusers" if superuser
 
     mock_cis2_auth(


### PR DESCRIPTION
This allows users to sign in to any team that's part of an organisation, even if they're not part of the workgroup for that team.

This is necessary to allow release 2.17 to be deployed even if the SAIS teams haven't yet updated their CIS2 workgroups. This change will need to be reverted in 2.18.