### PR TITLE
Fix merging patients with session attendances

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -63,9 +63,14 @@ class PatientMerger
         patient_id: patient_to_keep.id
       )
 
+      patient_to_destroy.session_attendances.update_all(
+        patient_id: patient_to_keep.id
+      )
+
       patient_to_destroy.session_notifications.update_all(
         patient_id: patient_to_keep.id
       )
+
       patient_to_destroy.triages.update_all(patient_id: patient_to_keep.id)
 
       vaccination_record_ids =

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -68,6 +68,9 @@ describe PatientMerger do
     let(:duplicate_school_move) do
       create(:school_move, patient: patient_to_keep, school: school_move.school)
     end
+    let(:session_attendance) do
+      create(:session_attendance, :present, patient: patient_to_destroy)
+    end
     let(:session_notification) do
       create(
         :session_notification,
@@ -172,6 +175,12 @@ describe PatientMerger do
     it "deletes duplicate school moves" do
       expect { call }.not_to change(duplicate_school_move, :patient)
       expect { school_move.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "moves session attendances" do
+      expect { call }.to change { session_attendance.reload.patient }.to(
+        patient_to_keep
+      )
     end
 
     it "moves session notifications" do


### PR DESCRIPTION
This fixes an issue where patients with session attendances cannot be merged together due to the foreign key constraint on the session attendance failing when the old patient is destroyed.

[Sentry Issue](https://good-machine.sentry.io/issues/6859186837/)