### PR TITLE
Fix flaky PDS import test

### DIFF
--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -427,11 +427,14 @@ describe "Import child records" do
   end
 
   def and_i_upload_import_file(filename)
+    travel 1.minute
+
     click_button "Import records"
     choose "Child records"
     click_button "Continue"
     attach_file("cohort_import[csv]", "spec/fixtures/cohort_import/#{filename}")
     click_on "Continue"
+
     wait_for_import_to_complete(CohortImport)
   end
 
@@ -462,7 +465,8 @@ describe "Import child records" do
 
   def when_i_go_back_to_the_import_page
     visit "/imports"
-    click_link "1 September 2025 at 12:00pm", match: :first
+
+    click_on_most_recent_import(CohortImport)
   end
 
   def when_i_click_review_for(name)

--- a/spec/features/import_child_pds_lookup_extravaganza_spec.rb
+++ b/spec/features/import_child_pds_lookup_extravaganza_spec.rb
@@ -426,25 +426,6 @@ describe "Import child records" do
     end
   end
 
-  def when_i_visit_the_import_page
-    visit "/"
-    click_link "Import", match: :first
-  end
-
-  def when_i_go_back_to_the_import_page
-    visit "/imports"
-    click_link "1 September 2025 at 12:00pm"
-  end
-
-  def when_i_click_review_for(name)
-    within(
-      :xpath,
-      "//div[h3[contains(text(), 'records with import issues')]]"
-    ) do
-      within(:xpath, ".//tr[contains(., '#{name}')]") { click_link "Review" }
-    end
-  end
-
   def and_i_upload_import_file(filename)
     click_button "Import records"
     choose "Child records"
@@ -460,25 +441,9 @@ describe "Import child records" do
     click_on "Waterloo Road"
   end
 
-  def and_i_start_adding_children_to_the_session
-    click_on "Import class lists"
-  end
-
-  def and_i_select_the_year_groups
-    check "Year 8"
-    check "Year 9"
-    check "Year 10"
-    check "Year 11"
-    click_on "Continue"
-  end
-
   def then_i_should_see_the_import_failed
     expect(page).to have_content("Too many records could not be matched")
     expect(page).to have_content("11 unmatched records")
-  end
-
-  def then_i_should_see_the_import_page
-    expect(page).to have_content("Import class list")
   end
 
   def when_i_upload_a_valid_file
@@ -518,10 +483,6 @@ describe "Import child records" do
     check "Year 9"
     check "Year 10"
     click_on "Continue"
-  end
-
-  def then_i_should_see_the_import_page
-    expect(page).to have_content("Import class list")
   end
 
   def and_an_existing_patient_records_exist_in_school
@@ -761,27 +722,6 @@ describe "Import child records" do
     expect(import.patients.count).to eq(10)
   end
 
-  def when_i_click_on_patient_with_unknown_relationship
-    click_link "GREEN, Oliver"
-  end
-
-  def then_i_see_patient_with_unknown_relationship_details
-    expect(page).to have_content("GREEN, Oliver")
-    expect(page).to have_content("15 August 2010")
-  end
-
-  def and_oliver_has_unknown_relationship_parent
-    oliver = Patient.find_by(given_name: "Oliver", family_name: "Green")
-    expect(oliver.parents.count).to eq(1)
-
-    parent = oliver.parents.first
-    expect(parent.full_name).to eq("Jane Doe")
-    expect(parent.email).to be_blank
-
-    relationship = oliver.parent_relationships.first
-    expect(relationship.type).to eq("unknown")
-    expect(relationship.label).to eq("Unknown")
-  end
   def when_i_click_on_patient_with_unknown_relationship
     click_link "GREEN, Oliver"
   end

--- a/spec/features/import_child_records_spec.rb
+++ b/spec/features/import_child_records_spec.rb
@@ -338,7 +338,7 @@ describe "Import child records" do
   end
 
   def when_i_go_to_the_import_page
-    click_link CohortImport.last.created_at.to_fs(:long), match: :first
+    click_on_most_recent_import(CohortImport)
   end
 
   def and_i_import_child_records_from_children_tab

--- a/spec/support/imports_helper.rb
+++ b/spec/support/imports_helper.rb
@@ -14,6 +14,10 @@ module ImportsHelper
 
     perform_enqueued_jobs(only: CommitPatientChangesetsJob)
 
+    click_on_most_recent_import(import_class)
+  end
+
+  def click_on_most_recent_import(import_class)
     click_on import_class.order(:created_at).last.created_at.to_fs(:long),
              match: :first
   end


### PR DESCRIPTION
This fixes the test by using `travel 1.minute` to ensure that we're always clicking on the most recent import (currently the test creates two imports at the same time which results in them having the same link text).