### PR TITLE
Add prescriber to SystmOne export

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -95,6 +95,7 @@ class Reports::SystmOneExporter
           :patient,
           :performed_by_user,
           :session,
+          :supplied_by,
           :vaccine
         )
 
@@ -209,14 +210,19 @@ class Reports::SystmOneExporter
   end
 
   def notes(vaccination_record)
-    notes = vaccination_record.notes.to_s
-    if vaccination_record.performed_by
-      notes += (notes.empty? ? "" : "\n ")
-      notes +=
-        "Administered by: #{vaccination_record.performed_by.given_name}" \
-          " #{vaccination_record.performed_by.family_name}"
-    end
-    notes
+    [
+      vaccination_record.notes,
+      if (user = vaccination_record.performed_by)
+        "Administered by: #{user.full_name}"
+      end,
+      if (user = vaccination_record.supplied_by)
+        if vaccination_record.pgd?
+          "Authorised by: #{user.full_name}"
+        else
+          "Prescribed by: #{user.full_name}"
+        end
+      end
+    ].compact_blank.join("\n")
   end
 
   def method(vaccination_record)

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -58,7 +58,7 @@ describe Reports::SystmOneExporter do
         "Reason" => "Routine",
         "Site" => "Left deltoid",
         "Method" => "Intramuscular",
-        "Notes" => "Administered by: Test User"
+        "Notes" => "Administered by: USER, Test"
       }
     )
   end
@@ -261,6 +261,47 @@ describe Reports::SystmOneExporter do
           "Postcode" => ""
         )
       end
+    end
+  end
+
+  describe "Notes field" do
+    subject { csv_row["Notes"] }
+
+    let(:nurse) { create(:nurse, given_name: "Nurse") }
+    let(:healthcare_assistant) do
+      create(:healthcare_assistant, given_name: "HCA")
+    end
+
+    context "nasal flu administered by healthcare assistant under PGD" do
+      let(:vaccination_record) do
+        create(
+          :vaccination_record,
+          programme:,
+          patient:,
+          session:,
+          protocol: "pgd",
+          performed_by: healthcare_assistant,
+          supplied_by: nurse
+        )
+      end
+
+      it { should eq("Administered by: USER, HCA\nAuthorised by: USER, Nurse") }
+    end
+
+    context "nasal flu administered by healthcare assistant under PSD" do
+      let(:vaccination_record) do
+        create(
+          :vaccination_record,
+          programme:,
+          patient:,
+          session:,
+          protocol: "psd",
+          performed_by: healthcare_assistant,
+          supplied_by: nurse
+        )
+      end
+
+      it { should eq("Administered by: USER, HCA\nPrescribed by: USER, Nurse") }
     end
   end
 


### PR DESCRIPTION
When exporting a SystmOne report, if the vaccination record was performed and supplied by two different people (in the case of delegation) then we need to include this information in the report.

[Jira Issue - MAV-1605](https://nhsd-jira.digital.nhs.uk/browse/MAV-1605)