### PR TITLE
Multiple PDS searches during import

### DIFF
--- a/app/jobs/patient_nhs_number_lookup_job.rb
+++ b/app/jobs/patient_nhs_number_lookup_job.rb
@@ -26,9 +26,22 @@ class PatientNHSNumberLookupJob < ApplicationJob
        )
       PatientMerger.call(to_keep: existing_patient, to_destroy: patient)
       existing_patient.update_from_pds!(pds_patient)
+
+      PDSSearchResult.create!(
+        patient_id: existing_patient.id,
+        step: :no_fuzzy_with_history_daily,
+        result: :one_match,
+        nhs_number: pds_patient.nhs_number
+      )
     else
       patient.nhs_number = pds_patient.nhs_number
       patient.update_from_pds!(pds_patient)
+      PDSSearchResult.create!(
+        patient_id: patient.id,
+        step: :no_fuzzy_with_history_daily,
+        result: :one_match,
+        nhs_number: pds_patient.nhs_number
+      )
     end
   end
 end

--- a/app/jobs/process_patient_changesets_job.rb
+++ b/app/jobs/process_patient_changesets_job.rb
@@ -5,15 +5,154 @@ class ProcessPatientChangesetsJob < ApplicationJob
 
   queue_as :imports
 
-  def perform(patient_changeset)
-    attrs = patient_changeset.child_attributes
+  def perform(patient_changeset, step_name = nil)
+    step_name ||= first_step_name
+    step = steps[step_name]
 
-    pds_patient = search_for_patient(attrs)
-    if pds_patient.present?
-      attrs["nhs_number"] = pds_patient.nhs_number
-      patient_changeset.pds_nhs_number = pds_patient.nhs_number
+    result, pds_patient =
+      search_for_patient(patient_changeset.child_attributes, step_name)
+    patient_changeset.search_results << {
+      step: step_name,
+      result: result,
+      nhs_number: pds_patient&.nhs_number
+    }
+
+    if multiple_nhs_numbers_found?(patient_changeset)
+      finish_processing(patient_changeset)
     end
 
