### PR TITLE
Make superuser permissions based on activities

### DIFF
--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -6,9 +6,9 @@ class CIS2Info
   NURSE_ROLE = "S8000:G8000:R8001"
   MEDICAL_SECRETARY_ROLE = "S8000:G8001:R8006"
 
-  SUPERUSER_WORKGROUP = "mavissuperusers"
-
+  ACCESS_SENSITIVE_FLAGGED_RECORDS_ACTIVITY_CODE = "B1611"
   INDEPENDENT_PRESCRIBING_ACTIVITY_CODE = "B0420"
+  LOCAL_SYSTEM_ADMINISTRATION_ACTIVITY_CODE = "B0062"
   PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE = "B0428"
 
   attribute :organisation_name
@@ -57,7 +57,16 @@ class CIS2Info
   end
 
   def is_superuser?
-    workgroups.include?(SUPERUSER_WORKGROUP)
+    can_access_sensitive_flagged_records? ||
+      can_perform_local_system_administration?
+  end
+
+  def can_access_sensitive_flagged_records?
+    activity_codes.include?(ACCESS_SENSITIVE_FLAGGED_RECORDS_ACTIVITY_CODE)
+  end
+
+  def can_perform_local_system_administration?
+    activity_codes.include?(LOCAL_SYSTEM_ADMINISTRATION_ACTIVITY_CODE)
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -164,7 +164,24 @@ class User < ApplicationRecord
   end
 
   def is_superuser?
-    cis2_enabled? ? cis2_info.is_superuser? : fallback_role_superuser?
+    can_access_sensitive_flagged_records? ||
+      can_perform_local_system_administration?
+  end
+
+  def can_access_sensitive_flagged_records?
+    if cis2_enabled?
+      cis2_info.can_access_sensitive_flagged_records?
+    else
+      fallback_role_superuser?
+    end
+  end
+
+  def can_perform_local_system_administration?
+    if cis2_enabled?
+      cis2_info.can_perform_local_system_administration?
+    else
+      fallback_role_superuser?
+    end
   end
 
   private

--- a/app/policies/notices_policy.rb
+++ b/app/policies/notices_policy.rb
@@ -2,6 +2,6 @@
 
 class NoticesPolicy < ApplicationPolicy
   def index?
-    user.is_superuser?
+    user.can_access_sensitive_flagged_records?
   end
 end

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -32,7 +32,8 @@ class VaccinationRecordPolicy < ApplicationPolicy
   def update? = edit?
 
   def destroy?
-    user.is_superuser? && !record.sourced_from_nhs_immunisations_api?
+    user.can_perform_local_system_administration? &&
+      !record.sourced_from_nhs_immunisations_api?
   end
 
   private

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -44,7 +44,6 @@ FactoryBot.define do
       team { Team.includes(:organisation).first || create(:team) }
 
       role_code { CIS2Info::NURSE_ROLE }
-      role_workgroups { [] }
       activity_codes { [] }
 
       cis2_info_hash do
@@ -54,7 +53,7 @@ FactoryBot.define do
           "role_code" => role_code,
           "activity_codes" => activity_codes,
           "team_workgroup" => team.workgroup,
-          "workgroups" => role_workgroups + [team.workgroup]
+          "workgroups" => [team.workgroup]
         }
       end
     end
@@ -89,7 +88,12 @@ FactoryBot.define do
 
     trait :superuser do
       sequence(:email) { |n| "superuser-#{n}@example.com" }
-      role_workgroups { [CIS2Info::SUPERUSER_WORKGROUP] }
+      activity_codes do
+        [
+          CIS2Info::ACCESS_SENSITIVE_FLAGGED_RECORDS_ACTIVITY_CODE,
+          CIS2Info::LOCAL_SYSTEM_ADMINISTRATION_ACTIVITY_CODE
+        ]
+      end
       fallback_role { :superuser }
       show_in_suppliers { false }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -254,12 +254,6 @@ describe User do
 
           it { should be(true) }
         end
-
-        context "without workgroups" do
-          let(:user) { build(:medical_secretary, role_workgroups: []) }
-
-          it { should be(false) }
-        end
       end
 
       context "when the user is a nurse" do
@@ -271,12 +265,6 @@ describe User do
           let(:user) { build(:nurse, :superuser) }
 
           it { should be(true) }
-        end
-
-        context "without workgroups" do
-          let(:user) { build(:nurse, role_workgroups: []) }
-
-          it { should be(false) }
         end
       end
     end

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -135,8 +135,12 @@ module CIS2AuthHelper
       prescriber: [CIS2Info::INDEPENDENT_PRESCRIBING_ACTIVITY_CODE]
     }.fetch(role)
 
+    if superuser
+      activity_codes << CIS2Info::ACCESS_SENSITIVE_FLAGGED_RECORDS_ACTIVITY_CODE
+      activity_codes << CIS2Info::LOCAL_SYSTEM_ADMINISTRATION_ACTIVITY_CODE
+    end
+
     workgroups = user.teams.where(organisation:).pluck(:workgroup)
-    workgroups << CIS2Info::SUPERUSER_WORKGROUP if superuser
 
     cis2_sign_in(user, ods_code:, role_code:, activity_codes:, workgroups:)
   end


### PR DESCRIPTION
This updates how a user is allowed to perform certain superuser tasks by checking their activity codes rather than the `mavissuperusers` workgroup. This is being done to allow for a more granular permissions system where different users have permission to perform different tasks.

[Jira Issue - MAV-1681](https://nhsd-jira.digital.nhs.uk/browse/MAV-1681)