### PR TITLE
Ensure HCAs have medical secretary role

### DIFF
--- a/app/models/cis2_info.rb
+++ b/app/models/cis2_info.rb
@@ -48,7 +48,8 @@ class CIS2Info
   end
 
   def is_healthcare_assistant?
-    activity_codes.include?(PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE)
+    role_code == MEDICAL_SECRETARY_ROLE &&
+      activity_codes.include?(PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE)
   end
 
   def is_prescriber?

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -96,7 +96,7 @@ FactoryBot.define do
 
     trait :healthcare_assistant do
       sequence(:email) { |n| "healthcare-assistant-#{n}@example.com" }
-      role_code { nil }
+      role_code { CIS2Info::MEDICAL_SECRETARY_ROLE }
       activity_codes do
         [CIS2Info::PERSONAL_MEDICATION_ADMINISTRATION_ACTIVITY_CODE]
       end


### PR DESCRIPTION
In the original ticket it was specified that HCA should have the medical secretary role, and this was missed in the original commit that added this role.

[Jira Issue - MAV-1365](https://nhsd-jira.digital.nhs.uk/browse/MAV-1365)