### PR TITLE
Add `data_migrations:fix_vaccination_records_location`

### DIFF
--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :data_migrations do
+  desc "Fix vaccination record locations where both location_id and location_name is set"
+  task fix_vaccination_record_locations: :environment do
+    vaccination_records =
+      VaccinationRecord
+        .where.not(location_id: nil)
+        .where.not(location_name: nil)
+
+    puts "#{vaccination_records.count} vaccination records need fixing"
+
+    vaccination_records.update_all(location_id: nil)
+  end
+end


### PR DESCRIPTION
This fixes an issue where some vaccination records are currently invalid as they have both a `location_id` and a `location_name`.

[Jira Issue - MAV-2016](https://nhsd-jira.digital.nhs.uk/browse/MAV-2016)