### PR TITLE
Add parent details to consent summary

### DIFF
--- a/app/assets/stylesheets/components/_summary-list.scss
+++ b/app/assets/stylesheets/components/_summary-list.scss
@@ -23,4 +23,8 @@
     margin-bottom: 0;
     padding-bottom: 0;
   }
+
+  .nhsuk-summary-list__value {
+    padding-top: nhsuk-spacing(1);
+  }
 }

--- a/app/helpers/parents_helper.rb
+++ b/app/helpers/parents_helper.rb
@@ -11,7 +11,7 @@ module ParentsHelper
     end
   end
 
-  def format_parent_with_relationship(parent_relationship)
+  def format_parent_with_relationship(parent_relationship, include_phone: true)
     parent = parent_relationship.parent
 
     [
@@ -19,7 +19,7 @@ module ParentsHelper
       if (email = parent.email).present?
         tag.span(email, class: "nhsuk-u-secondary-text-color")
       end,
-      if (phone = parent.phone).present?
+      if include_phone && (phone = parent.phone).present?
         tag.span(phone, class: "nhsuk-u-secondary-text-color")
       end
     ].compact.join(tag.br).html_safe

--- a/app/views/consent_forms/search.html.erb
+++ b/app/views/consent_forms/search.html.erb
@@ -4,9 +4,6 @@
 
 <% page_title = "Search for a child record to match with #{@consent_form.full_name}" %>
 <%= h1 page_title: do %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    Consent response from <%= @consent_form.parent_full_name %>
-  </span>
   <%= page_title %>
 <% end %>
 
@@ -31,6 +28,10 @@
             summary_list.with_row do |row|
               row.with_key { "School" }
               row.with_value { patient_school(@consent_form) }
+            end
+            summary_list.with_row do |row|
+              row.with_key { "Parent" }
+              row.with_value { format_parent_with_relationship(@consent_form.parent_relationship, include_phone: false) }
             end
           end %>
 


### PR DESCRIPTION
When matching consent responses, it would be useful to see the submitted parent email, as a way to double check it is not a spoof parent, by comparing to details stored on patient in Mavis.

This allows us to send consent warning emails to non-matching parents, only where the consent form has _not_ been manually matched to the child. See [MAV-1717](https://nhsd-jira.digital.nhs.uk/browse/MAV-1717).

https://nhsd-jira.digital.nhs.uk/browse/MAV-1782

<img width="719" height="579" alt="image" src="https://github.com/user-attachments/assets/09171e0f-51ce-4625-b6a7-b7837631fdf1" />
