### PR TITLE
Handle unknown session keys

### DIFF
--- a/app/models/concerns/request_session_persistable.rb
+++ b/app/models/concerns/request_session_persistable.rb
@@ -13,7 +13,10 @@ module RequestSessionPersistable
 
     stored_attributes = @request_session[request_session_key] || {}
 
-    super(stored_attributes.merge(attributes))
+    super({})
+
+    assign_attributes(stored_attributes.slice(*attribute_names))
+    assign_attributes(attributes)
 
     clear_changes_information
 

--- a/spec/models/concerns/request_session_persistable_spec.rb
+++ b/spec/models/concerns/request_session_persistable_spec.rb
@@ -20,8 +20,17 @@ describe RequestSessionPersistable do
   let(:model) { model_class.new(request_session:, **attributes) }
 
   let(:request_session) { {} }
+  let(:attributes) { {} }
 
   describe "#initialize" do
+    context "with unknown attributes in the session" do
+      let(:request_session) { { "unknown" => "value" } }
+
+      it "does not raise an error" do
+        expect { model }.not_to raise_error
+      end
+    end
+
     context "with a datetime attribute" do
       let(:attributes) { { datetime: "2025-05-21 11:48:17 +0100" } }
 


### PR DESCRIPTION
This ensures that when creating an instance of a `RequestSessionPersistable` model, if there are unknown keys in the session data these get ignored rather than the current behaviour where an exception is raised.

This allows us to migrate attributes in these models without needing users to sign out and clear their browser session data, instead any old values will simply be ignored.