### PR TITLE
Make nurse permissions based on activities

### DIFF
--- a/app/forms/select_team_form.rb
+++ b/app/forms/select_team_form.rb
@@ -21,6 +21,7 @@ class SelectTeamForm
       cis2_info.update!(
         organisation_code: team.organisation.ods_code,
         role_code: CIS2Info::NURSE_ROLE,
+        activity_codes: [CIS2Info::PGD_SUPPLY_ACTIVITY_CODE],
         workgroups: [team.workgroup]
       )
     end

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -10,6 +10,7 @@ class CIS2Info
 
   INDEPENDENT_PRESCRIBING_ACTIVITY_CODE = "B0420"
   PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE = "B0428"
+  PGD_SUPPLY_ACTIVITY_CODE = "B0429"
 
   attribute :organisation_name
   attribute :organisation_code
@@ -44,7 +45,7 @@ class CIS2Info
   end
 
   def is_nurse?
-    role_code == NURSE_ROLE
+    role_code == NURSE_ROLE && activity_codes.include?(PGD_SUPPLY_ACTIVITY_CODE)
   end
 
   def is_healthcare_assistant?

--- a/spec/controllers/api/reporting/totals_controller_spec.rb
+++ b/spec/controllers/api/reporting/totals_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe API::Reporting::TotalsController do
         cis2_info: {
           organisation_code: team.organisation.ods_code,
           workgroups: [team.workgroup],
-          role_code: CIS2Info::NURSE_ROLE
+          role_code: CIS2Info::NURSE_ROLE,
+          activity_codes: [CIS2Info::PGD_SUPPLY_ACTIVITY_CODE]
         }
       }
     }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
 
       role_code { CIS2Info::NURSE_ROLE }
       role_workgroups { [] }
-      activity_codes { [] }
+      activity_codes { [CIS2Info::PGD_SUPPLY_ACTIVITY_CODE] }
 
       cis2_info_hash do
         {
@@ -83,6 +83,7 @@ FactoryBot.define do
     trait :admin do
       sequence(:email) { |n| "admin-#{n}@example.com" }
       role_code { CIS2Info::ADMIN_ROLE }
+      activity_codes { [] }
       fallback_role { :admin }
       show_in_suppliers { false }
     end

--- a/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_role_spec.rb
@@ -46,7 +46,7 @@ describe "User CIS2 authentication", :cis2 do
     mock_cis2_auth(
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
-      role_code: CIS2Info::NURSE_ROLE,
+      activity_codes: [CIS2Info::PGD_SUPPLY_ACTIVITY_CODE],
       workgroups: [@team.workgroup]
     )
     click_button "Change role"

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -130,7 +130,7 @@ module CIS2AuthHelper
       healthcare_assistant: [
         CIS2Info::PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE
       ],
-      nurse: []
+      nurse: [CIS2Info::PGD_SUPPLY_ACTIVITY_CODE]
     }.fetch(role)
 
     workgroups = user.teams.where(organisation:).pluck(:workgroup)
@@ -148,7 +148,7 @@ module CIS2AuthHelper
     org_code: nil,
     org_name: "Test SAIS Org",
     user_only_has_one_role: false,
-    activity_codes: [],
+    activity_codes: [CIS2Info::PGD_SUPPLY_ACTIVITY_CODE],
     workgroups: [],
     sid: nil,
     selected_roleid: "5555666677778888"


### PR DESCRIPTION
This updates how a user is allowed to perform certain nurse tasks by checking their activity codes rather than their role. This is being done to allow for a more granular permissions system where different users have permission to perform different tasks.

[Jira Issue - MAV-1680](https://nhsd-jira.digital.nhs.uk/browse/MAV-1680)