### PR TITLE
Warning notifications for unrecognised contact details

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -58,4 +58,37 @@ module ConsentFormMailerConcern
       SMSDeliveryJob.perform_later(:consent_confirmation_refused, **params)
     end
   end
+
+  def send_parental_contact_warning_if_needed(patient, consent_form, user)
+    return if patient.parents.empty? || user.present?
+
+    submitted_email = consent_form.parent_email
+    submitted_phone = consent_form.parent_phone
+
+    match_found =
+      patient.parents.any? do |parent|
+        email_match = parent.email.present? && submitted_email == parent.email
+        phone_match = parent.phone.present? && submitted_phone == parent.phone
+        email_match || phone_match
+      end
+
+    return if match_found
+
+    patient.parents.each do |parent|
+      if parent.email.present?
+        EmailDeliveryJob.perform_later(
+          :parental_consent_warning,
+          parent: parent,
+          patient: patient
+        )
+      end
+
+      next unless parent.phone.present? && parent.phone_receive_updates
+      SMSDeliveryJob.perform_later(
+        :parental_consent_warning,
+        parent: parent,
+        patient: patient
+      )
+    end
+  end
 end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -436,6 +436,8 @@ class ConsentForm < ApplicationRecord
   end
 
   def match_with_patient!(patient, current_user:)
+    send_parental_contact_warning_if_needed(patient, self, current_user)
+
     ActiveRecord::Base.transaction do
       notify_log_entries.update_all(patient_id: patient.id)
 

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -114,4 +114,175 @@ describe ConsentFormMailerConcern do
       end
     end
   end
+
+  describe "#send_parental_contact_warning_if_needed" do
+    subject(:send_warning) do
+      sample.send_parental_contact_warning_if_needed(
+        patient,
+        consent_form,
+        user
+      )
+    end
+
+    let(:user) { nil }
+
+    let(:parent) do
+      create(
+        :parent,
+        email: "existing@example.com",
+        phone: "07987654321",
+        phone_receive_updates: true
+      )
+    end
+    let(:patient) { create(:patient, parents: [parent]) }
+    let(:consent_form) do
+      create(
+        :consent_form,
+        parent_email: "submitted@example.com",
+        parent_phone: "07123456789"
+      )
+    end
+
+    it "can be called directly" do
+      expect { send_warning }.not_to raise_error
+    end
+
+    context "when patient has no parents" do
+      let(:patient) { create(:patient, parents: []) }
+
+      it "does not send any warning email" do
+        expect { send_warning }.not_to have_delivered_email
+      end
+
+      it "does not send any warning SMS" do
+        expect { send_warning }.not_to have_delivered_sms
+      end
+    end
+
+    context "when submitted email and phone both match existing parent" do
+      let(:consent_form) do
+        create(
+          :consent_form,
+          parent_email: "existing@example.com",
+          parent_phone: "07987654321"
+        )
+      end
+
+      it "does not send any warning email" do
+        expect { send_warning }.not_to have_delivered_email
+      end
+
+      it "does not send any warning SMS" do
+        expect { send_warning }.not_to have_delivered_sms
+      end
+    end
+
+    context "when only submitted email matches existing parent" do
+      let(:consent_form) do
+        create(
+          :consent_form,
+          parent_email: "existing@example.com",
+          parent_phone: "07111111111"
+        )
+      end
+
+      it "does not send any warning email" do
+        expect { send_warning }.not_to have_delivered_email
+      end
+
+      it "does not send any warning SMS" do
+        expect { send_warning }.not_to have_delivered_sms
+      end
+    end
+
+    context "when only submitted phone matches existing parent" do
+      let(:consent_form) do
+        create(
+          :consent_form,
+          parent_email: "different@example.com",
+          parent_phone: "07987654321"
+        )
+      end
+
+      it "does not send any warning email" do
+        expect { send_warning }.not_to have_delivered_email
+      end
+
+      it "does not send any warning SMS" do
+        expect { send_warning }.not_to have_delivered_sms
+      end
+    end
+
+    context "when neither email nor phone match existing parent" do
+      it "sends warning email and SMS to existing parent" do
+        expect { send_warning }.to have_delivered_email(
+          :parental_consent_warning
+        ).with(parent: parent, patient: patient).and have_delivered_sms(
+                :parental_consent_warning
+              ).with(parent: parent, patient: patient)
+      end
+
+      context "when parent has phone_receive_updates disabled" do
+        let(:parent) do
+          create(
+            :parent,
+            email: "existing@example.com",
+            phone: "07987654321",
+            phone_receive_updates: false
+          )
+        end
+
+        it "sends warning email" do
+          expect { send_warning }.to have_delivered_email(
+            :parental_consent_warning
+          ).with(parent: parent, patient: patient)
+        end
+
+        it "does not send warning SMS" do
+          expect { send_warning }.not_to have_delivered_sms
+        end
+      end
+
+      context "when multiple parents exist" do
+        let(:parent2) do
+          create(
+            :parent,
+            email: "parent2@example.com",
+            phone: "07111111111",
+            phone_receive_updates: true
+          )
+        end
+        let(:patient) { create(:patient, parents: [parent, parent2]) }
+
+        it "sends warnings to all existing parents" do
+          expect { send_warning }.to have_delivered_email(
+            :parental_consent_warning
+          ).with(parent: parent, patient: patient).and have_delivered_email(
+                  :parental_consent_warning
+                ).with(
+                  parent: parent2,
+                  patient: patient
+                ).and have_delivered_sms(:parental_consent_warning).with(
+                        parent: parent,
+                        patient: patient
+                      ).and have_delivered_sms(:parental_consent_warning).with(
+                              parent: parent2,
+                              patient: patient
+                            )
+        end
+      end
+
+      context "when user is present" do
+        let(:user) { create(:user) }
+
+        it "does not send warning email" do
+          expect { send_warning }.not_to have_delivered_email
+        end
+
+        it "does not send warning SMS" do
+          expect { send_warning }.not_to have_delivered_sms
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds an extra safety net to check that the consent form submitter's contact details match those which are already on the child's record. If they don't match, the existing contact details will be alerted. This only happens for consent forms that are matched to patients automatically by Mavis and have not been reviewed by a nurse.

We still need to add the notify template ids for email and SMS, and corresponding personalisation.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1717