### PR TITLE
Check all the relevant feature flags when displaying in the UI

### DIFF
--- a/app/components/app_vaccination_record_summary_component.rb
+++ b/app/components/app_vaccination_record_summary_component.rb
@@ -258,7 +258,8 @@ class AppVaccinationRecordSummaryComponent < ViewComponent::Base
       end
 
       if @vaccination_record.respond_to?(:sync_status) &&
-           Flipper.enabled?(:imms_api_sync_job)
+           Flipper.enabled?(:imms_api_sync_job) &&
+           Flipper.enabled?(:imms_api_integration)
         summary_list.with_row do |row|
           row.with_key { "Synced with NHS England?" }
           row.with_value do

--- a/spec/components/app_vaccination_record_summary_component_spec.rb
+++ b/spec/components/app_vaccination_record_summary_component_spec.rb
@@ -331,6 +331,55 @@ describe AppVaccinationRecordSummaryComponent do
     end
   end
 
+  describe "synced with NHS England row" do
+    after do
+      Flipper.disable(:imms_api_integration)
+      Flipper.disable(:imms_api_sync_job)
+    end
+
+    context "when the imms_api_integration and imms_api_sync_job feature flags are enabled" do
+      before do
+        Flipper.enable(:imms_api_integration)
+        Flipper.enable(:imms_api_sync_job)
+      end
+
+      it do
+        expect(rendered).to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Synced with NHS England?"
+        )
+      end
+    end
+
+    context "when the imms_api_integration feature flag is disabled" do
+      before do
+        Flipper.disable(:imms_api_integration)
+        Flipper.enable(:imms_api_sync_job)
+      end
+
+      it do
+        expect(rendered).not_to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Synced with NHS England?"
+        )
+      end
+    end
+
+    context "when the imms_api_sync_job feature flag is disabled" do
+      before do
+        Flipper.enable(:imms_api_integration)
+        Flipper.disable(:imms_api_sync_job)
+      end
+
+      it do
+        expect(rendered).not_to have_css(
+          ".nhsuk-summary-list__row",
+          text: "Synced with NHS England?"
+        )
+      end
+    end
+  end
+
   describe "with pending changes" do
     let(:component) do
       described_class.new(


### PR DESCRIPTION
The sync jobs won't run if `imms_api_integration` is disabled, so it feels ambiguous to show it.

[MAV-1968](https://nhsd-jira.digital.nhs.uk/browse/MAV-1968)