### PR TITLE
Add `is_prescriber?`

### DIFF
--- a/app/controllers/concerns/authentication_concern.rb
+++ b/app/controllers/concerns/authentication_concern.rb
@@ -50,7 +50,8 @@ module AuthenticationConcern
 
     def selected_cis2_role_is_valid?
       cis2_info.is_admin? || cis2_info.is_nurse? ||
-        cis2_info.is_healthcare_assistant? || cis2_info.is_superuser?
+        cis2_info.is_healthcare_assistant? || cis2_info.is_superuser? ||
+        cis2_info.is_prescriber?
     end
 
     def storable_location?

--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -8,6 +8,7 @@ class CIS2Info
 
   SUPERUSER_WORKGROUP = "mavissuperusers"
 
+  INDEPENDENT_PRESCRIBING_ACTIVITY_CODE = "B0420"
   PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE = "B0428"
 
   attribute :organisation_name
@@ -48,6 +49,10 @@ class CIS2Info
 
   def is_healthcare_assistant?
     activity_codes.include?(PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE)
+  end
+
+  def is_prescriber?
+    activity_codes.include?(INDEPENDENT_PRESCRIBING_ACTIVITY_CODE)
   end
 
   def is_superuser?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,6 +126,8 @@ class User < ApplicationRecord
     role =
       if is_healthcare_assistant?
         "Healthcare Assistant"
+      elsif is_prescriber?
+        "Prescriber"
       elsif is_nurse?
         "Nurse"
       else
@@ -149,6 +151,10 @@ class User < ApplicationRecord
     else
       fallback_role_healthcare_assistant?
     end
+  end
+
+  def is_prescriber?
+    cis2_enabled? ? cis2_info.is_prescriber? : fallback_role_prescriber?
   end
 
   def is_superuser?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -100,6 +100,13 @@ FactoryBot.define do
       fallback_role { :healthcare_assistant }
     end
 
+    trait :prescriber do
+      sequence(:email) { |n| "prescriber-#{n}@example.com" }
+      role_code { nil }
+      activity_codes { [CIS2Info::INDEPENDENT_PRESCRIBING_ACTIVITY_CODE] }
+      fallback_role { :prescriber }
+    end
+
     trait :signed_in do
       current_sign_in_at { Time.current }
       current_sign_in_ip { "127.0.0.1" }
@@ -108,5 +115,6 @@ FactoryBot.define do
 
   factory :admin, parent: :user, traits: %i[admin]
   factory :healthcare_assistant, parent: :user, traits: %i[healthcare_assistant]
+  factory :prescriber, parent: :user, traits: %i[prescriber]
   factory :superuser, parent: :user, traits: %i[superuser]
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -196,6 +196,50 @@ describe User do
     end
   end
 
+  describe "#is_prescriber?" do
+    subject { user.is_prescriber? }
+
+    context "cis2 is enabled", cis2: :enabled do
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be(false) }
+      end
+
+      context "when the user is admin staff" do
+        let(:user) { build(:admin) }
+
+        it { should be(false) }
+      end
+
+      context "when the user is a prescriber" do
+        let(:user) { build(:prescriber) }
+
+        it { should be(true) }
+      end
+    end
+
+    context "cis2 is disabled", cis2: :disabled do
+      context "when the user is a nurse" do
+        let(:user) { build(:nurse) }
+
+        it { should be(false) }
+      end
+
+      context "when the user is admin staff" do
+        let(:user) { build(:admin) }
+
+        it { should be(false) }
+      end
+
+      context "when the user is a prescriber" do
+        let(:user) { build(:prescriber) }
+
+        it { should be(true) }
+      end
+    end
+  end
+
   describe "#is_superuser?" do
     subject { user.is_superuser? }
 


### PR DESCRIPTION
This adds a method to `User` and `CIS2Info` which can be used to determine with a particular user has permission to prescribe a vaccination using either a PSD or the national protocol.

[Jira Issue - MAV-1400](https://nhsd-jira.digital.nhs.uk/browse/MAV-1400)