### PR TITLE
Add foundational delegation methods

### DIFF
--- a/app/models/programme.rb
+++ b/app/models/programme.rb
@@ -35,6 +35,8 @@ class Programme < ApplicationRecord
 
   has_many :teams, through: :team_programmes
 
+  scope :supports_delegation, -> { flu }
+
   enum :type,
        { flu: "flu", hpv: "hpv", menacwy: "menacwy", td_ipv: "td_ipv" },
        validate: true
@@ -50,6 +52,8 @@ class Programme < ApplicationRecord
   def doubles? = menacwy? || td_ipv?
 
   def seasonal? = flu?
+
+  def supports_delegation? = flu?
 
   DEFAULT_YEAR_GROUPS_BY_TYPE = {
     "flu" => (0..11).to_a,

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -197,6 +197,8 @@ class Session < ApplicationRecord
 
   def supports_delegation? = programmes.any?(&:supports_delegation?)
 
+  def pgd_supply_enabled? = supports_delegation?
+
   def year_groups
     @year_groups ||= location_programme_year_groups.pluck_year_groups
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -77,6 +77,9 @@ class Session < ApplicationRecord
           )
         end
 
+  scope :supports_delegation,
+        -> { has_programmes(Programme.supports_delegation) }
+
   scope :in_progress, -> { has_date(Date.current) }
   scope :unscheduled, -> { where.not(SessionDate.for_session.arel.exists) }
   scope :scheduled,
@@ -191,6 +194,8 @@ class Session < ApplicationRecord
     return false if dates.empty?
     Date.current > dates.min
   end
+
+  def supports_delegation? = programmes.any?(&:supports_delegation?)
 
   def year_groups
     @year_groups ||= location_programme_year_groups.pluck_year_groups

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -256,6 +256,11 @@ unless Settings.cis2.enabled
   user = create_user(team:, email: "nurse.joy@example.com")
   create_user(team:, email: "admin.hope@example.com", fallback_role: "admin")
   create_user(team:, email: "superuser@example.com", fallback_role: "superuser")
+  create_user(
+    team:,
+    email: "hca@example.com",
+    fallback_role: "healthcare_assistant"
+  )
 
   attach_sample_of_schools_to(team)
 

--- a/spec/models/programme_spec.rb
+++ b/spec/models/programme_spec.rb
@@ -17,6 +17,22 @@
 describe Programme do
   subject(:programme) { build(:programme) }
 
+  describe "scopes" do
+    describe "#supports_delegation" do
+      subject(:scope) { described_class.supports_delegation }
+
+      let(:flu_programme) { create(:programme, :flu) }
+      let(:hpv_programme) { create(:programme, :hpv) }
+      let(:menacwy_programme) { create(:programme, :menacwy) }
+      let(:td_ipv_programme) { create(:programme, :td_ipv) }
+
+      it { should include(flu_programme) }
+      it { should_not include(hpv_programme) }
+      it { should_not include(menacwy_programme) }
+      it { should_not include(td_ipv_programme) }
+    end
+  end
+
   describe "validations" do
     it { should validate_presence_of(:type) }
     it { should validate_inclusion_of(:type).in_array(%w[flu hpv]) }
@@ -56,6 +72,34 @@ describe Programme do
 
   describe "#seasonal?" do
     subject { programme.seasonal? }
+
+    context "with a flu programme" do
+      let(:programme) { build(:programme, :flu) }
+
+      it { should be(true) }
+    end
+
+    context "with an HPV programme" do
+      let(:programme) { build(:programme, :hpv) }
+
+      it { should be(false) }
+    end
+
+    context "with an MenACWY programme" do
+      let(:programme) { build(:programme, :menacwy) }
+
+      it { should be(false) }
+    end
+
+    context "with an Td/IPV programme" do
+      let(:programme) { build(:programme, :td_ipv) }
+
+      it { should be(false) }
+    end
+  end
+
+  describe "#supports_delegation?" do
+    subject { programme.supports_delegation? }
 
     context "with a flu programme" do
       let(:programme) { build(:programme, :flu) }

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -84,6 +84,26 @@ describe Session do
       end
     end
 
+    describe "#supports_delegation" do
+      subject(:scope) { described_class.supports_delegation }
+
+      let!(:hpv_programme) { create(:programme, :hpv) }
+      let!(:flu_programme) { create(:programme, :flu) }
+      let(:session) { create(:session, programmes:) }
+
+      context "with a session for flu" do
+        let(:programmes) { [flu_programme] }
+
+        it { should include(session) }
+      end
+
+      context "with a session for HPV" do
+        let(:programmes) { [hpv_programme] }
+
+        it { should_not include(session) }
+      end
+    end
+
     describe "#in_progress" do
       subject(:scope) { described_class.in_progress }
 
