### PR TITLE
Prevent Imms API syncs from changing vaccs record `updated_at` field

### DIFF
--- a/app/lib/nhs/immunisations_api.rb
+++ b/app/lib/nhs/immunisations_api.rb
@@ -53,7 +53,7 @@ module NHS::ImmunisationsAPI
       )
 
       if response.status == 201
-        vaccination_record.update!(
+        vaccination_record.update_columns(
           nhs_immunisations_api_id:
             extract_nhs_id(response.headers.fetch("location")),
           nhs_immunisations_api_synced_at: Time.current,
@@ -169,7 +169,7 @@ module NHS::ImmunisationsAPI
       )
 
       if response.status == 200
-        vaccination_record.update!(
+        vaccination_record.update_columns(
           nhs_immunisations_api_synced_at: Time.current,
           # This simplistic approach is based on the assumption that the NHS
           # Immunisations API will always simply increment the ETag. Alternative
@@ -235,10 +235,10 @@ module NHS::ImmunisationsAPI
 
       if response.status == 204
         # It's not entirely clear if the e-tag should be changed here, but
-        # experiments show (by deletind and then re-creating a vaccination
+        # experiments show (by deleting and then re-creating a vaccination
         # record with an "update") that it appears that the e-tag is incremented
         # on the reviving update.
-        vaccination_record.update!(
+        vaccination_record.update_columns(
           nhs_immunisations_api_synced_at: Time.current
         )
       else
@@ -309,7 +309,7 @@ module NHS::ImmunisationsAPI
       )
 
       if response.status == 200
-        # # To create fixtures for testing
+        # To create fixtures for testing
         # File.write("tmp/search_response.json", response.body.to_json)
         # Rails.logger.debug "Successfully saved"
 

--- a/spec/lib/nhs/immunisations_api_spec.rb
+++ b/spec/lib/nhs/immunisations_api_spec.rb
@@ -277,6 +277,17 @@ describe NHS::ImmunisationsAPI do
       expect(vaccination_record.nhs_immunisations_api_etag).to eq "1"
     end
 
+    it "does not change the updated_at timestamp" do
+      original_updated_at = vaccination_record.updated_at
+
+      # Small delay to ensure time difference if updated_at were to change
+      travel 1.second
+
+      perform_request
+
+      expect(vaccination_record.reload.updated_at).to eq original_updated_at
+    end
+
     context "an error is returned by the api" do
       let(:code) { nil }
       let(:diagnostics) { nil }
@@ -484,6 +495,17 @@ describe NHS::ImmunisationsAPI do
       end
     end
 
+    it "does not change the updated_at timestamp" do
+      original_updated_at = vaccination_record.updated_at
+
+      # Small delay to ensure time difference if updated_at were to change
+      travel 1.second
+
+      perform_request
+
+      expect(vaccination_record.reload.updated_at).to eq original_updated_at
+    end
+
     it "increments the etag" do
       perform_request
 
@@ -571,6 +593,17 @@ describe NHS::ImmunisationsAPI do
           vaccination_record.nhs_immunisations_api_synced_at
         ).to eq Time.current
       end
+    end
+
+    it "does not change the updated_at timestamp" do
+      original_updated_at = vaccination_record.updated_at
+
+      # Small delay to ensure time difference if updated_at were to change
+      travel 1.second
+
+      perform_request
+
+      expect(vaccination_record.reload.updated_at).to eq original_updated_at
     end
 
     context "an error is returned by the api" do


### PR DESCRIPTION
This prevents the `RECORD_UPDATED_AT` column in the vaccination report download from being updated, ensuring only genuine user edits to the record are reflected in the report.

Fixes [MAV-1988](https://nhsd-jira.digital.nhs.uk/browse/MAV-1988).