### PR TITLE
Add /api/reporting controllers, config and tests

### DIFF
--- a/app/controllers/api/reporting/base_controller.rb
+++ b/app/controllers/api/reporting/base_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class API::Reporting::BaseController < ActionController::API
+  # we need to still include the AuthenticationConcern even though
+  # we're not using the authenticate_user! callback, because we call it
+  # explicitly after validating the users' JWT in order to use the
+  # CIS2 organisation/workgroup validation code
+  include AuthenticationConcern
+  include ReportingAPI::TokenAuthenticationConcern
+
+  before_action :ensure_reporting_api_feature_enabled
+  before_action :authenticate_user_by_jwt!
+
+  private
+
+  def ensure_reporting_api_feature_enabled
+    render status: :forbidden and return unless Flipper.enabled?(:reporting_api)
+  end
+end

--- a/app/controllers/api/reporting/one_time_tokens_controller.rb
+++ b/app/controllers/api/reporting/one_time_tokens_controller.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class API::Reporting::OneTimeTokensController < API::Reporting::BaseController
+  # skip_before_action :authenticate_user!
+  before_action :ensure_reporting_api_feature_enabled,
+                :authenticate_app_by_client_id!,
+                :verify_grant_type!
+
+  def authorize
+    @token = ReportingAPI::OneTimeToken.find_by!(token: params[:code])
+    @token.delete # <- Tokens are one-time use
+    json_data = { jwt: jwt(@token) }
+    render json: json_data
+  rescue ActiveRecord::RecordNotFound
+    render json: { errors: "invalid_grant" }, status: :forbidden
+  end
+
+  private
+
+  def verify_grant_type!
+    unless params["grant_type"] == "authorization_code"
+      render json: { error: "unsupported_grant_type" }, status: :bad_request and
+        return
+    end
+  end
+
+  def jwt_payload(token)
+    {
+      "iat" => Time.current.utc.to_i,
+      "data" => {
+        "user" => token.user.as_json,
+        "cis2_info" => token.cis2_info
+      }
+    }
+  end
+
+  def jwt(token)
+    JWT.encode(
+      jwt_payload(token),
+      Settings.reporting_api.client_app.secret,
+      "HS512"
+    )
+  end
+
+  def ensure_reporting_api_feature_enabled
+    render status: :forbidden and return unless Flipper.enabled?(:reporting_api)
+  end
+end

--- a/app/controllers/api/reporting/totals_controller.rb
+++ b/app/controllers/api/reporting/totals_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class API::Reporting::TotalsController < API::Reporting::BaseController
+  def index
+    render json: { total: "dummy data" }
+  end
+end

--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -111,7 +111,12 @@ module AuthenticationConcern
       if Flipper.enabled?(:reporting_api)
         urls << reporting_app_redirect_uri_with_auth_code_for(current_user)
       end
-      urls += [stored_location_for(scope), dashboard_path]
+      urls += [
+        stored_location_for(scope),
+        session[:user_return_to],
+        dashboard_path
+      ]
+
       urls.compact.find do
         is_valid_redirect?(it) && (it != request.fullpath) &&
           (it != new_users_teams_path)

--- a/app/controllers/users/teams_controller.rb
+++ b/app/controllers/users/teams_controller.rb
@@ -35,6 +35,7 @@ class Users::TeamsController < ApplicationController
   private
 
   def return_to_path
-    session[:user_return_to] || dashboard_path
+    after_sign_in_path_for(current_user) || session[:user_return_to] ||
+      dashboard_path
   end
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -21,3 +21,7 @@ pds_lookup_during_import: Perform PDS lookups as part of the patient import
   processing.
 
 testing_api: Basic API useful for automated testing.
