### PR TITLE
Make `VaccinationRecord.protocol` optional from imports and API

### DIFF
--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -106,7 +106,6 @@ class ImmunisationImportRow
       performed_by_user:,
       performed_ods_code: performed_ods_code&.to_s,
       programme:,
-      protocol: "pgd",
       session:
     }
 
@@ -117,7 +116,7 @@ class ImmunisationImportRow
       )
     end
 
-    attributes.merge!(notify_parents: true) if session
+    attributes.merge!(notify_parents: true, protocol: "pgd") if session
 
     attributes_to_stage_if_already_exists = {
       batch_id: batch&.id,

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -141,10 +141,10 @@ class VaccinationRecord < ApplicationRecord
 
   encrypts :notes
 
-  with_options if: :administered? do
-    validates :full_dose, inclusion: [true, false]
-    validates :protocol, presence: true
-  end
+  validates :full_dose, inclusion: [true, false], if: :administered?
+  validates :protocol,
+            presence: true,
+            if: -> { administered? && recorded_in_service? }
 
   validates :notes, length: { maximum: 1000 }
 

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -74,7 +74,11 @@ describe VaccinationRecord do
       it { should allow_values(true, false).for(:full_dose) }
       it { should_not allow_values(nil).for(:full_dose) }
 
-      it { should validate_presence_of(:protocol) }
+      context "when administered in mavis" do
+        before { vaccination_record.session = create(:session) }
+
+        it { should validate_presence_of(:protocol) }
+      end
     end
 
     context "when not administered" do


### PR DESCRIPTION
This allows historic records, and records received from the API to leave `protocol = nil`.

Also set imported records' protocol to `nil`.