### PR TITLE
Hide discontinued vaccines from summary table

### DIFF
--- a/app/components/app_vaccinations_summary_table_component.html.erb
+++ b/app/components/app_vaccinations_summary_table_component.html.erb
@@ -8,18 +8,19 @@
   <% end %>
 
   <% table.with_body do |body| %>
-    <% tally_results.each do |(vaccine_brand_name, tally_data)| %>
+    <% count_by_vaccine.each do |(vaccine, count)| %>
       <% body.with_row do |row| %>
         <% row.with_cell do %>
-          <%= vaccine_brand_name %>
+          <%= vaccine.brand %>
         <% end %>
         <% row.with_cell do %>
-          <%= tally_data[:count] %>
+          <%= count %>
         <% end %>
         <% row.with_cell do %>
-          <%= tally_data[:default_batch] || "Not set" %>
-          <% if tally_data[:default_batch] %>
-            <%= link_to "Change", batch_session_record_path(session, tally_data[:programme], tally_data[:vaccine_method]) %>
+          <% batch = default_batch(vaccine) %>
+          <%= batch&.name || "Not set" %>
+          <% if batch %>
+            <%= link_to "Change", batch_session_record_path(session, vaccine.programme, vaccine.method) %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/components/app_vaccinations_summary_table_component.rb
+++ b/app/components/app_vaccinations_summary_table_component.rb
@@ -14,7 +14,7 @@ class AppVaccinationsSummaryTableComponent < ViewComponent::Base
   delegate :govuk_table, to: :helpers
 
   def count_by_vaccine
-    vaccines = session.vaccines.includes(:programme).order(:brand)
+    vaccines = session.vaccines.active.includes(:programme).order(:brand)
 
     vaccination_records =
       session

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -9,7 +9,6 @@ class Sessions::RecordController < ApplicationController
   before_action :set_session
   before_action :set_patient_search_form
 
-  before_action :set_todays_batches, only: :show
   before_action :set_programme, except: :show
   before_action :set_vaccine_method, except: :show
   before_action :set_batches, except: :show
@@ -72,24 +71,6 @@ class Sessions::RecordController < ApplicationController
       policy_scope(Session).includes(programmes: :vaccines).find_by!(
         slug: params[:session_slug]
       )
-  end
-
-  def set_todays_batches
-    all_batches =
-      @session.programmes.index_with do |programme|
-        programme.vaccine_methods.filter_map do |vaccine_method|
-          id = todays_batch_id(programme:, vaccine_method:)
-          next if id.nil?
-
-          policy_scope(Batch)
-            .where(vaccine: @session.vaccines)
-            .not_archived
-            .not_expired
-            .find_by(id:)
-        end
-      end
-
-    @todays_batches = all_batches.compact_blank
   end
 
   def set_programme

--- a/spec/components/app_vaccinations_summary_table_component_spec.rb
+++ b/spec/components/app_vaccinations_summary_table_component_spec.rb
@@ -9,11 +9,25 @@ describe AppVaccinationsSummaryTableComponent do
   let(:flu_programme) { create(:programme, :flu, vaccines: []) }
   let(:hpv_programme) { create(:programme, :hpv, vaccines: []) }
   let(:programmes) { [hpv_programme] }
-  let(:session) { build(:session, :today, programmes:, team:) }
+  let(:session) { create(:session, :today, programmes:, team:) }
   let(:team) { create(:team, :with_generic_clinic, programmes:) }
 
   let(:component) do
     described_class.new(current_user:, session:, request_session:)
+  end
+
+  context "with an active vaccine" do
+    let(:hpv_vaccine) { create(:vaccine, programme: hpv_programme) }
+
+    it { should have_content(hpv_vaccine.brand) }
+  end
+
+  context "with a discontinued vaccine" do
+    let(:hpv_vaccine) do
+      create(:vaccine, :discontinued, programme: hpv_programme)
+    end
+
+    it { should_not have_content(hpv_vaccine.brand) }
   end
 
   context "bad data exists where we have Flu vaccination records in an HPV session" do

--- a/spec/features/tallying_spec.rb
+++ b/spec/features/tallying_spec.rb
@@ -149,16 +149,16 @@ describe "Tallying" do
 
   def then_i_see_my_vaccination_tallies_for_today_with_default_batches
     rows = page.all(".nhsuk-table__row")
