### PR TITLE
Hide PSD tags on session activity page

### DIFF
--- a/app/components/app_activity_log_component.rb
+++ b/app/components/app_activity_log_component.rb
@@ -63,7 +63,8 @@ class AppActivityLogComponent < ViewComponent::Base
         :vaccine
       )
 
-    @patient_specific_directions = @patient.patient_specific_directions
+    @patient_specific_directions =
+      @patient.patient_specific_directions.includes(:created_by)
 
     @archive_reasons = @patient.archive_reasons.where(team:)
   end

--- a/app/views/patient_sessions/_header.html.erb
+++ b/app/views/patient_sessions/_header.html.erb
@@ -28,7 +28,7 @@
 </p>
 
 <ul class="app-action-list">
-  <% if @session.psd_enabled? %>
+  <% if @programme && @session.psd_enabled? %>
     <li class="app-action-list__item">
       <% if @patient_session.has_patient_specific_direction?(programme: @programme, team: current_team) %>
         <%= render AppStatusTagComponent.new(:added, context: :patient_specific_direction) %>

--- a/spec/features/flu_vaccination_hca_psd_spec.rb
+++ b/spec/features/flu_vaccination_hca_psd_spec.rb
@@ -67,6 +67,9 @@ describe "Flu vaccination" do
     when_i_visit_the_session_patient_programme_page
     then_i_am_able_to_vaccinate_them_with_nasal_via_psd
     and_the_vaccination_record_has_psd_as_the_protocol
+
+    when_i_visit_the_session_activity_page
+    then_i_see_no_psd_status_tag
   end
 
   scenario "Nasal flu cannot be administered without a PSD even if national protocol enabled" do
@@ -235,5 +238,14 @@ describe "Flu vaccination" do
 
   def and_the_vaccination_record_has_psd_as_the_protocol
     expect(@patient_nasal_only.vaccination_records.first.protocol).to eq("psd")
+  end
+
+  def when_i_visit_the_session_activity_page
+    click_on "Session activity"
+  end
+
+  def then_i_see_no_psd_status_tag
+    expect(page).not_to have_css(".nhsuk-tag", text: "PSD added")
+    expect(page).not_to have_css(".nhsuk-tag", text: "PSD not added")
   end
 end


### PR DESCRIPTION
On this page we're not in the context of a specific programme so the tag always shows as "PSD not added", instead the users can see the entries in the activity log.

[Jira Issue - MAV-1912](https://nhsd-jira.digital.nhs.uk/browse/MAV-1912)