### PR TITLE
Render import errors inside AppCardComponent

### DIFF
--- a/app/components/app_import_errors_component.rb
+++ b/app/components/app_import_errors_component.rb
@@ -2,39 +2,37 @@
 
 class AppImportErrorsComponent < ViewComponent::Base
   erb_template <<-ERB
-    <div class="nhsuk-card nhsuk-card--feature app-card--red">
-      <div class="nhsuk-card__content nhsuk-card__content--feature">
-        <h2 class="nhsuk-card__heading nhsuk-card__heading--feature nhsuk-heading-m">
-          <%= @title %>
-        </h2>
+    <%= render AppCardComponent.new(feature: true) do |card| %>
+      <% card.with_heading(level: 2, colour: "red") do %>
+        <%= @title %>
+      <% end %>
 
-        <%= content %>
+      <%= content %>
 
-        <% if @errors.present? %>
-          <div data-testid="import-errors">
-            <% @errors.each do |error| %>
-              <h3 class="nhsuk-heading-s" data-testid="import-errors__heading">
-                <% if error.attribute == :csv %>
-                  CSV
-                <% else %>
-                  <%= error.attribute.to_s.humanize %>
-                <% end %>
-              </h3>
+      <% if @errors.present? %>
+        <div data-testid="import-errors">
+          <% @errors.each do |error| %>
+            <h3 class="nhsuk-heading-s" data-testid="import-errors__heading">
+              <% if error.attribute == :csv %>
+                CSV
+              <% else %>
+                <%= error.attribute.to_s.humanize %>
+              <% end %>
+            </h3>
 
-              <ul class="nhsuk-list nhsuk-list--bullet" data-testid="import-errors__list">
+            <ul class="nhsuk-list nhsuk-list--bullet" data-testid="import-errors__list">
               <% if error.type.is_a?(Array) %>
                 <% error.type.each do |type| %>
                   <li><%= sanitize type %></li>
                 <% end %>
               <% else %>
                 <li><%= sanitize error.type %></li>
-                <% end %>
-              </ul>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
-    </div>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
   ERB
 
   def initialize(errors: nil, title: "Records could not be imported")


### PR DESCRIPTION
Replace custom card markup in AppImportErrorsComponent with AppCardComponent for consistency. The main heading is now styled via the card heading slot with `colour: "red"`, so only the title text is highlighted while the card itself is white.

JIRA- [MAV-2092](https://nhsd-jira.digital.nhs.uk/browse/MAV-2092)

## Screenshots
<img width="779" height="623" alt="Screenshot 2025-09-24 at 17 23 39" src="https://github.com/user-attachments/assets/c8e7ee62-49a2-453e-aa6d-b4753cb65397" />
## Pre-release tasks

- ...

## Post-release tasks

- ...
