### PR TITLE
Use `mail_to` helper

### DIFF
--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -6,8 +6,7 @@
   If you reached this page after submitting information then it has not
   been saved. You’ll need to enter it again when the service is available.
 </p>
+
 <p class="nhsuk-body">
-  If you have any questions, please email us at
-  <a class="nhsuk-link" href="mailto:<%= t("service.email") %>">
-  <%= t("service.email") %></a>.
+  If you have any questions, please email us at <%= mail_to t("service.email") %>.
 </p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -3,11 +3,12 @@
 <p class="nhsuk-body">
   If you entered a web address, check it is correct.
 </p>
+
 <p class="nhsuk-body">
   If you pasted the web address, check you copied the entire address.
 </p>
+
 <p class="nhsuk-body">
   If the web address is correct and you need to speak to someone about this
-  problem, contact <a class="nhsuk-link" href="mailto:<%= t("service.email") %>">
-  <%= t("service.email") %></a>.
+  problem, contact <%= mail_to t("service.email") %>.
 </p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -4,6 +4,5 @@
 
 <p class="nhsuk-body">
   If you continue to see this error contact the <%= @service_name %>
-  team: <a class="nhsuk-link" href="mailto:<%= t("service.email") %>">
-  <%= t("service.email") %></a>.
+  team: <%= mail_to t("service.email") %>.
 </p>

--- a/app/views/parent_interface/consent_forms/deadline_passed.html.erb
+++ b/app/views/parent_interface/consent_forms/deadline_passed.html.erb
@@ -5,5 +5,5 @@
 <h2 class="nhsuk-heading-m">You can still book a clinic appointment</h2>
 
 <p class="govuk-body">
-  Contact <%= link_to @subteam.email, "mailto:#{@subteam.email}" %> to book a clinic appointment.
+  Contact <%= mail_to @subteam.email %> to book a clinic appointment.
 </p>


### PR DESCRIPTION
This simplifies some code related to generating links to emails, instead of using `link_to` and linking to `mailto:` href, we can instead use the `mail_to` helper.