### PR TITLE
Hide button to send reminders if not open 

### DIFF
--- a/app/controllers/sessions/manage_consent_reminders_controller.rb
+++ b/app/controllers/sessions/manage_consent_reminders_controller.rb
@@ -3,6 +3,9 @@
 class Sessions::ManageConsentRemindersController < ApplicationController
   before_action :set_session
 
+  def show
+  end
+
   def create
     SendManualSchoolConsentRemindersJob.perform_now(@session, current_user:)
 

--- a/app/views/sessions/manage_consent_reminders/show.html.erb
+++ b/app/views/sessions/manage_consent_reminders/show.html.erb
@@ -64,11 +64,8 @@
       <%= t(".pre_confirm") %>
     </p>
 
-    <% if @session.today_or_future_dates.present? %>
-      <%= button_to t(".confirm"),
-                    session_manage_consent_reminders_path(@session),
-                    method: :post,
-                    class: "nhsuk-button" %>
+    <% if @session.open_for_consent? %>
+      <%= govuk_button_to t(".confirm"), session_manage_consent_reminders_path(@session) %>
   <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,8 +695,8 @@ en:
       triage: Triage
     manage_consent_reminders:
       show:
-        label: "Send reminders"
-        title: "Manage consent reminders"
+        label: Send reminders
+        title: Manage consent reminders
         description: >
           Mavis automatically sends email and text reminders to parents who have not
           responded to the initial consent request.
@@ -705,21 +705,21 @@ en:
   
           You can also send reminders manually. Mavis will then skip the next automatic
           reminder if it's due to be sent within 3 days.
-        your_schedule: "For this session, reminders are sent %{days} (%{weeks}) before each session."
+        your_schedule: For this session, reminders are sent %{days} (%{weeks}) before each session.
         reminder_dates:
-          label: "Automatic consent reminder schedule"
+          label: Automatic consent reminder schedule
           description: "Reminders will be sent automatically on these dates:"
         patients_to_get_consent:
-          label: "Parents who need to give consent"
+          label: Parents who need to give consent
           status: "%{count} parents out of %{total} have not responded yet"
         next_reminder_date:
-          label: "Next reminder"
+          label: Next reminder
           text:
-            zero: "There are no more automatic consent reminders to be sent"
-            one: "The next automatic consent reminder will be sent on %{date}"
-        session_dates:  Session dates
-        pre_confirm: "Mavis will skip the next automatic reminder if it's scheduled to be sent within 3 days."
-        confirm: "Send manual consent reminders"
+            zero: There are no more automatic consent reminders to be sent
+            one: The next automatic consent reminder will be sent on %{date}
+        session_dates: Session dates
+        pre_confirm: Mavis will skip the next automatic reminder if it's scheduled to be sent within 3 days.
+        confirm: Send manual consent reminders
   table:
     no_filtered_results: We couldn’t find any children that matched your filters.
     no_results: No results


### PR DESCRIPTION
This slightly changes the logic related to when the button is shown to ensure that it's not shown when the consent is not open. The logic was already close to this, but it would show on the last session day when consent is already closed.

[Jira Issue - MAV-1894](https://nhsd-jira.digital.nhs.uk/browse/MAV-1894)