### PR TITLE
Fix queue for `SyncVaccinationRecordToNHSJob`

### DIFF
--- a/app/jobs/sync_vaccination_record_to_nhs_job.rb
+++ b/app/jobs/sync_vaccination_record_to_nhs_job.rb
@@ -3,7 +3,7 @@
 class SyncVaccinationRecordToNHSJob < ApplicationJob
   include ImmunisationsAPIThrottlingConcern
 
-  queue_as :immunisation_api
+  queue_as :immunisations_api
 
   def perform(vaccination_record)
     tx_id = SecureRandom.urlsafe_base64(16)

--- a/spec/models/immunisation_import_spec.rb
+++ b/spec/models/immunisation_import_spec.rb
@@ -358,7 +358,7 @@ describe ImmunisationImport do
       }.to have_enqueued_job(SyncVaccinationRecordToNHSJob)
         .with(vaccination_record)
         .once
-        .on_queue(:immunisation_api)
+        .on_queue(:immunisations_api)
     end
   end
 end


### PR DESCRIPTION
This fixes the queue name as currently it refers to a queue that doesn't exist and isn't processed by Sidekiq.