### PR TITLE
Update `AppCardComponent` to allow for more variants and content types

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -3,78 +3,68 @@
 
 .app-card {
   &--aqua-green {
-    .nhsuk-card__heading--feature {
-      background-color: nhsuk-colour("aqua-green");
+    background-color: nhsuk-tint(nhsuk-colour("aqua-green"), 80%);
+    border-color: nhsuk-tint(nhsuk-colour("aqua-green"), 50%);
+    color: nhsuk-shade(nhsuk-colour("aqua-green"), 50%);
+
+    &.nhsuk-card--clickable:active {
+      border-color: nhsuk-shade(nhsuk-colour("aqua-green"), 50%);
     }
   }
 
-  &--dark-orange {
-    .nhsuk-card__heading--feature {
-      background-color: app.$dark-orange-colour;
+  &--blue {
+    background-color: nhsuk-tint(nhsuk-colour("blue"), 80%);
+    border-color: nhsuk-tint(nhsuk-colour("blue"), 30%);
+    color: nhsuk-shade(nhsuk-colour("blue"), 30%);
+
+    &.nhsuk-card--clickable:active {
+      border-color: nhsuk-shade(nhsuk-colour("blue"), 30%);
     }
   }
 
   &--green {
-    .nhsuk-card__heading--feature {
-      background-color: nhsuk-colour("green");
+    background-color: nhsuk-tint(nhsuk-colour("green"), 80%);
+    border-color: nhsuk-tint(nhsuk-colour("green"), 40%);
+    color: nhsuk-shade(nhsuk-colour("green"), 40%);
+
+    &.nhsuk-card--clickable:active {
+      border-color: nhsuk-shade(nhsuk-colour("green"), 40%);
     }
   }
 
   &--grey {
-    .nhsuk-card__heading--feature {
-      background-color: nhsuk-colour("grey-1");
-    }
-  }
+    background-color: nhsuk-tint(nhsuk-colour("grey-1"), 80%);
+    border-color: nhsuk-tint(nhsuk-colour("grey-1"), 30%);
+    color: nhsuk-shade(nhsuk-colour("grey-1"), 30%);
 
-  &--purple {
-    .nhsuk-card__heading--feature {
-      background-color: nhsuk-colour("purple");
+    &.nhsuk-card--clickable:active {
+      border-color: nhsuk-shade(nhsuk-colour("grey-1"), 30%);
     }
   }
 
   &--red {
-    .nhsuk-card__heading--feature {
-      background-color: nhsuk-colour("red");
+    background-color: nhsuk-tint(nhsuk-colour("red"), 80%);
+    border-color: nhsuk-tint(nhsuk-colour("red"), 50%);
+    color: nhsuk-shade(nhsuk-colour("red"), 50%);
+
+    &.nhsuk-card--clickable:active {
+      border-color: nhsuk-shade(nhsuk-colour("red"), 50%);
     }
   }
 
-  &--reversed {
-    background-color: nhsuk-colour("blue");
-    border-color: nhsuk-shade(nhsuk-colour("blue"), 25%);
-    color: nhsuk-colour("white");
-
-    &:active {
-      border-color: nhsuk-shade(nhsuk-colour("blue"), 50%);
-    }
-
-    .nhsuk-card__link {
-      @include nhsuk-link-style-white;
+  &--aqua-green,
+  &--blue,
+  &--green,
+  &--grey,
+  &--red {
+    .nhsuk-card__link,
+    .nhsuk-card__link:hover {
+      color: inherit;
     }
   }
 
   &--offset {
     background-color: rgba(nhsuk-colour("grey-5"), 0.5);
-  }
-
-  &--data {
-    display: flex;
-
-    .nhsuk-card__content {
-      display: flex;
-      flex-direction: column;
-      flex-grow: 1;
-    }
-
-    .nhsuk-card__heading {
-      @include nhsuk-typography-weight-normal;
-    }
-
-    .nhsuk-card__description {
-      margin-top: auto;
-
-      @include nhsuk-font-size(48);
-      @include nhsuk-typography-weight-bold;
-    }
   }
 }
 
@@ -88,5 +78,57 @@
   .nhsuk-card__content {
     @include nhsuk-responsive-padding(4);
     @include nhsuk-responsive-padding(3, "bottom");
+  }
+}
+
+// Align counts across cards
+.nhsuk-card:has(> .nhsuk-card__content > .app-card__data) {
+  display: flex;
+
+  .nhsuk-card__heading {
+    line-height: 1.2;
+  }
+
+  .nhsuk-card__content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+}
+
+.app-card__data {
+  @include nhsuk-font-size(48);
+  @include nhsuk-typography-weight-bold;
+}
+
+.app-card__heading {
+  &--aqua-green {
+    background-color: nhsuk-colour("aqua-green");
+  }
+
+  &--dark-orange {
+    background-color: app.$dark-orange-colour;
+  }
+
+  &--green {
+    background-color: nhsuk-colour("green");
+  }
+
+  &--grey {
+    background-color: nhsuk-colour("grey-1");
+  }
+
+  &--purple {
+    background-color: nhsuk-colour("purple");
+  }
+
+  &--red {
+    background-color: nhsuk-colour("red");
+  }
+
+  &--warm-yellow {
+    background-color: nhsuk-colour("warm-yellow");
+    color: $nhsuk-text-colour;
   }
 }

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -4,20 +4,18 @@ class AppCardComponent < ViewComponent::Base
   erb_template <<-ERB
     <<%= top_level_tag %> class="<%= card_classes %>">
       <div class="<%= content_classes %>">
-        <% if heading.present? %>
-          <h<%= @heading_level %> class="<%= heading_classes %>">
-            <% if @link_to.present? %>
-              <%= link_to @link_to, class: "nhsuk-card__link" do %>
-                <%= heading %>
-              <% end %>
-            <% else %>
-              <%= heading %>
-            <% end %>
-          </h<%= @heading_level %>>
-        <% end %>
+        <%= heading %>
 
         <% if description.present? %>
           <p class="nhsuk-card__description"><%= description %></p>
+        <% end %>
+
+        <% if data.present? %>
+          <p class="nhsuk-card__description app-card__data"><%= data %></p>
+        <% end %>
+
+        <% if meta.present? %>
+          <p class="nhsuk-body-s"><%= meta %></p>
         <% end %>
 
         <%= content %>
@@ -25,29 +23,37 @@ class AppCardComponent < ViewComponent::Base
     </<%= top_level_tag %>>
   ERB
 
-  renders_one :heading
+  renders_one :heading,
+              ->(level: 3, size: nil, colour: nil) do
+                AppCardHeadingComponent.new(
+                  level: level,
+                  size: size,
+                  colour: colour,
+                  feature: @feature,
+                  link_to: @link_to
+                )
+              end
+
   renders_one :description
+  renders_one :data
+  renders_one :meta
 
   def initialize(
     colour: nil,
     link_to: nil,
-    heading_level: 3,
+    feature: false,
     secondary: false,
-    data: false,
     compact: false,
     filters: false,
     section: false
   )
     @link_to = link_to
     @colour = colour
-    @heading_level = heading_level
+    @feature = filters || feature
     @secondary = secondary
-    @data = data
     @compact = compact
     @filters = filters
     @section = section
-
-    @feature = (colour.present? && !data && !compact) || filters
   end
 
   private
@@ -57,13 +63,12 @@ class AppCardComponent < ViewComponent::Base
   def card_classes
     [
       "nhsuk-card",
-      "app-card",
-      ("nhsuk-card--feature" if @feature),
-      ("app-card--#{@colour}" if @colour.present?),
       ("nhsuk-card--clickable" if @link_to.present?),
+      ("nhsuk-card--feature" if @feature),
       ("nhsuk-card--secondary" if @secondary),
-      ("app-card--data" if @data),
+      "app-card",
       ("app-card--compact" if @compact),
+      ("app-card--#{@colour}" if @colour.present?),
       ("app-filters" if @filters)
     ].compact.join(" ")
   end
@@ -71,27 +76,8 @@ class AppCardComponent < ViewComponent::Base
   def content_classes
     [
       "nhsuk-card__content",
-      ("app-card__content" unless @data),
       ("nhsuk-card__content--feature" if @feature),
       ("nhsuk-card__content--secondary" if @secondary)
-    ].compact.join(" ")
-  end
-
-  def heading_modifier
-    if @data
-      "xs"
-    elsif @secondary || @compact
-      "s"
-    else
-      "m"
-    end
-  end
-
-  def heading_classes
-    [
-      "nhsuk-card__heading",
-      "nhsuk-heading-#{heading_modifier}",
-      ("nhsuk-card__heading--feature" if @feature)
     ].compact.join(" ")
   end
 end

--- a/app/components/app_card_heading_component.rb
+++ b/app/components/app_card_heading_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class AppCardHeadingComponent < ViewComponent::Base
+  def initialize(level: 3, size: nil, colour: nil, feature: false, link_to: nil)
+    @level = level
+    @size = size
+    @colour = colour
+    @feature = colour.present? || feature
+    @link_to = link_to
+  end
+
+  def call
+    content_tag(:"h#{@level}", class: heading_classes) do
+      if @link_to.present?
+        link_to(@link_to, class: "nhsuk-card__link") { content }
+      else
+        content
+      end
+    end
+  end
+
+  private
+
+  def heading_modifier
+    return @size if @size.present?
+
+    if @level >= 4
+      "s"
+    else
+      "m"
+    end
+  end
+
+  def heading_classes
+    [
+      "nhsuk-card__heading",
+      "nhsuk-heading-#{heading_modifier}",
+      ("nhsuk-card__heading--feature" if @feature),
+      ("app-card__heading--#{@colour}" if @colour)
+    ].compact.join(" ")
+  end
+end

--- a/app/components/app_compare_consent_form_and_patient_component.rb
+++ b/app/components/app_compare_consent_form_and_patient_component.rb
@@ -4,15 +4,15 @@ class AppCompareConsentFormAndPatientComponent < ViewComponent::Base
   erb_template <<-ERB
     <div class="nhsuk-grid-row nhsuk-card-group">
       <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |card| %>
-          <% card.with_heading { "Consent response" } %>
+        <%= render AppCardComponent.new(feature: true) do |card| %>
+          <% card.with_heading(level: 2) { "Consent response" } %>
           <%= govuk_summary_list(rows: consent_form_rows) %>
         <% end %>
       </div>
 
       <div class="nhsuk-grid-column-one-half nhsuk-card-group__item">
-        <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |card| %>
-          <% card.with_heading { "Child record" } %>
+        <%= render AppCardComponent.new(feature: true) do |card| %>
+          <% card.with_heading(level: 2) { "Child record" } %>
           <%= govuk_summary_list(rows: patient_rows) %>
         <% end %>
       </div>

--- a/app/components/app_consent_card_component.rb
+++ b/app/components/app_consent_card_component.rb
@@ -8,7 +8,7 @@ class AppConsentCardComponent < ViewComponent::Base
 
   def call
     render AppCardComponent.new(**card_options) do |card|
-      card.with_heading { heading }
+      card.with_heading(level: 6) { heading }
       govuk_summary_list(rows:)
     end
   end
@@ -24,8 +24,7 @@ class AppConsentCardComponent < ViewComponent::Base
     session_patient_programme_consent_path(session, patient, programme, consent)
   end
 
-  def card_options =
-    { link_to:, heading_level: 6, colour: "offset", compact: true }
+  def card_options = { link_to:, colour: "offset", compact: true }
 
   def heading
     if consent.via_self_consent?

--- a/app/components/app_consent_form_card_component.rb
+++ b/app/components/app_consent_form_card_component.rb
@@ -6,8 +6,8 @@ class AppConsentFormCardComponent < ViewComponent::Base
   end
 
   def call
-    render AppCardComponent.new(heading_level: 2) do |card|
-      card.with_heading { "Consent response" }
+    render AppCardComponent.new do |card|
+      card.with_heading(level: 2) { "Consent response" }
 
       govuk_summary_list do |summary_list|
         summary_list.with_row do |row|

--- a/app/components/app_health_answers_card_component.rb
+++ b/app/components/app_health_answers_card_component.rb
@@ -7,8 +7,8 @@ class AppHealthAnswersCardComponent < ViewComponent::Base
   end
 
   def call
-    render AppCardComponent.new(heading_level: 2) do |card|
-      card.with_heading { heading }
+    render AppCardComponent.new do |card|
+      card.with_heading(level: 2) { heading }
       render AppHealthAnswersSummaryComponent.new(objects)
     end
   end

--- a/app/components/app_parent_card_component.rb
+++ b/app/components/app_parent_card_component.rb
@@ -7,8 +7,8 @@ class AppParentCardComponent < ViewComponent::Base
   end
 
   def call
-    render AppCardComponent.new(heading_level: 2) do |card|
-      card.with_heading { "Parent or guardian" }
+    render AppCardComponent.new do |card|
+      card.with_heading(level: 2) { "Parent or guardian" }
       render AppParentSummaryComponent.new(parent_relationship:, change_links:)
     end
   end

--- a/app/components/app_patient_card_component.rb
+++ b/app/components/app_patient_card_component.rb
@@ -2,8 +2,8 @@
 
 class AppPatientCardComponent < ViewComponent::Base
   erb_template <<-ERB
-    <%= render AppCardComponent.new(heading_level:, section: true) do |card| %>
-      <% card.with_heading { "Child’s details" } %>
+    <%= render AppCardComponent.new(section: true) do |card| %>
+      <% card.with_heading(level: heading_level) { "Child’s details" } %>
       
       <% important_notices.each do |notice| %>
         <%= render AppStatusComponent.new(text: notice[:message]) %>

--- a/app/components/app_patient_search_form_component.rb
+++ b/app/components/app_patient_search_form_component.rb
@@ -3,8 +3,8 @@
 class AppPatientSearchFormComponent < ViewComponent::Base
   erb_template <<-ERB
     <%= form_with url:, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= render AppCardComponent.new(heading_level:, filters: true) do |card| %>
-        <% card.with_heading { "Find children" } %>
+      <%= render AppCardComponent.new(filters: true) do |card| %>
+        <% card.with_heading(level: heading_level) { "Find children" } %>
 
         <div class="app-search-input" role="search">
           <%= f.govuk_text_field :q,

--- a/app/components/app_patient_search_result_card_component.rb
+++ b/app/components/app_patient_search_result_card_component.rb
@@ -25,12 +25,8 @@ class AppPatientSearchResultCardComponent < ViewComponent::Base
   end
 
   def call
-    render AppCardComponent.new(
-             link_to: @link_to,
-             heading_level: 4,
-             compact: true
-           ) do |card|
-      card.with_heading { @patient.full_name_with_known_as }
+    render AppCardComponent.new(link_to: @link_to, compact: true) do |card|
+      card.with_heading(level: 4) { @patient.full_name_with_known_as }
 
       govuk_summary_list do |summary_list|
         summary_list.with_row do |row|

--- a/app/components/app_patient_session_consent_component.html.erb
+++ b/app/components/app_patient_session_consent_component.html.erb
@@ -1,7 +1,7 @@
 <h3 class="nhsuk-heading-m">Consent</h3>
 
-<%= render AppCardComponent.new(heading_level: 4, colour:) do |card| %>
-  <% card.with_heading { heading } %>
+<%= render AppCardComponent.new(feature: true) do |card| %>
+  <% card.with_heading(level: 4, colour:) { heading } %>
 
   <% unless vaccination_status.vaccinated? %>
     <% if consent_status.no_response? %>

--- a/app/components/app_patient_session_outcome_component.rb
+++ b/app/components/app_patient_session_outcome_component.rb
@@ -4,8 +4,8 @@ class AppPatientSessionOutcomeComponent < ViewComponent::Base
   erb_template <<-ERB
     <h3 class="nhsuk-heading-m">Programme outcome</h3>
     
-    <%= render AppCardComponent.new(heading_level: 4, colour:) do |card| %>
-      <% card.with_heading { heading } %>
+    <%= render AppCardComponent.new(feature: true) do |card| %>
+      <% card.with_heading(level: 4, colour:) { heading } %>
       <%= render AppPatientVaccinationTableComponent.new(
             patient,
             programme:,

--- a/app/components/app_patient_session_search_result_card_component.rb
+++ b/app/components/app_patient_session_search_result_card_component.rb
@@ -3,11 +3,11 @@
 class AppPatientSessionSearchResultCardComponent < ViewComponent::Base
   erb_template <<-ERB
     <% card_link = @context != :register ? patient_path : nil %>
-    <%= render AppCardComponent.new(link_to: card_link, heading_level: 4, compact: true) do |card| %>
+    <%= render AppCardComponent.new(link_to: card_link, compact: true) do |card| %>
       <% if card_link.nil? %>
-        <% card.with_heading { link_to(patient.full_name_with_known_as, patient_path) } %>
+        <% card.with_heading(level: 4) { link_to(patient.full_name_with_known_as, patient_path) } %>
       <% else %>
-        <% card.with_heading { patient.full_name_with_known_as } %>
+        <% card.with_heading(level: 4) { patient.full_name_with_known_as } %>
       <% end %>
 
       <%= govuk_summary_list(actions: false) do |summary_list|

--- a/app/components/app_patient_session_triage_component.html.erb
+++ b/app/components/app_patient_session_triage_component.html.erb
@@ -1,7 +1,7 @@
 <h3 class="nhsuk-heading-m">Triage</h3>
 
-<%= render AppCardComponent.new(heading_level: 4, colour:) do |card| %>
-  <% card.with_heading { heading } %>
+<%= render AppCardComponent.new(feature: true) do |card| %>
+  <% card.with_heading(level: 4, colour:) { heading } %>
 
   <% if latest_triage.nil? || latest_triage.needs_follow_up? %>
     <% if helpers.policy(Triage).new? %>

--- a/app/components/app_programme_stats_component.html.erb
+++ b/app/components/app_programme_stats_component.html.erb
@@ -1,22 +1,22 @@
 <div class="nhsuk-grid-row nhsuk-card-group">
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: programme_patients_path(programme, academic_year), colour: "reversed", data: true) do |card| %>
-      <% card.with_heading { "Children" } %>
-      <% card.with_description { patients_count.to_s } %>
+    <%= render AppCardComponent.new(link_to: programme_patients_path(programme, academic_year), colour: "blue") do |card| %>
+      <% card.with_heading(size: "xs") { "Children" } %>
+      <% card.with_data { patients_count.to_s } %>
     <% end %>
   </div>
 
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(colour: "reversed", data: true) do |card| %>
-      <% card.with_heading { "Vaccinations" } %>
-      <% card.with_description { vaccinations_count.to_s } %>
+    <%= render AppCardComponent.new(colour: "green") do |card| %>
+      <% card.with_heading(size: "xs") { "Vaccinations" } %>
+      <% card.with_data { vaccinations_count.to_s } %>
     <% end %>
   </div>
 
   <div class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(data: true, colour: "reversed") do |card| %>
-      <% card.with_heading { "Consent requests and reminders sent" } %>
-      <% card.with_description { consent_notifications_count.to_s } %>
+    <%= render AppCardComponent.new do |card| %>
+      <% card.with_heading(size: "xs") { "Consent requests and reminders sent" } %>
+      <% card.with_data { consent_notifications_count.to_s } %>
     <% end %>
   </div>
 </div>

--- a/app/components/app_session_card_component.rb
+++ b/app/components/app_session_card_component.rb
@@ -8,7 +8,7 @@ class AppSessionCardComponent < ViewComponent::Base
 
   def call
     render AppCardComponent.new(**card_options) do |card|
-      card.with_heading { session.location.name }
+      card.with_heading(level: 4) { session.location.name }
       govuk_summary_list(rows:)
     end
   end

--- a/app/components/app_session_search_form_component.rb
+++ b/app/components/app_session_search_form_component.rb
@@ -3,8 +3,8 @@
 class AppSessionSearchFormComponent < ViewComponent::Base
   erb_template <<-ERB
     <%= form_with url:, method: :get, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-      <%= render AppCardComponent.new(heading_level: 2, filters: true) do |card| %>
-        <% card.with_heading { "Find session" } %>
+      <%= render AppCardComponent.new(filters: true) do |card| %>
+        <% card.with_heading(level: 2) { "Find session" } %>
 
         <div class="app-search-input" role="search">
           <%= f.govuk_text_field :q,

--- a/app/views/consent_forms/search.html.erb
+++ b/app/views/consent_forms/search.html.erb
@@ -9,8 +9,8 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-third" data-module="app-sticky">
-    <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |card| %>
-      <% card.with_heading { "Consent response" } %>
+    <%= render AppCardComponent.new(feature: true) do |card| %>
+      <% card.with_heading(level: 2) { "Consent response" } %>
 
       <%= govuk_summary_list(classes: %w[nhsuk-u-margin-bottom-4 nhsuk-summary-list--no-border app-summary-list--full-width]) do |summary_list|
             summary_list.with_row do |row|

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -20,8 +20,8 @@
 
 <%= render AppParentCardComponent.new(parent_relationship: @consent_form.parent_relationship) %>
 
-<%= render AppCardComponent.new(heading_level: 2) do |card| %>
-  <% card.with_heading { "Child" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading(level: 2) { "Child" } %>
   <%= render AppChildSummaryComponent.new(@consent_form) %>
 <% end %>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -8,8 +8,8 @@
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: programmes_path, heading_level: 2) do |card| %>
-      <% card.with_heading { t("programmes.index.title") } %>
+    <%= render AppCardComponent.new(link_to: programmes_path) do |card| %>
+      <% card.with_heading(level: 2) { t("programmes.index.title") } %>
       <p class="nhsuk-body">Use this area to:</p>
       <ul class="nhsuk-list nhsuk-list--bullet">
         <li>import child records</li>
@@ -20,8 +20,8 @@
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: sessions_path, heading_level: 2) do |card| %>
-      <% card.with_heading { t("sessions.index.title") } %>
+    <%= render AppCardComponent.new(link_to: sessions_path) do |card| %>
+      <% card.with_heading(level: 2) { t("sessions.index.title") } %>
       <p class="nhsuk-body">Use this area to:</p>
       <ul class="nhsuk-list nhsuk-list--bullet">
         <li>review consent responses</li>
@@ -33,8 +33,8 @@
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: patients_path, heading_level: 2) do |card| %>
-      <% card.with_heading { t("patients.index.title") } %>
+    <%= render AppCardComponent.new(link_to: patients_path) do |card| %>
+      <% card.with_heading(level: 2) { t("patients.index.title") } %>
       <p class="nhsuk-body">Use this area to:</p>
       <ul class="nhsuk-list nhsuk-list--bullet">
         <li>find child records</li>
@@ -46,43 +46,43 @@
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: consent_forms_path, heading_level: 2, secondary: true) do |card| %>
-      <% card.with_heading { t("consent_forms.index.title") } %>
+    <%= render AppCardComponent.new(link_to: consent_forms_path, secondary: true) do |card| %>
+      <% card.with_heading(level: 2, size: "s") { t("consent_forms.index.title") } %>
       <% card.with_description { "Review incoming consent responses that can’t be automatically matched" } %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: school_moves_path, heading_level: 2, secondary: true) do |card| %>
-      <% card.with_heading { t("school_moves.index.title") } %>
+    <%= render AppCardComponent.new(link_to: school_moves_path, secondary: true) do |card| %>
+      <% card.with_heading(level: 2, size: "s") { t("school_moves.index.title") } %>
       <% card.with_description { "Review children who have moved schools" } %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: imports_path, heading_level: 2, secondary: true) do |card| %>
-      <% card.with_heading { t("imports.index.title") } %>
+    <%= render AppCardComponent.new(link_to: imports_path, secondary: true) do |card| %>
+      <% card.with_heading(level: 2, size: "s") { t("imports.index.title") } %>
       <% card.with_description { "Import child, cohort and vaccination records and see important notices" } %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: vaccines_path, heading_level: 2, secondary: true) do |card| %>
-      <% card.with_heading { t("vaccines.index.title") } %>
+    <%= render AppCardComponent.new(link_to: vaccines_path, secondary: true) do |card| %>
+      <% card.with_heading(level: 2, size: "s") { t("vaccines.index.title") } %>
       <% card.with_description { "Add and edit vaccine batches" } %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: team_path, heading_level: 2, secondary: true) do |card| %>
