### PR TITLE
Fix tests outside of preparation period

### DIFF
--- a/app/views/sessions/manage_consent_reminders/show.html.erb
+++ b/app/views/sessions/manage_consent_reminders/show.html.erb
@@ -4,7 +4,6 @@
                                           { text: t("sessions.index.title"), href: sessions_path },
                                           { text: @session.location.name, href: session_path(@session) },
                                         ]) %>
-  <%= render AppBacklinkComponent.new(session_path(@session), name: @session.location.name) %>
 <% end %>
 
 <%= h1 t(".title") %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,8 +88,11 @@ def create_session(user, team, programmes:, completed: false, year_groups: nil)
 
   session = FactoryBot.create(:session, date:, team:, programmes:, location:)
 
-  session.session_dates.create!(value: date - 1.day)
-  session.session_dates.create!(value: date + 1.day)
+  [date - 1.day, date + 1.day].each do |value|
+    if value.in?(session.academic_year.to_academic_year_date_range)
+      session.session_dates.create!(value:)
+    end
+  end
 
   programmes.each do |programme|
     year_groups.each do |year_group|

--- a/spec/components/app_patient_session_table_component_spec.rb
+++ b/spec/components/app_patient_session_table_component_spec.rb
@@ -16,16 +16,16 @@ describe AppPatientSessionTableComponent do
 
     let(:location) { create(:school, name: "Waterloo Road", programmes:) }
     let(:session) do
-      create(
-        :session,
-        location:,
-        programmes:,
-        academic_year: 2024,
-        date: Date.new(2025, 1, 1)
-      )
+      create(:session, location:, programmes:, date: Date.new(2025, 1, 1))
     end
 
-    let(:patient_sessions) { create_list(:patient_session, 1, session:) }
+    # Can't use year_group here because we need an absolute date, not one
+    # relative to the current academic year.
+    let(:patient) { create(:patient, date_of_birth: Date.new(2011, 9, 1)) }
+
+    let(:patient_sessions) do
+      create_list(:patient_session, 1, patient:, session:)
+    end
 
     it { should have_content("Location") }
     it { should have_content("Session dates") }

--- a/spec/features/cli_gias_check_import_spec.rb
+++ b/spec/features/cli_gias_check_import_spec.rb
@@ -22,7 +22,7 @@ describe "mavis gias check_import" do
       create(
         :session,
         location: @school_with_future_session,
-        dates: [Date.tomorrow],
+        date: Date.tomorrow,
         programmes: [@programme]
       )
 
@@ -32,7 +32,7 @@ describe "mavis gias check_import" do
       create(
         :session,
         location: @school2_with_future_session,
-        dates: [Date.tomorrow],
+        date: Date.tomorrow,
         programmes: [@programme]
       )
 
@@ -42,7 +42,7 @@ describe "mavis gias check_import" do
       create(
         :session,
         location: @school_without_future_session,
-        dates: [Date.yesterday],
+        date: Date.yesterday,
         programmes: [@programme]
       )
   end

--- a/spec/features/cli_stats_organisations_spec.rb
+++ b/spec/features/cli_stats_organisations_spec.rb
@@ -112,8 +112,9 @@ describe "mavis stats organisations" do
       create(
         :session,
         team: @team_a,
-        academic_year: (Date.current.year - 1),
-        programmes: [programme_flu]
+        academic_year: AcademicYear.current - 1,
+        programmes: [programme_flu],
+        date: (AcademicYear.current - 1).to_academic_year_date_range.end
       )
 
     patient_year_8 = create(:patient, team: @team_a, year_group: 8)

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 describe "HPV vaccination" do
-  scenario "Download spreadsheet, record offline at a school session, upload vaccination outcomes back into Mavis" do
-    travel_to(Time.zone.local(2024, 2, 1, 12, 0, 0))
+  around do |example|
+    travel_to(Time.zone.local(2024, 2, 1, 12)) { example.run }
+  end
 
+  scenario "Download spreadsheet, record offline at a school session, upload vaccination outcomes back into Mavis" do
     stub_pds_get_nhs_number_to_return_a_patient
 
     given_an_hpv_programme_is_underway
@@ -22,8 +24,6 @@ describe "HPV vaccination" do
   end
 
   scenario "Download spreadsheet, record offline at a clinic, upload vaccination outcomes back into Mavis" do
-    travel_to(Time.zone.local(2024, 2, 1, 12, 0, 0))
-
     stub_pds_get_nhs_number_to_return_a_patient
 
     given_an_hpv_programme_is_underway(clinic: true)
@@ -355,6 +355,8 @@ describe "HPV vaccination" do
   end
 
   def and_i_upload_the_modified_csv_file
+    travel 1.minute
+
     visit "/"
 
     click_on "Import", match: :first

--- a/spec/forms/triage_form_spec.rb
+++ b/spec/forms/triage_form_spec.rb
@@ -16,12 +16,7 @@ describe TriageForm do
     it { should_not validate_presence_of(:notes) }
     it { should_not validate_presence_of(:vaccine_methods) }
     it { should validate_length_of(:notes).is_at_most(1000) }
