### PR TITLE
Ensure reliable NHS number retrieval from search results

### DIFF
--- a/app/jobs/process_patient_changesets_job.rb
+++ b/app/jobs/process_patient_changesets_job.rb
@@ -51,7 +51,7 @@ class ProcessPatientChangesetsJob < ApplicationJob
   private
 
   def unique_nhs_numbers(patient_changeset)
-    patient_changeset.search_results.pluck(:nhs_number).compact.uniq
+    patient_changeset.search_results.pluck("nhs_number").compact.uniq
   end
 
   def get_unique_nhs_number(patient_changeset)

--- a/spec/jobs/process_patient_changesets_job_spec.rb
+++ b/spec/jobs/process_patient_changesets_job_spec.rb
@@ -79,6 +79,7 @@ describe ProcessPatientChangesetsJob do
           nhs_number: "1234567890"
         }
       ]
+      patient_changeset.save!
       allow(PDS::Patient).to receive(:search).and_raise(
         NHS::PDS::TooManyMatches
       )
@@ -104,6 +105,7 @@ describe ProcessPatientChangesetsJob do
           nhs_number: "1234567890"
         }
       ]
+      patient_changeset.save!
       different_patient =
         instance_double(PDS::Patient, nhs_number: "1112223333")
       allow(PDS::Patient).to receive(:search).and_return(different_patient)

--- a/spec/support/pds_helper.rb
+++ b/spec/support/pds_helper.rb
@@ -2,8 +2,7 @@
 
 module PDSHelper
   def stub_pds_search_to_return_no_patients(**query)
-    query["_history"] ||= "true"
-    query.delete("_history") if query["_history"] == "false"
+    query["_history"] ||= "true" unless query["_fuzzy-match"] == "true"
 
     stub_request(
       :get,
@@ -19,7 +18,7 @@ module PDSHelper
   end
 
   def stub_pds_search_to_return_a_patient(nhs_number = "9449306168", **query)
-    query["_history"] ||= "true"
+    query["_history"] ||= "true" unless query["_fuzzy-match"] == "true"
 
     response_data =
       JSON.parse(file_fixture("pds/search-patients-response.json").read)


### PR DESCRIPTION
Previously, `nhs_number` within `patient_changeset.search_results` was accessed using symbol keys (e.g., `sr[:nhs_number]`). However, when `search_results` (stored in a `jsonb` column) are deserialized from the database, they become standard Ruby hash objects with string keys, causing symbol access to fail.

Updated the `unique_nhs_numbers` method to use string keys (`sr["nhs_number"]`) for accessing the NHS number.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1887