### PR TITLE
Combine consent given status and vaccine method

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -331,9 +331,12 @@ class AppActivityLogComponent < ViewComponent::Base
     triages.map do |triage|
       programmes = programmes_for(triage)
       title = "Triaged decision: #{triage.human_enum_name(:status)}"
-      title +=
-        " with #{triage.human_enum_name(:vaccine_method)}" if triage.vaccine_method.present? &&
-        programmes.first.has_multiple_vaccine_methods?
+
+      if triage.vaccine_method.present? &&
+           programmes.first.has_multiple_vaccine_methods?
+        title += " with #{triage.human_enum_name(:vaccine_method)}"
+      end
+
       {
         title:,
         body: triage.notes,

--- a/app/components/app_programme_status_tags_component.rb
+++ b/app/components/app_programme_status_tags_component.rb
@@ -10,8 +10,18 @@ class AppProgrammeStatusTagsComponent < ViewComponent::Base
     safe_join(
       status_by_programme.map do |programme, hash|
         status = hash[:status]
+
         vaccine_methods =
-          (hash[:vaccine_methods] if programme.has_multiple_vaccine_methods?)
+          if programme.has_multiple_vaccine_methods?
+            if outcome == :consent &&
+                 (vaccine_method = hash[:vaccine_methods]&.first)
+              status = :"#{status}_#{vaccine_method}"
+              nil
+            else
+              hash[:vaccine_methods]
+            end
+          end
+
         latest_session_status = hash[:latest_session_status] if status !=
           hash[:latest_session_status]
 

--- a/app/controllers/sessions/consent_controller.rb
+++ b/app/controllers/sessions/consent_controller.rb
@@ -9,14 +9,31 @@ class Sessions::ConsentController < ApplicationController
   layout "full"
 
   def show
-    @statuses = Patient::ConsentStatus.statuses.keys - %w[not_required]
+    statuses_except_not_required =
+      Patient::ConsentStatus.statuses.keys - %w[not_required]
+
+    @statuses =
+      if @session.has_multiple_vaccine_methods?
+        statuses_except_not_required.flat_map do |status|
+          if status == "given"
+            @session.vaccine_methods.map { "given_#{it}" }
+          else
+            status
+          end
+        end
+      else
+        statuses_except_not_required
+      end
 
     scope =
       @session
         .patient_sessions
         .includes_programmes
         .includes(:latest_note, patient: :consent_statuses)
-        .has_consent_status(@statuses, programme: @form.programmes)
+        .has_consent_status(
+          statuses_except_not_required,
+          programme: @form.programmes
+        )
 
     patient_sessions = @form.apply(scope)
     @pagy, @patient_sessions = pagy(patient_sessions)
@@ -25,6 +42,9 @@ class Sessions::ConsentController < ApplicationController
   private
 
   def set_session
-    @session = policy_scope(Session).find_by!(slug: params[:session_slug])
+    @session =
+      policy_scope(Session).includes(programmes: :vaccines).find_by!(
+        slug: params[:session_slug]
+      )
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -209,6 +209,8 @@ class Session < ApplicationRecord
     @vaccine_methods ||= programmes.flat_map(&:vaccine_methods).uniq.sort
   end
 
+  def has_multiple_vaccine_methods? = vaccine_methods.length > 1
+
   def programmes_for(year_group: nil, patient: nil, academic_year: nil)
     year_group ||= patient.year_group(academic_year:)
 

--- a/config/locales/status.en.yml
+++ b/config/locales/status.en.yml
@@ -10,12 +10,16 @@ en:
       label:
         conflicts: Conflicting consent
         given: Consent given
+        given_injection: Consent given for injected vaccine
+        given_nasal: Consent given for nasal spray
         no_response: No response
         not_required: No consent needed
         refused: Consent refused
       colour:
         conflicts: dark-orange
         given: aqua-green
+        given_injection: aqua-green
+        given_nasal: aqua-green
         no_response: grey
         not_required: grey
         refused: red

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -72,7 +72,7 @@ describe AppPatientSessionSearchResultCardComponent do
       let(:programme) { create(:programme, :flu) }
 
       it { should_not have_text("Vaccination method") }
-      it { should have_text("Nasal") }
+      it { should have_text("Consent given for nasal spray") }
     end
   end
 

--- a/spec/components/app_programme_status_tags_component_spec.rb
+++ b/spec/components/app_programme_status_tags_component_spec.rb
@@ -29,7 +29,7 @@ describe AppProgrammeStatusTagsComponent do
 
     it { should have_content("MenACWYConsent given") }
     it { should have_content("Td/IPVConsent refused") }
-    it { should have_content("FluConsent givenNasal spray") }
+    it { should have_content("FluConsent given for nasal spray") }
   end
 
   context "for programme outcome" do

--- a/spec/forms/patient_search_form_spec.rb
+++ b/spec/forms/patient_search_form_spec.rb
@@ -419,6 +419,29 @@ describe PatientSearchForm do
           patient_session_refused
         )
       end
+
+      context "with combined consent status and vaccine method" do
+        let(:consent_statuses) { %w[given_nasal] }
+
+        it "filters on consent status" do
+          patient_session_given_nasal =
+            create(
+              :patient,
+              :consent_given_nasal_only_triage_not_needed,
+              session:
+            ).patient_sessions.first
+
+          create(
+            :patient,
+            :consent_given_injection_only_triage_not_needed,
+            session:
+          )
+
+          expect(form.apply(scope)).to contain_exactly(
+            patient_session_given_nasal
+          )
+        end
+      end
     end
 
     context "filtering on register status" do

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -296,6 +296,24 @@ describe Session do
     it { should contain_exactly("injection", "nasal") }
   end
 
+  describe "#has_multiple_vaccine_methods?" do
+    subject { session.has_multiple_vaccine_methods? }
+
+    let(:session) { create(:session, programmes: [programme]) }
+
+    context "with a flu session" do
+      let(:programme) { create(:programme, :flu) }
+
+      it { should be(true) }
+    end
+
+    context "with an HPV session" do
+      let(:programme) { create(:programme, :hpv) }
+
+      it { should be(false) }
+    end
+  end
+
   describe "#today_or_future_dates" do
     subject(:today_or_future_dates) do
       travel_to(today) { session.today_or_future_dates }


### PR DESCRIPTION
This updates the consent status as shown in the "Consent" tab, so that when consent has been given for the flu programme, it is shown with the chosen vaccine method as a single status rather than currently where the vaccine method is shown in text next to the status. This matches the latest designs in the prototype.

[Jira Issue - MAV-1847](https://nhsd-jira.digital.nhs.uk/browse/MAV-1847)

## Screenshot

<img width="1172" height="692" alt="Screenshot 2025-08-28 at 15 35 39" src="https://github.com/user-attachments/assets/065ca22f-27ac-419c-aa85-b1aecd1c55f3" />