-      <% card.with_heading { t("teams.show.title") } %>
+    <%= render AppCardComponent.new(link_to: team_path, secondary: true) do |card| %>
+      <% card.with_heading(level: 2, size: "s") { t("teams.show.title") } %>
       <% card.with_description { "Manage your team’s settings" } %>
     <% end %>
   </li>
 
   <li class="nhsuk-grid-column-one-third nhsuk-card-group__item">
-    <%= render AppCardComponent.new(link_to: @service_guide_url, heading_level: 2, secondary: true) do |card| %>
-      <% card.with_heading { t("service.guide.title") } %>
+    <%= render AppCardComponent.new(link_to: @service_guide_url, secondary: true) do |card| %>
+      <% card.with_heading(level: 2, size: "s") { t("service.guide.title") } %>
       <% card.with_description { "How to use this service" } %>
     <% end %>
   </li>

--- a/app/views/imports/issues/show.html.erb
+++ b/app/views/imports/issues/show.html.erb
@@ -13,8 +13,8 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-half">
-    <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |c| %>
-      <% c.with_heading { "Uploaded record" } %>
+    <%= render AppCardComponent.new(feature: true) do |c| %>
+      <% c.with_heading(level: 2) { "Uploaded record" } %>
       <% if @type == "child" %>
         <%= render AppChildSummaryComponent.new(@patient.with_pending_changes) %>
       <% else %>
