### PR TITLE
Prescribers can create PSD instructions during triage

### DIFF
--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -3,7 +3,15 @@
 
     <%= f.govuk_radio_buttons_fieldset :status_and_vaccine_method, **fieldset_options do %>
       <% triage_form.safe_to_vaccinate_options.each do |option| %>
-        <%= f.govuk_radio_button :status_and_vaccine_method, option %>
+        <%= f.govuk_radio_button :status_and_vaccine_method, option do %>
+        <% if show_psd_options?(option) %>
+          <%= f.govuk_radio_buttons_fieldset :psd_action,
+                                             legend: { text: "Do you want to add a PSD?", size: "s" } do %>
+            <%= f.govuk_radio_button :add_psd, "true", label: { text: "Yes" } %>
+            <%= f.govuk_radio_button :add_psd, "false", label: { text: "No" } %>
+          <% end %>
+        <% end %>
+      <% end %>
       <% end %>
       <%= f.govuk_radio_divider %>
       <% triage_form.other_options.each do |option| %>

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -26,6 +26,13 @@ class AppTriageFormComponent < ViewComponent::Base
 
   def builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
+  def show_psd_options?(option)
+    Flipper.enabled?(:delegation) &&
+      helpers.policy(PatientSpecificDirection).create? &&
+      patient_session.session.psd_enabled? &&
+      option == "safe_to_vaccinate_nasal"
+  end
+
   def fieldset_options
     text = "Is it safe to vaccinate #{patient.given_name}?"
     hint =

--- a/app/forms/triage_form.rb
+++ b/app/forms/triage_form.rb
@@ -7,6 +7,7 @@ class TriageForm
   attr_accessor :patient_session, :programme, :current_user
 
   attribute :status_and_vaccine_method, :string
+  attribute :add_psd, :boolean
   attribute :notes, :string
   attribute :vaccine_methods, array: true, default: []
 
@@ -15,6 +16,13 @@ class TriageForm
               in: :status_and_vaccine_method_options
             }
   validates :notes, length: { maximum: 1000 }
+  validates :add_psd,
+            inclusion: {
+              in: [true, false]
+            },
+            if: -> { add_psd.present? }
+
+  def add_psd? = add_psd
 
   def triage=(triage)
     self.status_and_vaccine_method =

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -77,6 +77,7 @@ class Patient < ApplicationRecord
   has_many :triages
   has_many :vaccination_records, -> { kept }
   has_many :vaccination_statuses
+  has_many :patient_specific_directions
 
   has_many :gillick_assessments
   has_many :parents, through: :parent_relationships

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -265,6 +265,13 @@ class PatientSession < ApplicationRecord
 
   delegate :academic_year, to: :session
 
+  def psd_added?(programme:)
+    patient
+      .patient_specific_directions
+      .where(programme:, academic_year:)
+      .exists?
+  end
+
   def safe_to_destroy?
     vaccination_records.empty? && gillick_assessments.empty? &&
       session_attendances.none?(&:attending?)

--- a/app/models/patient_specific_direction.rb
+++ b/app/models/patient_specific_direction.rb
@@ -7,7 +7,6 @@
 #  id                 :bigint           not null, primary key
 #  academic_year      :integer          not null
 #  delivery_site      :integer          not null
-#  full_dose          :boolean          not null
 #  vaccine_method     :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
@@ -38,8 +37,6 @@ class PatientSpecificDirection < ApplicationRecord
   belongs_to :patient
   belongs_to :programme
   belongs_to :vaccine
-
-  validates :full_dose, inclusion: { in: [true, false] }
 
   enum :delivery_site,
        {

--- a/app/policies/patient_specific_direction_policy.rb
+++ b/app/policies/patient_specific_direction_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PatientSpecificDirectionPolicy < ApplicationPolicy
+  def create?
+    user.is_nurse?
+  end
+end

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -29,6 +29,12 @@
 
 <ul class="app-action-list">
   <% if (session_attendance = @patient_session.todays_attendance) %>
+    <% if @patient_session.psd_added?(programme: @programme) %>
+      <li class="app-action-list__item">
+        <strong class="nhsuk-tag nhsuk-tag--aqua-green">PSD added</strong>
+      </li>
+    <% end %>
+
     <li class="app-action-list__item">
       <%= render AppRegisterStatusTagComponent.new(@patient_session.registration_status&.status || "unknown") %>
     </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,6 +146,9 @@ en:
             status_and_vaccine_method:
               blank: Choose a status
               inclusion: Choose a status
+            add_psd:
+              blank: Select yes or no
+              inclusion: Select yes or no
         vaccinate_form:
           attributes:
             delivery_site:

--- a/db/migrate/20250827091512_remove_full_dose_from_patient_specific_directions.rb
+++ b/db/migrate/20250827091512_remove_full_dose_from_patient_specific_directions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveFullDoseFromPatientSpecificDirections < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :patient_specific_directions, :full_dose, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_26_135132) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_27_091512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -641,7 +641,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_26_135132) do
     t.bigint "vaccine_id", null: false
     t.integer "vaccine_method", null: false
     t.integer "delivery_site", null: false
