### PR TITLE
Disallow offline spreadsheets from editing records received from the Imms API

### DIFF
--- a/app/forms/import_duplicate_form.rb
+++ b/app/forms/import_duplicate_form.rb
@@ -35,10 +35,23 @@ class ImportDuplicateForm
   end
 
   def apply_changes_options
-    can_keep_both? ? %w[apply discard keep_both] : %w[apply discard]
+    if can_apply?
+      can_keep_both? ? %w[apply discard keep_both] : %w[apply discard]
+    else
+      %w[discard]
+    end
+  end
+
+  def can_apply?
+    !(
+      object.is_a?(VaccinationRecord) &&
+        object.sourced_from_nhs_immunisations_api?
+    )
   end
 
   def apply_pending_changes!
+    return unless can_apply?
+
     object.patient.apply_pending_changes! if object.respond_to?(:patient)
 
     object.apply_pending_changes!
@@ -51,7 +64,7 @@ class ImportDuplicateForm
   end
 
   def keep_both_changes!
-    object.apply_pending_changes_to_new_record! if can_keep_both?
+    object.apply_pending_changes_to_new_record! if can_keep_both? && can_apply?
   end
 
   def reset_count!

--- a/app/lib/reports/offline_session_exporter.rb
+++ b/app/lib/reports/offline_session_exporter.rb
@@ -263,7 +263,6 @@ class Reports::OfflineSessionExporter
       patient_specific_directions.dig(patient.id, programme.id)
     triage = triages.dig(patient.id, programme.id)
 
-    row[:organisation_code] = organisation.ods_code
     row[:person_forename] = patient.given_name
     row[:person_surname] = patient.family_name
     row[:person_dob] = patient.date_of_birth
@@ -310,6 +309,8 @@ class Reports::OfflineSessionExporter
     session = vaccination_record.session
     vaccine = vaccination_record.vaccine
     location = session&.location
