### PR TITLE
Track which users should be shown in list of suppliers

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -24,6 +24,9 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       @user = User.find_or_create_from_cis2_oidc(user_cis2_info, valid_teams)
 
+      # Track which users have authorisation to supply using the PGD protocol.
+      @user.update!(show_in_suppliers: cis2_info.is_nurse?)
+
       # give them a session token for the reporting app also
       @user.update!(reporting_api_session_token: SecureRandom.hex(32))
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -8,4 +8,8 @@ class Users::SessionsController < Devise::SessionsController
   before_action :store_redirect_uri!, only: :new
 
   layout "one_half"
+
+  def create
+    super { |user| user.update!(show_in_suppliers: user.is_nurse?) }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@
 #  remember_created_at         :datetime
 #  reporting_api_session_token :string
 #  session_token               :string
+#  show_in_suppliers           :boolean          default(FALSE), not null
 #  sign_in_count               :integer          default(0), not null
 #  uid                         :string
 #  created_at                  :datetime         not null

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -29,6 +29,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "ODS"
   inflect.acronym "OpenID"
   inflect.acronym "PDS"
+  inflect.acronym "PGD"
   inflect.acronym "QA"
   inflect.acronym "SMS"
   inflect.acronym "URN"

--- a/db/migrate/20250822094829_add_show_in_suppliers_to_users.rb
+++ b/db/migrate/20250822094829_add_show_in_suppliers_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddShowInSuppliersToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :show_in_suppliers, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_21_102030) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_22_094829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -914,6 +914,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_21_102030) do
     t.string "session_token"
     t.integer "fallback_role"
     t.string "reporting_api_session_token"
+    t.boolean "show_in_suppliers", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reporting_api_session_token"], name: "index_users_on_reporting_api_session_token", unique: true

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,6 +18,7 @@
 #  remember_created_at         :datetime
 #  reporting_api_session_token :string
 #  session_token               :string
+#  show_in_suppliers           :boolean          default(FALSE), not null
 #  sign_in_count               :integer          default(0), not null
 #  uid                         :string
 #  created_at                  :datetime         not null

--- a/spec/features/user_cis2_authentication_from_redirect_spec.rb
+++ b/spec/features/user_cis2_authentication_from_redirect_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "User CIS2 authentication" do
+describe "User CIS2 authentication", :cis2 do
   include RedirectHelper
 
   scenario "from redirect" do

--- a/spec/features/user_cis2_authentication_spec.rb
+++ b/spec/features/user_cis2_authentication_spec.rb
@@ -1,14 +1,37 @@
 # frozen_string_literal: true
 
 describe "User CIS2 authentication", :cis2 do
-  scenario "from start page" do
-    given_a_test_team_is_setup_in_mavis_and_cis2
+  before { given_a_test_team_is_setup_in_mavis_and_cis2 }
+
+  scenario "as an admin" do
+    given_an_admin_user_is_mocked
+
     when_i_go_to_the_start_page
     then_i_should_see_the_cis2_login_button
 
     when_i_click_the_cis2_login_button
-    and_i_am_logged_in
+    and_i_am_logged_in_as_an_admin
     and_i_am_added_to_the_team
+    and_i_am_not_marked_as_a_pgd_supplier
+
+    when_i_click_the_change_role_button
+    then_i_see_the_dashboard
+
+    when_i_log_out
+    then_i_am_on_the_start_page
+    and_i_am_logged_out
+  end
+
+  scenario "as a nurse" do
+    given_a_nurse_user_is_mocked
+
+    when_i_go_to_the_start_page
+    then_i_should_see_the_cis2_login_button
+
+    when_i_click_the_cis2_login_button
+    and_i_am_logged_in_as_a_nurse
+    and_i_am_added_to_the_team
+    and_i_am_marked_as_a_pgd_supplier
 
     when_i_click_the_change_role_button
     then_i_see_the_dashboard
@@ -21,11 +44,25 @@ describe "User CIS2 authentication", :cis2 do
   def given_a_test_team_is_setup_in_mavis_and_cis2
     @user = create(:user, uid: "123")
     @team = create(:team, users: [@user])
+  end
 
