### PR TITLE
Ensure cache invalidation happens

### DIFF
--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -35,6 +35,8 @@ class ConsentFormsController < ApplicationController
   def update_match
     @consent_form.match_with_patient!(@patient, current_user:)
 
+    reset_count!
+
     session =
       @patient
         .sessions
@@ -109,6 +111,8 @@ class ConsentFormsController < ApplicationController
       school_move.confirm!
 
       @consent_form.match_with_patient!(patient, current_user:)
+
+      reset_count!
     end
 
     if patient.nhs_number.nil?
@@ -143,5 +147,9 @@ class ConsentFormsController < ApplicationController
 
   def archive_params
     params.expect(consent_form: :notes).merge(archived_at: Time.current)
+  end
+
+  def reset_count!
+    TeamCachedCounts.new(current_team).reset_unmatched_consent_responses!
   end
 end

--- a/app/controllers/imports/issues_controller.rb
+++ b/app/controllers/imports/issues_controller.rb
@@ -70,7 +70,8 @@ class Imports::IssuesController < ApplicationController
   def set_form
     apply_changes = params.dig(:import_duplicate_form, :apply_changes)
 
-    @form = ImportDuplicateForm.new(object: @record, apply_changes:)
+    @form =
+      ImportDuplicateForm.new(current_team:, object: @record, apply_changes:)
   end
 
   def set_type

--- a/app/forms/import_duplicate_form.rb
+++ b/app/forms/import_duplicate_form.rb
@@ -3,7 +3,7 @@
 class ImportDuplicateForm
   include ActiveModel::Model
 
-  attr_accessor :object, :apply_changes
+  attr_accessor :current_team, :object, :apply_changes
 
   validates :apply_changes, inclusion: { in: :apply_changes_options }
 
@@ -20,6 +20,8 @@ class ImportDuplicateForm
         keep_both_changes!
       end
     end
+
+    reset_count!
 
     true
   rescue ActiveRecord::RecordInvalid
@@ -50,5 +52,9 @@ class ImportDuplicateForm
 
   def keep_both_changes!
     object.apply_pending_changes_to_new_record! if can_keep_both?
+  end
+
+  def reset_count!
+    TeamCachedCounts.new(current_team).reset_import_issues!
   end
 end

--- a/app/forms/school_move_form.rb
+++ b/app/forms/school_move_form.rb
@@ -20,6 +20,12 @@ class SchoolMoveForm
       @school_move.ignore!
     end
 
+    TeamCachedCounts.new(team).reset_school_moves!
+
     true
   end
+
+  private
+
+  def team = current_user.selected_team
 end

--- a/spec/features/import_child_records_with_duplicates_spec.rb
+++ b/spec/features/import_child_records_with_duplicates_spec.rb
@@ -242,6 +242,7 @@ describe "Child record imports duplicates" do
   end
 
   def then_i_should_see_the_import_page_with_duplicate_records
+    expect(page).to have_content("Imports (3)")
     expect(page).to have_content(
       "3 records have import issues to resolve before they can be imported into Mavis"
     )
@@ -364,11 +365,13 @@ describe "Child record imports duplicates" do
   end
 
   def then_i_should_see_import_issues_with_the_count
+    expect(page).to have_content("Imports (1)")
     expect(page).to have_link("Import issues")
     expect(page).to have_selector(".app-count", text: "(1)")
   end
 
   def then_i_should_see_no_import_issues_with_the_count
+    expect(page).to have_content("Imports (0)")
     expect(page).to have_link("Import issues")
     expect(page).to have_selector(".app-count", text: "(0)")
   end

--- a/spec/features/parental_consent_clinic_spec.rb
+++ b/spec/features/parental_consent_clinic_spec.rb
@@ -256,6 +256,7 @@ describe "Parental consent" do
     choose "Update record with new school"
     click_on "Update child record"
     expect(page).to have_content("Success")
+    expect(page).to have_content("School moves (0)")
   end
 
   def then_the_nurse_should_see_no_moves

--- a/spec/features/parental_consent_manual_matching_spec.rb
+++ b/spec/features/parental_consent_manual_matching_spec.rb
@@ -91,6 +91,7 @@ describe "Parental consent manual matching" do
   def when_i_go_to_the_dashboard
     sign_in @user
     visit dashboard_path
+    expect(page).to have_content("Unmatched responses (1)")
   end
 
   def and_i_click_on_unmatched_consent_responses
@@ -135,6 +136,7 @@ describe "Parental consent manual matching" do
 
   def when_i_link_the_response_with_the_record
     click_on "Link response with record"
+    expect(page).to have_content("Unmatched responses (0)")
   end
 
   def and_i_click_on_the_patient


### PR DESCRIPTION
This fixes a number of places where the cache for the counts in the header weren't being invalidated meaning they would end up with the incorrect value.

[Jira Issue - MAV-2004](https://nhsd-jira.digital.nhs.uk/browse/MAV-2004)