### PR TITLE
Allow writing to db/data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ USER 1000:1000
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
-VOLUME ["/rails/tmp", "rails/log", "/tmp", "/var/log", "/var/lib/amazon/ssm"]
+VOLUME ["/rails/db/data", "/rails/tmp", "/rails/log", "/tmp", "/var/log", "/var/lib/amazon/ssm"]
 
 # Start web server by default, this can be overwritten by environment variable
 EXPOSE 4000


### PR DESCRIPTION
This is needed to support the GIAS download command which gets the latest school data from GIAS so it can be imported.