### PR TITLE
Move logging line in to correct place

### DIFF
--- a/app/lib/team_migration/base.rb
+++ b/app/lib/team_migration/base.rb
@@ -71,8 +71,8 @@ class TeamMigration::Base
     location.location_programme_year_groups.destroy_all
     location.create_default_programme_year_groups!(programmes)
 
-    log("Adding additional flu year groups to #{location.urn}")
     if sen && (programme = programmes.find(&:flu?))
+      log("Adding additional flu year groups to #{location.urn}")
       location
         .year_groups
         .select { it >= 12 }


### PR DESCRIPTION
This moves the log line that is displayed when adding additional flu year groups to a school to make it clear when this is happening. Currently the log entry prints always, whereas it should only print it when it happens.