### PR TITLE
Limit cohort imports by team's schools

### DIFF
--- a/app/models/cohort_import_row.rb
+++ b/app/models/cohort_import_row.rb
@@ -20,8 +20,8 @@ class CohortImportRow < PatientImportRow
     @school ||=
       if (urn = school_urn&.to_s).present? &&
            ![SCHOOL_URN_HOME_EDUCATED, SCHOOL_URN_UNKNOWN].include?(urn)
-        Location.school.find_by_urn_and_site(urn) ||
-          Location.school.find_by(systm_one_code: urn)
+        schools.find_by_urn_and_site(urn) ||
+          schools.find_by(systm_one_code: urn)
       end
   end
 
@@ -34,6 +34,10 @@ class CohortImportRow < PatientImportRow
   end
 
   private
+
+  def schools
+    Location.school.eager_load(:team).where(subteam: { team: })
+  end
 
   def stage_registration?
     true
@@ -56,8 +60,8 @@ class CohortImportRow < PatientImportRow
       errors.add(school_urn.header, "is required but missing")
     elsif !school_urn.to_s.in?(
           [SCHOOL_URN_HOME_EDUCATED, SCHOOL_URN_UNKNOWN]
-        ) && !Location.school.where_urn_and_site(school_urn.to_s).exists? &&
-          !Location.school.exists?(systm_one_code: school_urn.to_s)
+        ) && !schools.where_urn_and_site(school_urn.to_s).exists? &&
+          !schools.exists?(systm_one_code: school_urn.to_s)
       errors.add(
         school_urn.header,
         "The school URN is not recognised. If you’ve checked the URN, " \

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -58,7 +58,7 @@ describe CohortImportRow do
     }
   end
 
-  before { create(:school, urn: "123456", team:) }
+  let!(:school) { create(:school, urn: "123456", team:) }
 
   describe "validations" do
     let(:data) { valid_data }
@@ -108,6 +108,19 @@ describe CohortImportRow do
         expect(cohort_import_row.errors["CHILD_SCHOOL_URN"]).to contain_exactly(
           "The school URN is not recognised. If you’ve checked the URN, " \
             "and you believe it’s valid, contact our support team."
+        )
+      end
+    end
+
+    context "with a school for a different team" do
+      let(:data) { valid_data }
+
+      before { school.update!(subteam: nil) }
+
+      it "is invalid" do
+        expect(cohort_import_row).to be_invalid
+        expect(cohort_import_row.errors["CHILD_SCHOOL_URN"].first).to include(
+          "The school URN is not recognised."
         )
       end
     end
@@ -661,12 +674,12 @@ describe CohortImportRow do
     end
 
     describe "#school" do
-      subject(:school) { school_move.school }
+      subject { school_move.school }
 
       context "with a school location" do
         let(:school_urn) { "123456" }
 
-        it { should eq(Location.first) }
+        it { should eq(school) }
       end
 
       context "with an unknown school" do
@@ -683,7 +696,7 @@ describe CohortImportRow do
     end
 
     describe "#home_educated" do
-      subject(:home_educated) { school_move.home_educated }
+      subject { school_move.home_educated }
 
       context "with a school location" do
         let(:school_urn) { "123456" }


### PR DESCRIPTION
This ensures that when importing a cohort, you can only provide school URNs for schools managed by the team, avoiding the possibility of editing the cohort of a different team.

[Jira Ticket - MAV-503](https://nhsd-jira.digital.nhs.uk/browse/MAV-503)