### PR TITLE
Fix tests that fail during preparation period

### DIFF
--- a/spec/features/parental_consent_school_session_completed_spec.rb
+++ b/spec/features/parental_consent_school_session_completed_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Parental consent" do
+  around { |example| travel_to(Date.new(2025, 8, 1)) { example.run } }
+
   scenario "Move to a completed session" do
     stub_pds_search_to_return_no_patients
 

--- a/spec/features/triage_then_parental_consent_refused_spec.rb
+++ b/spec/features/triage_then_parental_consent_refused_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe "Triage" do
+  around { |example| travel_to(Date.new(2025, 8, 1)) { example.run } }
+
   scenario "Nurse triages a patient and then consent is refused" do
     stub_pds_search_to_return_no_patients
 

--- a/spec/jobs/send_clinic_subsequent_invitations_job_spec.rb
+++ b/spec/jobs/send_clinic_subsequent_invitations_job_spec.rb
@@ -3,6 +3,8 @@
 describe SendClinicSubsequentInvitationsJob do
   subject(:perform_now) { described_class.perform_now(session) }
 
+  around { |example| travel_to(Date.new(2025, 8, 1)) { example.run } }
+
   let(:programmes) { [create(:programme, :hpv)] }
   let(:team) { create(:team, programmes:) }
   let(:parents) { create_list(:parent, 2) }


### PR DESCRIPTION
These tests are currently failing as they all schedule sessions for a week in to the future which falls on the next academic year resulting in a validation failure on the academic year of the session.