-
-    it do
-      expect(form).to validate_inclusion_of(:add_psd).in_array(
-        [true, false]
-      ).allow_nil
-    end
+    it { should allow_values(true, false).for(:add_psd) }
   end
 
   describe "when the patient is safe to vaccinate for HPV" do

--- a/spec/lib/reports/careplus_exporter_spec.rb
+++ b/spec/lib/reports/careplus_exporter_spec.rb
@@ -11,6 +11,8 @@ describe Reports::CareplusExporter do
     )
   end
 
+  around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
   let(:academic_year) { AcademicYear.current }
 
   shared_examples "generates a report" do

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -5,6 +5,8 @@ describe Reports::SystmOneExporter do
 
   before { vaccination_record }
 
+  around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
   let(:csv) do
     described_class.call(
       team:,

--- a/spec/lib/stats/consents_by_school_spec.rb
+++ b/spec/lib/stats/consents_by_school_spec.rb
@@ -31,21 +31,20 @@ describe Stats::ConsentsBySchool do
           team: team,
           location: school,
           programmes: [programme_flu],
-          academic_year: academic_year,
+          academic_year:,
           send_consent_requests_at: 10.days.ago
         )
       end
 
-      let!(:patient) { create(:patient, team: team) }
-      let(:patient_session) do
-        create(:patient_session, session: session, patient: patient)
-      end
+      let!(:patient) { create(:patient, team:) }
+      let(:patient_session) { create(:patient_session, session:, patient:) }
 
       let(:consent) do
         create(
           :consent,
           :given,
-          patient: patient,
+          patient:,
+          academic_year:,
           programme: programme_flu,
           submitted_at: 8.days.ago,
           created_at: 8.days.ago
@@ -92,7 +91,7 @@ describe Stats::ConsentsBySchool do
         described_class.new(
           teams: [team],
           programmes: [programme_flu],
-          academic_year: academic_year
+          academic_year:
         )
       end
 
@@ -100,10 +99,10 @@ describe Stats::ConsentsBySchool do
         create(
           :session,
           date: Date.new(AcademicYear.current, 12, 15),
-          team: team,
+          team:,
           location: school,
           programmes: [programme_flu],
-          academic_year: academic_year,
+          academic_year:,
           send_consent_requests_at: Date.new(AcademicYear.current, 12, 1)
         )
       end
@@ -112,10 +111,10 @@ describe Stats::ConsentsBySchool do
         create(
           :session,
           date: Date.new(AcademicYear.current, 11, 15),
-          team: team,
+          team:,
           location: school,
           programmes: [programme_hpv],
-          academic_year: academic_year,
+          academic_year:,
           send_consent_requests_at: Date.new(AcademicYear.current, 11, 1)
         )
       end
@@ -143,7 +142,7 @@ describe Stats::ConsentsBySchool do
       let!(:current_year_session) do
         create(
           :session,
-          team: team,
+          team:,
           location: school,
           programmes: [programme_flu],
           academic_year: current_year
@@ -154,7 +153,7 @@ describe Stats::ConsentsBySchool do
         create(
           :session,
           date: Date.new(AcademicYear.current - 1, 12, 15),
-          team: team,
+          team:,
           location: school,
           programmes: [programme_flu],
           academic_year: previous_year
@@ -192,7 +191,8 @@ describe Stats::ConsentsBySchool do
         create(
           :consent,
           :given,
-          patient: patient,
+          patient:,
+          academic_year:,
           programme: programme_flu,
           submitted_at: 8.days.ago,
           created_at: 8.days.ago
@@ -203,7 +203,8 @@ describe Stats::ConsentsBySchool do
         create(
           :consent,
           :given,
-          patient: patient,
+          patient:,
+          academic_year:,
           programme: programme_hpv,
           submitted_at: 6.days.ago,
           created_at: 6.days.ago

--- a/spec/lib/status_generator/consent_spec.rb
+++ b/spec/lib/status_generator/consent_spec.rb
@@ -129,6 +129,7 @@ describe StatusGenerator::Consent do
           :refused,
           patient:,
           programme:,
+          academic_year: AcademicYear.current,
           created_at: 1.day.ago,
           submitted_at: 2.days.ago
         )
@@ -137,6 +138,7 @@ describe StatusGenerator::Consent do
           :given,
           patient:,
           programme:,
+          academic_year: AcademicYear.current,
           created_at: 2.days.ago,
           submitted_at: 1.day.ago
         )

--- a/spec/lib/status_generator/registration_spec.rb
+++ b/spec/lib/status_generator/registration_spec.rb
@@ -12,6 +12,8 @@ describe StatusGenerator::Registration do
     )
   end
 
+  around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
   let(:programmes) do
     [create(:programme, :menacwy), create(:programme, :td_ipv)]
   end

--- a/spec/lib/vaccination_notification_criteria_spec.rb
+++ b/spec/lib/vaccination_notification_criteria_spec.rb
@@ -7,7 +7,13 @@ describe VaccinationNotificationCriteria do
     let(:programme) { build(:programme) }
     let(:patient) { create(:patient) }
     let(:vaccination_record) do
-      build(:vaccination_record, patient:, programme:, session:)
+      build(
+        :vaccination_record,
+        patient:,
+        programme:,
+        session:,
+        performed_at: Date.new(2025, 2, 1)
+      )
     end
     let(:session) { create(:session, programmes: [programme]) }
 
@@ -53,6 +59,7 @@ describe VaccinationNotificationCriteria do
             :self_consent,
             patient:,
             programme:,
+            submitted_at: Date.new(2025, 1, 1),
             notify_parents_on_vaccination: false
           )
         end
@@ -66,6 +73,7 @@ describe VaccinationNotificationCriteria do
             :consent,
             patient:,
             programme:,
+            submitted_at: Date.new(2025, 1, 1),
             notify_parents_on_vaccination: nil
           )
         end

