### PR TITLE
Use `EXISTS` instead of `IN`

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,10 +18,9 @@ class SessionsController < ApplicationController
 
     @patient_count_by_session_id =
       PatientLocation
-        .joins_sessions
-        .where("sessions.id IN (?)", sessions.pluck(:id))
         .joins(:patient)
         .appear_in_programmes(@programmes)
+        .where("sessions.id IN (?)", sessions.pluck(:id))
         .group("sessions.id")
         .count
 

--- a/app/models/patient_location.rb
+++ b/app/models/patient_location.rb
@@ -80,17 +80,10 @@ class PatientLocation < ApplicationRecord
 
   scope :appear_in_programmes,
         ->(programmes) do
-          where(
-            id:
-              joins_session_programmes
-                .joins_location_programme_year_groups
-                .where(
-                  session_programmes: {
-                    programme_id: programmes.map(&:id)
-                  }
-                )
-                .select("patient_locations.id")
-          )
+          joins_sessions
+            .joins_session_programmes
+            .joins_location_programme_year_groups
+            .where(session_programmes: { programme_id: programmes.map(&:id) })
         end
 
   scope :destroy_all_if_safe,


### PR DESCRIPTION
This should have an improvement on performance, avoiding the need to compare the entire result set. Due to the size of the set, it's unlikely to be able to use a hash and instead performs a sequential scan.

[Jira Issue - MAV-2004](https://nhsd-jira.digital.nhs.uk/browse/MAV-2004)