### PR TITLE
Deduplicate parents and relationships before incrementing import counts

### DIFF
--- a/app/jobs/commit_patient_changesets_job.rb
+++ b/app/jobs/commit_patient_changesets_job.rb
@@ -138,8 +138,8 @@ class CommitPatientChangesetsJob < ApplicationJob
       count_column_to_increment =
         import.count_column(
           changeset.patient,
-          changeset.parents,
-          changeset.parent_relationships
+          changeset.parents.uniq,
+          changeset.parent_relationships.uniq
         )
       counts[count_column_to_increment] += 1
     end

--- a/app/models/patient_import.rb
+++ b/app/models/patient_import.rb
@@ -56,7 +56,7 @@ class PatientImport < ApplicationRecord
     end
 
     count_column_to_increment =
-      count_column(patient, parents, parent_relationships)
+      count_column(patient, parents.uniq, parent_relationships.uniq)
 
     # Instead of saving individually, we'll collect the records
     @parents_batch ||= Set.new


### PR DESCRIPTION
Parents could appear multiple times in memory during import, causing `parents.any?(&:changed?)` to incorrectly return true even when no data had actually changed. This was due to duplicate Parent instances with the same ID being included in the batch.

Ensure we call `.uniq` on parents and relationships before checking for changes to avoid false positives.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1825
