### PR TITLE
Allow HCAs to administer injected flu

### DIFF
--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -73,6 +73,14 @@ class VaccinateForm
     super
   end
 
+  def protocol
+    if current_user.is_nurse? || vaccine_method == "nasal"
+      "pgd"
+    else
+      "national"
+    end
+  end
+
   def supplied_by_users
     current_user.selected_team.users.show_in_suppliers
   end
@@ -113,10 +121,11 @@ class VaccinateForm
     draft_vaccination_record.patient_id = patient.id
     draft_vaccination_record.performed_at = Time.current
     draft_vaccination_record.performed_by_user = current_user
-    draft_vaccination_record.supplied_by_user_id = supplied_by_user_id
     draft_vaccination_record.performed_ods_code = organisation.ods_code
     draft_vaccination_record.programme = programme
+    draft_vaccination_record.protocol = protocol
     draft_vaccination_record.session_id = session.id
+    draft_vaccination_record.supplied_by_user_id = supplied_by_user_id
 
     draft_vaccination_record.save # rubocop:disable Rails/SaveBang
   end

--- a/app/models/draft_vaccination_record.rb
+++ b/app/models/draft_vaccination_record.rb
@@ -25,6 +25,7 @@ class DraftVaccinationRecord
   attribute :performed_by_family_name, :string
   attribute :performed_by_given_name, :string
   attribute :performed_by_user_id, :integer
+  attribute :protocol, :string
   attribute :performed_ods_code, :string
   attribute :programme_id, :integer
   attribute :protocol, :string
@@ -129,10 +130,6 @@ class DraftVaccinationRecord
 
   # So that a form error matches to a field in this model
   alias_method :administered, :administered?
-
-  def protocol
-    :pgd
-  end
 
   def batch
     return nil if batch_id.nil?

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -221,8 +221,16 @@ class Session < ApplicationRecord
   def vaccine_methods_for(user:)
     if user.is_nurse?
       vaccine_methods
-    elsif user.is_healthcare_assistant? && pgd_supply_enabled?
-      %w[nasal]
+    elsif user.is_healthcare_assistant?
+      if pgd_supply_enabled? && national_protocol_enabled?
+        vaccine_methods
+      elsif national_protocol_enabled?
+        vaccine_methods.include?("injection") ? %w[injection] : []
+      elsif pgd_supply_enabled?
+        vaccine_methods.include?("nasal") ? %w[nasal] : []
+      else
+        []
+      end
     else
       []
     end

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -117,7 +117,7 @@ class VaccinationRecord < ApplicationRecord
 
   scope :recorded_in_service, -> { where.not(session_id: nil) }
 
-  enum :protocol, { pgd: 0, psd: 1 }, validate: { allow_nil: true }
+  enum :protocol, { pgd: 0, psd: 1, national: 2 }, validate: { allow_nil: true }
 
   enum :delivery_method,
        { intramuscular: 0, subcutaneous: 1, nasal_spray: 2 },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -260,6 +260,7 @@ en:
           not_well: Unwell
           refused: Refused vaccine
         protocols:
+          national: National protocol
           pgd: Patient Group Direction (PGD)
         sync_statuses:
           cannot_sync: Cannot sync

--- a/spec/features/flu_vaccination_hca_national_protocol_spec.rb
+++ b/spec/features/flu_vaccination_hca_national_protocol_spec.rb
@@ -3,21 +3,21 @@
 describe "Flu vaccination" do
   around { |example| travel_to(Time.zone.local(2024, 10, 1)) { example.run } }
 
-  scenario "Administered by HCA under PGD supply" do
+  scenario "Administered by HCA under national protocol" do
     given_a_session_exists
     and_patients_exist
 
     when_i_visit_the_session_record_tab
-    then_i_only_see_nasal_spray_patients
+    then_i_see_all_the_patients
 
     when_i_click_on_the_nasal_only_patient
-    then_i_am_able_to_vaccinate_them
+    then_i_am_able_to_vaccinate_them(nasal: true)
 
     when_i_click_on_the_nasal_and_injection_patient
-    then_i_am_able_to_vaccinate_them
+    then_i_am_able_to_vaccinate_them(nasal: true)
 
     when_i_click_on_the_injection_patient
-    then_i_am_not_able_to_vaccinate_them
+    then_i_am_able_to_vaccinate_them(nasal: false)
   end
 
   def given_a_session_exists
@@ -26,12 +26,20 @@ describe "Flu vaccination" do
 
     @team = create(:team, programmes:)
 
-    @batch =
+    @nasal_batch =
       create(
         :batch,
         :not_expired,
         team: @team,
         vaccine: @programme.vaccines.nasal.first
+      )
+
+    @injection_batch =
+      create(
+        :batch,
+        :not_expired,
+        team: @team,
+        vaccine: @programme.vaccines.injection.first
       )
 
     @nurse = create(:nurse, team: @team)
@@ -42,6 +50,7 @@ describe "Flu vaccination" do
         :session,
         :today,
         :requires_no_registration,
+        :national_protocol_enabled,
         team: @team,
         programmes:
       )
@@ -73,10 +82,10 @@ describe "Flu vaccination" do
     visit session_record_path(@session)
   end
 
-  def then_i_only_see_nasal_spray_patients
+  def then_i_see_all_the_patients
     expect(page).to have_content(@patient_nasal_only.full_name)
     expect(page).to have_content(@patient_nasal_and_injection.full_name)
-    expect(page).not_to have_content(@patient_injection_only.full_name)
+    expect(page).to have_content(@patient_injection_only.full_name)
   end
 
   def when_i_click_on_the_nasal_only_patient
@@ -88,34 +97,32 @@ describe "Flu vaccination" do
   end
 
   def when_i_click_on_the_injection_patient
-    # This patient won't be in the "Record" tab.
-    expect(page).not_to have_content(@patient_injection_only.full_name)
-
-    within(".app-secondary-navigation") { click_on "Children" }
     click_on @patient_injection_only.full_name
   end
 
-  def then_i_am_able_to_vaccinate_them
+  def then_i_am_able_to_vaccinate_them(nasal:)
     check "I have checked that the above statements are true"
     select @nurse.full_name
     within all("section")[1] do
       choose "Yes"
+      choose "Left arm (upper position)" unless nasal
     end
     click_on "Continue"
 
-    choose @batch.name
+    batch = nasal ? @nasal_batch : @injection_batch
+
+    choose batch.name
     click_on "Continue"
 
     click_on "Change supplier"
     choose @nurse.full_name
-    4.times { click_on "Continue" }
+    (nasal ? 4 : 3).times { click_on "Continue" }
+
+    protocol = nasal ? "Patient Group Direction (PGD)" : "National"
+
+    expect(page).to have_content("Protocol#{protocol}")
 
     click_on "Confirm"
     click_on "Record vaccinations"
-  end
-
-  def then_i_am_not_able_to_vaccinate_them
-    expect(page).not_to have_content("Pre-screening checks")
-    expect(page).not_to have_content("ready for their")
   end
 end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -313,6 +313,14 @@ describe Session do
       let(:user) { create(:healthcare_assistant) }
 
       it { should eq(%w[nasal]) }
+
+      context "with national protocol enabled" do
+        let(:session) do
+          create(:session, :national_protocol_enabled, programmes:)
+        end
+
+        it { should match_array(%w[nasal injection]) }
+      end
     end
 
     context "with an admin staff" do


### PR DESCRIPTION
This adds support for healthcase assistants to administer the injected flu vaccine under the national protocol, requiring the session to have the national protocol enabled and for the HCA to specify which nurse supplied to them the vaccine.