### PR TITLE
Ensure deceased archive reason is created

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -687,7 +687,13 @@ class Patient < ApplicationRecord
         ArchiveReason.new(team:, patient: self, type: :deceased)
       end
 
-    ArchiveReason.import!(archive_reasons, on_duplicate_key_update: :all)
+    ArchiveReason.import!(
+      archive_reasons,
+      on_duplicate_key_update: {
+        conflict_target: %i[team_id patient_id],
+        columns: %i[type]
+      }
+    )
   end
 
   def fhir_mapper = @fhir_mapper ||= FHIRMapper::Patient.new(self)

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -956,6 +956,23 @@ describe Patient do
           expect(archive_reason).to be_deceased
           expect(archive_reason.team_id).to eq(session.team_id)
         end
+
+        context "when already archived" do
+          let!(:archive_reason) do
+            create(
+              :archive_reason,
+              :moved_out_of_area,
+              patient:,
+              team: session.team
+            )
+          end
+
+          it "updates the existing archive reason" do
+            expect(archive_reason).to be_moved_out_of_area
+            expect { update_from_pds! }.not_to change(ArchiveReason, :count)
+            expect(archive_reason.reload).to be_deceased
+          end
+        end
       end
     end
 


### PR DESCRIPTION
This ensures that we handle the situation where an archive reason needs to be created because we get a notification from PDS that the patient is deceased, but the patient record already has an archive reason.

[Sentry Issue](https://good-machine.sentry.io/issues/6885440241/)