### PR TITLE
Add conflicting session status

### DIFF
--- a/app/lib/status_generator/consent.rb
+++ b/app/lib/status_generator/consent.rb
@@ -29,6 +29,10 @@ class StatusGenerator::Consent
     end
   end
 
+  def status_changed_at
+    consents_for_status.map(&:submitted_at).max
+  end
+
   def vaccine_methods
     status_should_be_given? ? agreed_vaccine_methods : []
   end

--- a/app/lib/status_generator/session.rb
+++ b/app/lib/status_generator/session.rb
@@ -6,6 +6,7 @@ class StatusGenerator::Session
     academic_year:,
     session_attendance:,
     programme:,
+    patient:,
     consents:,
     triages:,
     vaccination_records:
@@ -14,6 +15,7 @@ class StatusGenerator::Session
     @academic_year = academic_year
     @session_attendance = session_attendance
     @programme = programme
+    @patient = patient
     @consents = consents
     @triages = triages
     @vaccination_records = vaccination_records
@@ -59,6 +61,7 @@ class StatusGenerator::Session
               :academic_year,
               :session_attendance,
               :programme,
+              :patient,
               :consents,
               :triages,
               :vaccination_records

--- a/app/lib/status_generator/session.rb
+++ b/app/lib/status_generator/session.rb
@@ -5,7 +5,7 @@ class StatusGenerator::Session
     session_id:,
     academic_year:,
     session_attendance:,
-    programme_id:,
+    programme:,
     consents:,
     triages:,
     vaccination_records:
@@ -13,7 +13,7 @@ class StatusGenerator::Session
     @session_id = session_id
     @academic_year = academic_year
     @session_attendance = session_attendance
-    @programme_id = programme_id
+    @programme = programme
     @consents = consents
     @triages = triages
     @vaccination_records = vaccination_records
@@ -58,7 +58,7 @@ class StatusGenerator::Session
   attr_reader :session_id,
               :academic_year,
               :session_attendance,
-              :programme_id,
+              :programme,
               :consents,
               :triages,
               :vaccination_records
@@ -129,18 +129,19 @@ class StatusGenerator::Session
 
   def latest_consents
     @latest_consents ||=
-      ConsentGrouper.call(consents, programme_id:, academic_year:)
+      ConsentGrouper.call(consents, programme_id: programme.id, academic_year:)
   end
 
   def triage
-    @triage ||= TriageFinder.call(triages, programme_id:, academic_year:)
+    @triage ||=
+      TriageFinder.call(triages, programme_id: programme.id, academic_year:)
   end
 
   def vaccination_record
     @vaccination_record ||=
       if session_id
         vaccination_records.find do
-          it.programme_id == programme_id && it.session_id == session_id
+          it.programme_id == programme.id && it.session_id == session_id
         end
       end
   end

--- a/app/lib/status_generator/session.rb
+++ b/app/lib/status_generator/session.rb
@@ -34,6 +34,8 @@ class StatusGenerator::Session
       :absent_from_session
     elsif status_should_be_unwell?
       :unwell
+    elsif status_should_be_conflicting_consent?
+      :conflicting_consent
     else
       :none_yet
     end
@@ -52,6 +54,8 @@ class StatusGenerator::Session
       absence_date
     elsif status_should_be_unwell?
       unwell_date
+    elsif status_should_be_conflicting_consent?
+      conflicting_consent_date
     end
   end
 
@@ -127,6 +131,14 @@ class StatusGenerator::Session
 
   def unwell_date
     vaccination_record.performed_at
+  end
+
+  def status_should_be_conflicting_consent?
+    consent_generator.status == :conflicts
+  end
+
+  def conflicting_consent_date
+    consent_generator.status_changed_at
   end
 
   def consent_generator

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -92,7 +92,7 @@ class Patient::VaccinationStatus < ApplicationRecord
         session_id:,
         academic_year:,
         session_attendance:,
-        programme_id:,
+        programme:,
         consents:,
         triages:,
         vaccination_records:

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -58,7 +58,8 @@ class Patient::VaccinationStatus < ApplicationRecord
          had_contraindications: 3,
          refused: 4,
          absent_from_session: 5,
-         unwell: 6
+         unwell: 6,
+         conflicting_consent: 7
        },
        default: :none_yet,
        prefix: true,

