### PR TITLE
Fix viewing patient when there's no date today

### DIFF
--- a/app/components/app_patient_session_record_component.rb
+++ b/app/components/app_patient_session_record_component.rb
@@ -20,7 +20,7 @@ class AppPatientSessionRecordComponent < ViewComponent::Base
       (
         patient_session.registration_status&.attending? ||
           patient_session.registration_status&.completed? ||
-          !session.requires_registration?
+          (!session.requires_registration? && session.today?)
       )
   end
 

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -71,6 +71,10 @@ FactoryBot.define do
       date { Date.current }
     end
 
+    trait :yesterday do
+      date { Date.yesterday }
+    end
+
     trait :unscheduled do
       date { nil }
     end


### PR DESCRIPTION
If viewing a patient in a session that has no date today, and has registration disabled, the users will see an error when trying to view the patient.

This happens because we try to render the vaccinate form, which fails when there isn't a session date today.

[Sentry Issue](https://good-machine.sentry.io/issues/6864512518/)