### PR TITLE
Spoof user agent when downloading GIAS data

### DIFF
--- a/app/lib/mavis_cli/gias/download.rb
+++ b/app/lib/mavis_cli/gias/download.rb
@@ -19,6 +19,7 @@ module MavisCLI
 
         puts "Starting schools data download process..."
         agent = Mechanize.new
+        agent.user_agent_alias = "Mac Safari"
 
         puts "Visiting the downloads page"
         page =


### PR DESCRIPTION
Without this the script seems to fail with a forbidden HTTP status code.

```
/usr/local/bundle/ruby/3.4.0/gems/mechanize-2.14.0/lib/mechanize/http/agent.rb:340:in 'Mechanize::HTTP::Agent#fetch': 403 => Net::HTTPForbidden for https://get-information-schools.service.gov.uk/Downloads -- unhandled response (Mechanize::ResponseCodeError)
```