### PR TITLE
Hide session attendance when not required

### DIFF
--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -28,18 +28,18 @@
 </p>
 
 <ul class="app-action-list">
-  <% if (session_attendance = @patient_session.todays_attendance) %>
-    <% if @patient_session.psd_added?(programme: @programme) %>
-      <li class="app-action-list__item">
-        <strong class="nhsuk-tag nhsuk-tag--aqua-green">PSD added</strong>
-      </li>
-    <% end %>
+  <% if @patient_session.psd_added?(programme: @programme) %>
+    <li class="app-action-list__item">
+      <strong class="nhsuk-tag nhsuk-tag--aqua-green">PSD added</strong>
+    </li>
+  <% end %>
 
+  <% if @session.requires_registration? && (session_attendance = @patient_session.todays_attendance) %>
     <li class="app-action-list__item">
       <%= render AppStatusTagComponent.new(@patient_session.registration_status&.status || "unknown", context: :register) %>
     </li>
 
-    <% if policy(session_attendance).edit? && @session.requires_registration? %>
+    <% if policy(session_attendance).edit? %>
       <li class="app-action-list__item">
         <%= link_to(
               "Update attendance",


### PR DESCRIPTION
If a session doesn't require registration then we should hide the session attendance tag for the patient as it could be potentially misleading/confusing.

[Jira Issue - MAV-1292](https://nhsd-jira.digital.nhs.uk/browse/MAV-1292)