### PR TITLE
Use global ODS code sequence in tests

### DIFF
--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -14,9 +14,9 @@
 #  index_organisations_on_ods_code  (ods_code) UNIQUE
 #
 FactoryBot.define do
-  factory :organisation do
-    transient { sequence(:identifier) }
+  sequence(:ods_code) { |n| "U#{n}" }
 
-    ods_code { "U#{identifier}" }
+  factory :organisation do
+    ods_code { generate(:ods_code) }
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -35,7 +35,7 @@ FactoryBot.define do
   factory :team do
     transient do
       sequence(:identifier)
-      ods_code { "U#{identifier}" }
+      ods_code { generate(:ods_code) }
     end
 
     organisation { association(:organisation, ods_code:) }


### PR DESCRIPTION
This refactors the team and organisation test factory to share the same ODS code sequence generator, ensuring that they can never generate the same ODS code, leading to test failures due to unique constraints on the `ods_code` column.

Specifically, this fixes the flaky tests in `programme_vaccinations_exporter_spec.rb` where they will fail occasionally due to an ODS code already existing when the organisation is created.