### PR TITLE
Only reassign consent and triages that belong to original team

### DIFF
--- a/app/lib/team_migration/east_of_england.rb
+++ b/app/lib/team_migration/east_of_england.rb
@@ -301,8 +301,11 @@ class TeamMigration::EastOfEngland < TeamMigration::Base
           log(
             "Reassigning consents and triages of #{patient.id} to #{team.workgroup}"
           )
-          patient.consents.update_all(team_id: team.id)
-          patient.triages.update_all(team_id: team.id)
+          patient
+            .consents
+            .where(team: current_team)
+            .update_all(team_id: team.id)
+          patient.triages.where(team: current_team).update_all(team_id: team.id)
         end
 
       session


### PR DESCRIPTION
There are 3 patients which have moved from Coventry to Hertfordshire which means we shouldn't modify their original consent responses that are part of a different team.