--- a/app/models/patient/vaccination_status.rb
+++ b/app/models/patient/vaccination_status.rb
@@ -93,6 +93,7 @@ class Patient::VaccinationStatus < ApplicationRecord
         academic_year:,
         session_attendance:,
         programme:,
+        patient:,
         consents:,
         triages:,
         vaccination_records:

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -44,7 +44,6 @@ class Team < ApplicationRecord
   has_many :cohort_imports
   has_many :consent_forms
   has_many :consents
-  has_many :immunisation_records
   has_many :locations
   has_many :team_programmes, -> { joins(:programme).order(:"programmes.type") }
   has_many :sessions

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -50,6 +50,7 @@ en:
       label:
         absent_from_session: Absent from session
         already_had: Already had vaccine
+        conflicting_consent: Conflicting consent
         had_contraindications: Had contraindications
         none_yet: No outcome
         refused: Refused vaccine
@@ -58,6 +59,7 @@ en:
       colour:
         absent_from_session: dark-orange
         already_had: green
+        conflicting_consent: orange
         had_contraindications: red
         none_yet: white
         refused: red

--- a/spec/lib/status_generator/session_spec.rb
+++ b/spec/lib/status_generator/session_spec.rb
@@ -7,6 +7,7 @@ describe StatusGenerator::Session do
       academic_year: patient_session.academic_year,
       session_attendance: patient_session.session_attendances.last,
       programme:,
+      patient:,
       consents: patient.consents,
       triages: patient.triages,
       vaccination_records: patient.vaccination_records

--- a/spec/lib/status_generator/session_spec.rb
+++ b/spec/lib/status_generator/session_spec.rb
@@ -69,7 +69,7 @@ describe StatusGenerator::Session do
         create(:consent, :given, patient:, programme:, parent:)
       end
 
-      it { should be(:none_yet) }
+      it { should be(:conflicting_consent) }
     end
 
     context "when triaged as do not vaccinate" do

--- a/spec/lib/status_generator/session_spec.rb
+++ b/spec/lib/status_generator/session_spec.rb
@@ -6,7 +6,7 @@ describe StatusGenerator::Session do
       session_id: patient_session.session_id,
       academic_year: patient_session.academic_year,
       session_attendance: patient_session.session_attendances.last,
-      programme_id: programme.id,
+      programme:,
       consents: patient.consents,
       triages: patient.triages,
       vaccination_records: patient.vaccination_records

--- a/spec/lib/status_generator/session_spec.rb
+++ b/spec/lib/status_generator/session_spec.rb
@@ -233,46 +233,29 @@ describe StatusGenerator::Session do
     end
 
     context "with refused from both vaccination record and consent" do
-      let(:earlier_date) { 3.days.ago }
-      let(:later_date) { 1.day.ago }
+      let(:vaccination_record_date) { 1.day.ago }
+      let(:consent_date) { 3.days.ago }
 
-      context "when vaccination record date is earlier" do
-        before do
-          create(
-            :vaccination_record,
-            :refused,
-            patient: patient,
-            session: session,
-            programme: programme,
-            performed_at: earlier_date
-          )
+      before do
+        create(
+          :vaccination_record,
+          :refused,
+          patient: patient,
+          session: session,
+          programme: programme,
+          performed_at: vaccination_record_date
+        )
 
-          consent =
-            create(:consent, :refused, patient: patient, programme: programme)
-          consent.update_column(:submitted_at, later_date)
-        end
-
-        it { should eq(earlier_date) }
+        create(
+          :consent,
+          :refused,
+          patient: patient,
+          programme: programme,
+          submitted_at: consent_date
+        )
       end
 
-      context "when consent date is earlier" do
-        before do
-          create(
-            :vaccination_record,
-            :refused,
-            patient: patient,
-            session: session,
-            programme: programme,
-            performed_at: later_date
-          )
-
-          consent =
-            create(:consent, :refused, patient: patient, programme: programme)
-          consent.update_column(:submitted_at, earlier_date)
-        end
-
-        it { should eq(earlier_date) }
-      end
+      it { should eq(vaccination_record_date) }
     end
 
     context "with absent from vaccination record" do


### PR DESCRIPTION
This ensures that when consent is in the conflicting status, the session outcome is set to conflicting. This was a missing session outcome from the design.

[Jira Issue - MAV-1793](https://nhsd-jira.digital.nhs.uk/browse/MAV-1793)