### PR TITLE
Ensure patients with notes can be merged

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -28,6 +28,9 @@ class PatientMerger
         patient_id: patient_to_keep.id
       )
       patient_to_destroy.consents.update_all(patient_id: patient_to_keep.id)
+
+      patient_to_destroy.notes.update_all(patient_id: patient_to_keep.id)
+
       patient_to_destroy.notify_log_entries.update_all(
         patient_id: patient_to_keep.id
       )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -45,6 +45,7 @@ describe PatientMerger do
     let(:gillick_assessment) do
       create(:gillick_assessment, :competent, patient: patient_to_destroy)
     end
+    let(:note) { create(:note, patient: patient_to_destroy) }
     let(:notify_log_entry) do
       create(:notify_log_entry, :email, patient: patient_to_destroy)
     end
@@ -120,6 +121,10 @@ describe PatientMerger do
       expect { call }.to change { gillick_assessment.reload.patient }.to(
         patient_to_keep
       )
+    end
+
+    it "moves notes" do
+      expect { call }.to change { note.reload.patient }.to(patient_to_keep)
     end
 
     it "moves notify log entries" do


### PR DESCRIPTION
This fixes an issue where patients with notes cannot be merged as the foreign key constraint prevents the patient from being deleted.

[Sentry Issue](https://good-machine.sentry.io/issues/6859186837/)