### PR TITLE
Ensure nurses can't create PSDs

### DIFF
--- a/app/policies/patient_specific_direction_policy.rb
+++ b/app/policies/patient_specific_direction_policy.rb
@@ -2,6 +2,6 @@
 
 class PatientSpecificDirectionPolicy < ApplicationPolicy
   def create?
-    user.is_nurse? || user.is_prescriber?
+    user.is_prescriber?
   end
 end

--- a/spec/features/patient_specific_directions_spec.rb
+++ b/spec/features/patient_specific_directions_spec.rb
@@ -7,7 +7,7 @@ describe "Patient Specific Directions" do
     given_a_flu_programme_with_a_running_session(user_type: :with_one_nurse)
     and_a_patient_with_consent_given_nasal_only_triage_not_needed
     and_a_patient_with_consent_given_injection_only_triage_not_needed
-    and_i_am_signed_in
+    and_i_am_signed_in(role: :prescriber)
 
     when_i_go_to_the_session_psds_tab
     then_the_patients_should_have_psd_status_not_added
@@ -77,9 +77,8 @@ describe "Patient Specific Directions" do
       )
   end
 
-  def and_i_am_signed_in(role: :nurse)
-    @user = @team.users.first
-    sign_in @user, role:
+  def and_i_am_signed_in(role:)
+    sign_in @team.users.first, role:
   end
 
   def when_i_go_to_the_session_psds_tab

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -72,11 +72,11 @@ describe "Triage" do
     and_the_vaccine_method_is_recorded_as_nasal
   end
 
-  scenario "adding PSD instruction" do
+  scenario "prescriber can add add PSD instruction" do
     given_delegation_feature_flag_is_enabled
     and_a_flu_programme_with_a_running_session_with_psd_enabled
     and_a_patient_with_nasal_consent_who_needs_triage_exists
-    and_i_am_signed_in
+    and_i_am_signed_in_as_a_prescriber
 
     when_i_go_to_the_session_triage_tab
     then_i_see_the_patient_who_needs_triage
@@ -185,6 +185,11 @@ describe "Triage" do
   def and_i_am_signed_in
     @user = @team.users.first
     sign_in @user
+  end
+
+  def and_i_am_signed_in_as_a_prescriber
+    @user = @team.users.first
+    sign_in @user, role: :prescriber
   end
 
   def when_i_go_to_the_session_triage_tab

--- a/spec/policies/patient_specific_direction_policy_spec.rb
+++ b/spec/policies/patient_specific_direction_policy_spec.rb
@@ -4,22 +4,22 @@ describe PatientSpecificDirectionPolicy do
   subject(:policy) { described_class.new(user, PatientSpecificDirection) }
 
   describe "#create?" do
-    subject(:create?) { policy.create? }
+    subject { policy.create? }
 
     context "when user is a nurse" do
-      let(:user) { build(:user, :nurse) }
+      let(:user) { build(:nurse) }
 
-      it { should be(true) }
+      it { should be(false) }
     end
 
     context "when user is a prescriber" do
-      let(:user) { build(:user, :prescriber) }
+      let(:user) { build(:prescriber) }
 
       it { should be(true) }
     end
 
     context "when user is a healthcare assistant" do
-      let(:user) { build(:user, :healthcare_assistant) }
+      let(:user) { build(:healthcare_assistant) }
 
       it { should be(false) }
     end

--- a/spec/support/cis2_auth_helper.rb
+++ b/spec/support/cis2_auth_helper.rb
@@ -122,7 +122,8 @@ module CIS2AuthHelper
     role_code = {
       admin: CIS2Info::ADMIN_ROLE,
       healthcare_assistant: CIS2Info::ADMIN_ROLE,
-      nurse: CIS2Info::NURSE_ROLE
+      nurse: CIS2Info::NURSE_ROLE,
+      prescriber: nil
     }.fetch(role)
 
     activity_codes = {
@@ -130,7 +131,8 @@ module CIS2AuthHelper
       healthcare_assistant: [
         CIS2Info::PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE
       ],
-      nurse: []
+      nurse: [],
+      prescriber: [CIS2Info::INDEPENDENT_PRESCRIBING_ACTIVITY_CODE]
     }.fetch(role)
 
     workgroups = user.teams.where(organisation:).pluck(:workgroup)


### PR DESCRIPTION
Only prescribers should be allowed to create PSDs as it's a specific qualification, nurses would instead perform the vaccinations directly.