-    expect(rows[1]).to have_content("Cervarix 1 #{@cervarix_batch.name} Change")
-    expect(rows[2]).to have_content("Gardasil 2 Not set")
-    expect(rows[3]).to have_content("Fluenz 1 #{@fluenz_batch.name} Change")
+    expect(rows[1]).to have_content("Fluenz 1 #{@fluenz_batch.name} Change")
+    expect(rows[2]).to have_content("Cervarix 1 #{@cervarix_batch.name} Change")
+    expect(rows[3]).to have_content("Gardasil 2 Not set")
   end
 
   def then_i_see_my_vaccination_tallies_with_all_zero_values_with_default_batches
     rows = page.all(".nhsuk-table__row")
-    expect(rows[1]).to have_content("Cervarix 0 #{@cervarix_batch.name} Change")
-    expect(rows[2]).to have_content("Gardasil 0 Not set")
-    expect(rows[3]).to have_content("Fluenz 0 #{@fluenz_batch.name} Change")
+    expect(rows[1]).to have_content("Fluenz 0 #{@fluenz_batch.name} Change")
+    expect(rows[2]).to have_content("Cervarix 0 #{@cervarix_batch.name} Change")
+    expect(rows[3]).to have_content("Gardasil 0 Not set")
   end
 
   def and_i_click_on_the_expander_your_vaccinations_today

--- a/spec/features/tallying_spec.rb
+++ b/spec/features/tallying_spec.rb
@@ -38,8 +38,9 @@ describe "Tallying" do
     @cervarix_vaccine = create(:vaccine, :cervarix, programme: @hpv_programme)
     @cervarix_batch = create(:batch, :not_expired, vaccine: @cervarix_vaccine)
 
-    @gardasil_vaccine = create(:vaccine, :gardasil, programme: @hpv_programme)
-    @gardasil_batch = create(:batch, :not_expired, vaccine: @gardasil_vaccine)
+    @gardasil9_vaccine =
+      create(:vaccine, :gardasil_9, programme: @hpv_programme)
+    @gardasil9_batch = create(:batch, :not_expired, vaccine: @gardasil9_vaccine)
 
     @fluenz_vaccine = create(:vaccine, :fluenz, programme: @flu_programme)
     @fluenz_batch = create(:batch, :not_expired, vaccine: @fluenz_vaccine)
@@ -95,8 +96,8 @@ describe "Tallying" do
 
     create(
       :vaccination_record,
-      batch: @gardasil_batch,
-      vaccine: @gardasil_vaccine,
+      batch: @gardasil9_batch,
+      vaccine: @gardasil9_vaccine,
       session: @session,
       programme: @hpv_programme,
       performed_by: @user
@@ -106,8 +107,8 @@ describe "Tallying" do
   def and_administered_one_gardasil_vaccine_for_hpv_programme
     create(
       :vaccination_record,
-      batch: @gardasil_batch,
-      vaccine: @gardasil_vaccine,
+      batch: @gardasil9_batch,
+      vaccine: @gardasil9_vaccine,
       session: @session,
       programme: @hpv_programme,
       performed_by: @user
@@ -149,16 +150,17 @@ describe "Tallying" do
 
   def then_i_see_my_vaccination_tallies_for_today_with_default_batches
     rows = page.all(".nhsuk-table__row")
+    expect(rows.count).to eq(4)
     expect(rows[1]).to have_content("Fluenz 1 #{@fluenz_batch.name} Change")
-    expect(rows[2]).to have_content("Cervarix 1 #{@cervarix_batch.name} Change")
-    expect(rows[3]).to have_content("Gardasil 2 Not set")
+    expect(rows[2]).to have_content("Gardasil 9 2 Not set")
+    expect(rows[3]).to have_content("Cervarix 1 #{@cervarix_batch.name} Change")
   end
 
   def then_i_see_my_vaccination_tallies_with_all_zero_values_with_default_batches
     rows = page.all(".nhsuk-table__row")
+    expect(rows.count).to eq(3)
     expect(rows[1]).to have_content("Fluenz 0 #{@fluenz_batch.name} Change")
-    expect(rows[2]).to have_content("Cervarix 0 #{@cervarix_batch.name} Change")
-    expect(rows[3]).to have_content("Gardasil 0 Not set")
+    expect(rows[2]).to have_content("Gardasil 9 0 Not set")
   end
 
   def and_i_click_on_the_expander_your_vaccinations_today


### PR DESCRIPTION
This ensures that when the summary table is shown, any discontinued vaccines are not shown, unless vaccinations are recorded against them in the session in which case they will show in the table.

I've also refactored the `AppVaccinationsSummaryTableComponent` to simplify the code.

[Jira Issue - MAV-1991](https://nhsd-jira.digital.nhs.uk/browse/MAV-1991)