### PR TITLE
Fix HCAs unable to record vaccination if PSD exists

### DIFF
--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -59,12 +59,13 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def has_patient_specific_direction?(vaccine_method:)
-    patient.has_patient_specific_direction?(
-      academic_year:,
-      programme:,
-      team:,
-      vaccine_method:
-    )
+    session.psd_enabled? &&
+      patient.has_patient_specific_direction?(
+        academic_year:,
+        programme:,
+        team:,
+        vaccine_method:
+      )
   end
 
   def healthcare_assistant? = current_user.is_healthcare_assistant?

--- a/spec/features/flu_vaccination_hca_national_protocol_spec.rb
+++ b/spec/features/flu_vaccination_hca_national_protocol_spec.rb
@@ -20,6 +20,18 @@ describe "Flu vaccination" do
     then_i_am_able_to_vaccinate_them(nasal: false)
   end
 
+  scenario "Administered by HCA under national protocol but had a previous PSD" do
+    given_a_session_exists
+    and_patients_exist
+    and_the_nasal_and_injection_patient_has_a_psd
+
+    when_i_visit_the_session_record_tab
+    then_i_see_all_the_patients
+
+    when_i_click_on_the_nasal_and_injection_patient
+    then_i_am_able_to_vaccinate_them(nasal: true)
+  end
+
   scenario "Administered by HCA under national protocol with PSD enabled" do
     given_a_session_exists(psd_enabled: true)
     and_patients_exist

--- a/spec/features/flu_vaccination_hca_pgd_supply_spec.rb
+++ b/spec/features/flu_vaccination_hca_pgd_supply_spec.rb
@@ -20,6 +20,18 @@ describe "Flu vaccination" do
     then_i_am_not_able_to_vaccinate_them
   end
 
+  scenario "Administered by HCA under PGD supply, patient has previous PSD" do
+    given_a_session_exists
+    and_patients_exist
+    and_the_nasal_only_patient_has_a_psd
+
+    when_i_visit_the_session_record_tab
+    then_i_only_see_nasal_spray_patients
+
+    when_i_click_on_the_nasal_only_patient
+    then_i_am_able_to_vaccinate_them_nasal_only
+  end
+
   scenario "Patient consents nasal, has health issues, and is triaged as safe to vaccinate" do
     given_a_session_exists
     and_a_nasal_patient_exists_with_health_issues_marked_safe_vaccinate_with_nasal
@@ -75,6 +87,15 @@ describe "Flu vaccination" do
         :consent_given_injection_only_triage_not_needed,
         session: @session
       )
+  end
+
+  def and_the_nasal_only_patient_has_a_psd
+    create(
+      :patient_specific_direction,
+      patient: @patient_nasal_only,
+      programme: @programme,
+      team: @team
+    )
   end
 
   def and_a_nasal_patient_exists_with_health_issues_marked_safe_vaccinate_with_nasal


### PR DESCRIPTION
If a PSD exists on a patient from when the session had PSD enabled, and then PSD is subsequently disabled, HCAs are unable to record vaccinations for these patients. This is because the service thinks we're using the PSD to record the vaccination and doesn't display the field asking the HCA to specify who supplied the vaccine. Instead, even if the patient has a PSD, when PSD is disabled on the session, the HCA will not be using the PSD protocol, they will be using PGD with supply.