### PR TITLE
Ensure `NotifyLogEntry` is deleted in testing

### DIFF
--- a/app/controllers/api/testing/teams_controller.rb
+++ b/app/controllers/api/testing/teams_controller.rb
@@ -26,6 +26,7 @@ class API::Testing::TeamsController < API::Testing::BaseController
         log_destroy(VaccinationRecord.where(session: sessions))
 
         patient_ids = team.patients.pluck(:id)
+        consent_form_ids = team.consent_forms.pluck(:id)
 
         log_destroy(PatientSession.where(session: sessions))
 
@@ -38,6 +39,7 @@ class API::Testing::TeamsController < API::Testing::BaseController
         # In local dev we can end up with NotifyLogEntries without a patient
         log_destroy(NotifyLogEntry.where(patient_id: nil))
         log_destroy(NotifyLogEntry.where(patient_id: patient_ids))
+        log_destroy(NotifyLogEntry.where(consent_form_id: consent_form_ids))
         log_destroy(PatientChangeset.where(patient_id: patient_ids))
         log_destroy(PatientSession.where(patient_id: patient_ids))
         log_destroy(PatientSpecificDirection.where(patient_id: patient_ids))
@@ -48,10 +50,10 @@ class API::Testing::TeamsController < API::Testing::BaseController
         log_destroy(SchoolMoveLogEntry.where(patient_id: patient_ids))
         log_destroy(VaccinationRecord.where(patient_id: patient_ids))
 
+        log_destroy(ConsentForm.where(id: consent_form_ids))
         log_destroy(SessionDate.where(session: sessions))
 
         log_destroy(ArchiveReason.where(team:))
-        log_destroy(ConsentForm.where(team:))
         log_destroy(Consent.where(team:))
         log_destroy(Triage.where(team:))
 


### PR DESCRIPTION
This makes a small change to the endpoint to delete teams using the testing API to ensure any notify log entries attached to the team's consent forms get deleted.