### PR TITLE
Fix migration on pre-screenings

### DIFF
--- a/db/migrate/20250821124416_remove_patient_session_from_pre_screenings.rb
+++ b/db/migrate/20250821124416_remove_patient_session_from_pre_screenings.rb
@@ -15,7 +15,7 @@ class RemovePatientSessionFromPreScreenings < ActiveRecord::Migration[8.0]
         SessionDate.find_by!(
           session_id:,
           value: pre_screening.created_at.to_date
-        )
+        ).id
       pre_screening.update_columns(patient_id:, session_date_id:)
     end
 


### PR DESCRIPTION
This fixes an issue where the migration is failing during the deploy because it tries to assign the `SessionDate` object to an `id` column and ends up being set to `nil`.