### PR TITLE
Add new vaccine icons

### DIFF
--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -17,3 +17,4 @@
 @forward "summary-list";
 @forward "tables";
 @forward "tag";
+@forward "vaccine-method";

--- a/app/assets/stylesheets/components/_vaccine-method.scss
+++ b/app/assets/stylesheets/components/_vaccine-method.scss
@@ -1,0 +1,28 @@
+@use "../vendor/nhsuk-frontend" as *;
+@use "../core" as app;
+
+.app-vaccine-method {
+  align-items: center;
+  column-gap: nhsuk-spacing(2);
+  display: inline-flex;
+
+  &::before {
+    content: "";
+    height: 1em;
+    width: 1em;
+  }
+
+  &[data-method="injection"]::before {
+    background-color: currentcolor;
+    rotate: 45deg;
+    scale: 0.75;
+    transform-origin: center;
+  }
+
+  &[data-method="nasal"]::before {
+    border: 0.25em solid currentcolor;
+    border-radius: 100%;
+    height: 1em;
+    width: 1em;
+  }
+}

--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -51,6 +51,8 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
         "vaccination"
       end
 
-    "Record #{programme.name_in_sentence} #{vaccination}"
+    tag.span(class: "app-vaccine-method", data: { method: vaccine_method }) do
+      "Record #{programme.name_in_sentence} #{vaccination}"
+    end
   end
 end

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -139,7 +139,12 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
 
     return if vaccine_methods.empty?
 
-    Vaccine.human_enum_name(:method, vaccine_methods.first)
+    tag.span(
+      class: "app-vaccine-method",
+      data: {
+        method: vaccine_methods.first
+      }
+    ) { Vaccine.human_enum_name(:method, vaccine_methods.first) }
   end
 
   def status_tags


### PR DESCRIPTION
Bringing this back to life now that v3.1 has gone live.

Nurses and Healthcare Assistants (HCAs) found that the "donuts and diamonds" significantly helped them understand what vaccination method (e.g., nasal or injection) was needed for a particular child.

The icon will show up on the "Vaccination method" row and also on the record vaccination page.

[Jira Issue - MAV-1794](https://nhsd-jira.digital.nhs.uk/browse/MAV-1794)

### Screenshots

| nasal - donut | injection - diamond |
|------------------|---------------------------|
| <img width="765" height="289" alt="Screenshot 2025-08-18 at 15 12 55" src="https://github.com/user-attachments/assets/37a3f34e-595e-45c7-b693-e26fee108d6c" />  | <img width="747" height="290" alt="Screenshot 2025-08-18 at 15 21 15" src="https://github.com/user-attachments/assets/f76b09c9-05f1-47cf-bd8d-51306cd425dc" /> | 

| nasal - donut | injection - diamond |
|------------------|---------------------------|
| <img width="818" height="1173" alt="Screenshot 2025-08-18 at 15 17 16" src="https://github.com/user-attachments/assets/ed8f07a1-2975-4f3e-90c2-aff5416e2afc" />  | <img width="818" height="1174" alt="Screenshot 2025-08-18 at 15 16 24" src="https://github.com/user-attachments/assets/b3fb2470-fe6e-43ec-9e97-7692e1b0a21f" /> | 







