### PR TITLE
Add sha to title of build image run

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,4 +1,5 @@
 name: Build and push image
+run-name: Build and push image for ${{ inputs.git-sha || github.sha }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
It's useful to easily tell which image was built form the GitHub action page.

Tested both with the SHA and without.

<img width="859" height="375" alt="image" src="https://github.com/user-attachments/assets/8e899462-6ae5-47e9-b022-653b63fb2a6a" />