+
+reporting_api: Enables the Commissioner reporting component to authenticate to Mavis via OAUTH 2.0 
+  Authorization Code Flow (https://datatracker.ietf.org/doc/html/rfc6749#section-4.1), and retrieve 
+  statistics from /api/reporting/

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,10 @@ Rails.application.routes.draw do
         resources :teams, only: :destroy, param: :workgroup
         post "/onboard", to: "onboard#create"
       end
+      namespace :reporting do
+        post "authorize", to: "one_time_tokens#authorize"
+        get "totals", controller: :totals, action: :index
+      end
     end
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -49,3 +49,5 @@ splunk:
 reporting_api:
   client_app:
     token_ttl_seconds: 600
+    root_url:
+    secret:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -24,3 +24,5 @@ splunk:
 reporting_api:
   client_app:
     root_url: http://localhost:5001/
+    secret: ""
+    client_id: "testing_client_id"

--- a/spec/controllers/api/reporting/one_time_tokens_controller_spec.rb
+++ b/spec/controllers/api/reporting/one_time_tokens_controller_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe API::Reporting::OneTimeTokensController do
+  let(:user) { create(:user) }
+  let(:mock_cis2_info) { { "some_key" => "some value" } }
+  let(:valid_token) do
+    ReportingAPI::OneTimeToken.find_or_generate_for!(
+      user:,
+      cis2_info: mock_cis2_info
+    )
+  end
+  let(:invalid_token) { SecureRandom.hex(32) }
+
+  describe "#authorize" do
+    context "given a valid client_id when reporting_api is enabled" do
+      before { Flipper.enable(:reporting_api) }
+
+      let(:client_id) { Settings.reporting_api.client_app.client_id }
+      let(:grant_type) { "some_grant_type" }
+
+      let(:do_the_request) do
+        post :authorize,
+             params: {
+               code: token.token,
+               grant_type: grant_type,
+               client_id: client_id
+             },
+             format: :json
+      end
+
+      context "and a valid OneTimeToken in the code param" do
+        let(:token) { valid_token }
+
+        context "and a grant_type which is not authorization_code" do
+          let(:grant_type) { "not_an_authorization_code" }
+
+          it "responds with HTTP 400" do
+            do_the_request
+            expect(response.status).to eq(400)
+          end
+
+          describe "the response json" do
+            let(:response_json) { JSON.parse(response.body) }
+
+            it "has an error key set to unsupported_grant_type" do
+              do_the_request
+              expect(response_json["error"]).to eq("unsupported_grant_type")
+            end
+          end
+        end
+      end
+
+      context "and a grant_type of authorization_code" do
+        # this param name and value is required by the OAUTH 2.0 spec
+        # see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
+        let(:grant_type) { "authorization_code" }
+
+        context "and a valid OneTimeToken in the code param" do
+          let(:token) { valid_token }
+
+          it "responds with 200" do
+            do_the_request
+            expect(response.status).to eq(200)
+          end
+
+          it "deletes the OneTimeToken" do
+            do_the_request
+            expect(ReportingAPI::OneTimeToken.exists?(token.id)).to be(false)
+          end
+
+          it "responds with json" do
+            do_the_request
+            expect(response.headers["Content-type"]).to eq(
+              "application/json; charset=utf-8"
+            )
+          end
+
+          describe "the response json" do
+            let(:response_json) { JSON.parse(response.body) }
+
+            it "includes a JWT" do
+              do_the_request
+              expect(response_json["jwt"]).not_to be_empty
+            end
+
+            describe "the JWT payload" do
+              let(:payload) { response_json["jwt"] }
+
+              it "is encoded with the Mavis reporting app secret" do
+                do_the_request
+                expect {
+                  JWT.decode(
+                    response_json["jwt"],
+                    Settings.reporting_api.client_app.secret,
+                    true,
+                    { algorithm: "HS512" }
+                  )
+                }.not_to raise_error
+              end
+
+              describe "once decoded" do
+                let(:decoded_payload) do
+                  JWT.decode(
+                    response_json["jwt"],
+                    Settings.reporting_api.client_app.secret,
+                    true,
+                    { algorithm: "HS512" }
+                  )
+                end
+                let(:jwt_data) { decoded_payload.first["data"] }
+
+                it "includes the user attributes" do
+                  do_the_request
+                  expect(jwt_data["user"]).to eq(user.as_json)
+                end
+
+                it "includes the users cis2_info" do
+                  do_the_request
+                  expect(jwt_data["cis2_info"]).to eq(mock_cis2_info)
+                end
+              end
+            end
+          end
+        end
+
+        context "and a OneTimeToken in the code param which can't be found in the users table" do
+          let(:do_the_request) do
+            post :authorize,
+                 params: {
+                   code: invalid_token,
+                   grant_type: grant_type,
+                   client_id: client_id
+                 },
+                 format: :json
+          end
+          let(:response_json) { JSON.parse(response.body) }
+
+          it "returns 403" do
+            do_the_request
+            expect(response.status).to eq(403)
+          end
+
+          it "returns an error in the body" do
+            do_the_request
+            expect(response_json).to eq({ "errors" => "invalid_grant" })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/reporting/totals_controller_spec.rb
+++ b/spec/controllers/api/reporting/totals_controller_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe API::Reporting::TotalsController do
+  let(:team) { create(:team, :with_one_nurse) }
+  let(:user) { team.users.first }
+
+  let(:valid_payload) do
+    {
+      data: {
+        user: user.as_json,
+        cis2_info: {
+          organisation_code: team.organisation.ods_code,
+          workgroups: [team.workgroup],
+          role_code: CIS2Info::NURSE_ROLE
+        }
+      }
+    }
+  end
+
+  let(:invalid_payload) { { user: { id: -1 } } }
+
+  context "when the :reporting_api feature flag is not enabled" do
+    before { Flipper.disable(:reporting_api) }
+
+    describe "#index" do
+      context "when the request has a JWT param" do
+        let(:params) { { jwt: jwt } }
+
+        context "which is valid" do
+          let(:jwt) do
+            JWT.encode(
+              valid_payload,
+              Settings.reporting_api.client_app.secret,
+              "HS512"
+            )
+          end
+
+          it "responds with status :forbidden" do
+            get :index, params: { jwt: jwt }
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+    end
+  end
+
+  context "when the :reporting_api feature flag is enabled" do
+    before { Flipper.enable(:reporting_api) }
+
+    describe "#index" do
+      context "when the request has a JWT param" do
+        let(:params) { { jwt: jwt } }
+
+        context "which is valid" do
+          let(:jwt) do
+            JWT.encode(
+              valid_payload,
+              Settings.reporting_api.client_app.secret,
+              "HS512"
+            )
+          end
+
+          it "responds with status 200" do
+            get :index, params: { jwt: jwt }
+            expect(response.status).to eq(200)
+          end
+        end
+
+        context "which is not valid" do
+          let(:jwt) do
+            JWT.encode(
+              invalid_payload,
+              Settings.reporting_api.client_app.secret,
+              "HS512"
+            )
+          end
+
+          it "responds with status :forbidden" do
+            get :index, params: { jwt: jwt }
+            expect(response.status).to eq(403)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These controllers are disabled by default, through the `:reporting_api` feature flag.
As an extra safeguard against accidental enablement, for now they are also only routable on non-production environments, regardless of the feature flag settings.

**Do Not Merge Yet** - as this adds API endpoints, we need this to be tested and allocated to a release before merging.
 
Jira-Issue: MAV-1784