### PR TITLE
Fix low pds match rate rendering

### DIFF
--- a/app/assets/stylesheets/vendor/nhsuk-frontend/overrides/_index.scss
+++ b/app/assets/stylesheets/vendor/nhsuk-frontend/overrides/_index.scss
@@ -1,2 +1,3 @@
+@forward "details";
 @forward "summary-list";
 @forward "tables";

--- a/app/components/app_import_pds_unmatched_summary_component.rb
+++ b/app/components/app_import_pds_unmatched_summary_component.rb
@@ -2,7 +2,7 @@
 
 class AppImportPDSUnmatchedSummaryComponent < ViewComponent::Base
   def initialize(changesets:)
-    @changesets = changesets
+    @changesets = changesets.sort_by(&:row_number)
   end
 
   def call

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -101,7 +101,7 @@
   <% end %>
 
   <details class="nhsuk-details nhsuk-expander">
-    <summary class="nhsuk-details__summary" data-module="app-sticky" data-app-sticky-init>
+    <summary class="nhsuk-details__summary" data-module="app-sticky">
       <span class="nhsuk-details__summary-text">
         <%= import.changesets.without_pds_match.count %> unmatched records
       </span>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -203,6 +203,20 @@ def create_imports(user, team)
       uploaded_by: user
     )
   end
+
+  low_pds_import =
+    FactoryBot.create(
+      :cohort_import,
+      :low_pds_match_rate,
+      team:,
+      uploaded_by: user
+    )
+  FactoryBot.create_list(
+    :patient_changeset,
+    15,
+    import: low_pds_import,
+    pds_nhs_number: nil
+  )
 end
 
 def create_school_moves(team)

--- a/spec/components/app_import_pds_unmatched_summary_component_spec.rb
+++ b/spec/components/app_import_pds_unmatched_summary_component_spec.rb
@@ -20,7 +20,8 @@ describe AppImportPDSUnmatchedSummaryComponent, type: :component do
           "address_postcode" => "AB1 2CD"
         }
       },
-      import:
+      import:,
+      row_number: 2
     )
   end
 
@@ -52,7 +53,8 @@ describe AppImportPDSUnmatchedSummaryComponent, type: :component do
             "address_postcode" => "ZZ9 9ZZ"
           }
         },
-        import:
+        import:,
+        row_number: 1
       )
     end
 
@@ -62,6 +64,13 @@ describe AppImportPDSUnmatchedSummaryComponent, type: :component do
       expect(rendered).to have_content("Jones")
       expect(rendered).to have_content("20 August 2011")
       expect(rendered).to have_content("ZZ9 9ZZ")
+    end
+
+    it "renders records in row number order" do
+      rows = rendered.css("tbody tr").map(&:text)
+
+      expect(rows.first).to include("Bob")
+      expect(rows.last).to include("Alice")
     end
   end
 


### PR DESCRIPTION
When an import fails due to a low PDS match rate, we should render the unmatched records in row number order to allow the user in easily identifying and editing the original file.
The summary component should also be sticky to handle large numbers of records.

JIRA: [MAV-2126](https://nhsd-jira.digital.nhs.uk/browse/MAV-2126)

## Screenshots

## Pre-release tasks

- ...

## Post-release tasks

- ...
