### PR TITLE
Gracefully handle page overflow errors

### DIFF
--- a/app/controllers/api/reporting/base_controller.rb
+++ b/app/controllers/api/reporting/base_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pagy/extras/jsonapi"
-
 class API::Reporting::BaseController < ActionController::API
   # we need to still include the AuthenticationConcern even though
   # we're not using the authenticate_user! callback, because we call it
@@ -23,7 +21,7 @@ class API::Reporting::BaseController < ActionController::API
   private
 
   def render_paginated_json(records:)
-    pagy, this_page_records = pagy(records, json_api: true)
+    pagy, this_page_records = pagy(records, jsonapi: true)
 
     set_json_headers
     render json: { data: this_page_records, links: pagy_jsonapi_links(pagy) }

--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pagy/extras/array"
-
 class Sessions::RecordController < ApplicationController
   include PatientSearchFormConcern
   include TodaysBatchConcern

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pagy/extras/array"
-
 class SessionsController < ApplicationController
   include SessionSearchFormConcern
 

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,3 +1,9 @@
 # frozen_string_literal: true
 
+require "pagy/extras/array"
+require "pagy/extras/jsonapi"
+require "pagy/extras/overflow"
+
+Pagy::DEFAULT[:jsonapi] = false
 Pagy::DEFAULT[:limit] = 50
+Pagy::DEFAULT[:overflow] = :last_page

--- a/spec/features/manage_children_spec.rb
+++ b/spec/features/manage_children_spec.rb
@@ -19,6 +19,17 @@ describe "Manage children" do
     then_i_see_the_activity_log
   end
 
+  scenario "Viewing children paginated" do
+    given_many_patients_exist
+
+    when_i_click_on_children
+    then_i_see_the_children
+    and_i_see_the_pages
+
+    when_i_visit_an_overflow_page
+    then_i_see_the_last_page
+  end
+
   scenario "Viewing children who have aged out" do
     given_patients_exist
     and_todays_date_is_in_the_far_future
@@ -194,6 +205,12 @@ describe "Manage children" do
       )
   end
 
+  def given_many_patients_exist
+    @session = create(:session, team: @team, programmes: [@programme])
+
+    create_list(:patient, 100, session: @session)
+  end
+
   def given_an_invalidated_patient_exists
     session = create(:session, team: @team, programmes: [@programme])
 
@@ -268,6 +285,20 @@ describe "Manage children" do
 
   def then_i_see_no_children
     expect(page).to have_content("No children")
+  end
+
+  def and_i_see_the_pages
+    expect(page).to have_content("Next page")
+    expect(page).to have_content("Showing 1 to 50 of 100 children")
+  end
+
+  def when_i_visit_an_overflow_page
+    visit patients_path(page: "100")
+  end
+
+  def then_i_see_the_last_page
+    expect(page).to have_content("Previous page")
+    expect(page).to have_content("Showing 51 to 100 of 100 children")
   end
 
   def when_i_click_on_view_aged_out_children


### PR DESCRIPTION
This configures Pagy to ensure that if a user tries to access a page that doesn't exist, rather than seeing an error page (and an unhandled exception going to Sentry), the user is shown the last possible page.

To support this I've also reconfigured how we include the Pagy extras to make it globally configured across the codebase. This is because the Pagy behaviour was dependent on which files had been executed and which `pagy/extra` files had been required, meaning the tests were flaky depending on the order.