### PR TITLE
Refactor JWT-generation methods out of ReportingAPI controller and into the model

### DIFF
--- a/app/controllers/api/reporting/one_time_tokens_controller.rb
+++ b/app/controllers/api/reporting/one_time_tokens_controller.rb
@@ -9,7 +9,7 @@ class API::Reporting::OneTimeTokensController < API::Reporting::BaseController
   def authorize
     @token = ReportingAPI::OneTimeToken.find_by!(token: params[:code])
     @token.delete # <- Tokens are one-time use
-    json_data = { jwt: jwt(@token) }
+    json_data = { jwt: @token.to_jwt }
     render json: json_data
   rescue ActiveRecord::RecordNotFound
     render json: { errors: "invalid_grant" }, status: :forbidden
@@ -22,27 +22,5 @@ class API::Reporting::OneTimeTokensController < API::Reporting::BaseController
       render json: { error: "unsupported_grant_type" }, status: :bad_request and
         return
     end
-  end
-
-  def jwt_payload(token)
-    {
-      "iat" => Time.current.utc.to_i,
-      "data" => {
-        "user" => token.user.as_json,
-        "cis2_info" => token.cis2_info
-      }
-    }
-  end
-
-  def jwt(token)
-    JWT.encode(
-      jwt_payload(token),
-      Settings.reporting_api.client_app.secret,
-      "HS512"
-    )
-  end
-
-  def ensure_reporting_api_feature_enabled
-    render status: :forbidden and return unless Flipper.enabled?(:reporting_api)
   end
 end

--- a/app/controllers/concerns/reporting_api/token_authentication_concern.rb
+++ b/app/controllers/concerns/reporting_api/token_authentication_concern.rb
@@ -64,7 +64,7 @@ module ReportingAPI::TokenAuthenticationConcern
         jwt,
         Settings.reporting_api.client_app.secret,
         true,
-        { algorithm: "HS512" }
+        { algorithm: ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM }
       )
     end
   end

--- a/spec/controllers/api/reporting/one_time_tokens_controller_spec.rb
+++ b/spec/controllers/api/reporting/one_time_tokens_controller_spec.rb
@@ -95,7 +95,10 @@ RSpec.describe API::Reporting::OneTimeTokensController do
                     response_json["jwt"],
                     Settings.reporting_api.client_app.secret,
                     true,
-                    { algorithm: "HS512" }
+                    {
+                      algorithm:
+                        ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM
+                    }
                   )
                 }.not_to raise_error
               end
@@ -106,7 +109,10 @@ RSpec.describe API::Reporting::OneTimeTokensController do
                     response_json["jwt"],
                     Settings.reporting_api.client_app.secret,
                     true,
-                    { algorithm: "HS512" }
+                    {
+                      algorithm:
+                        ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM
+                    }
                   )
                 end
                 let(:jwt_data) { decoded_payload.first["data"] }

--- a/spec/controllers/api/reporting/totals_controller_spec.rb
+++ b/spec/controllers/api/reporting/totals_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe API::Reporting::TotalsController do
             JWT.encode(
               valid_payload,
               Settings.reporting_api.client_app.secret,
-              "HS512"
+              ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM
             )
           end
 
@@ -58,7 +58,7 @@ RSpec.describe API::Reporting::TotalsController do
             JWT.encode(
               valid_payload,
               Settings.reporting_api.client_app.secret,
-              "HS512"
+              ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM
             )
           end
 
@@ -73,7 +73,7 @@ RSpec.describe API::Reporting::TotalsController do
             JWT.encode(
               invalid_payload,
               Settings.reporting_api.client_app.secret,
-              "HS512"
+              ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM
             )
           end
 

--- a/spec/controllers/concerns/reporting_api/token_authentication_concern_spec.rb
+++ b/spec/controllers/concerns/reporting_api/token_authentication_concern_spec.rb
@@ -273,7 +273,7 @@ describe ReportingAPI::TokenAuthenticationConcern do
           jwt,
           Settings.reporting_api.client_app.secret,
           true,
-          { algorithm: "HS512" }
+          { algorithm: ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM }
         ) #.and_return(decoded_jwt)
         an_object_which_includes_the_concern.send(:decode_jwt!, jwt)
       end
@@ -284,7 +284,7 @@ describe ReportingAPI::TokenAuthenticationConcern do
             jwt,
             Settings.reporting_api.client_app.secret,
             true,
-            { algorithm: "HS512" }
+            { algorithm: ReportingAPI::OneTimeToken::JWT_SIGNING_ALGORITHM }
           ).and_return(decoded_jwt)
         end
 


### PR DESCRIPTION
An 'under the hood' PR which does two things:


1. Moves the JWT-generation methods out of the OneTimeTokens controller, and into the OneTimeToken model.

This is tidier, and also enables a one-liner in the console which is useful when developing locally:
```
> jwt = ReportingAPI::OneTimeToken.find_or_generate_for!(user: User.first, cis2_info: {...}).to_jwt
```

2. Adds a `JWT_SIGNING_ALGORITHM` constant to define the `HS512` algorithm in one place, rather than hard-coding it everywhere