### PR TITLE
Ensure `patient_id` is not null

### DIFF
--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -31,7 +31,7 @@
 #  batch_id                              :bigint
 #  location_id                           :bigint
 #  nhs_immunisations_api_id              :string
-#  patient_id                            :bigint
+#  patient_id                            :bigint           not null
 #  performed_by_user_id                  :bigint
 #  programme_id                          :bigint           not null
 #  session_id                            :bigint

--- a/db/migrate/20250903153120_make_vaccination_record_patient_id_not_null.rb
+++ b/db/migrate/20250903153120_make_vaccination_record_patient_id_not_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeVaccinationRecordPatientIdNotNull < ActiveRecord::Migration[8.0]
+  def change
+    change_column_null :vaccination_records, :patient_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_29_172505) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_03_153120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -938,7 +938,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_29_172505) do
     t.string "location_name"
     t.datetime "discarded_at"
     t.datetime "confirmation_sent_at"
-    t.bigint "patient_id"
+    t.bigint "patient_id", null: false
     t.bigint "session_id"
     t.string "performed_ods_code"
     t.bigint "vaccine_id"

--- a/spec/factories/vaccination_records.rb
+++ b/spec/factories/vaccination_records.rb
@@ -31,7 +31,7 @@
 #  batch_id                              :bigint
 #  location_id                           :bigint
 #  nhs_immunisations_api_id              :string
-#  patient_id                            :bigint
+#  patient_id                            :bigint           not null
 #  performed_by_user_id                  :bigint
 #  programme_id                          :bigint           not null
 #  session_id                            :bigint

--- a/spec/models/vaccination_record_spec.rb
+++ b/spec/models/vaccination_record_spec.rb
@@ -31,7 +31,7 @@
 #  batch_id                              :bigint
 #  location_id                           :bigint
 #  nhs_immunisations_api_id              :string
-#  patient_id                            :bigint
+#  patient_id                            :bigint           not null
 #  performed_by_user_id                  :bigint
 #  programme_id                          :bigint           not null
 #  session_id                            :bigint


### PR DESCRIPTION
Vaccination records will always be associated with a patient so we can make this column not nullable. This is likely a historical oversight, we didn't have `optional: true` specified on the `belongs_to`.