### PR TITLE
Skip wildcard searches for names ≤ 3 characters

### DIFF
--- a/app/models/pds_search_result.rb
+++ b/app/models/pds_search_result.rb
@@ -42,6 +42,13 @@ class PDSSearchResult < ApplicationRecord
        validate: true
 
   enum :result,
-       { no_matches: 0, one_match: 1, too_many_matches: 2, error: 3 },
+       {
+         no_matches: 0,
+         one_match: 1,
+         too_many_matches: 2,
+         error: 3,
+         skip_step: 4,
+         no_postcode: 5
+       },
        validate: true
 end


### PR DESCRIPTION
Wildcard searches like "Al*" are ineffective, so skip directly to the next search step when given/family names are 3 characters or less.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1415