### PR TITLE
Improve performance of lookup by ensuring patient results have hash

### DIFF
--- a/app/policies/vaccination_record_policy.rb
+++ b/app/policies/vaccination_record_policy.rb
@@ -64,9 +64,28 @@ class VaccinationRecordPolicy < ApplicationPolicy
       team = user.selected_team
       return scope.none if team.nil?
 
+      patient_subquery =
+        Patient
+          .joins(patient_sessions: :session)
+          .select(:id)
+          .distinct
+          .where(sessions: { team_id: team.id })
+          .arel
+          .as("patients")
       scope
+        .joins(
+          VaccinationRecord
+            .arel_table
+            .join(patient_subquery, Arel::Nodes::OuterJoin)
+            .on(
+              VaccinationRecord.arel_table[:patient_id].eq(
+                patient_subquery[:id]
+              )
+            )
+            .join_sources
+        )
         .kept
-        .where(patient: team.patients)
+        .where(patient_subquery[:id].not_eq(nil))
         .or(scope.kept.where(session: team.sessions))
         .or(
           scope.kept.where(


### PR DESCRIPTION
- This is guaranteed by forcing a JOIN instead of an IN clause on an indexed column
- In testing this reduces execution time from ca 60s to 1s

JIRA: [MAV-1927](https://nhsd-jira.digital.nhs.uk/browse/MAV-1927)