### PR TITLE
Ensure triage and consent tags use the correct status colour

### DIFF
--- a/app/helpers/consents_helper.rb
+++ b/app/helpers/consents_helper.rb
@@ -34,7 +34,7 @@ module ConsentsHelper
       if consent.withdrawn? || consent.invalidated?
         "grey"
       elsif consent.response_given?
-        "green"
+        "aqua-green"
       elsif consent.response_refused?
         "red"
       else
@@ -50,10 +50,12 @@ module ConsentsHelper
         )
       end
 
+    # We can’t use the colour param as NHS.UK frontend uses different colour
+    # names (aqua-green) than those supported by GOV.UK Frontend (turquoise)
     if consent.invalidated?
       safe_join(
         [
-          govuk_tag(text: tag.s(text), colour:),
+          govuk_tag(text: tag.s(text), classes: "nhsuk-tag--#{colour}"),
           vaccine_method,
           tag.span("Invalid", class: "nhsuk-u-secondary-text-color")
         ].compact
@@ -61,13 +63,18 @@ module ConsentsHelper
     elsif consent.withdrawn?
       safe_join(
         [
-          govuk_tag(text: tag.s(text), colour:),
+          govuk_tag(text: tag.s(text), classes: "nhsuk-tag--#{colour}"),
           vaccine_method,
           tag.span("Withdrawn", class: "nhsuk-u-secondary-text-color")
         ].compact
       )
     else
-      safe_join([govuk_tag(text:, colour:), vaccine_method].compact)
+      safe_join(
+        [
+          govuk_tag(text:, classes: "nhsuk-tag--#{colour}"),
+          vaccine_method
+        ].compact
+      )
     end
   end
 end

--- a/app/helpers/triages_helper.rb
+++ b/app/helpers/triages_helper.rb
@@ -16,22 +16,24 @@ module TriagesHelper
       if triage.invalidated?
         "grey"
       elsif triage.ready_to_vaccinate?
-        "green"
+        "aqua-green"
       elsif triage.do_not_vaccinate?
         "red"
       else
         "blue"
       end
 
+    # We can’t use the colour param as NHS.UK frontend uses different colour
+    # names (aqua-green) than those supported by GOV.UK Frontend (turquoise)
     if triage.invalidated?
       safe_join(
         [
-          govuk_tag(text: tag.s(text), colour:),
+          govuk_tag(text: tag.s(text), classes: "nhsuk-tag--#{colour}"),
           tag.span("Invalid", class: "nhsuk-u-secondary-text-color")
         ]
       )
     else
-      govuk_tag(text:, colour:)
+      govuk_tag(text:, classes: "nhsuk-tag--#{colour}")
     end
   end
 end


### PR DESCRIPTION
In terms of the vaccination journey, green is reserved the final programme outcome, with all other intermediate success states using aqua-green.

Because there is no `aqua-green` tag colour in GOV.UK Frontend but there is in NHS.UK frontend, we can’t use the `colour` param on `govuk_tag` and instead have to supply the (correct) colour as an explicit class. 