### PR TITLE
Remove `team` from `create_from_fhir`

### DIFF
--- a/app/lib/mavis_cli/vaccination_records/create_from_fhir.rb
+++ b/app/lib/mavis_cli/vaccination_records/create_from_fhir.rb
@@ -8,9 +8,6 @@ module MavisCLI
       argument :patient_id,
                required: true,
                desc: "ID of the patient to attach the vaccination record to"
-      argument :team_id,
-               required: false,
-               desc: "ID of the team (optional, used for batch association)"
 
       option :file,
              type: :string,
@@ -21,7 +18,7 @@ module MavisCLI
              required: false,
              desc: "Raw FHIR Immunization JSON string"
 
-      def call(patient_id:, team_id: nil, file: nil, json: nil, **)
+      def call(patient_id:, file: nil, json: nil, **)
         MavisCLI.load_rails
 
         unless Flipper.enabled?(:imms_api_integration)
@@ -42,12 +39,6 @@ module MavisCLI
         patient = Patient.find_by(id: patient_id)
         if patient.nil?
           puts "Error: Patient with ID #{patient_id} not found"
-          return
-        end
-
-        team = team_id.present? ? Team.find_by(id: team_id) : nil
-        if team_id.present? && team.nil?
-          puts "Error: Team with ID #{team_id} not found"
           return
         end
 
@@ -73,8 +64,7 @@ module MavisCLI
           record =
             FHIRMapper::VaccinationRecord.from_fhir_record(
               fhir_record,
-              patient: patient,
-              team: team
+              patient:
             )
 
           record.save!


### PR DESCRIPTION
This should have been changed as part of https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4566

[MAV-1969](https://nhsd-jira.digital.nhs.uk/browse/MAV-1969)