### PR TITLE
Ensure `Patient#teams` doesn't return duplicates

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -428,12 +428,12 @@ class Patient < ApplicationRecord
   end
 
   def teams
-    Team.left_outer_joins(:sessions).joins(<<-SQL)
-        INNER JOIN patient_locations
-        ON patient_locations.patient_id = #{id}
-        AND patient_locations.location_id = sessions.location_id
-        AND patient_locations.academic_year = sessions.academic_year 
-      SQL
+    Team.distinct.joins(:sessions).joins(<<-SQL)
+      INNER JOIN patient_locations
+      ON patient_locations.patient_id = #{id}
+      AND patient_locations.location_id = sessions.location_id
+      AND patient_locations.academic_year = sessions.academic_year 
+    SQL
   end
 
   def archived?(team:)


### PR DESCRIPTION
If a patient belongs to multiple sessions for the same team (which is normal) then this method returns the same team multiple times. Although this is not really an issue in the way this method is used, it does cause a problem when creating archive reasons when the patient is deceased as we try and create multiple archive reasons for the same team which results in a unique constraint failing.

[Sentry Issue](https://good-machine.sentry.io/issues/6902363114/)