### PR TITLE
Fix grammar in PSD eligibility message for singular case

### DIFF
--- a/app/views/sessions/patient_specific_directions/show.html.erb
+++ b/app/views/sessions/patient_specific_directions/show.html.erb
@@ -23,8 +23,9 @@
     <%= govuk_inset_text do %>
       <span class="nhsuk-u-visually-hidden">Information: </span>
       <p class="nhsuk-body">
-        There are <%= @eligible_for_bulk_psd_count %> children with consent for the nasal flu vaccine
-        who do not require triage and do not yet have a PSD in place.
+        There <%= @eligible_for_bulk_psd_count == 1 ? "is" : "are" %>
+        <%= pluralize(@eligible_for_bulk_psd_count, "child") %> with consent for
+        the nasal flu vaccine who do not require triage and do not yet have a PSD in place.
       </p>
 
       <% if policy(PatientSpecificDirection).create? %>

--- a/spec/features/flu_vaccination_hca_psd_spec.rb
+++ b/spec/features/flu_vaccination_hca_psd_spec.rb
@@ -181,7 +181,7 @@ describe "Flu vaccination" do
   end
 
   def and_i_should_see_one_child_eligible_for_psd
-    expect(page).to have_text("There are 1 children")
+    expect(page).to have_text("There is 1 child")
   end
 
   def and_should_see_again_one_child_eligible_for_psd
@@ -206,7 +206,7 @@ describe "Flu vaccination" do
 
   def and_i_should_only_see_one_child_eligible_for_bulk_adding_psd
     expect(page).to have_text(
-      "There are 1 children with consent for the nasal flu vaccine"
+      "There is 1 child with consent for the nasal flu vaccine"
     )
   end
 


### PR DESCRIPTION
Use `pluralize` helper to correctly display "There is 1 child" instead of "There are 1 children" when only one child is eligible for PSD creation.