### PR TITLE
Autoscaling for sidekiq

### DIFF
--- a/terraform/app/ecs.tf
+++ b/terraform/app/ecs.tf
@@ -102,12 +102,20 @@ module "sidekiq_service" {
     subnets = [aws_subnet.private_subnet_a.id, aws_subnet.private_subnet_b.id]
     vpc_id  = aws_vpc.application_vpc.id
   }
-  minimum_replica_count = var.sidekiq_replicas
-  maximum_replica_count = var.sidekiq_replicas
-  cluster_id            = aws_ecs_cluster.cluster.id
-  cluster_name          = aws_ecs_cluster.cluster.name
-  environment           = var.environment
-  server_type           = "sidekiq"
+  minimum_replica_count = var.minimum_sidekiq_replicas
+  maximum_replica_count = var.maximum_sidekiq_replicas
+  autoscaling_policies = tomap({
+    cpu = {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+      target_value           = 60
+      scale_in_cooldown      = 600
+      scale_out_cooldown     = 300
+    }
+  })
+  cluster_id   = aws_ecs_cluster.cluster.id
+  cluster_name = aws_ecs_cluster.cluster.name
+  environment  = var.environment
+  server_type  = "sidekiq"
 
   depends_on = [
     aws_elasticache_replication_group.valkey

--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -19,9 +19,7 @@ http_hosts = {
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "preview.mavistesting.com"
 }
 
-appspec_bucket       = "nhse-mavis-appspec-bucket-preview"
-minimum_web_replicas = 2
-maximum_web_replicas = 4
+appspec_bucket = "nhse-mavis-appspec-bucket-preview"
 
 valkey_node_type          = "cache.t4g.micro"
 valkey_log_retention_days = 3

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -26,8 +26,6 @@ backup_retention_period   = 7
 ssl_policy                = "ELBSecurityPolicy-TLS13-1-2-2021-06"
 access_logs_bucket        = "nhse-mavis-access-logs-production"
 max_aurora_capacity_units = 32
-minimum_web_replicas      = 2
-maximum_web_replicas      = 4
 container_insights        = "enhanced"
 
 enable_backup_to_vault        = true

--- a/terraform/app/env/qa.tfvars
+++ b/terraform/app/env/qa.tfvars
@@ -22,8 +22,6 @@ http_hosts = {
 }
 appspec_bucket            = "nhse-mavis-appspec-bucket-qa"
 max_aurora_capacity_units = 32
-minimum_web_replicas      = 2
-maximum_web_replicas      = 4
 container_insights        = "enhanced"
 
 enable_backup_to_vault        = true

--- a/terraform/app/env/sandbox-alpha.tfvars
+++ b/terraform/app/env/sandbox-alpha.tfvars
@@ -16,10 +16,12 @@ enable_splunk                   = false
 enable_cis2                     = false
 enable_pds_enqueue_bulk_updates = false
 
-appspec_bucket       = "nhse-mavis-appspec-bucket-sandbox-alpha"
-minimum_web_replicas = 1
-maximum_web_replicas = 2
-good_job_replicas    = 1
+appspec_bucket           = "nhse-mavis-appspec-bucket-sandbox-alpha"
+minimum_web_replicas     = 1
+maximum_web_replicas     = 2
+minimum_sidekiq_replicas = 1
+maximum_sidekiq_replicas = 2
+good_job_replicas        = 1
 
 valkey_node_type          = "cache.t4g.micro"
 valkey_log_retention_days = 3

--- a/terraform/app/env/sandbox-beta.tfvars
+++ b/terraform/app/env/sandbox-beta.tfvars
@@ -16,10 +16,12 @@ enable_splunk                   = false
 enable_cis2                     = false
 enable_pds_enqueue_bulk_updates = false
 
-appspec_bucket       = "nhse-mavis-appspec-bucket-sandbox-beta"
-minimum_web_replicas = 1
-maximum_web_replicas = 2
-good_job_replicas    = 1
+appspec_bucket           = "nhse-mavis-appspec-bucket-sandbox-beta"
+minimum_web_replicas     = 1
+maximum_web_replicas     = 2
+minimum_sidekiq_replicas = 1
+maximum_sidekiq_replicas = 2
+good_job_replicas        = 1
 
 # Valkey serverless configuration - minimal settings for sandbox
 valkey_node_type          = "cache.t4g.micro"

--- a/terraform/app/env/test.tfvars
+++ b/terraform/app/env/test.tfvars
@@ -17,9 +17,7 @@ http_hosts = {
   MAVIS__HOST                        = "test.mavistesting.com"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "test.mavistesting.com"
 }
-appspec_bucket       = "nhse-mavis-appspec-bucket-test"
-minimum_web_replicas = 2
-maximum_web_replicas = 4
+appspec_bucket = "nhse-mavis-appspec-bucket-test"
 
 valkey_node_type          = "cache.t4g.micro"
 valkey_log_retention_days = 3

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -21,9 +21,7 @@ http_hosts = {
   MAVIS__HOST                        = "training.manage-vaccinations-in-schools.nhs.uk"
   MAVIS__GIVE_OR_REFUSE_CONSENT_HOST = "training.give-or-refuse-consent-for-vaccinations.nhs.uk"
 }
-appspec_bucket       = "nhse-mavis-appspec-bucket-training"
-minimum_web_replicas = 2
-maximum_web_replicas = 4
+appspec_bucket = "nhse-mavis-appspec-bucket-training"
 
 valkey_node_type          = "cache.t4g.micro"
 valkey_log_retention_days = 3

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -308,13 +308,13 @@ variable "container_insights" {
 
 variable "minimum_web_replicas" {
   type        = number
-  default     = 3
+  default     = 2
   description = "Minimum amount of allowed replicas for web service. Also the replica count when creating th service."
 }
 
 variable "maximum_web_replicas" {
   type        = number
-  default     = 3
+  default     = 4
   description = "Maximum amount of allowed replicas for web service"
 }
 
@@ -324,9 +324,15 @@ variable "good_job_replicas" {
   description = "Amount of replicas for the good-job service"
 }
 
-variable "sidekiq_replicas" {
+variable "minimum_sidekiq_replicas" {
   type        = number
   default     = 2
+  description = "Amount of replicas for the sidekiq service"
+}
+
+variable "maximum_sidekiq_replicas" {
+  type        = number
+  default     = 4
   description = "Amount of replicas for the sidekiq service"
 }
 


### PR DESCRIPTION
- This ensures service has adequate capacity for now and 
- Service never goes above 60 unless it is processing pds jobs at which point it goes up to 100% CPU utilization, so the bounds are fine
- Also update default max/min config for the web service and remove redundant variable declarations