### PR TITLE
Improve performance of team reset endpoint

### DIFF
--- a/app/models/class_imports_parent.rb
+++ b/app/models/class_imports_parent.rb
@@ -13,8 +13,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (class_import_id => class_imports.id)
-#  fk_rails_...  (parent_id => parents.id)
+#  fk_rails_...  (class_import_id => class_imports.id) ON DELETE => cascade
+#  fk_rails_...  (parent_id => parents.id) ON DELETE => cascade
 #
 class ClassImportsParent < ApplicationRecord
   belongs_to :class_import

--- a/app/models/class_imports_parent_relationship.rb
+++ b/app/models/class_imports_parent_relationship.rb
@@ -13,8 +13,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (class_import_id => class_imports.id)
-#  fk_rails_...  (parent_relationship_id => parent_relationships.id)
+#  fk_rails_...  (class_import_id => class_imports.id) ON DELETE => cascade
+#  fk_rails_...  (parent_relationship_id => parent_relationships.id) ON DELETE => cascade
 #
 class ClassImportsParentRelationship < ApplicationRecord
   belongs_to :class_import

--- a/app/models/class_imports_patient.rb
+++ b/app/models/class_imports_patient.rb
@@ -13,8 +13,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (class_import_id => class_imports.id)
-#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (class_import_id => class_imports.id) ON DELETE => cascade
+#  fk_rails_...  (patient_id => patients.id) ON DELETE => cascade
 #
 class ClassImportsPatient < ApplicationRecord
   belongs_to :class_import

--- a/app/models/cohort_imports_parent.rb
+++ b/app/models/cohort_imports_parent.rb
@@ -13,8 +13,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (cohort_import_id => cohort_imports.id)
-#  fk_rails_...  (parent_id => parents.id)
+#  fk_rails_...  (cohort_import_id => cohort_imports.id) ON DELETE => cascade
+#  fk_rails_...  (parent_id => parents.id) ON DELETE => cascade
 #
 class CohortImportsParent < ApplicationRecord
   belongs_to :cohort_import

--- a/app/models/cohort_imports_parent_relationship.rb
+++ b/app/models/cohort_imports_parent_relationship.rb
@@ -13,8 +13,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (cohort_import_id => cohort_imports.id)
-#  fk_rails_...  (parent_relationship_id => parent_relationships.id)
+#  fk_rails_...  (cohort_import_id => cohort_imports.id) ON DELETE => cascade
+#  fk_rails_...  (parent_relationship_id => parent_relationships.id) ON DELETE => cascade
 #
 class CohortImportsParentRelationship < ApplicationRecord
   belongs_to :cohort_import

--- a/app/models/cohort_imports_patient.rb
+++ b/app/models/cohort_imports_patient.rb
@@ -13,8 +13,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (cohort_import_id => cohort_imports.id)
-#  fk_rails_...  (patient_id => patients.id)
+#  fk_rails_...  (cohort_import_id => cohort_imports.id) ON DELETE => cascade
+#  fk_rails_...  (patient_id => patients.id) ON DELETE => cascade
 #
 class CohortImportsPatient < ApplicationRecord
   belongs_to :cohort_import

--- a/app/models/consent_form_programme.rb
+++ b/app/models/consent_form_programme.rb
@@ -17,8 +17,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (consent_form_id => consent_forms.id)
-#  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (consent_form_id => consent_forms.id) ON DELETE => cascade
+#  fk_rails_...  (programme_id => programmes.id) ON DELETE => cascade
 #
 class ConsentFormProgramme < ApplicationRecord
   include HasVaccineMethods

--- a/db/migrate/20250918075325_add_foreign_key_cascade_to_join_tables.rb
+++ b/db/migrate/20250918075325_add_foreign_key_cascade_to_join_tables.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AddForeignKeyCascadeToJoinTables < ActiveRecord::Migration[8.0]
+  FOREIGN_KEYS = [
+    %w[batches_immunisation_imports batches],
+    %w[batches_immunisation_imports immunisation_imports],
+    %w[class_imports_parent_relationships class_imports],
+    %w[class_imports_parent_relationships parent_relationships],
+    %w[class_imports_parents class_imports],
+    %w[class_imports_parents parents],
+    %w[class_imports_patients class_imports],
+    %w[class_imports_patients patients],
+    %w[cohort_imports_parent_relationships cohort_imports],
+    %w[cohort_imports_parent_relationships parent_relationships],
+    %w[cohort_imports_parents cohort_imports],
+    %w[cohort_imports_parents parents],
+    %w[cohort_imports_patients cohort_imports],
+    %w[cohort_imports_patients patients],
+    %w[consent_form_programmes consent_forms],
+    %w[consent_form_programmes programmes],
+    %w[immunisation_imports_patient_locations immunisation_imports],
+    %w[immunisation_imports_patient_locations patient_locations],
+    %w[immunisation_imports_patients immunisation_imports],
+    %w[immunisation_imports_patients patients],
+    %w[immunisation_imports_sessions immunisation_imports],
+    %w[immunisation_imports_sessions sessions],
+    %w[immunisation_imports_vaccination_records immunisation_imports],
+    %w[immunisation_imports_vaccination_records vaccination_records]
+  ].freeze
+
+  def change
+    FOREIGN_KEYS.each do |foreign_key|
+      remove_foreign_key foreign_key.first, foreign_key.last
+      add_foreign_key foreign_key.first, foreign_key.last, on_delete: :cascade
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -971,27 +971,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_122640) do
   add_foreign_key "attendance_records", "patients"
   add_foreign_key "batches", "teams"
   add_foreign_key "batches", "vaccines"
