### PR TITLE
Prevent deleting sessions if Gillick assessment was performed

### DIFF
--- a/app/models/session_date.rb
+++ b/app/models/session_date.rb
@@ -39,12 +39,12 @@ class SessionDate < ApplicationRecord
 
   delegate :today?, :past?, :future?, to: :value
 
-  def today_or_past?
-    today? || past?
-  end
+  def today_or_past? = today? || past?
 
-  def today_or_future?
-    today? || future?
+  def today_or_future? = today? || future?
+
+  def has_been_attended?
+    gillick_assessments.any? || session_attendances.any?
   end
 
   private

--- a/app/views/session_dates/show.html.erb
+++ b/app/views/session_dates/show.html.erb
@@ -11,7 +11,7 @@
     <ol class="nhsuk-list app-add-another__list">
       <%= f.fields_for :session_dates do |date_f| %>
         <li class="app-add-another__list-item">
-          <% if date_f.object.persisted? && date_f.object.session_attendances.any? %>
+          <% if date_f.object.persisted? && date_f.object.has_been_attended? %>
             <h2 class="nhsuk-heading-m">
               <%= date_f.object.value.to_fs(:long) %>
             </h2>

--- a/spec/models/session_date_spec.rb
+++ b/spec/models/session_date_spec.rb
@@ -33,7 +33,7 @@ describe SessionDate do
   end
 
   describe "#today_or_future?" do
-    subject(:today_or_future?) { session_date.today_or_future? }
+    subject { session_date.today_or_future? }
 
     context "with a today's date" do
       it { should be(true) }
@@ -47,6 +47,33 @@ describe SessionDate do
 
     context "with a date in the future" do
       let(:value) { Date.tomorrow }
+
+      it { should be(true) }
+    end
+  end
+
+  describe "#has_been_attended?" do
+    subject { session_date.has_been_attended? }
+
+    let(:session) { create(:session) }
+    let(:session_date) { session.session_dates.first }
+
+    it { should be(false) }
+
+    context "with a Gillick assessment" do
+      before { create(:gillick_assessment, :competent, session:) }
+
+      it { should be(true) }
+    end
+
+    context "with a session attendance" do
+      before do
+        create(
+          :session_attendance,
+          :present,
+          patient_session: create(:patient_session, session:)
+        )
+      end
 
       it { should be(true) }
     end


### PR DESCRIPTION
This updates the criteria for when a session date can be deleted to ensure that if a Gillick assessment exists for that date, it should not be deleted as that means that a patient was seen on that date.

Previously it was possible to delete session dates as they didn't have a foreign key to the Gillick assessment, but with the recent refactor they now do and therefore the UI needs to be updated to match.

[Jira Issue - MAV-1818](https://nhsd-jira.digital.nhs.uk/browse/MAV-1818)