### PR TITLE
Add SystmOne codes for flu

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -9,10 +9,22 @@ class Reports::SystmOneExporter
   }.with_indifferent_access.freeze
 
   VACCINE_DOSE_MAPPINGS = {
+    "Cell-based Trivalent Influenza Vaccine Seqirus" => {
+      nil => "YcjYj"
+    },
     "Gardasil 9" => {
-      "1" => "Y19a4",
-      "2" => "Y19a5",
-      "3" => "Y19a6"
+      1 => "Y19a4",
+      2 => "Y19a5",
+      3 => "Y19a6"
+    },
+    "Fluenz" => {
+      nil => "YcjAC"
+    },
+    "Vaxigrip" => {
+      nil => "YcjYf"
+    },
+    "Viatris" => {
+      nil => "YcjYh"
     }
   }.freeze
 
@@ -183,12 +195,14 @@ class Reports::SystmOneExporter
   def vaccination(vaccination_record)
     return if vaccination_record.not_administered?
 
-    VACCINE_DOSE_MAPPINGS.dig(
-      vaccination_record.vaccine.brand,
-      vaccination_record.dose_sequence.to_s
-    ) ||
-      "#{vaccination_record.vaccine.brand} " \
-        "Part #{vaccination_record.dose_sequence}"
+    vaccine_brand = vaccination_record.vaccine.brand
+    dose_sequence = vaccination_record.dose_sequence
+
+    mapping = VACCINE_DOSE_MAPPINGS.dig(vaccine_brand, dose_sequence)
+
+    return mapping if mapping.present?
+
+    dose_sequence ? "#{vaccine_brand} Part #{dose_sequence}" : vaccine_brand
   end
 
   def reason(vaccination_record)

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -206,25 +206,67 @@ describe Reports::SystmOneExporter do
       )
     end
 
-    context "HPV Gardasil 9 dose 2" do
-      let(:vaccine) { Vaccine.find_by(brand: "Gardasil 9") }
-      let(:dose_sequence) { 2 }
+    context "HPV" do
+      context "Gardasil 9 dose 2" do
+        let(:vaccine) { Vaccine.find_by!(brand: "Gardasil 9") }
+        let(:dose_sequence) { 2 }
 
-      it { should eq "Y19a5" }
+        it { should eq("Y19a5") }
+      end
+
+      context "Gardasil 9 dose 3" do
+        let(:vaccine) { Vaccine.find_by!(brand: "Gardasil 9") }
+        let(:dose_sequence) { 3 }
+
+        it { should eq("Y19a6") }
+      end
     end
 
-    context "HPV Gardasil 9 dose 3" do
-      let(:vaccine) { Vaccine.find_by(brand: "Gardasil 9") }
-      let(:dose_sequence) { 3 }
+    context "flu" do
+      let(:programme) { create(:programme, :flu_all_vaccines) }
+      let(:dose_sequence) { nil }
 
-      it { should eq "Y19a6" }
+      context "Cell-based Trivalent Influenza Vaccine Seqirus" do
+        let(:vaccine) do
+          Vaccine.find_by!(
+            brand: "Cell-based Trivalent Influenza Vaccine Seqirus"
+          )
+        end
+
+        it { should eq("YcjYj") }
+      end
+
+      context "Fluenz" do
+        let(:vaccine) { Vaccine.find_by!(brand: "Fluenz") }
+
+        it { should eq("YcjAC") }
+      end
+
+      context "Vaxigrip" do
+        let(:vaccine) { Vaccine.find_by!(brand: "Vaxigrip") }
+
+        it { should eq("YcjYf") }
+      end
+
+      context "Viatris" do
+        let(:vaccine) { Vaccine.find_by!(brand: "Viatris") }
+
+        it { should eq("YcjYh") }
+      end
     end
 
     context "unknown vaccine and no dose sequence" do
-      let(:vaccine) { create(:vaccine, :fluenz) }
+      let(:vaccine) { create(:vaccine, :menquadfi) }
+      let(:dose_sequence) { nil }
+
+      it { should eq("MenQuadfi") }
+    end
+
+    context "unknown vaccine and a dose sequence" do
+      let(:vaccine) { create(:vaccine, :menquadfi) }
       let(:dose_sequence) { 1 }
 
-      it { should eq "Fluenz Part 1" }
+      it { should eq("MenQuadfi Part 1") }
     end
   end
 


### PR DESCRIPTION
This adds the SystmOne codes for flu to ensure that the exporter includes the right values for the SAIS teams to import.

[Jira Issue - MAV-1678](https://nhsd-jira.digital.nhs.uk/browse/MAV-1678)