### PR TITLE
Persist `created_at` on PDS search results

### DIFF
--- a/app/jobs/commit_patient_changesets_job.rb
+++ b/app/jobs/commit_patient_changesets_job.rb
@@ -113,7 +113,8 @@ class CommitPatientChangesetsJob < ApplicationJob
           step: PDSSearchResult.steps[result["step"]],
           result: PDSSearchResult.results[result["result"]],
           nhs_number: result["nhs_number"],
-          import:
+          import:,
+          created_at: result["created_at"]
         )
       end
     end

--- a/app/jobs/process_patient_changesets_job.rb
+++ b/app/jobs/process_patient_changesets_job.rb
@@ -19,7 +19,8 @@ class ProcessPatientChangesetsJob < ApplicationJob
       patient_changeset.search_results << {
         step: step_name,
         result: result,
-        nhs_number: pds_patient&.nhs_number
+        nhs_number: pds_patient&.nhs_number,
+        created_at: Time.current
       }.with_indifferent_access
 
       next_step = step[result]

--- a/spec/jobs/process_patient_changesets_job_spec.rb
+++ b/spec/jobs/process_patient_changesets_job_spec.rb
@@ -23,6 +23,19 @@ describe ProcessPatientChangesetsJob do
       )
       expect(patient_changeset).to be_processed
     end
+
+    it "records the search result" do
+      freeze_time do
+        perform
+
+        expect(patient_changeset.search_results.last).to include(
+          "step" => "no_fuzzy_with_history",
+          "result" => "one_match",
+          "nhs_number" => "1234567890",
+          "created_at" => Time.current.iso8601(3)
+        )
+      end
+    end
   end
 
   context "when no match is found initially" do

--- a/spec/models/pds_search_result_spec.rb
+++ b/spec/models/pds_search_result_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: pds_search_results
+#
+#  id          :bigint           not null, primary key
+#  import_type :string
+#  nhs_number  :string
+#  result      :integer          not null
+#  step        :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  import_id   :bigint
+#  patient_id  :bigint           not null
+#
+# Indexes
+#
+#  index_pds_search_results_on_import      (import_type,import_id)
+#  index_pds_search_results_on_patient_id  (patient_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (patient_id => patients.id)
+#
+describe PDSSearchResult, type: :model do
+  subject(:pds_search_result) { build(:pds_search_result) }
+
+  describe "associations" do
+    it { should belong_to(:patient) }
+    it { should belong_to(:import).optional }
+  end
+end


### PR DESCRIPTION
Ensures search timestamps are preserved during the import process, rather than defaulting to current time in the final commit job.