### PR TITLE
Handle `nil` vaccination record location

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -89,7 +89,14 @@ class Reports::SystmOneExporter
         .administered
         .where(programme:)
         .for_academic_year(academic_year)
-        .includes(:batch, :location, :vaccine, :patient, :performed_by_user)
+        .includes(
+          :batch,
+          :location,
+          :patient,
+          :performed_by_user,
+          :session,
+          :vaccine
+        )
 
     if start_date.present?
       scope =
@@ -148,11 +155,19 @@ class Reports::SystmOneExporter
     ]
   end
 
-  # TODO: Needs support for community and generic clinics.
   def practice_code(vaccination_record)
     location = vaccination_record.location
 
-    location.school? ? location.urn : location.ods_code
+    if location&.school?
+      location.urn
+    elsif location
+      location.ods_code
+    else
+      # TODO: Needs support for generic clinics. The `location_id` is
+      #  `nil` but `location_name` is a human-readable string, so we
+      #  have no choice but to use the location of the session.
+      vaccination_record.session.location.ods_code
+    end
   end
 
   def gender_code(code)

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -103,7 +103,7 @@ FactoryBot.define do
     uuid { SecureRandom.uuid }
 
     location { session&.location unless session&.generic_clinic? }
-    location_name { "Unknown" if session.nil? }
+    location_name { "Unknown" if location.nil? }
 
     notify_parents { true }
 

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -149,9 +149,15 @@ describe Reports::SystmOneExporter do
     subject { csv_row["Practice code"] }
 
     context "location is a gp clinic" do
-      let(:location) { create(:gp_practice) }
+      let(:location) { create(:gp_practice, team:) }
 
-      it { should eq location.ods_code }
+      it { should eq(location.ods_code) }
+    end
+
+    context "location is a generic clinic" do
+      let(:location) { create(:generic_clinic, team:) }
+
+      it { should eq(location.ods_code) }
     end
   end
 


### PR DESCRIPTION
In the SystmOne exporter. This situation can occur if a vaccination is recorded in the community clinic, where the `location` will be `nil`, and the `location_name` will be set instead.

This change was made in aae7b838a035e4d7124b95c80702f29a1a1fd1f9, previously vaccination records in the generic clinic would have a location of the generic clinic, but we want to move to a world where the location is the specific community clinic where the record took place.

This error was spotted by the regression tests and fixes this Sentry error: https://good-machine.sentry.io/issues/6818602795/