@@ -149,18 +169,20 @@ describe Session do
     end
   end
 
-  describe "#programmes" do
-    subject(:programmes) { session.reload.programmes }
+  describe "associations" do
+    describe "#programmes" do
+      subject(:programmes) { session.reload.programmes }
 
-    let(:hpv_programme) { create(:programme, :hpv) }
-    let(:menacwy_programme) { create(:programme, :menacwy) }
+      let(:hpv_programme) { create(:programme, :hpv) }
+      let(:menacwy_programme) { create(:programme, :menacwy) }
 
-    let(:session) do
-      create(:session, programmes: [menacwy_programme, hpv_programme])
-    end
+      let(:session) do
+        create(:session, programmes: [menacwy_programme, hpv_programme])
+      end
 
-    it "is ordered by name" do
-      expect(programmes).to eq([hpv_programme, menacwy_programme])
+      it "is ordered by name" do
+        expect(programmes).to eq([hpv_programme, menacwy_programme])
+      end
     end
   end
 
@@ -195,6 +217,30 @@ describe Session do
 
     context "with a date" do
       before { create(:session_date, session:) }
+
+      it { should be(false) }
+    end
+  end
+
+  describe "#supports_delegation?" do
+    subject { session.supports_delegation? }
+
+    let(:session) { create(:session, programmes:) }
+
+    context "with only a flu programme" do
+      let(:programmes) { [create(:programme, :flu)] }
+
+      it { should be(true) }
+    end
+
+    context "with a flu and HPV programme" do
+      let(:programmes) { [create(:programme, :flu), create(:programme, :hpv)] }
+
+      it { should be(true) }
+    end
+
+    context "with only an HPV programme" do
+      let(:programmes) { [create(:programme, :hpv)] }
 
       it { should be(false) }
     end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -246,6 +246,30 @@ describe Session do
     end
   end
 
+  describe "#pgd_supply_enabled?" do
+    subject { session.pgd_supply_enabled? }
+
+    let(:session) { create(:session, programmes:) }
+
+    context "with only a flu programme" do
+      let(:programmes) { [create(:programme, :flu)] }
+
+      it { should be(true) }
+    end
+
+    context "with a flu and HPV programme" do
+      let(:programmes) { [create(:programme, :flu), create(:programme, :hpv)] }
+
+      it { should be(true) }
+    end
+
+    context "with only an HPV programme" do
+      let(:programmes) { [create(:programme, :hpv)] }
+
+      it { should be(false) }
+    end
+  end
+
   describe "#year_groups" do
     subject { session.year_groups }
 

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -93,7 +93,7 @@ module CIS2AuthHelper
     }
   end
 
-  def cis2_sign_in(user, ods_code:, role_code:, workgroups:)
+  def cis2_sign_in(user, ods_code:, role_code:, activity_codes:, workgroups:)
     mock_cis2_auth(
       uid: user.uid,
       given_name: user.given_name,
@@ -102,6 +102,7 @@ module CIS2AuthHelper
       sid: user.session_token,
       org_code: ods_code,
       role_code:,
+      activity_codes:,
       workgroups:
     )
 
@@ -118,15 +119,24 @@ module CIS2AuthHelper
 
     ods_code = organisation.ods_code
 
-    role_code ||= {
-      nurse: CIS2Info::NURSE_ROLE,
-      admin: CIS2Info::ADMIN_ROLE
+    role_code = {
+      admin: CIS2Info::ADMIN_ROLE,
+      healthcare_assistant: CIS2Info::ADMIN_ROLE,
+      nurse: CIS2Info::NURSE_ROLE
+    }.fetch(role)
+
+    activity_codes = {
+      admin: [],
+      healthcare_assistant: [
+        CIS2Info::PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE
+      ],
+      nurse: []
     }.fetch(role)
 
     workgroups = user.teams.where(organisation:).pluck(:workgroup)
     workgroups << CIS2Info::SUPERUSER_WORKGROUP if superuser
 
-    cis2_sign_in(user, ods_code:, role_code:, workgroups:)
+    cis2_sign_in(user, ods_code:, role_code:, activity_codes:, workgroups:)
   end
 
   def mock_cis2_auth(


### PR DESCRIPTION
This extracts a number of commits related to delegation from #4393 so they can be used in a number of different delegation PRs. This should have no user-facing changes to the service.