### PR TITLE
Remove redundant PDS fuzzy search with history

### DIFF
--- a/app/jobs/process_patient_changesets_job.rb
+++ b/app/jobs/process_patient_changesets_job.rb
@@ -79,7 +79,7 @@ class ProcessPatientChangesetsJob < ApplicationJob
         too_many_matches: :no_fuzzy_without_history
       },
       no_fuzzy_without_history: {
-        no_matches: :fuzzy_without_history,
+        no_matches: :fuzzy,
         one_match: :save_nhs_number_if_unique,
         too_many_matches: :give_up,
         format_query: ->(query) { query.merge(history: false) }
@@ -98,28 +98,21 @@ class ProcessPatientChangesetsJob < ApplicationJob
         format_query: ->(query) { query[:given_name][3..] = "*" }
       },
       no_fuzzy_with_wildcard_family_name: {
-        no_matches: :fuzzy_without_history,
-        one_match: :fuzzy_without_history,
-        too_many_matches: :fuzzy_without_history,
-        skip_step: :fuzzy_without_history,
+        no_matches: :fuzzy,
+        one_match: :fuzzy,
+        too_many_matches: :fuzzy,
+        skip_step: :fuzzy,
         format_query: ->(query) { query[:family_name][3..] = "*" }
       },
-      fuzzy_without_history: {
-        no_matches: :fuzzy_with_history,
-        one_match: :save_nhs_number_if_unique,
-        too_many_matches: :save_nhs_number_if_unique,
-        format_query: ->(query) do
-          query[:fuzzy] = true
-          query[:history] = false
-        end
-      },
-      fuzzy_with_history: {
+      fuzzy: {
         no_matches: :give_up,
         one_match: :save_nhs_number_if_unique,
         too_many_matches: :save_nhs_number_if_unique,
         format_query: ->(query) do
           query[:fuzzy] = true
-          query[:history] = true
+          # For fuzzy searches, history is the default. We get an error if we
+          # try to set it to true explicitly
+          query[:history] = nil
         end
       }
     }

--- a/app/models/pds_search_result.rb
+++ b/app/models/pds_search_result.rb
@@ -36,8 +36,7 @@ class PDSSearchResult < ApplicationRecord
          no_fuzzy_with_wildcard_postcode: 3,
          no_fuzzy_with_wildcard_given_name: 4,
          no_fuzzy_with_wildcard_family_name: 5,
-         fuzzy_without_history: 6,
-         fuzzy_with_history: 7
+         fuzzy: 6
        },
        validate: true
 

--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -797,15 +797,14 @@ describe "Import child records" do
 
   def and_maia_has_multiple_pds_search_results
     maia = Patient.find_by(given_name: "Maia", family_name: "Smith")
-    expect(maia.pds_search_results.count).to eq(6)
+    expect(maia.pds_search_results.count).to eq(5)
     expect(maia.pds_search_results.pluck(:step)).to eq(
       %w[
         no_fuzzy_with_history
         no_fuzzy_with_wildcard_postcode
         no_fuzzy_with_wildcard_given_name
         no_fuzzy_with_wildcard_family_name
-        fuzzy_without_history
-        fuzzy_with_history
+        fuzzy
       ]
     )
   end

--- a/spec/jobs/process_patient_changesets_job_spec.rb
+++ b/spec/jobs/process_patient_changesets_job_spec.rb
@@ -60,7 +60,7 @@ describe ProcessPatientChangesetsJob do
   end
 
   context "when a later fuzzy search finds a match" do
-    let(:step) { :fuzzy_without_history }
+    let(:step) { :fuzzy }
 
     before do
       patient_changeset["pending_changes"]["search_results"] = [
@@ -85,7 +85,7 @@ describe ProcessPatientChangesetsJob do
   end
 
   context "when fuzzy search returns conflicting NHS numbers" do
-    let(:step) { :fuzzy_without_history }
+    let(:step) { :fuzzy }
 
     before do
       patient_changeset["pending_changes"]["search_results"] = [


### PR DESCRIPTION
All fuzzy searches always include searching of history (see [the PDS FHIR API documentation](https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir#get-/Patient)).

This removes the `fuzzy_without_history` step, merging it in with `fuzzy_with_history`. Has been tested locally, here are what the search results look like when a patient isn't found in PDS:

```ruby
  [{"step" => "no_fuzzy_with_history", "result" => "no_matches", "nhs_number" => nil},
   {"step" => "no_fuzzy_with_wildcard_postcode", "result" => "no_matches", "nhs_number" => nil},
   {"step" => "no_fuzzy_with_wildcard_given_name", "result" => "no_matches", "nhs_number" => nil},
   {"step" => "no_fuzzy_with_wildcard_family_name", "result" => "no_matches", "nhs_number" => nil},
   {"step" => "fuzzy", "result" => "no_matches", "nhs_number" => nil}]]]
```


Jira-Issue: MAV-1415