### PR TITLE
Prevent delete endpoint from failing to delete teams

### DIFF
--- a/app/controllers/api/testing/teams_controller.rb
+++ b/app/controllers/api/testing/teams_controller.rb
@@ -37,15 +37,18 @@ class API::Testing::TeamsController < API::Testing::BaseController
         # In local dev we can end up with NotifyLogEntries without a patient
         log_destroy(NotifyLogEntry.where(patient_id: nil))
         log_destroy(NotifyLogEntry.where(patient_id: patient_ids))
+        log_destroy(PatientSession.where(patient_id: patient_ids))
         log_destroy(PDSSearchResult.where(patient_id: patient_ids))
         log_destroy(PreScreening.where(patient_id: patient_ids))
         log_destroy(SchoolMove.where(patient_id: patient_ids))
         log_destroy(SchoolMove.where(team:))
         log_destroy(SchoolMoveLogEntry.where(patient_id: patient_ids))
+        log_destroy(SessionAttendance.where(patient_id: patient_ids))
         log_destroy(VaccinationRecord.where(patient_id: patient_ids))
 
         log_destroy(SessionDate.where(session: sessions))
 
+        log_destroy(ArchiveReason.where(team:))
         log_destroy(ConsentForm.where(team:))
         log_destroy(Consent.where(team:))
         log_destroy(Triage.where(team:))


### PR DESCRIPTION
Under-the-hood change which only affects testing. 

Deletes PatientSession and SessionAttendance entries for patients and ArchiveReason entries for teams when the delete endpoint is called, which seems to prevent most errors that could appear when deleting teams.