### PR TITLE
Ensure patients with PDS search results can be merged

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -36,6 +36,10 @@ class PatientMerger
         patient_id: patient_to_keep.id
       )
 
+      patient_to_destroy.pds_search_results.update_all(
+        patient_id: patient_to_keep.id
+      )
+
       patient_to_destroy.school_moves.find_each do |school_move|
         if patient_to_keep.school_moves.exists?(
              home_educated: school_move.home_educated,

--- a/spec/factories/pds_search_results.rb
+++ b/spec/factories/pds_search_results.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: pds_search_results
+#
+#  id          :bigint           not null, primary key
+#  import_type :string
+#  nhs_number  :string
+#  result      :integer          not null
+#  step        :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  import_id   :bigint
+#  patient_id  :bigint           not null
+#
+# Indexes
+#
+#  index_pds_search_results_on_import               (import_type,import_id)
+#  index_pds_search_results_on_patient_id           (patient_id)
+#  index_pds_search_results_on_patient_import_step  (patient_id,import_type,import_id,step) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#
+
+FactoryBot.define do
+  factory :pds_search_result do
+    patient
+
+    step { PDSSearchResult.steps.values.sample }
+    result { PDSSearchResult.results.values.sample }
+  end
+end

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -48,6 +48,9 @@ describe PatientMerger do
     let(:notify_log_entry) do
       create(:notify_log_entry, :email, patient: patient_to_destroy)
     end
+    let(:pds_search_result) do
+      create(:pds_search_result, patient: patient_to_destroy)
+    end
     let(:parent_relationship) do
       create(:parent_relationship, patient: patient_to_destroy)
     end
@@ -121,6 +124,12 @@ describe PatientMerger do
 
     it "moves notify log entries" do
       expect { call }.to change { notify_log_entry.reload.patient }.to(
+        patient_to_keep
+      )
+    end
+
+    it "moves PDS search results" do
+      expect { call }.to change { pds_search_result.reload.patient }.to(
         patient_to_keep
       )
     end


### PR DESCRIPTION
Without this, if a user tries to merge a patient that has a PDS search result then they will see an error screen saying something went wrong.

[Sentry Issue](https://good-machine.sentry.io/issues/6819259117/)