### PR TITLE
Rename CIS2Info#can_prescribe_pgd? to can_supply_using_pgd?

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -49,7 +49,7 @@ module AuthenticationConcern
     end
 
     def selected_cis2_role_is_valid?
-      cis2_info.can_view? || cis2_info.can_prescribe_pgd? ||
+      cis2_info.can_view? || cis2_info.can_supply_using_pgd? ||
         cis2_info.can_perform_local_admin_tasks? ||
         cis2_info.can_access_sensitive_records?
     end

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -40,7 +40,7 @@ class CIS2Info
     [ADMIN_ROLE, NURSE_ROLE].include?(role_code)
   end
 
-  def can_prescribe_pgd?
+  def can_supply_using_pgd?
     role_code == NURSE_ROLE
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
   end
 
   def role_description
-    role = (can_prescribe_pgd? ? "Nurse" : "Administrator")
+    role = (can_supply_using_pgd? ? "Nurse" : "Administrator")
 
     if can_access_sensitive_records? || can_perform_local_admin_tasks?
       "#{role} (Superuser)"
@@ -135,8 +135,8 @@ class User < ApplicationRecord
     cis2_enabled? ? cis2_info.can_view? : !fallback_role.nil?
   end
 
-  def can_prescribe_pgd?
-    cis2_enabled? ? cis2_info.can_prescribe_pgd? : fallback_role_nurse?
+  def can_supply_using_pgd?
+    cis2_enabled? ? cis2_info.can_supply_using_pgd? : fallback_role_nurse?
   end
 
   def can_perform_local_admin_tasks?

--- a/app/policies/gillick_assessment_policy.rb
+++ b/app/policies/gillick_assessment_policy.rb
@@ -2,7 +2,7 @@
 
 class GillickAssessmentPolicy < ApplicationPolicy
   def create?
-    user.can_prescribe_pgd?
+    user.can_supply_using_pgd?
   end
 
   def new?
@@ -10,7 +10,7 @@ class GillickAssessmentPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.can_prescribe_pgd?
+    user.can_supply_using_pgd?
   end
 
   def update?

--- a/app/policies/triage_policy.rb
+++ b/app/policies/triage_policy.rb
@@ -2,11 +2,11 @@
 
 class TriagePolicy < ApplicationPolicy
   def create?
-    user.can_prescribe_pgd?
+    user.can_supply_using_pgd?
   end
 
   def update?
-    user.can_prescribe_pgd?
+    user.can_supply_using_pgd?
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -2,7 +2,7 @@
 
 class VaccinationRecordPolicy < ApplicationPolicy
   def create?
-    user.can_prescribe_pgd?
+    user.can_supply_using_pgd?
   end
 
   def new?
@@ -10,7 +10,7 @@ class VaccinationRecordPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.can_prescribe_pgd? && record.session_id.present? &&
+    user.can_supply_using_pgd? && record.session_id.present? &&
       record.performed_ods_code == user.selected_organisation.ods_code
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,8 +119,8 @@ describe User do
     end
   end
 
-  describe "#can_prescribe_pgd?" do
-    subject { user.can_prescribe_pgd? }
+  describe "#can_supply_using_pgd??" do
+    subject { user.can_supply_using_pgd? }
 
     context "cis2 is enabled", cis2: :enabled do
       context "when the user is a nurse" do


### PR DESCRIPTION
Renaming this method because it makes it clearer that nurses prescribe PSDs for vaccines (nasal only atm) or can supply injection vaccines to healthcare workers using a PGD (Patient Group Direction).