### PR TITLE
Ensure seeds don't create session dates outside range

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -161,9 +161,12 @@ def setup_clinic(team)
   academic_year = AcademicYear.current
   clinic_session = team.generic_clinic_session(academic_year:)
 
-  clinic_session.session_dates.create!(value: Date.current)
-  clinic_session.session_dates.create!(value: Date.current - 1.day)
-  clinic_session.session_dates.create!(value: Date.current + 1.day)
+  [Date.current, Date.yesterday, Date.tomorrow].each do |value|
+    if value.in?(academic_year.to_academic_year_date_range)
+      clinic_session.session_dates.create!(value:)
+    end
+  end
+
   clinic_session.update!(send_invitations_at: Date.current - 3.weeks)
 
   # All patients belong to the community clinic. This is normally


### PR DESCRIPTION
This ensures that when creating a session in the seeds, the date fits within the range of suitable dates for the current academic year. This fixes running the tests on the first and last day of the preparation period.

This was missed from #4453.