### PR TITLE
Create clinic sessions per programme

### DIFF
--- a/app/lib/location_sessions_factory.rb
+++ b/app/lib/location_sessions_factory.rb
@@ -8,15 +8,11 @@ class LocationSessionsFactory
 
   def call
     ActiveRecord::Base.transaction do
-      if location.generic_clinic?
-        find_or_create_session!(programmes: location.programmes)
-      else
-        ProgrammeGrouper
-          .call(location.programmes)
-          .values
-          .reject { |programmes| already_exists?(programmes:) }
-          .map { |programmes| create_session!(programmes:) }
-      end
+      ProgrammeGrouper
+        .call(location.programmes)
+        .values
+        .reject { |programmes| already_exists?(programmes:) }
+        .map { |programmes| create_session!(programmes:) }
 
       add_patients!
     end
@@ -38,20 +34,6 @@ class LocationSessionsFactory
 
   def create_session!(programmes:)
     team.sessions.create!(academic_year:, location:, programmes:)
-  end
-
-  def find_or_create_session!(programmes:)
-    team
-      .sessions
-      .create_with(programmes:)
-      .find_or_create_by!(academic_year:, location:)
-      .tap do |session|
-        programmes.each do |programme|
-          unless programme.in?(session.programmes)
-            session.programmes << programme
-          end
-        end
-      end
   end
 
   def add_patients!

--- a/spec/lib/location_sessions_factory_spec.rb
+++ b/spec/lib/location_sessions_factory_spec.rb
@@ -182,11 +182,17 @@ describe LocationSessionsFactory do
         let!(:location) { create(:generic_clinic, team:) }
 
         it "creates missing sessions for each programme group" do
-          expect { call }.to change(team.sessions, :count).by(1)
+          expect { call }.to change(team.sessions, :count).by(3)
 
           session =
-            team.sessions.includes(:location, :programmes).find_by(location:)
-          expect(session.programmes).to match_array(programmes)
+            team
+              .sessions
+              .order(:created_at)
+              .where(location:)
+              .includes(:programmes)
+          expect(session.first.programmes).to eq(flu_programmes)
+          expect(session.second.programmes).to eq(hpv_programmes)
+          expect(session.third.programmes).to eq(doubles_programmes)
         end
       end
 


### PR DESCRIPTION
This builds on top of the refactoring work done in https://github.com/nhsuk/manage-vaccinations-in-schools/pull/4526 which unlocked the ability for clinic sessions to work in a similar way to school sessions where there exists a session per group of programmes (HPV, Flu, and Doubles).

This is more of a proof of concept for now, we don't know operationally whether teams are more likely to use clinics per programme, or clinics for all the programmes ("make every contact count").