### PR TITLE
Add IAM policy to deny PII access

### DIFF
--- a/terraform/account/main.tf
+++ b/terraform/account/main.tf
@@ -44,6 +44,38 @@ resource "aws_iam_policy" "data_replication_access" {
   }
 }
 
+resource "aws_iam_policy" "deny_pii_access" {
+  name        = "DenyPIIAccess"
+  description = "Deny access to personal identifiable information"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Deny"
+        Action = [
+          "ecs:ExecuteCommand",
+          "sts:AssumeRole"
+        ]
+        Resource = [
+          "*"
+        ]
+      },
+      {
+        "Sid" : "DenySelfRoleModification",
+        Effect = "Deny"
+        Action = [
+          "iam:PutRolePolicy",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:UpdateAssumeRolePolicy"
+        ]
+        Resource = [
+          "*" # TODO Target only role created by aws-prod-sso-config automation
+        ]
+      }
+    ]
+  })
+}
 
 ### Service linked role for Database Migration Service (DMS) ###
 


### PR DESCRIPTION
This policy will restrict 
* Shell access to the ECS tasks
* Modifying the policies attached to the role

There is a bit of a circular dependency here, the role to which this policy will be attached doesn't exist yet and will be created in the aws-prod-sso-config repo.
However, for this role to be created, a policy already needs to exist. So we have to update the policy in a subsequent PR once the role exists

Jira-Issue: MAV-1973

## Post-release tasks
- Apply account stack