### PR TITLE
Ensure PSD status tag considered invalidated status

### DIFF
--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -262,7 +262,7 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
       value:
         render(
           AppStatusTagComponent.new(
-            psd_exists?(programmes.first) ? :added : :not_added,
+            has_patient_specific_direction? ? :added : :not_added,
             context: :patient_specific_direction
           )
         )
@@ -290,9 +290,11 @@ class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
     AppLogEventComponent.new(body:, at: note.created_at, by: note.created_by)
   end
 
-  def psd_exists?(programme)
+  def has_patient_specific_direction?
+    programme_ids = programmes.map(&:id)
     patient.patient_specific_directions.any? do
-      it.programme_id == programme.id && it.academic_year == academic_year
+      it.programme_id.in?(programme_ids) && it.academic_year == academic_year &&
+        !it.invalidated?
     end
   end
 end

--- a/spec/components/app_patient_session_search_result_card_component_spec.rb
+++ b/spec/components/app_patient_session_search_result_card_component_spec.rb
@@ -86,6 +86,27 @@ describe AppPatientSessionSearchResultCardComponent do
     end
   end
 
+  context "when context is patient specific direction" do
+    let(:context) { :patient_specific_direction }
+    let(:programme) { create(:programme, :flu) }
+
+    it { should have_text("PSD statusPSD not added") }
+
+    context "with a PSD" do
+      before { create(:patient_specific_direction, patient:, programme:) }
+
+      it { should have_text("PSD statusPSD added") }
+    end
+
+    context "with an invalidated PSD" do
+      before do
+        create(:patient_specific_direction, :invalidated, patient:, programme:)
+      end
+
+      it { should have_text("PSD statusPSD not added") }
+    end
+  end
+
   context "when context is register" do
     let(:context) { :register }
 


### PR DESCRIPTION
When a patient has a PSD but is invalid, it shouldn't count towards whether or not to show the status as having a PSD. This only affects the PSDs tab showing the list of patients with or without PSDs.