### PR TITLE
Remove fuzzy-search from cascading PDS search algorithm

### DIFF
--- a/app/jobs/process_patient_changesets_job.rb
+++ b/app/jobs/process_patient_changesets_job.rb
@@ -79,7 +79,7 @@ class ProcessPatientChangesetsJob < ApplicationJob
         too_many_matches: :no_fuzzy_without_history
       },
       no_fuzzy_without_history: {
-        no_matches: :fuzzy,
+        no_matches: :give_up,
         one_match: :save_nhs_number_if_unique,
         too_many_matches: :give_up,
         format_query: ->(query) { query.merge(history: false) }
@@ -98,22 +98,11 @@ class ProcessPatientChangesetsJob < ApplicationJob
         format_query: ->(query) { query[:given_name][3..] = "*" }
       },
       no_fuzzy_with_wildcard_family_name: {
-        no_matches: :fuzzy,
-        one_match: :fuzzy,
-        too_many_matches: :fuzzy,
-        skip_step: :fuzzy,
-        format_query: ->(query) { query[:family_name][3..] = "*" }
-      },
-      fuzzy: {
-        no_matches: :give_up,
+        no_matches: :save_nhs_number_if_unique,
         one_match: :save_nhs_number_if_unique,
         too_many_matches: :save_nhs_number_if_unique,
-        format_query: ->(query) do
-          query[:fuzzy] = true
-          # For fuzzy searches, history is the default. We get an error if we
-          # try to set it to true explicitly
-          query[:history] = nil
-        end
+        skip_step: :save_nhs_number_if_unique,
+        format_query: ->(query) { query[:family_name][3..] = "*" }
       }
     }
   end

--- a/spec/factories/patient_changesets.rb
+++ b/spec/factories/patient_changesets.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
       {
         child: {
           "given_name" => "John",
-          "family_name" => "Doe",
+          "family_name" => "Dover",
           "date_of_birth" => "2010-01-01",
           "address_postcode" => "SW1A 1AA",
           "nhs_number" => nil

--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -350,7 +350,7 @@ describe "Import child records" do
       address_postcode: "B1 1AA",
       steps: {
         wildcard_postcode: "1111111111",
-        fuzzy: "9435726097"
+        wildcard_family_name: "9435726097"
       }
     )
   end
@@ -387,13 +387,6 @@ describe "Import child records" do
         "given" => given_name,
         "birthdate" => birthdate,
         "address-postalcode" => address_postcode
-      },
-      fuzzy: {
-        "family" => family_name,
-        "given" => given_name,
-        "birthdate" => birthdate,
-        "address-postalcode" => address_postcode,
-        "_fuzzy-match" => "true"
       }
     }.each do |step, query|
       if steps[step]
@@ -827,14 +820,13 @@ describe "Import child records" do
 
   def and_maia_has_multiple_pds_search_results
     maia = Patient.find_by(given_name: "Maia", family_name: "Smith")
-    expect(maia.pds_search_results.count).to eq(5)
+    expect(maia.pds_search_results.count).to eq(4)
     expect(maia.pds_search_results.pluck(:step)).to eq(
       %w[
         no_fuzzy_with_history
         no_fuzzy_with_wildcard_postcode
         no_fuzzy_with_wildcard_given_name
         no_fuzzy_with_wildcard_family_name
-        fuzzy
       ]
     )
   end

--- a/spec/jobs/process_patient_changesets_job_spec.rb
+++ b/spec/jobs/process_patient_changesets_job_spec.rb
@@ -68,8 +68,8 @@ describe ProcessPatientChangesetsJob do
     end
   end
 
-  context "when a later fuzzy search finds a match" do
-    let(:step) { :fuzzy }
+  context "when a later wildcard-family-name search finds a match" do
+    let(:step) { :no_fuzzy_with_wildcard_family_name }
 
     before do
       patient_changeset["pending_changes"]["search_results"] = [
@@ -94,8 +94,8 @@ describe ProcessPatientChangesetsJob do
     end
   end
 
-  context "when fuzzy search returns conflicting NHS numbers" do
-    let(:step) { :fuzzy }
+  context "when wildcard-family-name search returns conflicting NHS numbers" do
+    let(:step) { :no_fuzzy_with_wildcard_family_name }
 
     before do
       patient_changeset["pending_changes"]["search_results"] = [
@@ -115,6 +115,7 @@ describe ProcessPatientChangesetsJob do
       perform
 
       expect(patient_changeset.child_attributes["nhs_number"]).to be_blank
+      expect(patient_changeset.pds_nhs_number).to be_nil
     end
   end
 


### PR DESCRIPTION
We have seen at least two cases where fuzzy matching in PDS returned a patient that was obviously wrong (first name and last name swapped around and spellings completely different, and postcode different). We think it is safest to remove the last search step (fuzzy step) from the cascading search. The updated flow is below.

https://nhsd-jira.digital.nhs.uk/browse/MAV-1886

<img width="1057" height="515" alt="Screenshot 2025-09-02 at 16 49 42" src="https://github.com/user-attachments/assets/19375f09-6f11-4d7b-a5ea-92c891ec96e4" />
