### PR TITLE
Ensure `LocationProgrammeYearGroups` are created

### DIFF
--- a/app/lib/mavis_cli/schools/move_patients.rb
+++ b/app/lib/mavis_cli/schools/move_patients.rb
@@ -39,6 +39,9 @@ module MavisCLI
         end
         new_loc.update!(subteam: old_loc.subteam)
 
+        LocationProgrammeYearGroup.where(location_id: old_loc.id).update_all(
+          location_id: new_loc.id
+        )
         Session.where(location_id: old_loc.id).update_all(
           location_id: new_loc.id
         )

--- a/spec/features/cli_schools_move_patients_spec.rb
+++ b/spec/features/cli_schools_move_patients_spec.rb
@@ -13,6 +13,13 @@ describe "schools move-patients" do
   let(:source_school) { create(:school, team: team, subteam:) }
   let(:target_school) { create(:school, team: team) }
   let(:programmes) { [create(:programme, :hpv)] }
+  let(:location_programme_year_group) do
+    create(
+      :location_programme_year_group,
+      location: source_school,
+      programme: programmes.first
+    )
+  end
   let!(:patient) { create(:patient, school: source_school) }
   let!(:session) { create(:session, location: source_school, programmes:) }
   let!(:school_move) do
@@ -42,7 +49,9 @@ describe "schools move-patients" do
                         source_school
                       ).to(target_school).and change {
                               school_move.reload.school
-                            }.from(source_school).to(target_school)
+                            }.from(source_school).to(target_school).and change {
+                                    location_programme_year_group.reload.location
+                                  }.from(source_school).to(target_school)
 
     expect(patient.school).to eq(target_school)
     expect(consent_form.school).to eq(target_school)

--- a/spec/forms/session_programmes_form_spec.rb
+++ b/spec/forms/session_programmes_form_spec.rb
@@ -3,24 +3,52 @@
 describe SessionProgrammesForm do
   subject(:form) { described_class.new(session:, programme_ids:) }
 
-  let(:programmes) do
+  let(:existing_programmes) do
     [create(:programme, :menacwy), create(:programme, :td_ipv)]
   end
+  let(:new_programme) { create(:programme, :hpv) }
 
-  let(:session) { create(:session, programmes:) }
-  let(:programme_ids) { programmes.map(&:id) }
+  let(:session) { create(:session, programmes: existing_programmes) }
+  let(:programme_ids) { existing_programmes.map(&:id) + [new_programme.id] }
 
-  it { should be_valid }
+  describe "validations" do
+    it { should be_valid }
 
-  it { should validate_presence_of(:programme_ids) }
+    it { should validate_presence_of(:programme_ids) }
 
-  context "when attempting to remove a programme" do
-    let(:programme_ids) { [programmes.first.id] }
+    context "when attempting to remove a programme" do
+      let(:programme_ids) { [existing_programmes.first.id] }
 
-    it "is invalid" do
-      expect(form).to be_invalid
-      expect(form.errors[:programme_ids]).to include(
-        "You cannot remove a programme from the session once it has been added"
+      it "is invalid" do
+        expect(form).to be_invalid
+        expect(form.errors[:programme_ids]).to include(
+          "You cannot remove a programme from the session once it has been added"
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    it "adds the sessions to the programme" do
+      expect { save }.to change { session.programmes.count }.by(1)
+
+      expect(session.programmes).to contain_exactly(
+        *existing_programmes,
+        new_programme
+      )
+    end
+
+    it "creates appropriate programme year groups" do
+      location = session.location
+
+      expect { save }.to change {
+        location.location_programme_year_groups.count
+      }.by(new_programme.default_year_groups.count)
+
+      expect(location.programme_year_groups[new_programme]).to eq(
+        new_programme.default_year_groups
       )
     end
   end


### PR DESCRIPTION
This fixes two scenarios where `LocationProgrammeYearGroups` are being created automatically meaning patients can't be seen in sessions.

- This ensures that when moving patients between locations, the `LocationProgrammeYearGroups` are moved as well otherwise the session won't have any patients in it.
- When adding a programme to a session we need to ensure that `LocationProgrammeYearGroups` are added to the location to ensure that any patients eligible for the new programme are shown.

[Jira Issue - MAV-1986](https://nhsd-jira.digital.nhs.uk/browse/MAV-1986)
[Jira Issue - MAV-2030](https://nhsd-jira.digital.nhs.uk/browse/MAV-2030)