+
+    row[:organisation_code] = vaccination_record.performed_ods_code
 
     row[:vaccinated] = Cell.new(
       vaccinated(vaccination_record:),
@@ -371,6 +372,8 @@ class Reports::OfflineSessionExporter
   end
 
   def add_new_row_cells(row, patient:, programme:)
+    row[:organisation_code] = organisation.ods_code
+
     row[:vaccinated] = Cell.new(allowed_values: %w[Y N])
     row[:date_of_vaccination] = Cell.new(type: :date)
     row[:school_name] = school_name(location:, patient:)

--- a/app/models/concerns/pending_changes_concern.rb
+++ b/app/models/concerns/pending_changes_concern.rb
@@ -55,6 +55,12 @@ module PendingChangesConcern
   private
 
   def normalised(value)
-    value.respond_to?(:downcase) ? value.downcase : value
+    if value.respond_to?(:downcase)
+      value.downcase
+    elsif value.is_a?(Time)
+      value.round
+    else
+      value
+    end
   end
 end

--- a/app/models/immunisation_import_row.rb
+++ b/app/models/immunisation_import_row.rb
@@ -95,7 +95,12 @@ class ImmunisationImportRow
     return unless valid?
 
     outcome = (administered ? "administered" : reason_not_administered_value)
-    source = (offline_recording? ? "service" : "historical_upload")
+    source =
+      if imms_api_record?
+        "nhs_immunisations_api"
+      else
+        offline_recording? ? "service" : "historical_upload"
+      end
 
     attributes = {
       dose_sequence: dose_sequence_value,
@@ -135,8 +140,7 @@ class ImmunisationImportRow
     vaccination_record =
       if uuid.present?
         VaccinationRecord
-          .joins(:team)
-          .find_by!(teams: { id: team.id }, uuid: uuid.to_s)
+          .find_by!(uuid: uuid.to_s)
           .tap { it.stage_changes(attributes) }
       else
         VaccinationRecord.find_or_initialize_by(attributes)
@@ -379,6 +383,13 @@ class ImmunisationImportRow
   delegate :default_dose_sequence, :maximum_dose_sequence, to: :programme
 
   def offline_recording? = session_id.present?
+
+  def imms_api_record?
+    uuid.present? &&
+      VaccinationRecord.find_by!(
+        uuid: uuid.to_s
+      ).sourced_from_nhs_immunisations_api?
+  end
 
   def academic_year = date_of_vaccination.to_date.academic_year
 
@@ -928,7 +939,15 @@ class ImmunisationImportRow
 
   def validate_session_id
     if session_id.present?
-      if session_id.to_i.nil?
+      if uuid.present? &&
+           VaccinationRecord.sourced_from_nhs_immunisations_api.exists?(
+             uuid: uuid.to_s
+           )
+        errors.add(
+          session_id.header,
+          "A session ID cannot be provided for this record; this record was sourced from an external source."
+        )
+      elsif session_id.to_i.nil?
         errors.add(
           session_id.header,
           "The session ID is not recognised. Download the offline spreadsheet " \
@@ -970,15 +989,16 @@ class ImmunisationImportRow
   def validate_uuid
     return if uuid.blank?
 
+    scope = VaccinationRecord.left_outer_joins(:session).where(uuid: uuid.to_s)
+
     scope =
-      VaccinationRecord.joins(:team).where(
-        teams: {
-          id: team.id
-        },
-        uuid: uuid.to_s
+      scope.where(sessions: { team: }).or(
+        scope.sourced_from_nhs_immunisations_api
       )
 
-    errors.add(uuid.header, "Enter an existing record.") unless scope.exists?
+    return if scope.exists?
+
+    errors.add(uuid.header, "Enter an existing record.")
   end
 
   def validate_vaccine

--- a/app/views/imports/issues/show.html.erb
+++ b/app/views/imports/issues/show.html.erb
@@ -43,17 +43,27 @@
       model: @form,
       url: imports_issue_path(@record, type: params[:type]),
       method: :patch,
-      class: "nhsuk-u-width-one-half",
+      class: "nhsuk-u-full-width",
     ) do |f| %>
-  <% content_for(:before_content) { f.govuk_error_summary } %>
+  <% if !@form.can_apply? %>
 
-  <%= f.govuk_collection_radio_buttons :apply_changes,
-                                       @form.apply_changes_options,
-                                       :itself,
-                                       ->(option) { I18n.t(option, scope: "import_duplicate_form.options.label.#{@existing_or_deleted}", type: @type) },
-                                       ->(option) { I18n.t(option, scope: "import_duplicate_form.options.hint.#{@existing_or_deleted}") },
-                                       bold_labels: false,
-                                       small: true %>
+    <h1 class="nhsuk-heading-m">You cannot keep the incoming changes</h1>
 
-  <%= f.govuk_submit "Resolve duplicate" %>
+    <p>The existing record was imported automatically from an external source, such as a GP practice, meaning that Mavis is not the primary source for this vaccination record.</p>
+
+    <%= f.hidden_field :apply_changes, value: "discard" %>
+    <%= f.govuk_submit "Discard incoming changes" %>
+  <% else %>
+    <% content_for(:before_content) { f.govuk_error_summary } %>
+
+    <%= f.govuk_collection_radio_buttons :apply_changes,
+                                         @form.apply_changes_options,
+                                         :itself,
+                                         ->(option) { I18n.t(option, scope: "import_duplicate_form.options.label.#{@existing_or_deleted}", type: @type) },
+                                         ->(option) { I18n.t(option, scope: "import_duplicate_form.options.hint.#{@existing_or_deleted}") },
+                                         bold_labels: false,
+                                         small: true %>
+
+    <%= f.govuk_submit "Resolve duplicate" %>
+  <% end %>
 <% end %>

--- a/spec/features/hpv_vaccination_offline_spec.rb
+++ b/spec/features/hpv_vaccination_offline_spec.rb
@@ -66,6 +66,42 @@ describe "HPV vaccination" do
     and_the_vaccination_record_is_deleted_from_nhs
   end
 
+  scenario "User tries to edit vaccination record sourced from NHS immunisations API in offline workflow" do
+    given_a_flu_programme_is_underway_with_a_single_patient
+    and_the_patients_record_is_sourced_from_nhs_api
+
+    when_i_choose_to_record_offline_from_a_school_session_page
+    and_alter_an_existing_vaccination_record_to_create_a_duplicate
+    and_i_upload_the_modified_csv_file
+    then_i_see_a_duplicate_record_needs_review
+
+    when_i_review_the_duplicate_record
+    then_i_should_see_the_nhs_api_restriction_message
+    and_i_should_only_see_discard_option
+    and_i_should_not_see_radio_buttons
+
+    when_i_discard_the_incoming_changes
+    then_i_should_see_a_success_message
+    and_the_nhs_api_record_should_remain_unchanged
+
+    when_i_go_to_the_import_page
+    then_i_should_see_no_import_issues_with_the_count
+  end
+
+  scenario "User can upload un-edited vaccination records sourced from NHS immunisations API in offline workflow" do
+    given_a_flu_programme_is_underway_with_a_single_patient
+    and_the_patients_record_is_sourced_from_nhs_api
+
+    when_i_choose_to_record_offline_from_a_school_session_page
+    and_i_save_the_csv_file
+    and_i_upload_the_modified_csv_file
+    then_i_see_that_no_records_need_review
+    and_the_nhs_api_record_should_remain_unchanged
+
+    when_i_go_to_the_import_page
+    then_i_should_see_no_import_issues_with_the_count
+  end
+
   def given_an_hpv_programme_is_underway(clinic: false)
     programmes = [create(:programme, :hpv)]
 
@@ -180,6 +216,38 @@ describe "HPV vaccination" do
     )
   end
 
+  def given_a_flu_programme_is_underway_with_a_single_patient
+    programmes = [create(:programme, :flu)]
+
+    @team = create(:team, :with_one_nurse, :with_generic_clinic, programmes:)
+    school = create(:school, team: @team)
+    previous_date = 1.month.ago
+
+    vaccine = programmes.first.vaccines.active.first
+    @batch = create(:batch, :not_expired, team: @team, vaccine:)
+
+    @session =
+      create(:session, :today, team: @team, programmes:, location: school)
+
+    @session.session_dates.create!(value: previous_date)
+
+    @previously_vaccinated_patient =
+      create(:patient, session: @session, school:, year_group: 8)
+  end
+
+  def and_the_patients_record_is_sourced_from_nhs_api
+    fhir_record =
+      FHIR.from_contents(file_fixture("fhir/fhir_record_full.json").read)
+    @nhs_api_vaccination_record =
+      FHIRMapper::VaccinationRecord.from_fhir_record(
+        fhir_record,
+        patient: @previously_vaccinated_patient
+      )
+    @nhs_api_vaccination_record.performed_at = 1.month.ago
+    @nhs_api_vaccination_record.notes = "Imported from NHS API"
+    @nhs_api_vaccination_record.save!
+  end
+
   def and_imms_api_sync_job_feature_is_enabled
     Flipper.enable(:imms_api_sync_job)
     Flipper.enable(:imms_api_integration)
@@ -189,6 +257,65 @@ describe "HPV vaccination" do
     @stubbed_put_request = stub_immunisations_api_put(uuid: immunisation_uuid)
     @stubbed_delete_request =
       stub_immunisations_api_delete(uuid: immunisation_uuid)
+  end
+
+  def and_i_upload_a_file_with_duplicate_nhs_api_records
+    visit "/"
+    click_on "Import", match: :first
+    click_on "Import records"
+    choose "Vaccination records"
+    click_on "Continue"
+
+    attach_file(
+      "immunisation_import[csv]",
+      "spec/fixtures/immunisation_import/valid_hpv_offline_spreadsheet.csv"
+    )
+    click_on "Continue"
+    wait_for_import_to_complete(ImmunisationImport)
+  end
+
+  def when_i_review_the_nhs_api_duplicate_record
+    click_link "Review"
+  end
+
+  def then_i_should_see_the_nhs_api_restriction_message
+    expect(page).to have_content("You cannot keep the incoming changes")
+    expect(page).to have_content(
+      "The existing record was imported automatically from an external source, such as a GP practice, meaning that " \
+        "Mavis is not the primary source for this vaccination record."
+    )
+  end
+
+  def and_i_should_only_see_discard_option
+    expect(page).to have_button("Discard incoming changes")
+  end
+
+  def and_i_should_not_see_radio_buttons
+    expect(page).not_to have_content("Apply the uploaded changes")
+    expect(page).not_to have_content("Keep the existing record")
+    expect(page).not_to have_selector("input[type='radio']")
+  end
+
+  def when_i_discard_the_incoming_changes
+    click_button "Discard incoming changes"
+  end
+
+  def and_the_nhs_api_record_should_remain_unchanged
+    @nhs_api_vaccination_record.reload
+    expect(@nhs_api_vaccination_record.notes).to eq("Imported from NHS API")
+    expect(@nhs_api_vaccination_record.source).to eq("nhs_immunisations_api")
+    expect(@nhs_api_vaccination_record.outcome).to eq("administered")
+    expect(@nhs_api_vaccination_record.delivery_site).to eq(
+      "left_arm_upper_position"
+    )
+  end
+
+  def when_i_go_to_the_import_page
+    click_link "Import", match: :first
+  end
+
+  def then_i_should_see_no_import_issues_with_the_count
+    expect(page).to have_content("Import issues (0)")
   end
 
   def when_i_choose_to_record_offline_from_a_school_session_page
@@ -231,6 +358,24 @@ describe "HPV vaccination" do
     # Change details for the vaccination record
     row_for_vaccinated_patient["DOSE_SEQUENCE"] = "2"
     row_for_vaccinated_patient["ANATOMICAL_SITE"] = "Right Upper Arm"
+
+    File.write("tmp/modified.csv", csv_table.to_csv)
+  end
+
+  def and_i_save_the_csv_file
+    expect(page.status_code).to eq(200)
+
+    @workbook = RubyXL::Parser.parse_buffer(page.body)
+    @sheet = @workbook["Vaccinations"]
+    @headers = @sheet[0].cells.map(&:value)
+
+    array = @workbook[0].to_a[1..].map(&:cells).map { it.map(&:value) }
+    csv_table =
+      CSV::Table.new(
+        array.map do |row|
+          CSV::Row.new(@headers, row.map { |cell| excel_cell_to_csv(cell) })
+        end
+      )
 
     File.write("tmp/modified.csv", csv_table.to_csv)
   end
@@ -477,6 +622,10 @@ describe "HPV vaccination" do
     expect(page).to have_content(
       "1 record has import issues to resolve before it can be imported into Mavis"
     )
+  end
+
+  def then_i_see_that_no_records_need_review
+    expect(page).not_to have_content("has import issues")
   end
 
   def then_i_should_see_a_success_message

--- a/spec/features/vaccination_offline_spec.rb
+++ b/spec/features/vaccination_offline_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe "HPV vaccination" do
+describe "offline vaccination" do
   around do |example|
     travel_to(Time.zone.local(2024, 2, 1, 12)) { example.run }
   end

--- a/spec/forms/import_duplicate_form_spec.rb
+++ b/spec/forms/import_duplicate_form_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+describe ImportDuplicateForm do
+  let(:programme) { create(:programme) }
+
+  describe "#can_apply?" do
+    subject { form.can_apply? }
+
+    let(:form) { described_class.new(object:) }
+
+    context "with vaccination records sourced from NHS immunisations API" do
+      let(:object) do
+        create(:vaccination_record, programme:, source: :nhs_immunisations_api)
+      end
+
+      it { should be false }
+    end
+
+    context "with vaccination records not sourced from NHS immunisations API" do
+      let(:session) { create(:session, programmes: [programme]) }
+      let(:object) do
+        create(:vaccination_record, programme:, source: :service, session:)
+      end
+
+      it { should be true }
+    end
+
+    context "with non-vaccination record objects" do
+      let(:object) { create(:patient) }
+
+      it { should be true }
+    end
+  end
+
+  describe "validation" do
+    subject { form.valid? }
+
+    let(:form) { described_class.new(apply_changes:) }
+
+    before do
+      allow(form).to receive(:apply_changes_options).and_return(
+        apply_changes_options
+      )
+    end
+
+    context "when apply_changes is one of the options" do
+      let(:apply_changes) { "apply" }
+      let(:apply_changes_options) { %w[apply discard keep_both] }
+
+      it { should be true }
+    end
+
+    context "when apply_changes is not one of the options" do
+      let(:apply_changes) { "apply" }
+      let(:apply_changes_options) { %w[discard keep_both] }
+
+      it { should be false }
+    end
+  end
+
+  describe "#apply_changes_options" do
+    let(:form) { described_class.new(object:) }
+
+    context "when object is a vaccination record" do
+      let(:object) do
+        create(:vaccination_record, programme:, source: :historical_upload)
+      end
+
+      before { allow(form).to receive(:can_keep_both?).and_return(false) }
+
+      it "returns reduced options" do
+        expect(form.apply_changes_options).to eq(%w[apply discard])
+      end
+    end
+
+    context "when object is a patient record" do
+      let(:object) { create(:patient) }
+
+      before { allow(form).to receive(:can_keep_both?).and_return(true) }
+
+      it "returns the standard options" do
+        expect(form.apply_changes_options).to eq(%w[apply discard keep_both])
+      end
+    end
+
+    context "when object is a vaccination record sourced from NHS immunisations API" do
+      let(:object) do
+        create(:vaccination_record, programme:, source: :nhs_immunisations_api)
+      end
+
+      it "returns the standard options" do
+        expect(form.apply_changes_options).to eq(%w[discard])
+      end
+    end
+  end
+end

--- a/spec/models/immunisation_import_row_spec.rb
+++ b/spec/models/immunisation_import_row_spec.rb
@@ -794,6 +794,37 @@ describe ImmunisationImportRow do
       end
     end
 
+    context "vaccination in a session, but UUID matches a record sourced from NHS immunisations API" do
+      let(:data) do
+        {
+          "VACCINATED" => "Y",
+          "PROGRAMME" => "Flu",
+          "SESSION_ID" => 1,
+          "DATE_OF_VACCINATION" => "#{AcademicYear.current}0901",
+          "UUID" => "12345678-1234-1234-1234-123456789abc"
+        }
+      end
+
+      before do
+        create(
+          :vaccination_record,
+          programme: create(:programme, :flu),
+          uuid: "12345678-1234-1234-1234-123456789abc",
+          source: :nhs_immunisations_api
+        )
+      end
+
+      it "has errors" do
+        expect(immunisation_import_row).to be_invalid
+        expect(immunisation_import_row.errors["SESSION_ID"]).to eq(
+          [
+            "A session ID cannot be provided for this record; " \
+              "this record was sourced from an external source."
+          ]
+        )
+      end
+    end
+
     context "with valid fields for Flu" do
       let(:programmes) { [create(:programme, :flu)] }
 


### PR DESCRIPTION
Vaccination records which are received from the Imms API are considered
immutable in Mavis, because we are not the vaccination record's primary
source. As such, users should not be allowed to edit the records by any
means, including an offline spreadsheet upload.

We (Thomas, Mike, Alistair) considered exposing this as a validation
error on the import, but that approach was discarded. This is because we
would have needed to duplicate a lot of the import logic to decide
whether it was appropriate to throw a validation error. This led to
circular dependencies in the validation logic.

Instead this approach was taken, where an adjusted import issue page is
shown, forcing the user to discard the incoming changes.

Off the back of this change, another issue needed to be resolved;
unedited vaccination records from the API were being flagged for review.
This required a bit of a rewrite of the import logic, as well as the offline
spreadsheet logic.

[MAV-1781](https://nhsd-jira.digital.nhs.uk/browse/MAV-1781)

<img width="1129" height="1312" alt="image" src="https://github.com/user-attachments/assets/80ce0d29-6eb8-4386-ab9d-c79825f1f8f6" />