-    t.boolean "full_dose", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "academic_year", null: false

--- a/spec/factories/patient_specific_directions.rb
+++ b/spec/factories/patient_specific_directions.rb
@@ -7,7 +7,6 @@
 #  id                 :bigint           not null, primary key
 #  academic_year      :integer          not null
 #  delivery_site      :integer          not null
-#  full_dose          :boolean          not null
 #  vaccine_method     :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
@@ -40,11 +39,6 @@ FactoryBot.define do
 
     delivery_site { "left_arm_upper_position" }
     vaccine_method { "injection" }
-    full_dose { true }
     academic_year { Time.current.to_date.academic_year }
-
-    trait :half_dose do
-      full_dose { false }
-    end
   end
 end

--- a/spec/factories/patient_specific_directions.rb
+++ b/spec/factories/patient_specific_directions.rb
@@ -37,8 +37,12 @@ FactoryBot.define do
     programme
     vaccine { programme.vaccines.sample || association(:vaccine) }
 
-    delivery_site { "left_arm_upper_position" }
-    vaccine_method { "injection" }
+    delivery_site { "nose" }
+    vaccine_method { "nasal" }
     academic_year { Time.current.to_date.academic_year }
+
+    trait :half_dose do
+      full_dose { false }
+    end
   end
 end

--- a/spec/forms/triage_form_spec.rb
+++ b/spec/forms/triage_form_spec.rb
@@ -16,6 +16,12 @@ describe TriageForm do
     it { should_not validate_presence_of(:notes) }
     it { should_not validate_presence_of(:vaccine_methods) }
     it { should validate_length_of(:notes).is_at_most(1000) }
+
+    it do
+      expect(form).to validate_inclusion_of(:add_psd).in_array(
+        [true, false]
+      ).allow_nil
+    end
   end
 
   describe "when the patient is safe to vaccinate for HPV" do

--- a/spec/models/patient_specific_direction_spec.rb
+++ b/spec/models/patient_specific_direction_spec.rb
@@ -7,7 +7,6 @@
 #  id                 :bigint           not null, primary key
 #  academic_year      :integer          not null
 #  delivery_site      :integer          not null
-#  full_dose          :boolean          not null
 #  vaccine_method     :integer          not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
@@ -70,7 +69,5 @@ describe PatientSpecificDirection, type: :model do
         :vaccine_method
       ).in_array(%w[injection nasal])
     end
-
-    it { should allow_values(true, false).for(:full_dose) }
   end
 end

--- a/spec/policies/patient_specific_direction_policy_spec.rb
+++ b/spec/policies/patient_specific_direction_policy_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe PatientSpecificDirectionPolicy do
+  subject(:policy) { described_class.new(user, PatientSpecificDirection) }
+
+  context "cis2 is disabled", cis2: :disabled do
+    describe "#create?" do
+      context "when user is a nurse" do
+        let(:user) { build(:user, :nurse) }
+
+        it "permits creation" do
+          expect(policy.create?).to be(true)
+        end
+      end
+
+      context "when user is not a nurse" do
+        let(:user) { build(:user, :healthcare_assistant) }
+
+        it "denies creation" do
+          expect(policy.create?).to be(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description

Implements the ability for prescribers (e.g. qualified nurses) to add Patient Specific Directions (PSDs) during the triage process when a child is marked as safe to vaccinate with nasal spray. This feature supports delegation workflows where Healthcare Assistants (HCAs) can administer vaccinations under PSD authority.

[Jira Ticket - MAV-1362](https://nhsd-jira.digital.nhs.uk/browse/MAV-1362)

### Changes proposed
- Added conditional PSD option when selecting "safe to vaccinate with nasal spray" in triage page
- Only appears when:
	- Delegation feature flag is enabled
	- User has permission to create PSDs
	- PSD functionality is enabled for the session
	- Vaccination method is nasal spray
- "PSD added" tag appears on patient page if they have a PSD record

### Screenshots

| Choosing to add PSD | Patient page after PSD added |
|------------------|---------------------------|
| <img width="711" height="1001" alt="Screenshot 2025-08-20 at 14 13 21" src="https://github.com/user-attachments/assets/19fceba8-cfca-4121-aef4-d901c133639f" />  | <img width="952" height="1037" alt="Screenshot 2025-08-20 at 12 24 16" src="https://github.com/user-attachments/assets/1b55f9fc-a353-42de-8b5b-3d75bf0a8922" /> | 