### PR TITLE
Ensure invalidated PSDs aren't in offline export

### DIFF
--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -198,6 +198,7 @@ class Reports::OfflineSessionExporter
           "DISTINCT ON (patient_id, programme_id) patient_specific_directions.*"
         )
         .where(academic_year:, patient_id: patient_sessions.select(:patient_id))
+        .not_invalidated
         .order(:patient_id, :programme_id, created_at: :desc)
         .includes(:created_by)
         .group_by(&:patient_id)

--- a/spec/factories/patient_specific_directions.rb
+++ b/spec/factories/patient_specific_directions.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
     delivery_site { "nose" }
     vaccine_method { "nasal" }
     academic_year { AcademicYear.current }
+
+    trait :invalidated do
+      invalidated_at { Time.current }
+    end
   end
 end

--- a/spec/lib/reports/offline_session_exporter_spec.rb
+++ b/spec/lib/reports/offline_session_exporter_spec.rb
@@ -195,6 +195,22 @@ describe Reports::OfflineSessionExporter do
                 expect(rows.first["PSD_STATUS"]).to eq("PSD added")
               end
             end
+
+            context "and the patient has an invalidated PSD" do
+              before do
+                create(
+                  :patient_specific_direction,
+                  :invalidated,
+                  programme:,
+                  patient:
+                )
+              end
+
+              it "adds a blank PSD status column" do
+                expect(rows.count).to eq(1)
+                expect(rows.first["PSD_STATUS"]).to eq("")
+              end
+            end
           end
         end
 


### PR DESCRIPTION
This ensures that when including in the offline spreadsheet whether or not a patient has a PSD, we ignore any that have been invalidated.

[Jira Issue - MAV-1914](https://nhsd-jira.digital.nhs.uk/browse/MAV-1914)