### PR TITLE
Ensure programme tags are ordered

### DIFF
--- a/app/components/app_programme_tags_component.rb
+++ b/app/components/app_programme_tags_component.rb
@@ -5,16 +5,13 @@ class AppProgrammeTagsComponent < ViewComponent::Base
     @programmes = programmes
   end
 
-  def call
-    safe_join(
-      programmes.map do
-        tag.strong(it.name, class: "nhsuk-tag nhsuk-tag--white")
-      end,
-      " "
-    )
-  end
+  def call = safe_join(tags, " ")
 
   private
 
   attr_reader :programmes
+
+  def names = programmes.map(&:name).sort
+
+  def tags = names.map { tag.strong(it, class: "nhsuk-tag nhsuk-tag--white") }
 end

--- a/spec/components/app_programme_tags_component_spec.rb
+++ b/spec/components/app_programme_tags_component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe AppProgrammeTagsComponent do
+  subject { render_inline(component) }
+
+  let(:component) { described_class.new(programmes) }
+
+  let(:programmes) do
+    [create(:programme, :menacwy), create(:programme, :td_ipv)]
+  end
+
+  it { should have_content("MenACWY Td/IPV") }
+
+  context "with unordered programmes" do
+    let(:programmes) do
+      [create(:programme, :td_ipv), create(:programme, :menacwy)]
+    end
+
+    it { should have_content("MenACWY Td/IPV") }
+  end
+end


### PR DESCRIPTION
This ensures that when displaying a list of programme tags they are always ordered alphabetically, even if they're not ordered in that way when they're passed in.

Generally we order the results of programmes when querying from the database, but there seems to be an issue in QA currently where preloading the programmes means they are not always ordered. This change guarantees that users will see the programmes in the correct order.