+    next_step = step[result]
+
+    if next_step == :give_up
+      finish_processing(patient_changeset)
+    elsif next_step == :save_nhs_number_if_unique
+      if nhs_number_is_unique_across_searches?(patient_changeset)
+        unique_nhs_number = get_unique_nhs_number(patient_changeset)
+        if unique_nhs_number
+          patient_changeset.child_attributes["nhs_number"] = unique_nhs_number
+          patient_changeset.pds_nhs_number = unique_nhs_number
+        end
+      end
+      finish_processing(patient_changeset)
+    elsif next_step.in?(steps.keys)
+      raise "Recursive step detected: #{next_step}" if next_step == step_name
+      enqueue_next_search(patient_changeset, next_step)
+    elsif result == :no_postcode
+      finish_processing(patient_changeset)
+    else
+      raise "Unknown step: #{next_step}"
+    end
+  end
+
+  private
+
+  def unique_nhs_numbers(patient_changeset)
+    patient_changeset.search_results.pluck(:nhs_number).compact.uniq
+  end
+
+  def get_unique_nhs_number(patient_changeset)
+    numbers = unique_nhs_numbers(patient_changeset)
+    numbers.count == 1 ? numbers.first : nil
+  end
+
+  def nhs_number_is_unique_across_searches?(patient_changeset)
+    unique_nhs_numbers(patient_changeset).count == 1
+  end
+
+  def multiple_nhs_numbers_found?(patient_changeset)
+    unique_nhs_numbers(patient_changeset).count > 1
+  end
+
+  def first_step_name
+    :no_fuzzy_with_history
+  end
+
+  def steps
+    {
+      no_fuzzy_with_history: {
+        no_matches: :no_fuzzy_with_wildcard_postcode,
+        one_match: :save_nhs_number_if_unique,
+        too_many_matches: :no_fuzzy_without_history
+      },
+      no_fuzzy_without_history: {
+        no_matches: :fuzzy_without_history,
+        one_match: :save_nhs_number_if_unique,
+        too_many_matches: :give_up,
+        format_query: ->(query) { query.merge(history: false) }
+      },
+      no_fuzzy_with_wildcard_postcode: {
+        no_matches: :no_fuzzy_with_wildcard_given_name,
+        one_match: :no_fuzzy_with_wildcard_given_name,
+        too_many_matches: :no_fuzzy_with_wildcard_given_name,
+        format_query: ->(query) { query[:address_postcode][2..] = "*" }
+      },
+      no_fuzzy_with_wildcard_given_name: {
+        no_matches: :no_fuzzy_with_wildcard_family_name,
+        one_match: :no_fuzzy_with_wildcard_family_name,
+        too_many_matches: :no_fuzzy_with_wildcard_family_name,
+        format_query: ->(query) { query[:given_name][3..] = "*" }
+      },
+      no_fuzzy_with_wildcard_family_name: {
+        no_matches: :fuzzy_without_history,
+        one_match: :fuzzy_without_history,
+        too_many_matches: :fuzzy_without_history,
+        format_query: ->(query) { query[:family_name][3..] = "*" }
+      },
+      fuzzy_without_history: {
+        no_matches: :fuzzy_with_history,
+        one_match: :save_nhs_number_if_unique,
+        too_many_matches: :save_nhs_number_if_unique,
+        format_query: ->(query) do
+          query[:fuzzy] = true
+          query[:history] = false
+        end
+      },
+      fuzzy_with_history: {
+        no_matches: :give_up,
+        one_match: :save_nhs_number_if_unique,
+        too_many_matches: :save_nhs_number_if_unique,
+        format_query: ->(query) do
+          query[:fuzzy] = true
+          query[:history] = true
+        end
+      }
+    }
+  end
+
+  def search_for_patient(attrs, step_name)
+    return :no_postcode, nil if attrs["address_postcode"].blank?
+    query = {
+      family_name: attrs["family_name"].dup,
+      given_name: attrs["given_name"].dup,
+      date_of_birth: attrs["date_of_birth"].dup,
+      address_postcode: attrs["address_postcode"].dup,
+      history: true,
+      fuzzy: false
+    }
+    if steps[step_name][:format_query].respond_to?(:call)
+      result = steps[step_name][:format_query].call(query)
+      query = result if result.is_a?(Hash)
+    end
+
+    patient = PDS::Patient.search(**query)
+    return :no_matches, nil if patient.nil?
+
+    [:one_match, patient]
+  rescue NHS::PDS::PatientNotFound
+    [:no_matches, nil]
+  rescue NHS::PDS::TooManyMatches
+    [:too_many_matches, nil]
+  end
+
+  def enqueue_next_search(patient_changeset, next_step)
+    if patient_changeset.import.slow?
+      ProcessPatientChangesetsJob.perform_later(patient_changeset, next_step)
+    else
+      ProcessPatientChangesetsJob.perform_now(patient_changeset, next_step)
+    end
+  end
+
+  def finish_processing(patient_changeset)
     patient_changeset.processed!
     patient_changeset.save!
 
@@ -25,19 +164,5 @@ class ProcessPatientChangesetsJob < ApplicationJob
         CommitPatientChangesetsJob.perform_now(patient_changeset.import)
       end
     end
-  end
-
-  private
-
-  def search_for_patient(attrs)
-    return nil if attrs["address_postcode"].blank?
-    PDS::Patient.search(
-      family_name: attrs["family_name"],
-      given_name: attrs["given_name"],
-      date_of_birth: attrs["date_of_birth"],
-      address_postcode: attrs["address_postcode"]
-    )
-  rescue NHS::PDS::PatientNotFound, NHS::PDS::TooManyMatches
-    nil
   end
 end

--- a/app/models/class_import.rb
+++ b/app/models/class_import.rb
@@ -46,6 +46,7 @@ class ClassImport < PatientImport
            class_name: "PatientChangeset",
            as: :import,
            dependent: :destroy
