### PR TITLE
Reduce GOV.UK Notify rate limit

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -28,7 +28,7 @@ govuk_notify:
   team_key: <%= Rails.application.credentials.govuk_notify&.team_key %>
   live_key: <%= Rails.application.credentials.govuk_notify&.live_key %>
   callback_bearer_token: <%= Rails.application.credentials.govuk_notify&.callback_bearer_token %>
-  rate_limit_per_minute: 3000
+  rate_limit_per_minute: 2500
 
 nhs_api:
   api_key: <%= Rails.application.credentials.nhs_api&.api_key %>


### PR DESCRIPTION
We're seeing in QA that even if we throttle emails and texts by 3000 requests per minute, we still experience the occasional errors related to rate limiting. Although the jobs now retry so this isn't an operational issue, we want to reduce throttling on our side to avoid this issue.