### PR TITLE
Sync vaccs record to API if `notify_parents` has changed due to consent changes

### DIFF
--- a/app/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern.rb
+++ b/app/models/concerns/vaccination_record_sync_to_nhs_immunisations_api_concern.rb
@@ -5,15 +5,11 @@ module VaccinationRecordSyncToNHSImmunisationsAPIConcern
 
   included do
     scope :syncable_to_nhs_immunisations_api,
-          -> do
-            includes(:patient, :programme).where(
-              notify_parents: true
-            ).recorded_in_service
-          end
+          -> { includes(:patient, :programme).recorded_in_service }
   end
 
   def syncable_to_nhs_immunisations_api?
-    recorded_in_service? && notify_parents
+    recorded_in_service?
   end
 
   def sync_status


### PR DESCRIPTION
Previously, when a consent was invalidated, and `notify_parents` was updated to `false` on the vaccination record, it wasn't triggering a sync to the Imms API