### PR TITLE
Skip triage after verbal consent if not required

### DIFF
--- a/app/controllers/draft_consents_controller.rb
+++ b/app/controllers/draft_consents_controller.rb
@@ -14,8 +14,7 @@ class DraftConsentsController < ApplicationController
 
   include WizardControllerConcern
 
-  before_action :set_triage_form,
-                if: -> { current_step.in?(%i[triage confirm]) }
+  before_action :set_triage_form, if: :includes_triage_step?
   before_action :set_parent_options, if: -> { current_step == :who }
   before_action :set_back_link_path
 
@@ -183,9 +182,13 @@ class DraftConsentsController < ApplicationController
     self.steps = @draft_consent.wizard_steps
   end
 
+  def includes_triage_step?
+    current_step.in?(%i[triage confirm]) && steps.include?("triage")
+  end
+
   def set_triage_form
     @triage_form =
-      if policy(Triage).new?
+      if includes_triage_step?
         TriageForm.new(
           add_patient_specific_direction:
             @draft_consent.triage_add_patient_specific_direction,

--- a/app/models/draft_consent.rb
+++ b/app/models/draft_consent.rb
@@ -53,7 +53,7 @@ class DraftConsent
       :agree,
       (:notify_parents_on_vaccination if response_given? && via_self_consent?),
       (:questions if response_given?),
-      (:triage if triage_allowed? && response_given?),
+      (:triage if triage_allowed? && requires_triage?),
       (:reason if response_refused?),
       (:notify_parent_on_refusal if ask_notify_parent_on_refusal?),
       (:notes if notes_required?),
@@ -306,7 +306,7 @@ class DraftConsent
     consent.submitted_at ||= Time.current
     consent.academic_year = academic_year if academic_year.present?
 
-    if triage_allowed? && response_given?
+    if triage_allowed? && requires_triage?
       triage_form.add_patient_specific_direction =
         triage_add_patient_specific_direction
       triage_form.notes = triage_notes || ""
@@ -441,6 +441,10 @@ class DraftConsent
 
   def triage_status_and_vaccine_method_options
     Triage.new(patient:, programme:).status_and_vaccine_method_options
+  end
+
+  def requires_triage?
+    response_given? && health_answers_require_triage?
   end
 
   def health_answers_are_valid

--- a/spec/features/e2e_journey_spec.rb
+++ b/spec/features/e2e_journey_spec.rb
@@ -23,7 +23,7 @@ describe "End-to-end journey" do
 
     # Verbal consent
     given_the_day_of_the_session_comes
-    when_i_register_verbal_consent_and_triage
+    when_i_register_verbal_consent
     then_i_should_see_that_the_patient_is_ready_for_vaccination
 
     # Attendance
@@ -182,7 +182,7 @@ describe "End-to-end journey" do
     sign_in @team.users.first
   end
 
-  def when_i_register_verbal_consent_and_triage
+  def when_i_register_verbal_consent
     click_link "Sessions", match: :first
     click_link "Pilot School"
     click_link "Register"
@@ -208,16 +208,13 @@ describe "End-to-end journey" do
     find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
-    choose "Yes, it’s safe to vaccinate"
-    click_button "Continue"
-
     click_button "Confirm"
 
     click_link "TABLES, Bobby", match: :first
   end
 
   def then_i_should_see_that_the_patient_is_ready_for_vaccination
-    expect(page).to have_content "Safe to vaccinate"
+    expect(page).to have_content("ready for the vaccinator")
   end
 
   def when_i_click_on_the_register_attendance_section

--- a/spec/features/self_consent_spec.rb
+++ b/spec/features/self_consent_spec.rb
@@ -236,16 +236,13 @@ describe "Self-consent" do
     # answer the health questions
     all("label", text: "No").each(&:click)
     click_on "Continue"
-
-    choose "Yes, it’s safe to vaccinate"
-    click_on "Continue"
   end
 
   def and_the_child_can_give_their_own_consent_that_the_nurse_records
     click_on "Change method"
 
     choose "Child (Gillick competent)"
-    5.times { click_on "Continue" }
+    4.times { click_on "Continue" }
 
     expect(page).to have_content("Confirmation of vaccination sent to parent")
 
@@ -264,7 +261,7 @@ describe "Self-consent" do
     choose "By phone"
     click_on "Continue"
 
-    3.times { click_on "Continue" }
+    2.times { click_on "Continue" }
   end
 
   def then_the_parent_can_give_consent
@@ -286,7 +283,7 @@ describe "Self-consent" do
   end
 
   def and_the_child_should_be_safe_to_vaccinate
-    expect(page).to have_content("Safe to vaccinate")
+    expect(page).to have_content("ready for the vaccinator")
   end
 
   def and_enqueued_jobs_run_with_no_errors

--- a/spec/features/verbal_consent_change_answers_spec.rb
+++ b/spec/features/verbal_consent_change_answers_spec.rb
@@ -76,9 +76,6 @@ describe "Verbal consent" do
     find_all(".nhsuk-fieldset")[2].choose "No"
     find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
-
-    choose "Yes, it’s safe to vaccinate"
-    click_button "Continue"
   end
 
   def then_i_see_the_confirmation_page

--- a/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
+++ b/spec/features/verbal_consent_given_by_new_parental_contact_spec.rb
@@ -90,9 +90,6 @@ describe "Verbal consent" do
     find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
-    choose "Yes, it’s safe to vaccinate"
-    click_button "Continue"
-
     # Confirm
     expect(page).to have_content("Check and confirm answers")
     expect(page).to have_content(["Method", "By phone"].join)

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -11,7 +11,6 @@ describe "Verbal consent" do
     when_i_confirm_the_consent_response
     then_an_email_is_sent_to_the_parent_confirming_their_consent
     and_a_text_is_sent_to_the_parent_confirming_their_consent
-    and_the_patients_status_is_safe_to_vaccinate
     and_i_can_see_the_consent_response_details
   end
 
@@ -39,7 +38,6 @@ describe "Verbal consent" do
     when_i_confirm_the_consent_response
     then_an_email_is_sent_to_the_parent_confirming_their_consent
     and_a_text_is_sent_to_the_parent_confirming_their_consent
-    and_the_patients_status_is_safe_to_vaccinate_with_nasal_spray
   end
 
   scenario "Given flu nasal spray and injection" do
@@ -89,16 +87,14 @@ describe "Verbal consent" do
   def when_i_record_that_verbal_injection_consent_was_given
     record_that_verbal_consent_was_given(
       consent_option: "Yes, for the injected vaccine only",
-      number_of_health_questions: 4,
-      triage_option: "Yes, it’s safe to vaccinate with injected vaccine"
+      number_of_health_questions: 4
     )
   end
 
   def when_i_record_that_verbal_nasal_consent_was_given
     record_that_verbal_consent_was_given(
       consent_option: "Yes, for the nasal spray",
-      number_of_health_questions: 9,
-      triage_option: "Yes, it’s safe to vaccinate with nasal spray"
+      number_of_health_questions: 9
     )
   end
 
@@ -106,7 +102,6 @@ describe "Verbal consent" do
     record_that_verbal_consent_was_given(
       consent_option: "Yes, for the nasal spray",
       number_of_health_questions: 10,
-      triage_option: "Yes, it’s safe to vaccinate with nasal spray",
       injective_alternative: true
     )
   end
@@ -114,7 +109,6 @@ describe "Verbal consent" do
   def record_that_verbal_consent_was_given(
     consent_option:,
     number_of_health_questions:,
-    triage_option: "Yes, it’s safe to vaccinate",
     injective_alternative: false
   )
     visit session_consent_path(@session)
@@ -153,9 +147,6 @@ describe "Verbal consent" do
     end
 
     click_button "Continue"
-
-    choose triage_option
-    click_button "Continue"
   end
 
   def then_i_see_the_check_and_confirm_page
@@ -185,17 +176,8 @@ describe "Verbal consent" do
     expect(page).to have_content("Consent recorded for #{@patient.full_name}")
   end
 
-  def and_the_patients_status_is_safe_to_vaccinate
-    click_link @patient.full_name, match: :first
-    expect(page).to have_content("Safe to vaccinate")
-  end
-
-  def and_the_patients_status_is_safe_to_vaccinate_with_nasal_spray
-    click_link @patient.full_name, match: :first
-    expect(page).to have_content("Safe to vaccinate with nasal spray")
-  end
-
   def and_i_can_see_the_consent_response_details
+    click_link @patient.full_name, match: :first
     click_link @parent.full_name
 
     expect(page).to have_content("Consent response from #{@parent.full_name}")

--- a/spec/features/verbal_consent_given_triage_psd_spec.rb
+++ b/spec/features/verbal_consent_given_triage_psd_spec.rb
@@ -84,7 +84,12 @@ describe "Verbal consent" do
     choose "No"
     click_button "Continue"
 
-    9.times { |index| find_all(".nhsuk-fieldset")[index].choose "No" }
+    fieldsets = find_all(".nhsuk-fieldset")
+
+    8.times { |index| fieldsets[index].choose "No" }
+
+    fieldsets.last.choose "Yes"
+    fieldsets.last.fill_in "Give details", with: "Some details"
 
     click_button "Continue"
 

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -37,6 +37,8 @@ feature "Verbal consent" do
   end
 
   def when_i_record_the_consent_given_for_that_child_from_the_same_parent
+    travel 1.minute
+
     @refusing_parent = @child.consents.first.parent
 
     visit "/dashboard"
@@ -74,9 +76,6 @@ feature "Verbal consent" do
     find_all(".nhsuk-fieldset")[3].choose "No"
     click_button "Continue"
 
-    choose "Yes, it’s safe to vaccinate"
-    click_button "Continue"
-
     click_button "Confirm"
 
     expect(page).to have_alert(
@@ -100,6 +99,6 @@ feature "Verbal consent" do
     expect(page).to have_content(@child.full_name)
 
     click_on @child.full_name
-    expect(page).to have_content("Safe to vaccinate")
+    expect(page).to have_content("ready for the vaccinator")
   end
 end


### PR DESCRIPTION
This allows nurses to skip the triage step when recording verbal consent if the answers to the health questions indicates that triage is not required. After this change, the triage requirements are the same for both verbal consent and online parental consent.

[Jira Issue - MAV-2109](https://nhsd-jira.digital.nhs.uk/browse/MAV-2109)