### PR TITLE
Allow users to sort offline sheet by consent time

### DIFF
--- a/app/lib/reports/export_formatters.rb
+++ b/app/lib/reports/export_formatters.rb
@@ -50,9 +50,13 @@ module Reports::ExportFormatters
 
   def consent_details(consents:)
     values =
-      consents.map do |consent|
-        "#{consent.response.humanize} by #{consent.name} at #{consent.created_at}"
-      end
+      consents
+        .sort_by(&:created_at)
+        .reverse
+        .map do |consent|
+          "On #{consent.created_at.to_date} at #{consent.created_at.strftime("%H:%M")} " \
+            "#{consent.response.humanize.upcase} by #{consent.name}"
+        end
 
     values.join(", ")
   end

--- a/spec/lib/reports/programme_vaccinations_exporter_spec.rb
+++ b/spec/lib/reports/programme_vaccinations_exporter_spec.rb
@@ -460,8 +460,7 @@ describe Reports::ProgrammeVaccinationsExporter do
 
         it "includes the information" do
           expect(rows.first.to_hash).to include(
-            "CONSENT_DETAILS" =>
-              "Given by John Smith at 2024-01-01 12:05:20 +0000",
+            "CONSENT_DETAILS" => "On 2024-01-01 at 12:05 GIVEN by John Smith",
             "CONSENT_STATUS" => expected_consent_status,
             "HEALTH_QUESTION_ANSWERS" =>
               consent


### PR DESCRIPTION
This moves the date to the start of the consent string,
allowing it to be sorted alphabetically.

Also, the newest consents must be shown first.

It now reads:
<img width="256" height="65" alt="image" src="https://github.com/user-attachments/assets/577afaed-1d04-4d41-8c79-58f5ed4433c1" />

[MAV-2025](https://nhsd-jira.digital.nhs.uk/browse/MAV-2025)