### PR TITLE
Optimise migration that replaces `patient_session_id`

### DIFF
--- a/db/migrate/20250822153747_remove_patient_session_from_patient_registration_statuses.rb
+++ b/db/migrate/20250822153747_remove_patient_session_from_patient_registration_statuses.rb
@@ -10,13 +10,12 @@ class RemovePatientSessionFromPatientRegistrationStatuses < ActiveRecord::Migrat
       t.index %i[patient_id session_id], unique: true
     end
 
-    Patient::RegistrationStatus.find_each do |registration_status|
-      patient_session =
-        PatientSession.find(registration_status.patient_session_id)
-      patient_id = patient_session.patient_id
-      session_id = patient_session.session_id
-      registration_status.update_columns(patient_id:, session_id:)
-    end
+    execute <<-SQL
+      UPDATE patient_registration_statuses
+      SET patient_id = patient_sessions.patient_id, session_id = patient_sessions.session_id
+      FROM patient_sessions
+      WHERE patient_registration_statuses.patient_session_id = patient_sessions.id
+    SQL
 
     change_table :patient_registration_statuses, bulk: true do |t|
       t.change_null :patient_id, false


### PR DESCRIPTION
This optimises the code we use in this migration to ensure it runs much quicker, by executing a single query. This is to avoid a situation where the migration takes too long to run in production and causes issues with the deployment.

This migration has already run in QA and test, but I've tested locally and this change does the same thing. I will test this in data replication before deploying.