### PR TITLE
Set performance insights retention period

### DIFF
--- a/terraform/app/rds.tf
+++ b/terraform/app/rds.tf
@@ -34,30 +34,31 @@ resource "aws_db_subnet_group" "core" {
 }
 
 resource "aws_rds_cluster" "core" {
-  cluster_identifier              = local.rds_cluster
-  engine                          = "aurora-postgresql"
-  engine_mode                     = "provisioned"
-  engine_version                  = "16.8"
-  database_name                   = "manage_vaccinations"
-  master_username                 = "postgres"
-  backup_retention_period         = var.backup_retention_period
-  skip_final_snapshot             = !local.is_production
-  final_snapshot_identifier       = "${local.rds_cluster}-final-snapshot"
-  db_subnet_group_name            = aws_db_subnet_group.core.name
-  vpc_security_group_ids          = [aws_security_group.rds_security_group.id]
-  kms_key_id                      = aws_kms_key.rds_cluster.arn
-  storage_encrypted               = true
-  manage_master_user_password     = true
-  deletion_protection             = true
-  allow_major_version_upgrade     = true
-  preferred_backup_window         = "01:00-01:30"
-  preferred_maintenance_window    = "sun:02:30-sun:03:00"
-  db_cluster_parameter_group_name = var.enable_enhanced_db_monitoring ? aws_rds_cluster_parameter_group.enhanced_monitoring[0].name : "default.aurora-postgresql16"
-  database_insights_mode          = var.enable_enhanced_db_monitoring ? "advanced" : "standard"
-  performance_insights_enabled    = var.enable_enhanced_db_monitoring
-  monitoring_interval             = var.enable_enhanced_db_monitoring ? 30 : 0
-  monitoring_role_arn             = var.enable_enhanced_db_monitoring ? aws_iam_role.enhanced_db_monitoring[0].arn : null
-  enabled_cloudwatch_logs_exports = ["postgresql", "instance"]
+  cluster_identifier                    = local.rds_cluster
+  engine                                = "aurora-postgresql"
+  engine_mode                           = "provisioned"
+  engine_version                        = "16.8"
+  database_name                         = "manage_vaccinations"
+  master_username                       = "postgres"
+  backup_retention_period               = var.backup_retention_period
+  skip_final_snapshot                   = !local.is_production
+  final_snapshot_identifier             = "${local.rds_cluster}-final-snapshot"
+  db_subnet_group_name                  = aws_db_subnet_group.core.name
+  vpc_security_group_ids                = [aws_security_group.rds_security_group.id]
+  kms_key_id                            = aws_kms_key.rds_cluster.arn
+  storage_encrypted                     = true
+  manage_master_user_password           = true
+  deletion_protection                   = true
+  allow_major_version_upgrade           = true
+  preferred_backup_window               = "01:00-01:30"
+  preferred_maintenance_window          = "sun:02:30-sun:03:00"
+  db_cluster_parameter_group_name       = var.enable_enhanced_db_monitoring ? aws_rds_cluster_parameter_group.enhanced_monitoring[0].name : "default.aurora-postgresql16"
+  database_insights_mode                = var.enable_enhanced_db_monitoring ? "advanced" : "standard"
+  performance_insights_enabled          = var.enable_enhanced_db_monitoring
+  performance_insights_retention_period = var.enable_enhanced_db_monitoring ? 465 : 7
+  monitoring_interval                   = var.enable_enhanced_db_monitoring ? 30 : 0
+  monitoring_role_arn                   = var.enable_enhanced_db_monitoring ? aws_iam_role.enhanced_db_monitoring[0].arn : null
+  enabled_cloudwatch_logs_exports       = ["postgresql", "instance"]
 
   serverlessv2_scaling_configuration {
     max_capacity = var.max_aurora_capacity_units


### PR DESCRIPTION
When Advanced DB Insights are enabled, AWS requires a performance insights retention period of at least 465 days