### PR TITLE
Ensure duplicate school moves don't exist

### DIFF
--- a/app/lib/patient_merger.rb
+++ b/app/lib/patient_merger.rb
@@ -63,11 +63,7 @@ class PatientMerger
       )
 
       patient_to_destroy.school_moves.find_each do |school_move|
-        if patient_to_keep.school_moves.exists?(
-             home_educated: school_move.home_educated,
-             team_id: school_move.team_id,
-             school_id: school_move.school_id
-           )
+        if patient_to_keep.school_moves.exists?
           school_move.destroy!
         else
           school_move.update_column(:patient_id, patient_to_keep.id)

--- a/spec/lib/patient_merger_spec.rb
+++ b/spec/lib/patient_merger_spec.rb
@@ -75,9 +75,6 @@ describe PatientMerger do
     let(:school_move_log_entry) do
       create(:school_move_log_entry, patient: patient_to_destroy)
     end
-    let(:duplicate_school_move) do
-      create(:school_move, patient: patient_to_keep, school: school_move.school)
-    end
     let(:session_notification) do
       create(
         :session_notification,
@@ -192,7 +189,10 @@ describe PatientMerger do
     end
 
     it "deletes duplicate school moves" do
-      expect { call }.not_to change(duplicate_school_move, :patient)
+      school_move # ensure school move on patient to destroy exists
+      create(:school_move, :to_home_educated, patient: patient_to_keep)
+
+      expect { call }.to change(SchoolMove, :count).by(-1)
       expect { school_move.reload }.to raise_error(ActiveRecord::RecordNotFound)
     end
 


### PR DESCRIPTION
This fixes a potential issue with the patient merger where it will try to create multiple school moves for the same patient which is no longer valid as of be2609ad7fd94e8ce037acfd890b5d0ec56406c0.