+  has_many :pds_search_results
 
   def postprocess_rows!
     # Remove patients already in the sessions but not in the class list.

--- a/app/models/class_imports_patient.rb
+++ b/app/models/class_imports_patient.rb
@@ -4,8 +4,8 @@
 #
 # Table name: class_imports_patients
 #
-#  class_import_id       :bigint           not null
-#  patient_id            :bigint           not null
+#  class_import_id :bigint           not null
+#  patient_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/cohort_import.rb
+++ b/app/models/cohort_import.rb
@@ -40,6 +40,7 @@ class CohortImport < PatientImport
            class_name: "PatientChangeset",
            as: :import,
            dependent: :destroy
+  has_many :pds_search_results
 
   def postprocess_rows!
     PatientsAgedOutOfSchoolJob.perform_later

--- a/app/models/cohort_imports_patient.rb
+++ b/app/models/cohort_imports_patient.rb
@@ -4,8 +4,8 @@
 #
 # Table name: cohort_imports_patients
 #
-#  cohort_import_id      :bigint           not null
-#  patient_id            :bigint           not null
+#  cohort_import_id :bigint           not null
+#  patient_id       :bigint           not null
 #
 # Indexes
 #

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -69,6 +69,7 @@ class Patient < ApplicationRecord
   has_many :notify_log_entries
   has_many :parent_relationships, -> { order(:created_at) }
   has_many :patient_sessions
+  has_many :pds_search_results
   has_many :school_move_log_entries
   has_many :school_moves
   has_many :session_notifications

--- a/app/models/patient_changeset.rb
+++ b/app/models/patient_changeset.rb
@@ -39,10 +39,8 @@ class PatientChangeset < ApplicationRecord
               },
               parent_2: {
               },
-              pds: {
-              }
+              search_results: []
             }
-
   belongs_to :import, polymorphic: true
   belongs_to :patient, optional: true
   belongs_to :school, class_name: "Location", optional: true
@@ -70,7 +68,8 @@ class PatientChangeset < ApplicationRecord
         #       Maybe one day.
         school_move_source: row.school_move_source,
         parent_1: row.parent_1_import_attributes,
-        parent_2: row.parent_2_import_attributes
+        parent_2: row.parent_2_import_attributes,
+        search_results: []
       }
     )
   end
@@ -82,6 +81,8 @@ class PatientChangeset < ApplicationRecord
   def parent_1_attributes = pending_changes["parent_1"]
 
   def parent_2_attributes = pending_changes["parent_2"]
+
+  def search_results = pending_changes["search_results"]
 
   def academic_year = pending_changes["academic_year"]
 

--- a/app/models/pds/patient.rb
+++ b/app/models/pds/patient.rb
@@ -16,13 +16,21 @@ class PDS::Patient
       from_pds_fhir_response(response.body)
     end
 
-    def search(family_name:, given_name:, date_of_birth:, address_postcode:)
+    def search(
+      family_name:,
+      given_name:,
+      date_of_birth:,
+      address_postcode:,
+      history: true,
+      fuzzy: false
+    )
       query = {
         "family" => family_name,
         "given" => given_name,
         "birthdate" => "eq#{date_of_birth}",
         "address-postalcode" => address_postcode,
-        "_history" => true # look up previous names and addresses,
+        "_history" => history, # look up previous names and addresses,
+        "_fuzzy-match" => fuzzy
       }.compact_blank
 
       results = NHS::PDS.search_patients(query).body

--- a/app/models/pds_search_result.rb
+++ b/app/models/pds_search_result.rb
@@ -31,12 +31,13 @@ class PDSSearchResult < ApplicationRecord
   enum :step,
        {
          no_fuzzy_with_history: 0,
-         no_fuzzy_without_history: 1,
-         no_fuzzy_with_wildcard_postcode: 2,
-         no_fuzzy_with_wildcard_given_name: 3,
-         no_fuzzy_with_wildcard_family_name: 4,
-         fuzzy_without_history: 5,
-         fuzzy_with_history: 6
+         no_fuzzy_with_history_daily: 1,
+         no_fuzzy_without_history: 2,
+         no_fuzzy_with_wildcard_postcode: 3,
+         no_fuzzy_with_wildcard_given_name: 4,
+         no_fuzzy_with_wildcard_family_name: 5,
+         fuzzy_without_history: 6,
+         fuzzy_with_history: 7
        },
        validate: true
 

