### PR TITLE
Fix updating registration status when there isn't a date

### DIFF
--- a/app/models/patient_session/registration_status.rb
+++ b/app/models/patient_session/registration_status.rb
@@ -37,7 +37,7 @@ class PatientSession::RegistrationStatus < ApplicationRecord
        validate: true
 
   def session_attendance
-    session_attendances.find { it.session_date_id == session_date.id }
+    session_attendances.find { it.session_date_id == session_date&.id }
   end
 
   def assign_status

--- a/spec/models/patient_session/registration_status_spec.rb
+++ b/spec/models/patient_session/registration_status_spec.rb
@@ -41,18 +41,31 @@ describe PatientSession::RegistrationStatus do
 
   describe "associations" do
     it { should belong_to(:patient_session) }
+  end
 
-    describe "#session_attendance" do
-      subject do
-        described_class
-          .includes(:session_attendances)
-          .find(patient_session_registration_status.id)
-          .session_attendance
-      end
+  describe "#session_attendance" do
+    subject do
+      described_class
+        .includes(:session_attendances)
+        .find(patient_session_registration_status.id)
+        .session_attendance
+    end
 
-      let(:patient_session_registration_status) do
-        create(:patient_session_registration_status, patient_session:)
-      end
+    let(:patient_session_registration_status) do
+      create(:patient_session_registration_status, patient_session:)
+    end
+
+    context "with no attendances" do
+      it { should be_nil }
+    end
+
+    context "with no session date today" do
+      let(:session) { create(:session, date: Date.yesterday, programmes:) }
+
+      it { should be_nil }
+    end
+
+    context "with an attendance today and yesterday" do
       let(:today_session_attendance) do
         create(
           :session_attendance,
@@ -76,7 +89,7 @@ describe PatientSession::RegistrationStatus do
   end
 
   describe "#status" do
-    subject(:status) { patient_session_registration_status.assign_status }
+    subject { patient_session_registration_status.assign_status }
 
     context "with no session attendance" do
       it { should be(:unknown) }


### PR DESCRIPTION
This fixes an issue where the registration status cannot be generated when there isn't a session date today. This fixes a regression from 7539761dbf475effc54f2f9feab0ab7b030e39a2.

[Sentry Issue](https://good-machine.sentry.io/issues/6860955503/)