### PR TITLE
Ensure already vaccinated patients don't receive clinic invitations

### DIFF
--- a/app/models/session_notification.rb
+++ b/app/models/session_notification.rb
@@ -102,7 +102,11 @@ class SessionNotification < ApplicationRecord
             )
           end
       else
-        session.programmes_for(patient:)
+        session
+          .programmes_for(patient:)
+          .reject do |programme|
+            patient.vaccination_status(programme:, academic_year:).vaccinated?
+          end
       end
 
     parents.each do |parent|


### PR DESCRIPTION
This fixes an issue where patients who are invited to a clinic, and are vaccinated for some of the programmes but not all of them, were receiving an email/text for all the programmes they're eligible for rather than just the programmes they are eligible for and need a vaccination for.

[Jira Issue - MAV-1994](https://nhsd-jira.digital.nhs.uk/browse/MAV-1994)