--- a/app/models/pds_search_result.rb
+++ b/app/models/pds_search_result.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: pds_search_results
+#
+#  id          :bigint           not null, primary key
+#  import_type :string
+#  nhs_number  :string
+#  result      :integer          not null
+#  step        :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  import_id   :bigint
+#  patient_id  :bigint           not null
+#
+# Indexes
+#
+#  index_pds_search_results_on_import               (import_type,import_id)
+#  index_pds_search_results_on_patient_id           (patient_id)
+#  index_pds_search_results_on_patient_import_step  (patient_id,import_type,import_id,step) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#
+class PDSSearchResult < ApplicationRecord
+  belongs_to :patient
+  belongs_to :import, polymorphic: true, optional: true
+
+  enum :step,
+       {
+         no_fuzzy_with_history: 0,
+         no_fuzzy_without_history: 1,
+         no_fuzzy_with_wildcard_postcode: 2,
+         no_fuzzy_with_wildcard_given_name: 3,
+         no_fuzzy_with_wildcard_family_name: 4,
+         fuzzy_without_history: 5,
+         fuzzy_with_history: 6
+       },
+       validate: true
+
+  enum :result,
+       { no_matches: 0, one_match: 1, too_many_matches: 2 },
+       validate: true
+end

--- a/db/migrate/20250815205653_create_pds_search_results.rb
+++ b/db/migrate/20250815205653_create_pds_search_results.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreatePDSSearchResults < ActiveRecord::Migration[7.0]
+  def change
+    create_table :pds_search_results do |t|
+      t.references :patient, null: false, foreign_key: true
+      t.references :import, polymorphic: true
+      t.integer :step, null: false
+      t.integer :result, null: false
+      t.string :nhs_number
+      t.timestamps
+    end
+
+    add_index :pds_search_results,
+              %i[patient_id import_type import_id step],
+              unique: true,
+              name: "index_pds_search_results_on_patient_import_step"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -695,6 +695,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_085332) do
     t.index ["school_id"], name: "index_patients_on_school_id"
   end
 
+  create_table "pds_search_results", force: :cascade do |t|
+    t.bigint "patient_id", null: false
+    t.string "import_type"
+    t.bigint "import_id"
+    t.integer "step", null: false
+    t.integer "result", null: false
+    t.string "nhs_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["import_type", "import_id"], name: "index_pds_search_results_on_import"
+    t.index ["patient_id", "import_type", "import_id", "step"], name: "index_pds_search_results_on_patient_import_step", unique: true
+    t.index ["patient_id"], name: "index_pds_search_results_on_patient_id"
+  end
+
   create_table "pre_screenings", force: :cascade do |t|
     t.bigint "patient_session_id", null: false
     t.bigint "performed_by_user_id", null: false
@@ -1041,6 +1055,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_085332) do
   add_foreign_key "patient_vaccination_statuses", "programmes"
   add_foreign_key "patients", "locations", column: "gp_practice_id"
   add_foreign_key "patients", "locations", column: "school_id"
+  add_foreign_key "pds_search_results", "patients"
   add_foreign_key "pre_screenings", "patient_sessions"
   add_foreign_key "pre_screenings", "programmes"
   add_foreign_key "pre_screenings", "users", column: "performed_by_user_id"

--- a/spec/factories/patient_changesets.rb
+++ b/spec/factories/patient_changesets.rb
@@ -28,8 +28,8 @@
 #
 FactoryBot.define do
   factory :patient_changeset do
