### PR TITLE
Show uploaded file name on import screens

### DIFF
--- a/app/components/app_imports_table_component.html.erb
+++ b/app/components/app_imports_table_component.html.erb
@@ -21,6 +21,10 @@
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Imported on</span>
             <%= link_to import.created_at.to_fs(:long), path(import) %>
+            <br />
+            <span class="nhsuk-u-secondary-text-color nhsuk-u-font-size-16">
+              <%= import.csv_filename %>
+            </span>
           <% end %>
           <% row.with_cell do %>
             <span class="nhsuk-table-responsive__heading">Type</span>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -26,6 +26,11 @@
     <% end %>
 
     <%= summary_list.with_row do |row| %>
+      <%= row.with_key { "Uploaded file" } %>
+      <%= row.with_value { import.csv_filename } %>
+    <% end %>
+
+    <%= summary_list.with_row do |row| %>
       <%= row.with_key { "Type" } %>
       <%= row.with_value {
             { "ClassImport" => "Class list",

--- a/spec/components/app_imports_table_component_spec.rb
+++ b/spec/components/app_imports_table_component_spec.rb
@@ -80,6 +80,10 @@ describe AppImportsTableComponent do
       ".nhsuk-table__cell",
       text: "1 January 2020 at 12:00am"
     )
+    expect(rendered).to have_css(
+      ".nhsuk-table__cell",
+      text: CohortImport.first.csv_filename
+    )
     expect(rendered).to have_css(".nhsuk-table__cell", text: "Child record")
     expect(rendered).to have_css(
       ".nhsuk-table__cell",


### PR DESCRIPTION
Displays the CSV file name on the import summary screens.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1827

<img width="946" height="605" alt="Screenshot 2025-08-31 at 22 17 05" src="https://github.com/user-attachments/assets/a36ac737-49aa-4bbb-b6bc-5a9997994b80" />
<img width="959" height="549" alt="Screenshot 2025-08-31 at 22 16 55" src="https://github.com/user-attachments/assets/060f6136-0076-421c-8d73-b5291891c723" />
