### PR TITLE
Check birth century

### DIFF
--- a/app/models/patient_import_row.rb
+++ b/app/models/patient_import_row.rb
@@ -411,6 +411,8 @@ class PatientImportRow
       errors.add(date_of_birth.header, "is required but missing")
     elsif date_of_birth.to_date.nil?
       errors.add(date_of_birth.header, "should be formatted as YYYY-MM-DD")
+    elsif date_of_birth.to_date < Date.new(2000, 1, 1)
+      errors.add(date_of_birth.header, "is too old to still be in school")
     end
   end
 

--- a/spec/models/class_import_row_spec.rb
+++ b/spec/models/class_import_row_spec.rb
@@ -53,7 +53,7 @@ describe ClassImportRow do
     it { should be_valid }
 
     context "when date of birth is outside the programme year group" do
-      let(:data) { valid_data.merge("CHILD_DATE_OF_BIRTH" => "1990-01-01") }
+      let(:data) { valid_data.merge("CHILD_DATE_OF_BIRTH" => "2000-01-01") }
 
       it "is invalid" do
         expect(class_import_row).to be_invalid

--- a/spec/models/cohort_import_row_spec.rb
+++ b/spec/models/cohort_import_row_spec.rb
@@ -66,7 +66,7 @@ describe CohortImportRow do
     it { should be_valid }
 
     context "when date of birth is outside the programme year group" do
-      let(:data) { valid_data.merge("CHILD_DATE_OF_BIRTH" => "1990-01-01") }
+      let(:data) { valid_data.merge("CHILD_DATE_OF_BIRTH" => "2000-01-01") }
 
       it "is invalid" do
         expect(cohort_import_row).to be_invalid
@@ -85,6 +85,22 @@ describe CohortImportRow do
         expect(
           cohort_import_row.errors["CHILD_DATE_OF_BIRTH"]
         ).to contain_exactly("should be formatted as YYYY-MM-DD")
+      end
+    end
+
+    context "when date of birth is in the previous century" do
+      let(:data) do
+        valid_data.merge(
+          { "CHILD_DATE_OF_BIRTH" => "1911-01-01", "CHILD_YEAR_GROUP" => "9" }
+        )
+      end
+
+      it "is invalid" do
+        expect(cohort_import_row).to be_invalid
+        expect(cohort_import_row.errors.size).to eq(1)
+        expect(
+          cohort_import_row.errors["CHILD_DATE_OF_BIRTH"]
+        ).to contain_exactly("is too old to still be in school")
       end
     end
 


### PR DESCRIPTION
Anyone born before 2000 is clearly not going to be in secondary education anymore.

This isn't a perfect cut-off point but it's low enough that it will never be a problem for anyone who still is going to school, but it will prevent uploads of children born in the wrong century, which we sometimes see when the CHILD_YEAR_GROUP parameter is set while the date of birth for example does not have a century set. (e.g. 01/01/0015 may show as 01/01/15 in excel)

This is [MAV-1833](https://nhsd-jira.digital.nhs.uk/browse/MAV-1833)