-    pending_changes { {} }
-    row_number { 0 }
+    row_number { 1 }
+    status { :pending }
 
     trait :class_import do
       import { association(:class_import) }
@@ -37,6 +37,39 @@ FactoryBot.define do
 
     trait :cohort_import do
       import { association(:cohort_import) }
+    end
+
+    pending_changes do
+      {
+        child: {
+          "given_name" => "John",
+          "family_name" => "Doe",
+          "date_of_birth" => "2010-01-01",
+          "address_postcode" => "SW1A 1AA",
+          "nhs_number" => nil
+        },
+        parent_1: {
+        },
+        parent_2: {
+        },
+        pds: {
+        },
+        search_results: []
+      }
+    end
+
+    after(:build) do |changeset|
+      changeset.import_type = changeset.import.class.name
+    end
+
+    trait :with_nhs_number do
+      after(:build) do |changeset|
+        changeset.pending_changes["child"]["nhs_number"] = "1234567890"
+      end
+    end
+
+    trait :processed do
+      status { :processed }
     end
   end
 end

--- a/spec/factories/patient_changesets.rb
+++ b/spec/factories/patient_changesets.rb
@@ -4,16 +4,19 @@
 #
 # Table name: patient_changesets
 #
-#  id              :bigint           not null, primary key
-#  import_type     :string           not null
-#  pending_changes :jsonb            not null
-#  row_number      :integer          not null
-#  status          :integer          default("pending"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  import_id       :bigint           not null
-#  patient_id      :bigint
-#  school_id       :bigint
+#  id                    :bigint           not null, primary key
+#  import_type           :string           not null
+#  matched_on_nhs_number :boolean
+#  pds_nhs_number        :string
+#  pending_changes       :jsonb            not null
+#  row_number            :integer          not null
+#  status                :integer          default("pending"), not null
+#  uploaded_nhs_number   :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  import_id             :bigint           not null
+#  patient_id            :bigint
+#  school_id             :bigint
 #
 # Indexes
 #

--- a/spec/features/import_child_records_preparation_spec.rb
+++ b/spec/features/import_child_records_preparation_spec.rb
@@ -196,7 +196,8 @@ describe "Import child records" do
   def and_pds_lookup_during_import_is_enabled
     Flipper.enable(:pds_lookup_during_import)
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-02",

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -140,7 +140,8 @@ describe "Import child records" do
   def and_pds_lookup_during_import_is_enabled
     Flipper.enable(:pds_lookup_during_import)
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-02",

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -112,7 +112,8 @@ describe "Child record imports duplicates" do
 
     Flipper.enable(:pds_lookup_during_import)
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-02",

--- a/spec/features/import_child_records_with_twins_spec.rb
+++ b/spec/features/import_child_records_with_twins_spec.rb
@@ -36,7 +36,8 @@ describe "Child record imports twins" do
   end
 
   def and_pds_lookup_during_import_returns_nhs_numbers
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-02",

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -83,7 +83,8 @@ describe "Import class lists - Moving patients" do
   def and_pds_lookup_during_import_is_enabled
     Flipper.enable(:pds_lookup_during_import)
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-02",

--- a/spec/features/import_class_lists_spec.rb
+++ b/spec/features/import_class_lists_spec.rb
@@ -89,7 +89,8 @@ describe "Import class lists" do
   def and_pds_lookup_during_import_is_enabled
     Flipper.enable(:pds_lookup_during_import)
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-02",

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -94,21 +94,24 @@ describe "Class list imports duplicates" do
   def and_pds_lookup_during_import_is_enabled
     Flipper.enable(:pds_lookup_during_import)
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000018",
       "family" => "Smith",
       "given" => "Jimmy",
       "birthdate" => "eq2010-01-01",
       "address-postalcode" => "SW1A 1BB"
     )
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000034",
       "family" => "Salles",
       "given" => "Rebecca",
       "birthdate" => "eq2010-02-03",
       "address-postalcode" => "SW1A 3BB"
     )
 
