### PR TITLE
Ensure patients are visible when PSDs only are enabled

### DIFF
--- a/app/controllers/sessions/record_controller.rb
+++ b/app/controllers/sessions/record_controller.rb
@@ -128,10 +128,14 @@ class Sessions::RecordController < ApplicationController
         programme:,
         academic_year:
       )
+    elsif @session.psd_enabled?
+      original_scope.with_patient_specific_direction(
+        programme:,
+        academic_year:,
+        team:
+      )
     elsif @session.pgd_supply_enabled?
       original_scope.has_vaccine_method("nasal", programme:, academic_year:)
-    elsif @session.national_protocol_enabled?
-      original_scope.has_vaccine_method("injection", programme:, academic_year:)
     else
       original_scope.none
     end

--- a/spec/features/flu_vaccination_hca_psd_spec.rb
+++ b/spec/features/flu_vaccination_hca_psd_spec.rb
@@ -53,6 +53,9 @@ describe "Flu vaccination" do
     and_patients_exist
     and_i_am_signed_in(role: :healthcare_assistant)
 
+    when_i_visit_the_record_vaccinations_tab
+    then_i_should_not_see_the_patient
+
     when_i_visit_the_session_patient_programme_page
     then_i_should_not_see_the_record_vaccination_section
   end
@@ -63,7 +66,8 @@ describe "Flu vaccination" do
     and_the_nasal_only_patient_has_a_psd
     and_i_am_signed_in(role: :healthcare_assistant)
 
-    when_i_visit_the_session_patient_programme_page
+    when_i_visit_the_record_vaccinations_tab
+    and_i_click_on_the_nasal_only_patient
     then_i_am_able_to_vaccinate_them_with_nasal_via_psd
     and_the_vaccination_record_has_psd_as_the_protocol
 
@@ -152,6 +156,10 @@ describe "Flu vaccination" do
 
   def when_i_visit_the_record_vaccinations_tab
     visit session_record_path(@session)
+  end
+
+  def and_i_click_on_the_nasal_only_patient
+    click_on @patient_nasal_only.full_name
   end
 
   def when_i_visit_the_session_patient_programme_page


### PR DESCRIPTION
This fixes a bug where patients don't appear to show in the "Record vaccinations" tab if they've got a PSD and only PSDs are enabled for the session (i.e. national protocol is switched off).

The bug was happening because we were not handling the situation where only PSD is enabled for the session, in that case the scope was being reduce to find no patients.

[Jira Issue - MAV-2065](https://nhsd-jira.digital.nhs.uk/browse/MAV-2065)
- ...
