### PR TITLE
Ensure `CommitPatientChangesetsJob` runs in `imports` queue

### DIFF
--- a/app/jobs/commit_patient_changesets_job.rb
+++ b/app/jobs/commit_patient_changesets_job.rb
@@ -3,6 +3,8 @@
 class CommitPatientChangesetsJob < ApplicationJob
   include SingleConcurrencyConcern
 
+  queue_as :imports
+
   def perform(import)
     counts = import.class.const_get(:COUNT_COLUMNS).index_with(0)
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -8,6 +8,7 @@
   - patients
   - pds
   - immunisations_api
+  - default
 :scheduler:
   :schedule:
     clinic_session_invitations:


### PR DESCRIPTION
This sets the right queue for the `CommitPatientChangesetsJob` which should be the `imports` queue as it's higher priority than other queues.

I've also added `default` to the Sidekiq configuration for the `TrimActiveRecordSessionsJob` job.