### PR TITLE
Send pseudo-postcode to Imms API when patient postcode nil

### DIFF
--- a/app/lib/fhir_mapper/patient.rb
+++ b/app/lib/fhir_mapper/patient.rb
@@ -22,7 +22,7 @@ module FHIRMapper
         name: [FHIR::HumanName.new(family: family_name, given: given_name)],
         birthDate: date_of_birth&.strftime("%Y-%m-%d"),
         gender: gender_fhir_value,
-        address: [FHIR::Address.new(postalCode: address_postcode)]
+        address: [FHIR::Address.new(postalCode: address_postcode || "ZZ99 3CZ")]
       )
     end
 

--- a/spec/lib/fhir_mapper/patient_spec.rb
+++ b/spec/lib/fhir_mapper/patient_spec.rb
@@ -31,6 +31,12 @@ describe FHIRMapper::Patient do
       subject { patient_fhir.address[0] }
 
       its(:postalCode) { should eq patient.address_postcode }
+
+      context "when the address postcode is not set" do
+        let(:patient) { create(:patient, address_postcode: nil) }
+
+        its(:postalCode) { should eq "ZZ99 3CZ" }
+      end
     end
 
     describe "gender" do


### PR DESCRIPTION
Postcode is a mandatory field when creating a new record in the Imms FHIR API. We need to handle the case where a patient in Mavis has a `nil` postcode, by sending a pseudo-postcode, similar to what we already do for location codes.

The postcode value was chosen from the ones described here: https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir/get-and-update-contact-details-in-pds

Fixes [MAV-1942](https://nhsd-jira.digital.nhs.uk/browse/MAV-1942).