### PR TITLE
Make flu SystmOne codes based on dose sequence

### DIFF
--- a/app/lib/reports/systm_one_exporter.rb
+++ b/app/lib/reports/systm_one_exporter.rb
@@ -10,7 +10,7 @@ class Reports::SystmOneExporter
 
   VACCINE_DOSE_MAPPINGS = {
     "Cell-based Trivalent Influenza Vaccine Seqirus" => {
-      nil => "YcjYj"
+      1 => "YcjYj"
     },
     "Gardasil 9" => {
       1 => "Y19a4",
@@ -18,13 +18,13 @@ class Reports::SystmOneExporter
       3 => "Y19a6"
     },
     "Fluenz" => {
-      nil => "YcjAC"
+      1 => "YcjAC"
     },
     "Vaxigrip" => {
-      nil => "YcjYf"
+      1 => "YcjYf"
     },
     "Viatris" => {
-      nil => "YcjYh"
+      1 => "YcjYh"
     }
   }.freeze
 

--- a/spec/lib/reports/systm_one_exporter_spec.rb
+++ b/spec/lib/reports/systm_one_exporter_spec.rb
@@ -224,7 +224,7 @@ describe Reports::SystmOneExporter do
 
     context "flu" do
       let(:programme) { create(:programme, :flu_all_vaccines) }
-      let(:dose_sequence) { nil }
+      let(:dose_sequence) { 1 }
 
       context "Cell-based Trivalent Influenza Vaccine Seqirus" do
         let(:vaccine) do
@@ -368,10 +368,6 @@ describe Reports::SystmOneExporter do
       let(:delivery_method) { :nasal_spray }
       let(:delivery_site) { :nose }
 
-      it "uses the generic SystmOne code" do
-        expect(csv_row["Vaccination"]).to eq "Fluenz Part 1"
-      end
-
       it "uses 'Nasal' as the method" do
         expect(csv_row["Method"]).to eq "Nasal"
       end
@@ -388,12 +384,6 @@ describe Reports::SystmOneExporter do
       end
       let(:delivery_method) { :intramuscular }
       let(:delivery_site) { :right_arm_upper_position }
-
-      it "uses the generic SystmOne code" do
-        expect(
-          csv_row["Vaccination"]
-        ).to eq "Cell-based Trivalent Influenza Vaccine Seqirus Part 1"
-      end
 
       it "uses 'Intramuscular' as the method" do
         expect(csv_row["Method"]).to eq "Intramuscular"


### PR DESCRIPTION
In 1a2f96876702a4da675b5045ff2fd4904bc1ba34 I added the SystmOne codes for flu under the assumption that the dose sequence would be `nil`, but actually the dose sequence will instead be `1`. This fixes an issue where the codes weren't coming through correctly.

[Jira Issue - MAV-1678](https://nhsd-jira.digital.nhs.uk/browse/MAV-1678)