### PR TITLE
Return user nav info in reporting token

### DIFF
--- a/app/controllers/api/reporting/one_time_tokens_controller.rb
+++ b/app/controllers/api/reporting/one_time_tokens_controller.rb
@@ -20,7 +20,7 @@ class API::Reporting::OneTimeTokensController < API::Reporting::BaseController
       user_nav: {
         items: [
           { text: display_name, icon: true },
-          { href: "/logout", text: "Log out" }
+          { href: logout_path, text: "Log out" }
         ]
       }
     }

--- a/app/controllers/api/reporting/one_time_tokens_controller.rb
+++ b/app/controllers/api/reporting/one_time_tokens_controller.rb
@@ -9,7 +9,21 @@ class API::Reporting::OneTimeTokensController < API::Reporting::BaseController
   def authorize
     @token = ReportingAPI::OneTimeToken.find_by!(token: params[:code])
     @token.delete # <- Tokens are one-time use
-    json_data = { jwt: @token.to_jwt }
+
+    user = @token.user
+    display_name = user.full_name
+    display_name +=
+      " (#{user.role_description})" if user.role_description.present?
+
+    json_data = {
+      jwt: @token.to_jwt,
+      user_nav: {
+        items: [
+          { text: display_name, icon: true },
+          { href: "/logout", text: "Log out" }
+        ]
+      }
+    }
     render json: json_data
   rescue ActiveRecord::RecordNotFound
     render json: { errors: "invalid_grant" }, status: :forbidden

--- a/app/controllers/users/logout_controller.rb
+++ b/app/controllers/users/logout_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Users::LogoutController < ApplicationController
+  layout "two_thirds"
+
+  skip_after_action :verify_policy_scoped
+
+  def show
+  end
+end

--- a/app/views/logout/show.html.erb
+++ b/app/views/logout/show.html.erb
@@ -1,0 +1,7 @@
+<%= h1 "Log out", size: "xl" %>
+
+<p class="nhsuk-body">
+  You are about to log out of the service. This will end your current session.
+</p>
+
+<%= govuk_button_to "Log out", logout_path, method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
           }
   end
 
+  get "/logout", to: "users/logout#show"
+
   if Settings.cis2.enabled
     devise_for :users,
                module: :users,

--- a/spec/controllers/api/reporting/one_time_tokens_controller_spec.rb
+++ b/spec/controllers/api/reporting/one_time_tokens_controller_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe API::Reporting::OneTimeTokensController do
           let(:token) { valid_token }
 
           before do
-            allow(ReportingAPI::OneTimeToken).to receive(:find_by!)
-              .with(token: token.token)
-              .and_return(token)
+            allow(ReportingAPI::OneTimeToken).to receive(:find_by!).with(
+              token: token.token
+            ).and_return(token)
             allow(token).to receive(:user).and_return(user)
           end
 


### PR DESCRIPTION
This will be used to populate the header on the reporting side.

It also adds a `GET /logout` page. This will not be linked to from Mavis, but from the Reporting app, which can't `POST /logout` as it can't generate CSRF tokens.

## After (Reporting app, not Mavis)

<img width="1383" height="576" alt="Screenshot 2025-09-04 at 13 06 11" src="https://github.com/user-attachments/assets/23600982-22a7-4805-a0d6-d96b9457e3f9" />

## Logout page

<img width="1181" height="781" alt="Screenshot 2025-09-04 at 13 28 09" src="https://github.com/user-attachments/assets/eab85ff7-d088-47d3-8de3-c6c68b817323" />

