### PR TITLE
Handle merging patients with PSDs

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -43,6 +43,10 @@ class PatientMerger
         patient_id: patient_to_keep.id
       )
 
+      patient_to_destroy.patient_specific_directions.update_all(
+        patient_id: patient_to_keep.id
+      )
+
       patient_to_destroy.pds_search_results.update_all(
         patient_id: patient_to_keep.id
       )

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -61,6 +61,13 @@ describe PatientMerger do
     let(:patient_session) do
       create(:patient_session, session:, patient: patient_to_destroy)
     end
+    let(:patient_specific_direction) do
+      create(
+        :patient_specific_direction,
+        programme:,
+        patient: patient_to_destroy
+      )
+    end
     let(:pre_screening) { create(:pre_screening, patient: patient_to_destroy) }
     let(:school_move) do
       create(:school_move, :to_school, patient: patient_to_destroy)
@@ -158,6 +165,12 @@ describe PatientMerger do
       expect { call }.to change { patient_session.reload.patient }.to(
         patient_to_keep
       )
+    end
+
+    it "moves patient specific directions" do
+      expect { call }.to change {
+        patient_specific_direction.reload.patient
+      }.to(patient_to_keep)
     end
 
     it "moves pre-screenings" do


### PR DESCRIPTION
This ensures that when merging two patients together, if the one to be destroyed has a PSD, this is moved across to the other patient rather than preventing the merge from happening due to a foreign key constraint.

[Sentry Issue](https://good-machine.sentry.io/issues/6859186837/?environment=production&project=4505625073876992&query=is%3Aunresolved&referrer=issue-stream)