### PR TITLE
Deduplicate parents with same email in same file

### DIFF
--- a/app/jobs/commit_patient_changesets_job.rb
+++ b/app/jobs/commit_patient_changesets_job.rb
@@ -60,6 +60,7 @@ class CommitPatientChangesetsJob < ApplicationJob
     changesets.each(&:assign_patient_id)
     PatientChangeset.import(changesets, on_duplicate_key_update: :all)
 
+    deduplicate_parents!(parents, relationships)
     Parent.import(parents.to_a, on_duplicate_key_update: :all)
     link_records_to_import(import, Parent, parents)
 
@@ -91,6 +92,25 @@ class CommitPatientChangesetsJob < ApplicationJob
       end
     end
     patients.uniq!
+  end
+
+  def deduplicate_parents!(parents, relationships)
+    @parents_by_email ||= {}
+    parents.reject! do |parent|
+      next false if parent.email.blank?
+
+      existing_parent = @parents_by_email[parent.email]
+      if parent.persisted? || existing_parent.nil?
+        @parents_by_email[parent.email] = parent
+        next false
+      else
+        relationships
+          .select { _1.parent == parent }
+          .each { _1.parent = existing_parent }
+        next true
+      end
+    end
+    parents.uniq!
   end
 
   def import_school_moves(changesets, import)

--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -701,10 +701,10 @@ describe "Import child records" do
 
   def and_all_parent_relationships_are_established
     expect(Parent.count).to eq(7)
-    expect(ParentRelationship.count).to eq(7)
+    expect(ParentRelationship.count).to eq(8)
 
     father_relationships = ParentRelationship.where(type: "father")
-    expect(father_relationships.count).to eq(3) # John Tweedle, Mike HomeDad, Robert Samson
+    expect(father_relationships.count).to eq(4) # John Tweedle, Mike HomeDad, Robert Samson
 
     mother_relationships = ParentRelationship.where(type: "mother")
     expect(mother_relationships.count).to eq(2) # Mary Tweedle, Linda Samson

--- a/spec/fixtures/cohort_import/pds_extravaganza.csv
+++ b/spec/fixtures/cohort_import/pds_extravaganza.csv
@@ -7,6 +7,6 @@ CHILD_SCHOOL_URN,PARENT_1_NAME,PARENT_1_RELATIONSHIP,PARENT_1_EMAIL,PARENT_1_PHO
 123456,Jane Doe,,,01234567896,,,,,Oliver,Green,,2010-08-15,8,789 Silent Street,,London,SW1W 8JL,9435753868
 123456,,,,,,,,,Lara,Williams,,2010-05-15,8,,,,B1 1AA,
 123456,,,,,,,,,Lucy,McCarthy,,2010-08-16,8,789 Silent Street,,London,SW7 5LE,9435815065
-123456,,,,,,,,,Maia,Smith,,2010-08-16,8,790 Silent Street,,London,W2 3PE,9435789102
+123456,Mike HomeDad,Father,mike@home.com,01234567895,,,,,Maia,Smith,,2010-08-16,8,790 Silent Street,,London,W2 3PE,9435789102
 123456,,,,,,,,,Caroline,Richard,,2010-05-15,8,,,,B1 1AA,
 123456,,,,,,,,,Caroline,Richard,,2010-05-15,8,,,,B1 1AA,


### PR DESCRIPTION
Previously, match_existing only handled deduplication against parents already persisted in the database. This meant that when the same parent appeared multiple times in a single import file, duplicate parent records could still be created. We now deduplicate parents within the import batch itself by email to ensure only one parent record is created per unique email.

JIRA: [MAV-1915](https://nhsd-jira.digital.nhs.uk/browse/MAV-1915)