-    stub_pds_search_to_return_no_patients(
+    stub_pds_search_to_return_a_patient(
+      "9990000026",
       "family" => "Jones",
       "given" => "Sara",
       "birthdate" => "eq2010-02-02",

--- a/spec/jobs/patient_nhs_number_lookup_job_spec.rb
+++ b/spec/jobs/patient_nhs_number_lookup_job_spec.rb
@@ -60,6 +60,13 @@ describe PatientNHSNumberLookupJob do
         expect(patient).to receive(:update_from_pds!)
         perform_now
       end
+
+      it "creates a PDSSearchResult" do
+        expect { perform_now }.to change(PDSSearchResult, :count).by(1)
+        expect(PDSSearchResult.last.step).to eq("no_fuzzy_with_history_daily")
+        expect(PDSSearchResult.last.result).to eq("one_match")
+        expect(PDSSearchResult.last.nhs_number).to eq("9449306168")
+      end
     end
 
     context "with a match and the patient already exists" do

--- a/spec/jobs/process_patient_changesets_job_spec.rb
+++ b/spec/jobs/process_patient_changesets_job_spec.rb
@@ -1,27 +1,140 @@
 # frozen_string_literal: true
 
 describe ProcessPatientChangesetsJob do
-  describe "performing the job" do
-    context "on the first step" do
-      it "searches for a patient without fuzzy matching" do
-        patient_changeset = create(:patient_changeset)
+  subject(:perform) { described_class.perform_now(patient_changeset, step) }
 
-        expect(PDS::Patient).to receive(:search).with(
-          family_name: patient_changeset.child_attributes["family_name"],
-          given_name: patient_changeset.child_attributes["given_name"],
-          date_of_birth: patient_changeset.child_attributes["date_of_birth"],
-          address_postcode:
-            patient_changeset.child_attributes["address_postcode"]
-        ).and_return([:one_match, instance_double(PDS::Patient, nhs_number: "1234567890")])
+  let(:patient_changeset) { create(:patient_changeset, :cohort_import) }
+  let(:mock_patient) { instance_double(PDS::Patient, nhs_number: "1234567890") }
 
-        described_class.perform_now(patient_changeset)
+  let(:step) { nil }
 
-        expect(patient_changeset.search_results).to include(
+  before do
+    allow(patient_changeset.import).to receive(:slow?).and_return(false)
+  end
+
+  context "when one match is found on initial search" do
+    before { allow(PDS::Patient).to receive(:search).and_return(mock_patient) }
+
+    it "saves NHS number and finishes processing" do
+      perform
+
+      expect(patient_changeset.child_attributes["nhs_number"]).to eq(
+        "1234567890"
+      )
+      expect(patient_changeset).to be_processed
+    end
+  end
+
+  context "when no match is found initially" do
+    before do
+      allow(PDS::Patient).to receive(:search).and_return(nil)
+      allow(described_class).to receive(:perform_now).and_call_original
+    end
+
+    it "proceeds to next search steps" do
+      perform
+
+      expect(described_class).to have_received(:perform_now).with(
+        patient_changeset,
+        :no_fuzzy_with_wildcard_postcode
+      )
+    end
+  end
+
+  context "when too many matches are found initially" do
+    before do
+      allow(PDS::Patient).to receive(:search).and_raise(
+        NHS::PDS::TooManyMatches
+      )
+      allow(described_class).to receive(:perform_now).and_call_original
+    end
+
+    it "falls back to no history search" do
+      perform
+
+      expect(described_class).to have_received(:perform_now).with(
+        patient_changeset,
+        :no_fuzzy_without_history
+      )
+    end
+  end
+
+  context "when a later fuzzy search finds a match" do
+    let(:step) { :fuzzy_without_history }
+
+    before do
+      patient_changeset["pending_changes"]["search_results"] = [
+        {
           step: :no_fuzzy_with_history,
           result: :one_match,
           nhs_number: "1234567890"
-        )
-      end
+        }
+      ]
+      allow(PDS::Patient).to receive(:search).and_raise(
+        NHS::PDS::TooManyMatches
+      )
+    end
+
+    it "saves the unique NHS number" do
+      perform
+
+      expect(patient_changeset.child_attributes["nhs_number"]).to eq(
+        "1234567890"
+      )
+    end
+  end
+
+  context "when fuzzy search returns conflicting NHS numbers" do
+    let(:step) { :fuzzy_without_history }
+
+    before do
+      patient_changeset["pending_changes"]["search_results"] = [
+        {
+          step: :no_fuzzy_with_history,
+          result: :one_match,
+          nhs_number: "1234567890"
+        }
+      ]
+      different_patient =
+        instance_double(PDS::Patient, nhs_number: "1112223333")
+      allow(PDS::Patient).to receive(:search).and_return(different_patient)
+    end
+
+    it "does not save any NHS number" do
+      perform
+
+      expect(patient_changeset.child_attributes["nhs_number"]).to be_blank
+    end
+  end
+
+  context "when import is slow" do
+    before do
+      allow(patient_changeset.import).to receive(:slow?).and_return(true)
+      allow(PDS::Patient).to receive(:search).and_return(nil)
+    end
+
+    it "enqueues the next search step" do
+      expect(described_class).to receive(:perform_later).with(
+        patient_changeset,
+        :no_fuzzy_with_wildcard_postcode
+      )
+
+      perform
+    end
+  end
+
+  context "when all changesets are processed" do
+    before do
+      allow(PDS::Patient).to receive(:search).and_return(mock_patient)
+      patient_changeset.import.changesets.update_all(status: :processed)
+    end
+
+    it "triggers CommitPatientChangesetsJob" do
+      expect(CommitPatientChangesetsJob).to receive(:perform_now).with(
+        patient_changeset.import
+      )
+
+      perform
     end
   end
 end

--- a/spec/jobs/process_patient_changesets_job_spec.rb
+++ b/spec/jobs/process_patient_changesets_job_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe ProcessPatientChangesetsJob do
+  describe "performing the job" do
+    context "on the first step" do
+      it "searches for a patient without fuzzy matching" do
+        patient_changeset = create(:patient_changeset)
+
+        expect(PDS::Patient).to receive(:search).with(
+          family_name: patient_changeset.child_attributes["family_name"],
+          given_name: patient_changeset.child_attributes["given_name"],
+          date_of_birth: patient_changeset.child_attributes["date_of_birth"],
+          address_postcode:
+            patient_changeset.child_attributes["address_postcode"]
+        ).and_return([:one_match, instance_double(PDS::Patient, nhs_number: "1234567890")])
+
+        described_class.perform_now(patient_changeset)
+
+        expect(patient_changeset.search_results).to include(
+          step: :no_fuzzy_with_history,
+          result: :one_match,
+          nhs_number: "1234567890"
+        )
+      end
+    end
+  end
+end

--- a/spec/models/patient_changeset_spec.rb
+++ b/spec/models/patient_changeset_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+describe PatientChangeset do
+  subject(:changeset) do
+    described_class.from_import_row(
+      row: import_row,
+      import: create(:class_import),
+      row_number: 1
+    )
+  end
+
+  let(:valid_data) do
+    {
+      child_school_urn: "123456",
+      child_first_name: "Jimmy",
+      child_last_name: "Smith",
+      child_date_of_birth: "2010-01-01",
+      child_address_line_1: "10 Downing Street",
+      child_postcode: "SW1A 1AA",
+      child_nhs_number: "999 000 0026",
+      parent_1_email: "john@example.com",
+      parent_1_phone: "07412345678"
+    }
+  end
+
+  let(:import_row) do
+    instance_double(
+      CohortImportRow,
+      school: create(:school, urn: "123456"),
+      import_attributes: patient_import_attributes,
+      parent_1_import_attributes: {
+        full_name: "John Smith",
+        relationship: "Father",
+        email: "john@example.com",
+        phone: "07412345678"
+      },
+      parent_2_import_attributes: {
+      },
+      academic_year: AcademicYear.current,
+      school_move_source: "import",
+      home_educated: false
+    )
+  end
+
+  let(:patient_import_attributes) do
+    {
+      address_line_1: valid_data[:child_address_line_1],
+      address_postcode: valid_data[:child_postcode],
+      date_of_birth: Date.parse(valid_data[:child_date_of_birth]),
+      family_name: valid_data[:child_last_name],
+      given_name: valid_data[:child_first_name],
+      nhs_number: valid_data[:child_nhs_number]&.gsub(/\s/, "")
+    }.compact
+  end
+
+  describe "#patient" do
+    it "builds patient with normalized attributes" do
+      patient = changeset.patient
+      expect(patient).to have_attributes(
+        given_name: "Jimmy",
+        family_name: "Smith",
+        date_of_birth: Date.new(2010, 1, 1),
+        nhs_number: "9990000026",
+        address_line_1: "10 Downing Street",
+        address_postcode: "SW1A 1AA"
+      )
+    end
+
+    context "with existing patient" do
+      let!(:existing_patient) do
+        create(:patient, nhs_number: "9990000026", given_name: "James")
+      end
+
+      it "updates existing patient" do
+        patient = changeset.patient
+        expect(patient).to eq(existing_patient)
+        expect(patient.given_name).to eq("James")
+      end
+    end
+  end
+
+  describe "#parents" do
+    it "builds parent with relationship" do
+      parents = changeset.parents
+      relationships = changeset.parent_relationships
+
+      expect(parents.size).to eq(1)
+      expect(parents.first).to have_attributes(
+        full_name: "John Smith",
+        email: "john@example.com"
+      )
+
+      expect(relationships.first).to have_attributes(type: "father")
+    end
+  end
+
+  describe "#school_move" do
+    context "with school change" do
+      before do
+        @existing_patient =
+          create(:patient, nhs_number: "9990000026", school: create(:school))
+      end
+
+      it "creates school move record" do
+        move = changeset.school_move
+        expect(move.school.urn).to eq("123456")
+      end
+    end
+  end
+end

--- a/spec/support/pds_helper.rb
+++ b/spec/support/pds_helper.rb
@@ -3,11 +3,19 @@
 module PDSHelper
   def stub_pds_search_to_return_no_patients(**query)
     query["_history"] ||= "true"
+    query.delete("_history") if query["_history"] == "false"
 
     stub_request(
       :get,
       "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
-    ).with(query: hash_including(query)).to_return_json(body: { total: 0 })
+    ).with(query: hash_including(query)).to_return_json(
+      body: {
+        total: 0
+      },
+      headers: {
+        "Content-Type" => "application/fhir+json"
+      }
+    )
   end
 
   def stub_pds_search_to_return_a_patient(nhs_number = "9449306168", **query)
@@ -29,6 +37,21 @@ module PDSHelper
       "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
     ).with(query: hash_including(query)).to_return(
       body: response_data.to_json,
+      headers: {
+        "Content-Type" => "application/fhir+json"
+      }
+    )
+  end
+
+  def stub_pds_search_to_return_too_many_matches(**query)
+    query["_history"] ||= "true"
+
+    stub_request(
+      :get,
+      "https://sandbox.api.service.nhs.uk/personal-demographics/FHIR/R4/Patient"
+    ).with(query: hash_including(query)).to_return(
+      body: file_fixture("pds/too-many-matches.json"),
+      status: 200,
       headers: {
         "Content-Type" => "application/fhir+json"
       }


### PR DESCRIPTION
This implements the "cascading" search in MAV-1415. In the event an NHS number isn't found
through our default search, we try different PDS search options and return any unique NHS number we find.

<img width="992" height="434" alt="Screenshot 2025-08-18 at 07 36 25" src="https://github.com/user-attachments/assets/fb151a70-137b-4f67-942e-f066dbaa9ad7" />

https://nhsd-jira.digital.nhs.uk/browse/MAV-1415