### PR TITLE
Disable PDS update during import completely

### DIFF
--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -126,22 +126,6 @@ module CSVImportable
     parse_rows! if rows.nil?
     return if invalid?
 
-    if Flipper.enabled? :pds_lookup_during_import
-      changesets =
-        rows.each_with_index.map do |row, row_number|
-          PatientChangeset.from_import_row(row:, import: self, row_number:)
-        end
-
-      changesets.each do
-        if slow?
-          ProcessPatientChangesetsJob.perform_later(it)
-        else
-          ProcessPatientChangesetsJob.perform_now(it)
-        end
-      end
-      return
-    end
-
     counts = COUNT_COLUMNS.index_with(0)
 
     ActiveRecord::Base.transaction do

--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -2,6 +2,8 @@
 
 describe "Import child records" do
   scenario "PDS lookup extravaganza" do
+    skip "Feature is completely disabled temporarily"
+
     given_i_am_signed_in
     and_an_hpv_programme_is_underway
     and_an_existing_patient_record_exists


### PR DESCRIPTION
This is being triggered for immunisations imports as well as patient imports. We also want to disable this for the next release so that we can say with 100% certainty the new code paths won't be triggered.