### PR TITLE
Update content shown in triage section

### DIFF
--- a/app/components/app_patient_session_triage_component.html.erb
+++ b/app/components/app_patient_session_triage_component.html.erb
@@ -4,17 +4,19 @@
   <% card.with_heading { heading } %>
 
   <% if latest_triage.nil? || latest_triage.needs_follow_up? %>
-    <p>You need to decide if it’s safe to vaccinate.</p>
-
-    <% if triage_status&.vaccination_history_requires_triage? %>
-      <p>Incomplete vaccination history for <%= programme.name_in_sentence %>. Check if the child needs another dose.</p>
-    <% end %>
-
     <% if helpers.policy(Triage).new? %>
+      <p>You need to decide if <%= patient.full_name %> is safe to vaccinate.</p>
+
+      <% if triage_status&.vaccination_history_requires_triage? %>
+        <p>Incomplete vaccination history for <%= programme.name_in_sentence %>. Check if the child needs another dose.</p>
+      <% end %>
+
       <%= render AppTriageFormComponent.new(
             triage_form,
             url: session_patient_programme_triages_path(session, patient, programme),
           ) %>
+    <% else %>
+      <p>A nurse needs to decide if <%= patient.full_name %> is safe to vaccinate.</p>
     <% end %>
   <% elsif latest_triage %>
     <% if latest_triage.ready_to_vaccinate? %>

--- a/spec/features/triage_spec.rb
+++ b/spec/features/triage_spec.rb
@@ -31,6 +31,18 @@ describe "Triage" do
     and_vaccination_will_happen_emails_are_sent_to_both_parents
   end
 
+  scenario "HCAs cannot triage" do
+    given_a_programme_with_a_running_session
+    and_a_patient_who_needs_triage_exists
+    and_i_am_signed_in_as_a_healthcare_assistant
+
+    when_i_go_to_the_session_triage_tab
+    then_i_see_the_patient_who_needs_triage
+
+    when_i_go_to_the_patient_that_needs_triage
+    then_i_dont_see_the_triage_options
+  end
+
   scenario "nurse can triage patients for a flu programme with different consent types" do
     given_a_flu_programme_with_a_running_session
     and_patients_with_different_flu_consent_types_exist
@@ -192,6 +204,11 @@ describe "Triage" do
     sign_in @user, role: :prescriber
   end
 
+  def and_i_am_signed_in_as_a_healthcare_assistant
+    @user = @team.users.first
+    sign_in @user, role: :healthcare_assistant
+  end
+
   def when_i_go_to_the_session_triage_tab
     visit session_triage_path(@session)
   end
@@ -220,7 +237,17 @@ describe "Triage" do
   end
 
   def then_i_see_the_triage_options
-    expect(page).to have_selector :heading, "Is it safe to vaccinate"
+    expect(page).to have_content(
+      "You need to decide if #{@patient_triage_needed.full_name} is safe to vaccinate."
+    )
+    expect(page).to have_selector(:heading, "Is it safe to vaccinate")
+  end
+
+  def then_i_dont_see_the_triage_options
+    expect(page).to have_content(
+      "A nurse needs to decide if #{@patient_triage_needed.full_name} is safe to vaccinate."
+    )
+    expect(page).not_to have_selector(:heading, "Is it safe to vaccinate")
   end
 
   def and_i_save_triage


### PR DESCRIPTION
If the user is logged in as a role who cannot triage, this updates the content to make it clear that a nurse needs to triage the patient and this is not something the current user can do.