-  add_foreign_key "batches_immunisation_imports", "batches"
-  add_foreign_key "batches_immunisation_imports", "immunisation_imports"
+  add_foreign_key "batches_immunisation_imports", "batches", on_delete: :cascade
+  add_foreign_key "batches_immunisation_imports", "immunisation_imports", on_delete: :cascade
   add_foreign_key "class_imports", "locations"
   add_foreign_key "class_imports", "teams"
   add_foreign_key "class_imports", "users", column: "uploaded_by_user_id"
-  add_foreign_key "class_imports_parent_relationships", "class_imports"
-  add_foreign_key "class_imports_parent_relationships", "parent_relationships"
-  add_foreign_key "class_imports_parents", "class_imports"
-  add_foreign_key "class_imports_parents", "parents"
-  add_foreign_key "class_imports_patients", "class_imports"
-  add_foreign_key "class_imports_patients", "patients"
+  add_foreign_key "class_imports_parent_relationships", "class_imports", on_delete: :cascade
+  add_foreign_key "class_imports_parent_relationships", "parent_relationships", on_delete: :cascade
+  add_foreign_key "class_imports_parents", "class_imports", on_delete: :cascade
+  add_foreign_key "class_imports_parents", "parents", on_delete: :cascade
+  add_foreign_key "class_imports_patients", "class_imports", on_delete: :cascade
+  add_foreign_key "class_imports_patients", "patients", on_delete: :cascade
   add_foreign_key "cohort_imports", "teams"
   add_foreign_key "cohort_imports", "users", column: "uploaded_by_user_id"
-  add_foreign_key "cohort_imports_parent_relationships", "cohort_imports"
-  add_foreign_key "cohort_imports_parent_relationships", "parent_relationships"
-  add_foreign_key "cohort_imports_parents", "cohort_imports"
-  add_foreign_key "cohort_imports_parents", "parents"
-  add_foreign_key "cohort_imports_patients", "cohort_imports"
-  add_foreign_key "cohort_imports_patients", "patients"
-  add_foreign_key "consent_form_programmes", "consent_forms"
-  add_foreign_key "consent_form_programmes", "programmes"
+  add_foreign_key "cohort_imports_parent_relationships", "cohort_imports", on_delete: :cascade
+  add_foreign_key "cohort_imports_parent_relationships", "parent_relationships", on_delete: :cascade
+  add_foreign_key "cohort_imports_parents", "cohort_imports", on_delete: :cascade
+  add_foreign_key "cohort_imports_parents", "parents", on_delete: :cascade
+  add_foreign_key "cohort_imports_patients", "cohort_imports", on_delete: :cascade
+  add_foreign_key "cohort_imports_patients", "patients", on_delete: :cascade
+  add_foreign_key "consent_form_programmes", "consent_forms", on_delete: :cascade
+  add_foreign_key "consent_form_programmes", "programmes", on_delete: :cascade
   add_foreign_key "consent_forms", "locations"
   add_foreign_key "consent_forms", "locations", column: "school_id"
   add_foreign_key "consent_forms", "teams"
@@ -1016,14 +1016,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_18_122640) do
   add_foreign_key "identity_checks", "vaccination_records", on_delete: :cascade
   add_foreign_key "immunisation_imports", "teams"
   add_foreign_key "immunisation_imports", "users", column: "uploaded_by_user_id"
-  add_foreign_key "immunisation_imports_patient_locations", "immunisation_imports"
-  add_foreign_key "immunisation_imports_patient_locations", "patient_locations"
-  add_foreign_key "immunisation_imports_patients", "immunisation_imports"
-  add_foreign_key "immunisation_imports_patients", "patients"
-  add_foreign_key "immunisation_imports_sessions", "immunisation_imports"
-  add_foreign_key "immunisation_imports_sessions", "sessions"
-  add_foreign_key "immunisation_imports_vaccination_records", "immunisation_imports"
-  add_foreign_key "immunisation_imports_vaccination_records", "vaccination_records"
+  add_foreign_key "immunisation_imports_patient_locations", "immunisation_imports", on_delete: :cascade
+  add_foreign_key "immunisation_imports_patient_locations", "patient_locations", on_delete: :cascade
+  add_foreign_key "immunisation_imports_patients", "immunisation_imports", on_delete: :cascade
+  add_foreign_key "immunisation_imports_patients", "patients", on_delete: :cascade
+  add_foreign_key "immunisation_imports_sessions", "immunisation_imports", on_delete: :cascade
+  add_foreign_key "immunisation_imports_sessions", "sessions", on_delete: :cascade
+  add_foreign_key "immunisation_imports_vaccination_records", "immunisation_imports", on_delete: :cascade
+  add_foreign_key "immunisation_imports_vaccination_records", "vaccination_records", on_delete: :cascade
   add_foreign_key "location_programme_year_groups", "locations", on_delete: :cascade
   add_foreign_key "location_programme_year_groups", "programmes", on_delete: :cascade
   add_foreign_key "locations", "subteams"

--- a/spec/factories/consent_form_programmes.rb
+++ b/spec/factories/consent_form_programmes.rb
@@ -17,8 +17,8 @@
 #
 # Foreign Keys
 #
-#  fk_rails_...  (consent_form_id => consent_forms.id)
-#  fk_rails_...  (programme_id => programmes.id)
+#  fk_rails_...  (consent_form_id => consent_forms.id) ON DELETE => cascade
+#  fk_rails_...  (programme_id => programmes.id) ON DELETE => cascade
 #
 FactoryBot.define do
   factory :consent_form_programmes do


### PR DESCRIPTION
This improves the performance of the endpoint we can use to reset a team while running performance or regression tests by using `delete_all` instead of `destroy_all` and avoiding the need to run Rails callbacks. To support this I've added `ON DELETE CASCADE` to the foreign keys of the join tables.