### PR TITLE
Use Sidekiq for comms and add rate limits

### DIFF
--- a/app/jobs/concerns/notify_throttling_concern.rb
+++ b/app/jobs/concerns/notify_throttling_concern.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module NotifyThrottlingConcern
+  extend ActiveSupport::Concern
+
+  include Sidekiq::Job
+  include Sidekiq::Throttled::Job
+
+  included do
+    self.queue_adapter = :sidekiq unless Rails.env.test?
+
+    sidekiq_throttle_as :notify
+
+    queue_as :notifications
+  end
+end

--- a/app/jobs/email_delivery_job.rb
+++ b/app/jobs/email_delivery_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class EmailDeliveryJob < NotifyDeliveryJob
+  include NotifyThrottlingConcern
+
   def perform(
     template_name,
     consent: nil,

--- a/app/jobs/notify_delivery_job.rb
+++ b/app/jobs/notify_delivery_job.rb
@@ -3,12 +3,6 @@
 require "notifications/client"
 
 class NotifyDeliveryJob < ApplicationJob
-  self.queue_adapter = :sidekiq unless Rails.env.test?
-
-  queue_as :notifications
-
-  retry_on Notifications::Client::ServerError, wait: :polynomially_longer
-
   def self.client
     @client ||=
       Notifications::Client.new(
@@ -20,13 +14,9 @@ class NotifyDeliveryJob < ApplicationJob
     @deliveries ||= []
   end
 
-  def self.send_via_notify?
-    Settings.govuk_notify&.enabled
-  end
+  def self.send_via_notify? = Settings.govuk_notify&.enabled
 
-  def self.send_via_test?
-    Rails.env.test?
-  end
+  def self.send_via_test? = Rails.env.test?
 
   class UnknownTemplate < StandardError
   end

--- a/app/jobs/notify_delivery_job.rb
+++ b/app/jobs/notify_delivery_job.rb
@@ -3,6 +3,9 @@
 require "notifications/client"
 
 class NotifyDeliveryJob < ApplicationJob
+  TEAM_ONLY_API_KEY_MESSAGE =
+    "Can’t send to this recipient using a team-only API key"
+
   def self.client
     @client ||=
       Notifications::Client.new(

--- a/app/jobs/notify_delivery_job.rb
+++ b/app/jobs/notify_delivery_job.rb
@@ -3,7 +3,9 @@
 require "notifications/client"
 
 class NotifyDeliveryJob < ApplicationJob
-  queue_as :mailer
+  self.queue_adapter = :sidekiq unless Rails.env.test?
+
+  queue_as :notifications
 
   retry_on Notifications::Client::ServerError, wait: :polynomially_longer
 

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SMSDeliveryJob < NotifyDeliveryJob
+  include NotifyThrottlingConcern
+
   def perform(
     template_name,
     consent: nil,

--- a/app/jobs/sms_delivery_job.rb
+++ b/app/jobs/sms_delivery_job.rb
@@ -41,7 +41,17 @@ class SMSDeliveryJob < NotifyDeliveryJob
 
     delivery_id =
       if self.class.send_via_notify?
-        self.class.client.send_sms(**args).id
+        begin
+          self.class.client.send_sms(**args).id
+        rescue Notifications::Client::BadRequestError => e
+          if !Rails.env.production? &&
+               e.message.include?(TEAM_ONLY_API_KEY_MESSAGE)
+            # Prevent retries and job failures.
+            Sentry.capture_exception(e)
+          else
+            raise
+          end
+        end
       elsif self.class.send_via_test?
         self.class.deliveries << args
         SecureRandom.uuid

--- a/app/jobs/status_updater_job.rb
+++ b/app/jobs/status_updater_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StatusUpdaterJob < NotifyDeliveryJob
+class StatusUpdaterJob < ApplicationJob
   include GoodJob::ActiveJobExtensions::Concurrency
 
   queue_as :statuses

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -54,7 +54,7 @@ Sentry.init do |config|
       if !Rails.env.production? &&
            hint[:exception].is_a?(Notifications::Client::BadRequestError) &&
            hint[:exception].message.include?(
-             "Can’t send to this recipient using a team-only API key"
+             NotifyDeliveryJob::TEAM_ONLY_API_KEY_MESSAGE
            )
         nil
       else

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -18,6 +18,15 @@ Sidekiq::Throttled.configure do |config|
   config.cooldown_threshold = 1000
 end
 
+# https://docs.notifications.service.gov.uk/rest-api.html#rate-limits
+Sidekiq::Throttled::Registry.add(
+  :notify,
+  threshold: {
+    limit: Settings.govuk_notify.rate_limit_per_minute.to_i,
+    period: 1.minute
+  }
+)
+
 Sidekiq::Throttled::Registry.add(
   :pds,
   threshold: {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,6 +28,7 @@ govuk_notify:
   team_key: <%= Rails.application.credentials.govuk_notify&.team_key %>
   live_key: <%= Rails.application.credentials.govuk_notify&.live_key %>
   callback_bearer_token: <%= Rails.application.credentials.govuk_notify&.callback_bearer_token %>
+  rate_limit_per_minute: 3000
 
 nhs_api:
   api_key: <%= Rails.application.credentials.nhs_api&.api_key %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,4 +3,5 @@
 :queues:
   - imports
   - consents
+  - notifications
   - pds

--- a/spec/jobs/email_delivery_job_spec.rb
+++ b/spec/jobs/email_delivery_job_spec.rb
@@ -180,9 +180,9 @@ describe EmailDeliveryJob do
       described_class.perform_later(GOVUK_NOTIFY_EMAIL_TEMPLATES.keys.first)
     end
 
-    it "uses the mailer queue" do
+    it "uses the notifications queue" do
       expect { perform_later }.to have_enqueued_job(described_class).on_queue(
-        :mailer
+        :notifications
       )
     end
   end

--- a/spec/jobs/sms_delivery_job_spec.rb
+++ b/spec/jobs/sms_delivery_job_spec.rb
@@ -145,9 +145,9 @@ describe SMSDeliveryJob do
       described_class.perform_later(GOVUK_NOTIFY_SMS_TEMPLATES.keys.first)
     end
 
-    it "uses the mailer queue" do
+    it "uses the notifications queue" do
       expect { perform_later }.to have_enqueued_job(described_class).on_queue(
-        :mailer
+        :notifications
       )
     end
   end


### PR DESCRIPTION
This updates the jobs which send emails and text messages to use Sidekiq as part of our general move towards using Sidekiq instead of Good Job. This allows us to get automatic job failure retries and also allows us to enable rate limiting to match GOV.UK Notify's rate limit.