### PR TITLE
Disable Sentry in sandbox environments

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+return if ENV["SENTRY_DISABLE"].present?
+
 require "active_support/parameter_filter"
 
 Sentry.init do |config|

--- a/terraform/app/variables.tf
+++ b/terraform/app/variables.tf
@@ -205,7 +205,16 @@ locals {
   }]
   parameter_store_arns = [for key, value in local.parameter_store_variables : aws_ssm_parameter.environment_config[key].arn]
 
-  task_envs = [
+  sandbox_envs = (
+    startswith(var.environment, "sandbox") ? [
+      {
+        name  = "SENTRY_DISABLE"
+        value = "true"
+      }
+    ] : []
+  )
+
+  task_envs = concat([
     {
       name  = "DB_HOST"
       value = aws_rds_cluster.core.endpoint
@@ -246,7 +255,8 @@ locals {
       name  = "SIDEKIQ_REDIS_URL"
       value = "rediss://${aws_elasticache_replication_group.valkey.primary_endpoint_address}:${var.valkey_port}"
     },
-  ]
+  ], local.sandbox_envs)
+
   task_secrets = concat([
     {
       name      = "DB_CREDENTIALS"


### PR DESCRIPTION
These environments are used for testing and can often be broken, and by sending errors to Sentry it makes Sentry harder to use for production as it includes lots of noise to filter through.