### PR TITLE
Ensure flu search is done before consents go out

### DIFF
--- a/app/jobs/enqueue_vaccinations_search_in_nhs_job.rb
+++ b/app/jobs/enqueue_vaccinations_search_in_nhs_job.rb
@@ -12,7 +12,7 @@ class EnqueueVaccinationsSearchInNHSJob < ApplicationJob
         Session
           .includes(:session_dates)
           .has_programmes([flu])
-          .where("sessions.send_invitations_at <= ?", 2.days.from_now)
+          .where("sessions.send_consent_requests_at <= ?", 2.days.from_now)
           .where("session_dates.value >= ?", Time.zone.today)
           .references(:session_dates)
       end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,6 +15,10 @@
       cron: "0 9 * * *"
       class: EnqueueClinicSessionInvitationsJob
       description: Send school clinic invitation emails to parents
+    enqueue_vaccinations_search_in_nhs_job:
+      cron: "19 13 * * *"
+      class: EnqueueVaccinationsSearchInNHSJob
+      description: Find upcoming sessions and enqueue jobs to find vaccinations for patients in them
     invalidate_self_consents:
       cron: "0 2 * * *"
       class: InvalidateSelfConsentsJob

--- a/spec/jobs/enqueue_vaccinations_search_in_nhs_job_spec.rb
+++ b/spec/jobs/enqueue_vaccinations_search_in_nhs_job_spec.rb
@@ -14,23 +14,26 @@ describe EnqueueVaccinationsSearchInNHSJob do
 
     before { allow(SearchVaccinationRecordsInNHSJob).to receive(:perform_bulk) }
 
-    let(:send_invitations_at) {}
+    let(:send_consent_requests_at) {}
+    let(:days_before_consent_reminders) { 7 }
     let!(:session) do
       create(
         :session,
         programmes: [flu],
         academic_year: AcademicYear.pending,
         dates:,
-        send_invitations_at:,
+        send_consent_requests_at:,
+        days_before_consent_reminders:,
         team:,
         location:
       )
     end
 
-    context "with a specific session" do
+    context "with an specific, unscheduled session" do
       before { described_class.perform_now([session]) }
 
       let(:dates) { [] }
+      let(:days_before_consent_reminders) { nil }
 
       it { should have_received(:perform_bulk).once.with([[patient.id]]) }
     end
@@ -39,7 +42,7 @@ describe EnqueueVaccinationsSearchInNHSJob do
       before { described_class.perform_now }
 
       let(:dates) { [7.days.from_now] }
-      let(:send_invitations_at) { 14.days.ago }
+      let(:send_consent_requests_at) { 14.days.ago }
 
       it { should have_received(:perform_bulk).once.with([[patient.id]]) }
 
@@ -58,6 +61,7 @@ describe EnqueueVaccinationsSearchInNHSJob do
       before { described_class.perform_now }
 
       let(:dates) { [7.days.ago] }
+      let(:send_consent_requests_at) { 30.days.ago }
 
       it { should_not have_received(:perform_bulk) }
     end
@@ -68,7 +72,7 @@ describe EnqueueVaccinationsSearchInNHSJob do
             } do
       before { described_class.perform_now }
 
-      let(:send_invitations_at) { 28.days.ago }
+      let(:send_consent_requests_at) { 28.days.ago }
       let(:dates) { [7.days.ago, 7.days.from_now] }
 
       it { should have_received(:perform_bulk).exactly(:once) }
@@ -77,14 +81,14 @@ describe EnqueueVaccinationsSearchInNHSJob do
     context "session with send_invitations_at in the future" do
       before { described_class.perform_now }
 
-      let(:send_invitations_at) { 2.days.from_now }
+      let(:send_consent_requests_at) { 2.days.from_now }
       let(:dates) { [17.days.from_now] }
 
       it { should have_received(:perform_bulk).exactly(:once) }
     end
 
-    context "session with send_invitations_at too far in the future" do
-      let(:send_invitations_at) { 3.days.from_now }
+    context "session with send_consent_requests_at too far in the future" do
+      let(:send_consent_requests_at) { 3.days.from_now }
       let(:dates) { [17.days.from_now] }
 
       it { should_not have_received(:perform_bulk) }


### PR DESCRIPTION
This PR:
* reverts #4630 
* fixes a bug in #4612 which prevented `EnqueueVaccinationsSearchInNHSJob` from running at the right time