### PR TITLE
Add delegation columns to sessions

### DIFF
--- a/app/models/class_imports_patient.rb
+++ b/app/models/class_imports_patient.rb
@@ -4,8 +4,8 @@
 #
 # Table name: class_imports_patients
 #
-#  class_import_id       :bigint           not null
-#  patient_id            :bigint           not null
+#  class_import_id :bigint           not null
+#  patient_id      :bigint           not null
 #
 # Indexes
 #

--- a/app/models/cohort_imports_patient.rb
+++ b/app/models/cohort_imports_patient.rb
@@ -4,8 +4,8 @@
 #
 # Table name: cohort_imports_patients
 #
-#  cohort_import_id      :bigint           not null
-#  patient_id            :bigint           not null
+#  cohort_import_id :bigint           not null
+#  patient_id       :bigint           not null
 #
 # Indexes
 #

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -7,6 +7,8 @@
 #  id                            :bigint           not null, primary key
 #  academic_year                 :integer          not null
 #  days_before_consent_reminders :integer
+#  national_protocol_enabled     :boolean          default(FALSE), not null
+#  psd_enabled                   :boolean          default(FALSE), not null
 #  requires_registration         :boolean          default(TRUE), not null
 #  send_consent_requests_at      :date
 #  send_invitations_at           :date

--- a/db/migrate/20250820145646_add_delegation_to_sessions.rb
+++ b/db/migrate/20250820145646_add_delegation_to_sessions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDelegationToSessions < ActiveRecord::Migration[8.0]
+  def change
+    change_table :sessions, bulk: true do |t|
+      t.boolean :psd_enabled, default: false, null: false
+      t.boolean :national_protocol_enabled, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_20_085332) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_20_145646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -796,6 +796,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_20_085332) do
     t.string "slug", null: false
     t.date "send_invitations_at"
     t.boolean "requires_registration", default: true, null: false
+    t.boolean "psd_enabled", default: false, null: false
+    t.boolean "national_protocol_enabled", default: false, null: false
     t.index ["location_id"], name: "index_sessions_on_location_id"
     t.index ["team_id", "academic_year"], name: "index_sessions_on_team_id_and_academic_year"
     t.index ["team_id", "location_id"], name: "index_sessions_on_team_id_and_location_id"

--- a/spec/factories/patient_changesets.rb
+++ b/spec/factories/patient_changesets.rb
@@ -4,16 +4,19 @@
 #
 # Table name: patient_changesets
 #
-#  id              :bigint           not null, primary key
-#  import_type     :string           not null
-#  pending_changes :jsonb            not null
-#  row_number      :integer          not null
-#  status          :integer          default("pending"), not null
-#  created_at      :datetime         not null
-#  updated_at      :datetime         not null
-#  import_id       :bigint           not null
-#  patient_id      :bigint
-#  school_id       :bigint
+#  id                    :bigint           not null, primary key
+#  import_type           :string           not null
+#  matched_on_nhs_number :boolean
+#  pds_nhs_number        :string
+#  pending_changes       :jsonb            not null
+#  row_number            :integer          not null
+#  status                :integer          default("pending"), not null
+#  uploaded_nhs_number   :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  import_id             :bigint           not null
+#  patient_id            :bigint
+#  school_id             :bigint
 #
 # Indexes
 #

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -7,6 +7,8 @@
 #  id                            :bigint           not null, primary key
 #  academic_year                 :integer          not null
 #  days_before_consent_reminders :integer
+#  national_protocol_enabled     :boolean          default(FALSE), not null
+#  psd_enabled                   :boolean          default(FALSE), not null
 #  requires_registration         :boolean          default(TRUE), not null
 #  send_consent_requests_at      :date
 #  send_invitations_at           :date
@@ -83,6 +85,14 @@ FactoryBot.define do
 
     trait :requires_no_registration do
       requires_registration { false }
+    end
+
+    trait :psd_enabled do
+      psd_enabled { true }
+    end
+
+    trait :national_protocol_enabled do
+      national_protocol_enabled { true }
     end
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -7,6 +7,8 @@
 #  id                            :bigint           not null, primary key
 #  academic_year                 :integer          not null
 #  days_before_consent_reminders :integer
+#  national_protocol_enabled     :boolean          default(FALSE), not null
+#  psd_enabled                   :boolean          default(FALSE), not null
 #  requires_registration         :boolean          default(TRUE), not null
 #  send_consent_requests_at      :date
 #  send_invitations_at           :date


### PR DESCRIPTION
As part of the delegation work, sessions will need a boolean field to determine if the session is using the PSD protocol or national protocol. PSD or Patient Specific Direction is the protocol that allows healthcare workers to administer nasal vaccines without having the necessary qualifications as a nurse.

Setting the default value to false until the full delegation feature is ready to go live.