### PR TITLE
Run sidekiq locally

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,8 +1,9 @@
-nodejs      22.15.0
-postgres    17.2
-ruby        3.4.3
 awscli      2.27.46
+hk          1.1.2
+nodejs      22.15.0
+pkl         0.28.1
+postgres    17.2
+redis       8.2.1
+ruby        3.4.3
 terraform   1.11.4
 tflint      0.55.1
-pkl         0.28.1
-hk          1.1.2

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,3 @@
+web: bin/rails server
 release: bin/rails db:prepare:ignore_concurrent_migration_exceptions
+sidekiq: bin/sidekiq

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: unset PORT && bin/rails server
+sidekiq: bin/sidekiq
 css: yarn build:css --watch
 js: yarn build --watch

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ This project depends on:
 - [Ruby on Rails](https://rubyonrails.org/)
 - [NodeJS](https://nodejs.org/)
 - [Yarn](https://yarnpkg.com/)
-- [Postgres](https://www.postgresql.org/)
+- [PostgreSQL](https://www.postgresql.org/)
+- [Redis](https://redis.io/) or [Valkey](https://valkey.io/)
 
 The instructions below assume you are using `mise` to manage the necessary
 versions of the above.


### PR DESCRIPTION
This makes it possible to run Sidekiq locally by adding Redis/Valkey as a dependency and adding the `sidekiq` process to the `Procfile`.