### PR TITLE
Always run imports in the background

### DIFF
--- a/app/controllers/class_imports_controller.rb
+++ b/app/controllers/class_imports_controller.rb
@@ -30,13 +30,8 @@ class ClassImportsController < ApplicationController
 
     @class_import.save!
 
-    if @class_import.slow?
-      ProcessImportJob.perform_later(@class_import)
-      redirect_to imports_path, flash: { success: "Import processing started" }
-    else
-      ProcessImportJob.perform_now(@class_import)
-      redirect_to class_import_path(@class_import)
-    end
+    ProcessImportJob.perform_later(@class_import)
+    redirect_to imports_path, flash: { success: "Import processing started" }
   end
 
   def show

--- a/app/controllers/cohort_imports_controller.rb
+++ b/app/controllers/cohort_imports_controller.rb
@@ -28,13 +28,8 @@ class CohortImportsController < ApplicationController
 
     @cohort_import.save!
 
-    if @cohort_import.slow?
-      ProcessImportJob.perform_later(@cohort_import)
-      redirect_to imports_path, flash: { success: "Import processing started" }
-    else
-      ProcessImportJob.perform_now(@cohort_import)
-      redirect_to cohort_import_path(@cohort_import)
-    end
+    ProcessImportJob.perform_later(@cohort_import)
+    redirect_to imports_path, flash: { success: "Import processing started" }
   end
 
   def show

--- a/app/controllers/immunisation_imports_controller.rb
+++ b/app/controllers/immunisation_imports_controller.rb
@@ -26,13 +26,8 @@ class ImmunisationImportsController < ApplicationController
 
     @immunisation_import.save!
 
-    if @immunisation_import.slow?
-      ProcessImportJob.perform_later(@immunisation_import)
-      redirect_to imports_path, flash: { success: "Import processing started" }
-    else
-      ProcessImportJob.perform_now(@immunisation_import)
-      redirect_to immunisation_import_path(@immunisation_import)
-    end
+    ProcessImportJob.perform_later(@immunisation_import)
+    redirect_to imports_path, flash: { success: "Import processing started" }
   end
 
   def show

--- a/app/jobs/process_patient_changesets_job.rb
+++ b/app/jobs/process_patient_changesets_job.rb
@@ -160,11 +160,7 @@ class ProcessPatientChangesetsJob < ApplicationJob
   end
 
   def enqueue_next_search(patient_changeset, next_step)
-    if patient_changeset.import.slow?
-      ProcessPatientChangesetsJob.perform_later(patient_changeset, next_step)
-    else
-      ProcessPatientChangesetsJob.perform_now(patient_changeset, next_step)
-    end
+    ProcessPatientChangesetsJob.perform_later(patient_changeset, next_step)
   end
 
   def finish_processing(patient_changeset)
@@ -173,11 +169,7 @@ class ProcessPatientChangesetsJob < ApplicationJob
 
     # TODO: Make this atomic
     if patient_changeset.import.changesets.pending.none?
-      if patient_changeset.import.slow?
-        CommitPatientChangesetsJob.perform_later(patient_changeset.import)
-      else
-        CommitPatientChangesetsJob.perform_now(patient_changeset.import)
-      end
+      CommitPatientChangesetsJob.perform_later(patient_changeset.import)
     end
   end
 end

--- a/app/models/concerns/csv_importable.rb
+++ b/app/models/concerns/csv_importable.rb
@@ -62,10 +62,6 @@ module CSVImportable
     csv_removed_at != nil
   end
 
-  def slow?
-    rows_count > 15
-  end
-
   def load_data!
     return if invalid?
 
@@ -132,13 +128,8 @@ module CSVImportable
           PatientChangeset.from_import_row(row:, import: self, row_number:)
         end
 
-      changesets.each do
-        if slow?
-          ProcessPatientChangesetsJob.perform_later(it)
-        else
-          ProcessPatientChangesetsJob.perform_now(it)
-        end
-      end
+      changesets.each { ProcessPatientChangesetsJob.perform_later(it) }
+
       return
     end
 

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -115,6 +115,11 @@ describe "End-to-end journey" do
     click_on "Continue"
     attach_file "cohort_import[csv]", csv_file.path
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
     visit cohort_import_path(CohortImport.last)
   end
 

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -364,6 +364,12 @@ describe "HPV vaccination" do
 
     attach_file("immunisation_import[csv]", "tmp/modified.csv")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link ImmunisationImport.last.created_at.to_fs(:long), match: :first
   end
 
   def when_i_navigate_to_the_session_page

--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -424,6 +424,15 @@ describe "Import child records" do
     click_button "Continue"
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/#{filename}")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    # TODO: Hack to make sure all the steps are processed.
+    10.times { perform_enqueued_jobs }
+
+    visit cohort_import_path(CohortImport.last)
   end
 
   def when_i_visit_a_session_page_for_the_hpv_programme
@@ -454,6 +463,13 @@ describe "Import child records" do
       "spec/fixtures/class_import/pds_extravaganza.csv"
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link ClassImport.order(:created_at).last.created_at.to_fs(:long),
+               match: :first
   end
 
   def when_i_visit_the_import_page
@@ -590,7 +606,6 @@ describe "Import child records" do
   end
 
   def and_i_should_see_correct_patient_counts