+  def given_a_nurse_user_is_mocked
     mock_cis2_auth(
-      uid: "123",
+      uid: @user.uid,
       given_name: "Nurse",
       family_name: "Test",
+      org_code: @team.organisation.ods_code,
+      org_name: @team.name,
+      workgroups: [@team.workgroup]
+    )
+  end
+
+  def given_an_admin_user_is_mocked
+    mock_cis2_auth(
+      uid: @user.uid,
+      given_name: "Admin",
+      family_name: "Test",
+      role_code: CIS2Info::ADMIN_ROLE,
       org_code: @team.organisation.ods_code,
       org_name: @team.name,
       workgroups: [@team.workgroup]
@@ -48,7 +85,12 @@ describe "User CIS2 authentication", :cis2 do
     expect(page).to have_current_path dashboard_path
   end
 
-  def and_i_am_logged_in
+  def and_i_am_logged_in_as_an_admin
+    expect(page).to have_content("TEST, Admin")
+    expect(page).to have_button "Log out"
+  end
+
+  def and_i_am_logged_in_as_a_nurse
     expect(page).to have_content("TEST, Nurse")
     expect(page).to have_button "Log out"
   end
@@ -57,6 +99,14 @@ describe "User CIS2 authentication", :cis2 do
     user = User.first
     expect(user).not_to be_nil
     expect(user.teams).to include(@team)
+  end
+
+  def and_i_am_not_marked_as_a_pgd_supplier
+    expect(@user.reload).not_to be_show_in_suppliers
+  end
+
+  def and_i_am_marked_as_a_pgd_supplier
+    expect(@user.reload).to be_show_in_suppliers
   end
 
   def when_i_click_the_change_role_button
@@ -72,6 +122,7 @@ describe "User CIS2 authentication", :cis2 do
   end
 
   def and_i_am_logged_out
+    expect(page).not_to have_content("TEST, Admin")
     expect(page).not_to have_content("TEST, Nurse")
     expect(page).not_to have_button("Log out")
   end

--- a/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
+++ b/spec/features/user_cis2_authentication_with_wrong_organisation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "User CIS2 authentication" do
+describe "User CIS2 authentication", :cis2 do
   scenario "user has wrong organisation selected" do
     given_i_am_setup_in_cis2_but_not_mavis
     when_i_go_to_the_sessions_page

--- a/spec/models/patient_changeset_spec.rb
+++ b/spec/models/patient_changeset_spec.rb
@@ -1,5 +1,34 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: patient_changesets
+#
+#  id                    :bigint           not null, primary key
+#  import_type           :string           not null
+#  matched_on_nhs_number :boolean
+#  pds_nhs_number        :string
+#  pending_changes       :jsonb            not null
+#  row_number            :integer          not null
+#  status                :integer          default("pending"), not null
+#  uploaded_nhs_number   :string
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  import_id             :bigint           not null
+#  patient_id            :bigint
+#  school_id             :bigint
+#
+# Indexes
+#
+#  index_patient_changesets_on_import      (import_type,import_id)
+#  index_patient_changesets_on_patient_id  (patient_id)
+#  index_patient_changesets_on_status      (status)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (school_id => locations.id)
+#
 describe PatientChangeset do
   subject(:changeset) do
     described_class.from_import_row(

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -18,6 +18,7 @@
 #  remember_created_at         :datetime
 #  reporting_api_session_token :string
 #  session_token               :string
+#  show_in_suppliers           :boolean          default(FALSE), not null
 #  sign_in_count               :integer          default(0), not null
 #  uid                         :string
 #  created_at                  :datetime         not null


### PR DESCRIPTION
This adds a new column to the users table which we can use to track which users should appear in the list of suppliers that healthcare assistances can choose from when they administer a nasal flu vaccine.

This is effectively the same as whether or not the user is a nurse, but I've decided to not name this column `is_nurse` for two reasons:

- To avoid confusing with the `nurse` `fallback_role` which is only used in non-CIS2 environments.
- To allow for flexibility in the future in case a new role type is added that can also supply a PGD vaccine to healthcare assistants.

Our users log in using CIS2, and it's only at the point of logging in do we know what permissions a user has, so at that point we will update the this value for them. For non-CIS2 environments, we could in theory rely on the `fallback_role` column instead, but I think to make the code consistent it makes sense to use same column in both cases.

[Jira Issue - MAV-1353](https://nhsd-jira.digital.nhs.uk/browse/MAV-1353)