### PR TITLE
Use dig for safe nested array navigation

### DIFF
--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -30,7 +30,7 @@
                   <%= batch.name %>
                 </span>
 
-                <% if batch.id == @todays_batch_id_by_programme_and_vaccine_methods[vaccine.programme][vaccine.method] %>
+                <% if batch.id == @todays_batch_id_by_programme_and_vaccine_methods&.dig(vaccine.programme, vaccine.method) %>
                   <br>
                   <span class="nhsuk-caption-m">
                     (Your default)


### PR DESCRIPTION
This fixes a potential issue trying to navigate a double-nested array by using `dig` instead.

[Sentry Issue](https://good-machine.sentry.io/issues/6855749667/)