--- a/spec/models/draft_vaccination_record_spec.rb
+++ b/spec/models/draft_vaccination_record_spec.rb
@@ -70,7 +70,7 @@ describe DraftVaccinationRecord do
         )
       end
 
-      around { |example| freeze_time { example.run } }
+      around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
 
       before { draft_vaccination_record.wizard_step = :date_and_time }
 

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -299,9 +299,11 @@ describe ImmunisationImportRow do
       before { immunisation_import_row.valid? }
 
       context "when importing for an existing session" do
+        around { |example| travel_to(Date.new(2025, 9, 1)) { example.run } }
+
         let(:data) do
           {
-            "DATE_OF_VACCINATION" => "#{AcademicYear.current}0901",
+            "DATE_OF_VACCINATION" => "20250902",
             "SESSION_ID" => session.id.to_s
           }
         end

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -78,6 +78,8 @@ describe ImmunisationImport do
   describe "#parse_rows!" do
     before { immunisation_import.parse_rows! }
 
+    around { |example| travel_to(Date.new(2025, 8, 1)) { example.run } }
+
     context "with valid Flu rows" do
       let(:programmes) { [create(:programme, :flu_all_vaccines)] }
       let(:file) { "valid_flu.csv" }
@@ -127,6 +129,8 @@ describe ImmunisationImport do
 
   describe "#process!" do
     subject(:process!) { immunisation_import.process! }
+
+    around { |example| travel_to(Date.new(2025, 8, 1)) { example.run } }
 
     context "with valid Flu rows" do
       let(:programmes) { [create(:programme, :flu_all_vaccines)] }

--- a/spec/models/patient/consent_status_spec.rb
+++ b/spec/models/patient/consent_status_spec.rb
@@ -183,6 +183,7 @@ describe Patient::ConsentStatus do
           :refused,
           patient:,
           programme:,
+          academic_year: AcademicYear.current,
           created_at: 1.day.ago,
           submitted_at: 2.days.ago
         )
@@ -191,6 +192,7 @@ describe Patient::ConsentStatus do
           :given,
           patient:,
           programme:,
+          academic_year: AcademicYear.current,
           created_at: 2.days.ago,
           submitted_at: 1.day.ago
         )

--- a/spec/models/patient_session/registration_status_spec.rb
+++ b/spec/models/patient_session/registration_status_spec.rb
@@ -22,6 +22,8 @@ describe PatientSession::RegistrationStatus do
     build(:patient_session_registration_status, patient_session:)
   end
 
+  around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
   let(:programmes) do
     [create(:programme, :menacwy), create(:programme, :td_ipv)]
   end

--- a/spec/models/pre_screening_spec.rb
+++ b/spec/models/pre_screening_spec.rb
@@ -47,6 +47,8 @@ describe PreScreening do
       end
 
       context "with an instance for yesterday" do
+        around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
         let(:session_date) { create(:session_date, value: Date.yesterday) }
         let(:pre_screening) { create(:pre_screening, session_date:) }
 

--- a/spec/models/session_date_spec.rb
+++ b/spec/models/session_date_spec.rb
@@ -19,7 +19,7 @@
 describe SessionDate do
   subject(:session_date) { build(:session_date, session:, value:) }
 
-  let(:session) { create(:session, academic_year: 2024) }
+  let(:session) { create(:session, :unscheduled, academic_year: 2024) }
   let(:value) { Date.current }
 
   describe "validations" do

--- a/spec/policies/session_attendance_policy_spec.rb
+++ b/spec/policies/session_attendance_policy_spec.rb
@@ -59,6 +59,8 @@ describe SessionAttendancePolicy do
     context "with session attendance and both vaccination records from a different date" do
       let(:session_attendance) { build(:session_attendance, patient_session:) }
 
+      around { |example| travel_to(Date.new(2025, 8, 31)) { example.run } }
+
       before do
         programmes.each do |programme|
           create(


### PR DESCRIPTION
This updates a number of tests that are now failing due to the current date being outside the preparation period. Where possible I've tried to avoid freezing time, but in most cases it's necessary to make sure we're always testing inside or outside a preparation period.