### PR TITLE
Verify that HCA's can't see triaged injected patients when national protocol is off

### DIFF
--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -546,6 +546,44 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_given_injection_and_nasal_triage_safe_to_vaccinate_injection do
+      consents do
+        programmes.map do |programme|
+          association(
+            :consent,
+            :given_nasal,
+            :from_mum,
+            :health_question_notes,
+            patient: instance,
+            team:,
+            programme:
+          )
+        end
+      end
+
+      consent_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_consent_status,
+            :given_nasal_or_injection,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+
+      triage_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_triage_status,
+            :safe_to_vaccinate,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+    end
+
     trait :consent_refused do
       triage_not_required
 

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -546,6 +546,44 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_given_nasal_triage_safe_to_vaccinate_nasal do
+      consents do
+        programmes.map do |programme|
+          association(
+            :consent,
+            :given_nasal,
+            :from_mum,
+            :health_question_notes,
+            patient: instance,
+            team:,
+            programme:
+          )
+        end
+      end
+
+      consent_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_consent_status,
+            :given_nasal_only,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+
+      triage_statuses do
+        programmes.map do |programme|
+          association(
+            :patient_triage_status,
+            :safe_to_vaccinate_nasal,
+            patient: instance,
+            programme:
+          )
+        end
+      end
+    end
+
     trait :consent_given_injection_and_nasal_triage_safe_to_vaccinate_injection do
       consents do
         programmes.map do |programme|

--- a/spec/features/flu_vaccination_hca_national_protocol_spec.rb
+++ b/spec/features/flu_vaccination_hca_national_protocol_spec.rb
@@ -32,7 +32,18 @@ describe "Flu vaccination" do
     then_i_am_able_to_vaccinate_them_using_injection_instead_of_nasal
   end
 
-  def given_a_session_exists(psd_enabled: false)
+  scenario "HCA viewing record tab where national protocol is turned off and patient triaged for injection" do
+    given_a_session_exists(national_protocol_enabled: false)
+    and_a_nasal_and_injection_patient_exists_triaged_as_safe_vaccinate_with_injection
+
+    when_i_visit_the_session_record_tab
+    then_i_should_not_see_the_patient
+  end
+
+  def given_a_session_exists(
+    psd_enabled: false,
+    national_protocol_enabled: true
+  )
     @programme = create(:programme, :flu)
     programmes = [@programme]
 
@@ -65,7 +76,8 @@ describe "Flu vaccination" do
         :national_protocol_enabled,
         team: @team,
         programmes:,
-        psd_enabled:
+        psd_enabled:,
+        national_protocol_enabled:
       )
   end
 
@@ -86,6 +98,15 @@ describe "Flu vaccination" do
       create(
         :patient,
         :consent_given_injection_only_triage_not_needed,
+        session: @session
+      )
+  end
+
+  def and_a_nasal_and_injection_patient_exists_triaged_as_safe_vaccinate_with_injection
+    @patient_nasal_and_injection =
+      create(
+        :patient,
+        :consent_given_injection_and_nasal_triage_safe_to_vaccinate_injection,
         session: @session
       )
   end
@@ -114,6 +135,10 @@ describe "Flu vaccination" do
     expect(page).not_to have_content(@patient_nasal_only.full_name)
     expect(page).to have_content(@patient_nasal_and_injection.full_name)
     expect(page).to have_content(@patient_injection_only.full_name)
+  end
+
+  def then_i_should_not_see_the_patient
+    expect(page).not_to have_content(@patient_nasal_and_injection.full_name)
   end
 
   def when_i_click_on_the_nasal_only_patient

--- a/spec/features/flu_vaccination_hca_pgd_supply_spec.rb
+++ b/spec/features/flu_vaccination_hca_pgd_supply_spec.rb
@@ -20,6 +20,15 @@ describe "Flu vaccination" do
     then_i_am_not_able_to_vaccinate_them
   end
 
+  scenario "Patient consents nasal, has health issues, and is triaged as safe to vaccinate" do
+    given_a_session_exists
+    and_a_nasal_patient_exists_with_health_issues_marked_safe_vaccinate_with_nasal
+
+    when_i_visit_the_session_record_tab
+    and_i_click_on_the_nasal_only_patient
+    then_i_am_able_to_vaccinate_them_nasal_only
+  end
+
   def given_a_session_exists
     @programme = create(:programme, :flu)
     programmes = [@programme]
@@ -68,6 +77,15 @@ describe "Flu vaccination" do
       )
   end
 
+  def and_a_nasal_patient_exists_with_health_issues_marked_safe_vaccinate_with_nasal
+    @patient_nasal_only =
+      create(
+        :patient,
+        :consent_given_nasal_triage_safe_to_vaccinate_nasal,
+        session: @session
+      )
+  end
+
   def when_i_visit_the_session_record_tab
     sign_in @user, role: :healthcare_assistant
     visit session_record_path(@session)
@@ -82,6 +100,8 @@ describe "Flu vaccination" do
   def when_i_click_on_the_nasal_only_patient
     click_on @patient_nasal_only.full_name
   end
+  alias_method :and_i_click_on_the_nasal_only_patient,
+               :when_i_click_on_the_nasal_only_patient
 
   def when_i_click_on_the_nasal_and_injection_patient
     click_on @patient_nasal_and_injection.full_name


### PR DESCRIPTION
This test verifies the existing behavior where Healthcare Assistants (HCAs) cannot see patients in the record vaccination tab when:
- National protocol is turned off
- Patients triaged for injection (consented for nasal, with injection as a second option)

This behavior is working as intended - HCAs can only record vaccinations under specific protocols, so hiding patients they cannot treat prevents confusion and maintains proper clinical governance.