-    perform_enqueued_jobs
     expect(Patient.count).to eq(11)
   end
 

--- a/spec/features/import_child_records_preparation_spec.rb
+++ b/spec/features/import_child_records_preparation_spec.rb
@@ -280,6 +280,12 @@ describe "Import child records" do
   def when_i_upload_a_valid_file
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link CohortImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_should_see_the_patients

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -192,6 +192,12 @@ describe "Import child records" do
   def and_i_upload_a_valid_file
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link CohortImport.last.created_at.to_fs(:long), match: :first
   end
 
   def and_i_should_see_the_patients
@@ -323,11 +329,9 @@ describe "Import child records" do
   end
 
   def when_i_wait_for_the_background_job_to_complete
-    perform_enqueued_jobs
-    # TODO: Temporary hack to ensure process patient changesets jobs are done
-    perform_enqueued_jobs if enqueued_jobs.any?
-    # TODO: Temporary hack to ensure commit patient  changesets jobs are done
-    perform_enqueued_jobs if enqueued_jobs.any?
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
   end
 
   def then_i_should_see_the_holding_page
@@ -355,6 +359,12 @@ describe "Import child records" do
       "spec/fixtures/cohort_import/valid_with_changes.csv"
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link CohortImport.last.created_at.to_fs(:long), match: :first
   end
 
   def and_i_go_to_the_import_page

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -216,6 +216,12 @@ describe "Child record imports duplicates" do
   def and_i_upload_a_file_with_duplicate_records
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link CohortImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records

--- a/spec/features/import_child_records_with_twins_spec.rb
+++ b/spec/features/import_child_records_with_twins_spec.rb
@@ -100,6 +100,12 @@ describe "Child record imports twins" do
   def and_i_upload_a_file_with_a_twin
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/valid.csv")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    visit cohort_import_path(CohortImport.last)
   end
 
   def then_i_should_see_the_import_page_with_successful_import

--- a/spec/features/import_class_lists_move_spec.rb
+++ b/spec/features/import_class_lists_move_spec.rb
@@ -152,7 +152,14 @@ describe "Import class lists - Moving patients" do
   def when_i_upload_a_valid_file
     attach_file("class_import[csv]", "spec/fixtures/class_import/valid.csv")
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    visit class_import_path(ClassImport.last)
   end
+
   alias_method :and_i_upload_a_valid_file, :when_i_upload_a_valid_file
 
   def when_i_go_to_the_upload_page

--- a/spec/features/import_class_lists_with_duplicates_spec.rb
+++ b/spec/features/import_class_lists_with_duplicates_spec.rb
@@ -204,6 +204,12 @@ describe "Class list imports duplicates" do
       "spec/fixtures/class_import/duplicates.csv"
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link ClassImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records

--- a/spec/features/import_vaccination_records_spec.rb
+++ b/spec/features/import_vaccination_records_spec.rb
@@ -95,6 +95,12 @@ describe "Immunisation imports" do
       "spec/fixtures/immunisation_import/invalid_rows.csv"
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    visit immunisation_import_path(ImmunisationImport.last)
   end
 
   def then_i_should_see_the_errors_page
@@ -122,6 +128,12 @@ describe "Immunisation imports" do
       "spec/fixtures/immunisation_import/valid_hpv.csv"
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    visit immunisation_import_path(ImmunisationImport.order(:created_at).last)
   end
 
   def then_i_should_see_the_success_heading

--- a/spec/features/import_vaccination_records_with_duplicates_spec.rb
+++ b/spec/features/import_vaccination_records_with_duplicates_spec.rb
@@ -149,6 +149,12 @@ describe "Immunisation imports duplicates" do
       "spec/fixtures/immunisation_import/valid_hpv.csv"
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    visit immunisation_import_path(ImmunisationImport.last)
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records

--- a/spec/features/triage_partially_vaccinated_spec.rb
+++ b/spec/features/triage_partially_vaccinated_spec.rb
@@ -64,6 +64,10 @@ describe "Triage" do
       file_fixture("td_ipv/vaccination_records.csv")
     )
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+
+    click_link ImmunisationImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_see_the_completed_upload
@@ -85,6 +89,12 @@ describe "Triage" do
 
     attach_file("class_import[csv]", file_fixture("td_ipv/class_list.csv"))
     click_on "Continue"
+
+    perform_enqueued_jobs(only: ProcessImportJob)
+    perform_enqueued_jobs(only: ProcessPatientChangesetsJob)
+    perform_enqueued_jobs(only: CommitPatientChangesetsJob)
+
+    click_link ClassImport.last.created_at.to_fs(:long), match: :first
   end
 
   def then_i_see_one_patient_needing_consent


### PR DESCRIPTION
With the new background process where PDS checks are performed, we're seeing a problem where if any of the PDS checks fail due to a 429 error, the users see an unexpected error page because we catch the error expecting Sidekiq to re-process it. However, if the user uploads a file that is smaller than 15 rows we currently process it synchronously meaning we can't take advantage of the retry behaviour in the job.

Rather than trying to make the synchronous process work well with retries, it seems simpler to make all imports run in the background, especially since in practice the vast majority of files are larger than 15 rows.