### PR TITLE
On-demand DB snapshot for data replication environment

### DIFF
--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -44,6 +44,9 @@ env:
   aws_role: ${{ inputs.environment == 'production'
     && 'arn:aws:iam::820242920762:role/GithubDeployDataReplicationInfrastructure'
     || 'arn:aws:iam::393416225559:role/GithubDeployDataReplicationInfrastructure' }}
+  db_snapshot_role: ${{ inputs.environment == 'production'
+    && 'arn:aws:iam::820242920762:role/DatabaseSnapshotRole'
+    || 'arn:aws:iam::393416225559:role/DatabaseSnapshotRole' }}
 
 defaults:
   run:
@@ -62,10 +65,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: Configure AWS Credentials
+      - name: Assume DB Snapshot role
+        if: inputs.take_db_snapshot
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.aws_role }}
+          role-to-assume: ${{ env.db_snapshot_role }}
           aws-region: eu-west-2
       - name: Take DB snapshot
         if: inputs.take_db_snapshot
@@ -76,6 +80,11 @@ jobs:
           echo "Waiting for snapshot to be available. This can take a while."
           aws rds wait db-cluster-snapshot-available --db-cluster-snapshot-identifier $snapshot_identifier
           echo "New snapshot is now available"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.aws_role }}
+          aws-region: eu-west-2
       - name: Get latest snapshot
         id: get-latest-snapshot
         run: |

--- a/.github/workflows/data-replication-pipeline.yml
+++ b/.github/workflows/data-replication-pipeline.yml
@@ -35,6 +35,10 @@ on:
         type: string
         required: true
         default: "[]"
+      take_db_snapshot:
+        description: Take a new DB snapshot before creating the environment
+        type: boolean
+        default: false
 
 env:
   aws_role: ${{ inputs.environment == 'production'
@@ -63,7 +67,16 @@ jobs:
         with:
           role-to-assume: ${{ env.aws_role }}
           aws-region: eu-west-2
-      - name: get latest snapshot
+      - name: Take DB snapshot
+        if: inputs.take_db_snapshot
+        run: |
+          set -e
+          snapshot_identifier=snapshot-for-data-replication-$(date +"%Y-%m-%d-%H-%M-%S")
+          aws rds create-db-cluster-snapshot --db-cluster-identifier mavis-${{ inputs.environment }} --db-cluster-snapshot-identifier $snapshot_identifier
+          echo "Waiting for snapshot to be available. This can take a while."
+          aws rds wait db-cluster-snapshot-available --db-cluster-snapshot-identifier $snapshot_identifier
+          echo "New snapshot is now available"
+      - name: Get latest snapshot
         id: get-latest-snapshot
         run: |
           set -e

--- a/terraform/account/resources/iam_policy_DatabaseSnapshotPolicy.json
+++ b/terraform/account/resources/iam_policy_DatabaseSnapshotPolicy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Statement1",
+      "Effect": "Allow",
+      "Action": [
+        "rds:CreateDBClusterSnapshot",
+        "rds:DescribeDBClusterSnapshots"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}


### PR DESCRIPTION
This adds an option to the data replication workflow to take a new DB snapshot as a base for the data replication environment

Jira-Issue: MAV-1864