### PR TITLE
Vaccine method icon incorrectly shown on consent and triage screens

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -119,7 +119,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
   end
 
   def vaccination_method
-    return if context == :patients
+    return unless %i[register record].include?(context)
 
     programmes_to_check = programmes.select(&:has_multiple_vaccine_methods?)
 

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -71,7 +71,7 @@ describe AppPatientSessionSearchResultCardComponent do
     context "and the programme is flu" do
       let(:programme) { create(:programme, :flu) }
 
-      it { should have_text("Vaccination method") }
+      it { should_not have_text("Vaccination method") }
       it { should have_text("Nasal") }
     end
   end
@@ -82,8 +82,7 @@ describe AppPatientSessionSearchResultCardComponent do
     context "and the programme is flu" do
       let(:programme) { create(:programme, :flu) }
 
-      it { should have_text("Vaccination method") }
-      it { should have_text("Nasal") }
+      it { should_not have_text("Vaccination method") }
     end
   end
 


### PR DESCRIPTION
Fixes issue where donut/diamond icons were incorrectly displayed on consent and triage screens when they should only appear on registration and record vaccination lists.

[Jira Issue - MAV-1849](https://nhsd-jira.digital.nhs.uk/browse/MAV-1849)