### PR TITLE
Don't ask who supplied the vaccine when not administered

### DIFF
--- a/app/forms/vaccinate_form.rb
+++ b/app/forms/vaccinate_form.rb
@@ -46,7 +46,7 @@ class VaccinateForm
             inclusion: {
               in: :supplied_by_user_id_values
             },
-            if: :requires_supplied_by_user_id?
+            if: -> { administered? && requires_supplied_by_user_id? }
 
   validates :vaccine_method, inclusion: { in: :vaccine_method_options }
   validates :delivery_site,
@@ -132,6 +132,9 @@ class VaccinateForm
         draft_vaccination_record.delivery_method = delivery_method
         draft_vaccination_record.delivery_site = delivery_site
       end
+
+      draft_vaccination_record.supplied_by_user_id =
+        supplied_by_user_id || psd_created_by_user_id
     end
 
     draft_vaccination_record.batch_id = todays_batch&.id
@@ -152,8 +155,6 @@ class VaccinateForm
     draft_vaccination_record.programme = programme
     draft_vaccination_record.protocol = protocol
     draft_vaccination_record.session_id = session.id
-    draft_vaccination_record.supplied_by_user_id =
-      supplied_by_user_id || psd_created_by_user_id
 
     draft_vaccination_record.save # rubocop:disable Rails/SaveBang
   end

--- a/spec/features/flu_vaccination_hca_national_protocol_spec.rb
+++ b/spec/features/flu_vaccination_hca_national_protocol_spec.rb
@@ -52,6 +52,15 @@ describe "Flu vaccination" do
     then_i_should_not_see_the_patient
   end
 
+  scenario "Vaccination refused by the patient" do
+    given_a_session_exists
+    and_patients_exist
+
+    when_i_visit_the_session_record_tab
+    and_i_click_on_the_nasal_and_injection_patient
+    then_i_am_able_to_record_the_refusal
+  end
+
   def given_a_session_exists(
     psd_enabled: false,
     national_protocol_enabled: true
@@ -162,6 +171,9 @@ describe "Flu vaccination" do
     click_on @patient_nasal_and_injection.full_name
   end
 
+  alias_method :and_i_click_on_the_nasal_and_injection_patient,
+               :when_i_click_on_the_nasal_and_injection_patient
+
   def when_i_click_on_the_injection_patient
     click_on @patient_injection_only.full_name
   end
@@ -209,5 +221,17 @@ describe "Flu vaccination" do
 
     click_on "Confirm"
     click_on "Record vaccinations"
+  end
+
+  def then_i_am_able_to_record_the_refusal
+    within all("section")[1] do
+      choose "No"
+    end
+    click_on "Continue"
+
+    choose "They refused it"
+    click_on "Continue"
+
+    click_on "Confirm"
   end
 end

--- a/spec/features/flu_vaccination_hca_pgd_supply_spec.rb
+++ b/spec/features/flu_vaccination_hca_pgd_supply_spec.rb
@@ -41,6 +41,15 @@ describe "Flu vaccination" do
     then_i_am_able_to_vaccinate_them_nasal_only
   end
 
+  scenario "Vaccination refused by the patient" do
+    given_a_session_exists
+    and_patients_exist
+
+    when_i_visit_the_session_record_tab
+    and_i_click_on_the_nasal_only_patient
+    then_i_am_able_to_record_the_refusal
+  end
+
   def given_a_session_exists
     @programme = create(:programme, :flu)
     programmes = [@programme]
@@ -121,6 +130,7 @@ describe "Flu vaccination" do
   def when_i_click_on_the_nasal_only_patient
     click_on @patient_nasal_only.full_name
   end
+
   alias_method :and_i_click_on_the_nasal_only_patient,
                :when_i_click_on_the_nasal_only_patient
 
@@ -160,5 +170,17 @@ describe "Flu vaccination" do
   def then_i_am_not_able_to_vaccinate_them
     expect(page).not_to have_content("Pre-screening checks")
     expect(page).not_to have_content("ready for their")
+  end
+
+  def then_i_am_able_to_record_the_refusal
+    within all("section")[1] do
+      choose "No"
+    end
+    click_on "Continue"
+
+    choose "They refused it"
+    click_on "Continue"
+
+    click_on "Confirm"
   end
 end


### PR DESCRIPTION
This updates the form for HCAs where normally they are asked to specify which nurse supplied the vaccine to ensure that the question is optional when the vaccination didn't happen.