@@ -26,8 +26,8 @@
   </div>
 
   <div class="nhsuk-grid-column-one-half">
-    <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |c| %>
-      <% c.with_heading { "#{@existing_or_deleted.capitalize} record" } %>
+    <%= render AppCardComponent.new(feature: true) do |c| %>
+      <% c.with_heading(level: 2) { "#{@existing_or_deleted.capitalize} record" } %>
       <% if @type == "child" %>
         <%= render AppChildSummaryComponent.new(@patient) %>
       <% else %>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -11,8 +11,8 @@
   <%= render AppImportStatusComponent.new(import: import) %>
 </p>
 
-<%= render AppCardComponent.new(heading_level: 2) do |card| %>
-  <% card.with_heading { "Details" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading(level: 2) { "Details" } %>
 
   <%= govuk_summary_list do |summary_list| %>
     <%= summary_list.with_row do |row| %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -105,8 +105,8 @@
   <% end %>
 <% end %>
 
-<%= render AppCardComponent.new do |c| %>
-  <% c.with_heading { "About your child" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading { "About your child" } %>
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Child’s name" }
@@ -168,8 +168,8 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new do |c| %>
-  <% c.with_heading { "About you" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading { "About you" } %>
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
           row.with_key { "Your name" }
@@ -226,8 +226,8 @@
 <% end %>
 
 <% if @consent_form.response_given? %>
-  <%= render AppCardComponent.new do |c| %>
-    <% c.with_heading { "Health questions" } %>
+  <%= render AppCardComponent.new do |card| %>
+    <% card.with_heading { "Health questions" } %>
     <%= govuk_summary_list classes: "app-summary-list--full-width" do |summary_list|
           @consent_form.each_health_answer do |ha|
             summary_list.with_row do |row|

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -10,8 +10,8 @@
 <% if @patients.any? %>
   <%= render AppPatientTableComponent.new(@patients, current_user:, count: @pagy.count) %>
 <% else %>
-  <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |card| %>
-    <% card.with_heading { "No children" } %>
+  <%= render AppCardComponent.new(feature: true) do |card| %>
+    <% card.with_heading(level: 2) { "No children" } %>
     <% card.with_description { "No children matching search criteria found." } %>
   <% end %>
 <% end %>

--- a/app/views/programmes/overview/show.html.erb
+++ b/app/views/programmes/overview/show.html.erb
@@ -15,13 +15,13 @@
 
 <%= render AppProgrammeStatsComponent.new(@programme, academic_year: @academic_year, patient_ids: @patient_ids) %>
 
-<h2 class="nhsuk-heading-m">Cohorts</h2>
+<h3 class="nhsuk-heading-m">Cohorts</h3>
 
 <ul class="nhsuk-grid-row nhsuk-card-group">
   <% @patient_count_by_year_group.each do |year_group, patient_count| %>
     <li class="nhsuk-grid-column-one-quarter nhsuk-card-group__item">
       <%= render AppCardComponent.new(link_to: patient_count > 0 ? programme_patients_path(@programme, @academic_year, year_groups: [year_group]) : nil) do |card| %>
-        <% card.with_heading { format_year_group(year_group) } %>
+        <% card.with_heading(level: 4) { format_year_group(year_group) } %>
         <% card.with_description { t("children", count: patient_count) } %>
       <% end %>
     </li>

--- a/app/views/school_moves/show.html.erb
+++ b/app/views/school_moves/show.html.erb
@@ -15,15 +15,15 @@
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-one-half">
-    <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |card| %>
-      <% card.with_heading { "#{@school_move.human_enum_name(:source)} record" } %>
+    <%= render AppCardComponent.new(feature: true) do |card| %>
+      <% card.with_heading(level: 2) { "#{@school_move.human_enum_name(:source)} record" } %>
       <%= render AppChildSummaryComponent.new(@patient_with_changes) %>
     <% end %>
   </div>
 
   <div class="nhsuk-grid-column-one-half">
-    <%= render AppCardComponent.new(heading_level: 2, colour: "blue") do |card| %>
-      <% card.with_heading { "Child record" } %>
+    <%= render AppCardComponent.new(feature: true) do |card| %>
+      <% card.with_heading(level: 2) { "Child record" } %>
       <%= render AppChildSummaryComponent.new(@patient) %>
     <% end %>
   </div>

--- a/app/views/sessions/edit/show.html.erb
+++ b/app/views/sessions/edit/show.html.erb
@@ -7,8 +7,8 @@
   Edit session
 <% end %>
 
-<%= render AppCardComponent.new(heading_level: 2) do |card| %>
-  <% card.with_heading { "Session details" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading(level: 2) { "Session details" } %>
 
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -3,8 +3,8 @@
   <%= t(".title") %>
 <% end %>
 
-<%= render AppCardComponent.new(heading_level: 2) do |card| %>
-  <% card.with_heading { "Contact details" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading(level: 2) { "Contact details" } %>
 
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|
@@ -19,8 +19,8 @@
       end %>
 <% end %>
 
-<%= render AppCardComponent.new(heading_level: 2) do |card| %>
-  <% card.with_heading { "Session defaults" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading(level: 2) { "Session defaults" } %>
 
   <%= govuk_summary_list do |summary_list|
         summary_list.with_row do |row|

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -1,8 +1,8 @@
 <%= h1 t(".title"), size: "xl" %>
 
 <% @vaccines.each do |vaccine| %>
-  <%= render AppCardComponent.new(heading_level: 2, section: true) do |card| %>
-    <% card.with_heading { link_to(vaccine_heading(vaccine), vaccine_path(vaccine)) } %>
+  <%= render AppCardComponent.new(section: true) do |card| %>
+    <% card.with_heading(level: 2) { link_to(vaccine_heading(vaccine), vaccine_path(vaccine)) } %>
 
     <p><%= vaccine.manufacturer %></p>
 

--- a/app/views/vaccines/show.html.erb
+++ b/app/views/vaccines/show.html.erb
@@ -4,8 +4,8 @@
 
 <%= h1 vaccine_heading(@vaccine), size: "l" %>
 
-<%= render AppCardComponent.new(heading_level: 2) do |card| %>
-  <% card.with_heading { "Vaccine details" } %>
+<%= render AppCardComponent.new do |card| %>
+  <% card.with_heading(level: 2) { "Vaccine details" } %>
 
   <dl class="nhsuk-summary-list">
     <div class="nhsuk-summary-list__row">

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -5,7 +5,7 @@ describe AppCardComponent do
 
   it { should have_css("div.nhsuk-card") }
 
-  context "with a title" do
+  context "with a heading" do
     subject do
       render_inline(described_class.new) { it.with_heading { "Test" } }
     end
@@ -19,6 +19,20 @@ describe AppCardComponent do
     end
 
     it { should have_css("p.nhsuk-card__description", text: "Test") }
+  end
+
+  context "with data" do
+    subject { render_inline(described_class.new) { it.with_data { "100%" } } }
+
+    it { should have_css("p.app-card__data", text: "100%") }
+  end
+
+  context "with meta" do
+    subject do
+      render_inline(described_class.new) { it.with_meta { "widgets" } }
+    end
+
+    it { should have_css("p.nhsuk-body-s", text: "widgets") }
   end
 
   context "with a link" do
@@ -35,8 +49,13 @@ describe AppCardComponent do
   context "with a colour" do
     subject { render_inline(described_class.new(colour: "red")) }
 
-    it { should have_css(".nhsuk-card--feature") }
     it { should have_css(".app-card--red") }
+  end
+
+  context "when feature" do
+    subject { render_inline(described_class.new(feature: true)) }
+
+    it { should have_css(".nhsuk-card--feature") }
   end
 
   context "when secondary" do

--- a/spec/components/app_card_heading_component_spec.rb
+++ b/spec/components/app_card_heading_component_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+describe AppCardHeadingComponent do
+  let(:content) { "Test Heading" }
+
+  context "with default parameters" do
+    subject(:rendered) { render_inline(described_class.new) { content } }
+
+    it do
+      expect(rendered).to have_css(
+        "h3.nhsuk-card__heading.nhsuk-heading-m",
+        text: content
+      )
+    end
+  end
+
+  context "with level 1" do
+    subject { render_inline(described_class.new(level: 1)) { content } }
+
+    it { should have_css("h1.nhsuk-heading-m") }
+  end
+
+  context "with level 2" do
+    subject { render_inline(described_class.new(level: 2)) { content } }
+
+    it { should have_css("h2.nhsuk-heading-m") }
+  end
+
+  context "with level 4" do
+    subject { render_inline(described_class.new(level: 4)) { content } }
+
+    it { should have_css("h4.nhsuk-heading-s") }
+  end
+
+  context "with level 5" do
+    subject { render_inline(described_class.new(level: 5)) { content } }
+
+    it { should have_css("h5.nhsuk-heading-s") }
+  end
+
+  context "with explicit size" do
+    subject do
+      render_inline(described_class.new(size: "xl", level: 4)) { content }
+    end
+
+    it { should have_css("h4.nhsuk-heading-xl") }
+  end
+
+  context "with small size" do
+    subject { render_inline(described_class.new(size: "s")) { content } }
+
+    it { should have_css("h3.nhsuk-heading-s") }
+  end
+
+  context "with large size" do
+    subject { render_inline(described_class.new(size: "l")) { content } }
+
+    it { should have_css("h3.nhsuk-heading-l") }
+  end
+
+  context "when feature" do
+    subject { render_inline(described_class.new(feature: true)) { content } }
+
+    it { should have_css(".nhsuk-card__heading--feature") }
+  end
+
+  context "with a colour" do
+    subject { render_inline(described_class.new(colour: "blue")) { content } }
+
+    it { should have_css(".nhsuk-card__heading--feature") }
+    it { should have_css(".app-card__heading--blue") }
+  end
+
+  context "with colour overriding feature" do
+    subject do
+      render_inline(described_class.new(colour: "red", feature: false)) do
+        content
+      end
+    end
+
+    it { should have_css(".nhsuk-card__heading--feature") }
+    it { should have_css(".app-card__heading--red") }
+  end
+
+  context "with a link" do
+    subject { render_inline(described_class.new(link_to: "#")) { content } }
+
+    it { should have_link(href: "#") }
+    it { should have_css("h3 > a.nhsuk-card__link") }
+  end
+
+  context "without a link" do
+    subject { render_inline(described_class.new(link_to: nil)) { content } }
+
+    it { should_not have_css("a") }
+  end
+
+  context "with empty link" do
+    subject { render_inline(described_class.new(link_to: "")) { content } }
+
+    it { should_not have_css("a") }
+  end
+
+  context "with all parameters" do
+    subject(:rendered) do
+      render_inline(
+        described_class.new(
+          level: 2,
+          size: "l",
+          colour: "green",
+          feature: false,
+          link_to: "#"
+        )
+      ) { content }
+    end
+
+    it do
+      expect(rendered).to have_css(
+        "h2.nhsuk-card__heading.nhsuk-heading-l.nhsuk-card__heading--feature.app-card__heading--green"
+      )
+    end
+
+    it { should have_link(href: "#") }
+  end
+end

--- a/spec/components/app_patient_session_consent_component_spec.rb
+++ b/spec/components/app_patient_session_consent_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AppPatientSessionConsentComponent do
-  subject { render_inline(component) }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) { described_class.new(patient:, session:, programme:) }
 
@@ -43,7 +43,7 @@ describe AppPatientSessionConsentComponent do
 
     before { create(:patient_consent_status, :refused, patient:, programme:) }
 
-    it { should have_css(".app-card--red", text: "Consent refused") }
+    it { should have_css(".app-card__heading--red", text: "Consent refused") }
     it { should have_content(consent.parent.full_name) }
     it { should have_content(consent.parent_relationship.label) }
     it { should have_content("Consent refused") }
@@ -55,7 +55,13 @@ describe AppPatientSessionConsentComponent do
 
     before { create(:patient_consent_status, :given, patient:, programme:) }
 
-    it { should have_css(".app-card--aqua-green", text: "Consent given") }
+    it do
+      expect(rendered).to have_css(
+        ".app-card__heading--aqua-green",
+        text: "Consent given"
+      )
+    end
+
     it { should_not have_css("a", text: "Contact #{consent.parent.full_name}") }
   end
 end

--- a/spec/components/app_patient_session_triage_component_spec.rb
+++ b/spec/components/app_patient_session_triage_component_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AppPatientSessionTriageComponent do
-  subject { render_inline(component) }
+  subject(:rendered) { render_inline(component) }
 
   let(:component) do
     described_class.new(patient:, session:, programme:, current_user:)
@@ -24,7 +24,13 @@ describe AppPatientSessionTriageComponent do
       create(:patient_triage_status, :safe_to_vaccinate, patient:, programme:)
     end
 
-    it { should have_css(".app-card--aqua-green", text: "Safe to vaccinate") }
+    it do
+      expect(rendered).to have_css(
+        ".app-card__heading--aqua-green",
+        text: "Safe to vaccinate"
+      )
+    end
+
     it { should have_content("safe to vaccinate") }
     it { should have_link("Update triage outcome") }
   end
@@ -35,7 +41,7 @@ describe AppPatientSessionTriageComponent do
       create(:patient_triage_status, :do_not_vaccinate, patient:, programme:)
     end
 
-    it { should have_css(".app-card--red", text: "Do not vaccinate") }
+    it { should have_css(".app-card__heading--red", text: "Do not vaccinate") }
     it { should have_content("should not be vaccinated") }
     it { should have_link("Update triage outcome") }
   end


### PR DESCRIPTION
- Adds `AppCardHeadingComponent`
- This component is then used for the `heading` slot in `AppCardComponent` and can take options for `level`, `size` and `colour` (among other inherited values) 
- This makes it possible to set a background colour for the entire card, separate to that for a feature card heading
- Adds support for supplying `data` and `meta` content for a card’s body, useful for data cards

This will be useful for upcoming changes to the session overview page, and future planned changes for programme overview pages.