### PR TITLE
Set `location_id` on vaccination records in clinic

### DIFF
--- a/app/controllers/draft_vaccination_records_controller.rb
+++ b/app/controllers/draft_vaccination_records_controller.rb
@@ -84,7 +84,7 @@ class DraftVaccinationRecordsController < ApplicationController
 
   def handle_outcome
     if !@draft_vaccination_record.administered? &&
-         @draft_vaccination_record.location_name.present?
+         @draft_vaccination_record.location_id.present?
       # If not administered and location is set, we can skip to confirm.
       # Otherwise, we need to get the location information from the user.
       jump_to("confirm")
@@ -163,7 +163,7 @@ class DraftVaccinationRecordsController < ApplicationController
         identity_check_confirmed_by_other_name
         identity_check_confirmed_by_other_relationship
       ],
-      location: %i[location_name],
+      location: %i[location_id],
       notes: %i[notes],
       outcome: %i[outcome]
     }.fetch(current_step)

--- a/app/controllers/patient_sessions/programmes_controller.rb
+++ b/app/controllers/patient_sessions/programmes_controller.rb
@@ -20,7 +20,7 @@ class PatientSessions::ProgrammesController < PatientSessions::BaseController
     draft_vaccination_record.clear_attributes
     draft_vaccination_record.update!(
       first_active_wizard_step: :confirm,
-      location: nil,
+      location_id: nil,
       location_name: "Unknown",
       outcome: :already_had,
       patient: @patient,

--- a/app/helpers/address_helper.rb
+++ b/app/helpers/address_helper.rb
@@ -8,10 +8,4 @@ module AddressHelper
   def format_address_single_line(addressable)
     addressable.address_parts.join(", ")
   end
-
-  def format_location_name_and_address_single_line(location)
-    [location.name, format_address_single_line(location)].compact_blank.join(
-      ", "
-    )
-  end
 end

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -90,7 +90,7 @@ class DraftVaccinationRecord
   end
 
   on_wizard_step :location, exact: true do
-    validates :location_name, presence: true
+    validates :location_id, presence: true
   end
 
   on_wizard_step :notes, exact: true do

--- a/app/views/draft_vaccination_records/location.html.erb
+++ b/app/views/draft_vaccination_records/location.html.erb
@@ -8,13 +8,13 @@
 <%= form_with model: @draft_vaccination_record, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset :location_name,
+  <%= f.govuk_radio_buttons_fieldset :location_id,
                                      caption: { text: @patient.full_name, size: "l" },
                                      legend: { size: "l", tag: "h1",
                                                text: title } do %>
 
     <% @locations.each do |location| %>
-      <%= f.govuk_radio_button :location_name, format_location_name_and_address_single_line(location),
+      <%= f.govuk_radio_button :location_id, location.id,
                                label: { text: location.name },
                                hint: { text: format_address_single_line(location) } %>
     <% end %>

--- a/spec/helpers/address_helper_spec.rb
+++ b/spec/helpers/address_helper_spec.rb
@@ -22,26 +22,4 @@ describe AddressHelper do
 
     it { should eq("10 Downing Street, London, SW1A 1AA") }
   end
-
-  describe "#format_location_name_and_address_single_line" do
-    subject(:formatted_string) do
-      helper.format_location_name_and_address_single_line(location)
-    end
-
-    it { should eq("School of Politics, 10 Downing Street, London, SW1A 1AA") }
-
-    context "with a nil address" do
-      let(:location) do
-        create(
-          :school,
-          name: "School of Politics",
-          address_line_1: "",
-          address_town: "",
-          address_postcode: ""
-        )
-      end
-
-      it { should eq("School of Politics") }
-    end
-  end
 end


### PR DESCRIPTION
This ensures that when we're recording a vaccination from a community clinic session, we link the location of the community clinic or school using the `location_id` foreign key rather than storing the name of the location in `location_name`. This enables us to have more structured data, including access to various other bits of information on the location.

We still need the `location_name` column to handle importing unknown locations.

[Jira Issue - MAV-550](https://nhsd-jira.digital.nhs.uk/browse/MAV-550)