### PR TITLE
Fix `session_attendance` association

### DIFF
--- a/app/lib/status_updater.rb
+++ b/app/lib/status_updater.rb
@@ -58,7 +58,7 @@ class StatusUpdater
     PatientSession::RegistrationStatus
       .where(patient_session_id: patient_sessions.select(:id))
       .includes(
-        :session_attendance,
+        :session_attendances,
         :vaccination_records,
         patient_session: {
           session: :programmes

--- a/app/models/patient_session/registration_status.rb
+++ b/app/models/patient_session/registration_status.rb
@@ -26,15 +26,16 @@ class PatientSession::RegistrationStatus < ApplicationRecord
            -> { kept.order(performed_at: :desc) },
            through: :patient
 
-  has_one :session_attendance,
-          -> { today },
-          through: :patient_session,
-          source: :session_attendances
+  has_many :session_attendances,
+           -> { includes(:session_date) },
+           through: :patient_session
 
   enum :status,
        { unknown: 0, attending: 1, not_attending: 2, completed: 3 },
        default: :unknown,
        validate: true
+
+  def session_attendance = session_attendances.find(&:today?)
 
   def assign_status
     self.status = generator.status

--- a/app/models/session_attendance.rb
+++ b/app/models/session_attendance.rb
@@ -32,4 +32,6 @@ class SessionAttendance < ApplicationRecord
   has_one :location, through: :session
 
   scope :today, -> { joins(:session_date).merge(SessionDate.today) }
+
+  delegate :today?, to: :session_date
 end

--- a/spec/models/patient_session/registration_status_spec.rb
+++ b/spec/models/patient_session/registration_status_spec.rb
@@ -43,7 +43,7 @@ describe PatientSession::RegistrationStatus do
     describe "#session_attendance" do
       subject do
         described_class
-          .includes(:session_attendance)
+          .includes(:session_attendances)
           .find(patient_session_registration_status.id)
           .session_attendance
       end


### PR DESCRIPTION
This fixes an issue where the `session_attendance` association on the `PatientSession::RegistrationStatus` ends up being attached to the wrong record when pre-loaded. As far as I can tell this appears to be a bug in Rails as I can't see anything wrong with the approach, but the test I've written reproduces the problem. When using `eager_load` the correct association is found, but when using `preload` the criteria for the session attendance to be today's atendance seems to be lost. Having investigated the queries a little, it seems to be due to the fact that the association is through `patient_session`.

The impact of this issue means that if a patient has multiple session attendance records (i.e. they have attended or not attended multiple session dates), then sometimes the status won't get updated correctly.