### PR TITLE
Validate `year_group` column

### DIFF
--- a/app/lib/mavis_cli/schools/add_programme_year_group.rb
+++ b/app/lib/mavis_cli/schools/add_programme_year_group.rb
@@ -33,15 +33,23 @@ module MavisCLI
 
         academic_year = AcademicYear.pending
 
-        ActiveRecord::Base.transaction do
-          year_groups.each do |year_group|
-            LocationProgrammeYearGroup.create!(
+        location_programme_year_groups =
+          year_groups.map do |year_group|
+            LocationProgrammeYearGroup.new(
               location:,
               programme:,
               academic_year:,
               year_group:
             )
           end
+
+        begin
+          LocationProgrammeYearGroup.import!(
+            location_programme_year_groups,
+            on_duplicate_key_ignore: true
+          )
+        rescue ActiveRecord::RecordInvalid => e
+          warn e.message
         end
       end
     end

--- a/app/models/location_programme_year_group.rb
+++ b/app/models/location_programme_year_group.rb
@@ -37,7 +37,13 @@ class LocationProgrammeYearGroup < ApplicationRecord
             .map { _2.to_birth_academic_year(academic_year: _1) }
         end
 
+  validates :year_group, inclusion: { in: :valid_year_groups }
+
   def birth_academic_year
     year_group.to_birth_academic_year(academic_year:)
   end
+
+  private
+
+  def valid_year_groups = location&.year_groups || []
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -414,6 +414,10 @@ en:
               blank: Choose a file
               empty: Choose a CSV file with at least one record
               invalid: Choose a CSV file in the correct format
+        location_programme_year_group:
+          attributes:
+            year_group:
+              inclusion: is not taught at the location
         note:
           attributes:
             body:

--- a/spec/features/cli_schools_add_programme_year_groups_spec.rb
+++ b/spec/features/cli_schools_add_programme_year_groups_spec.rb
@@ -19,9 +19,19 @@ describe "mavis schools add-programme-year-group" do
     end
   end
 
-  context "when the school and programme exists" do
+  context "when the school doesn't teach the year group" do
     it "runs successfully" do
       given_the_school_exists
+      and_the_programme_exists
+
+      when_i_run_the_command_expecting_an_error
+      then_a_validate_error_is_displayed
+    end
+  end
+
+  context "when the school and programme exists" do
+    it "runs successfully" do
+      given_the_school_exists_with_year_groups
       and_the_programme_exists
 
       when_i_run_the_command
@@ -41,12 +51,16 @@ describe "mavis schools add-programme-year-group" do
     @school = create(:school, urn: "123456")
   end
 
+  def given_the_school_exists_with_year_groups
+    @school = create(:school, urn: "123456", year_groups: [12, 13, 14])
+  end
+
   def and_the_programme_exists
     @programme = create(:programme, :flu)
   end
 
   def when_i_run_the_command
-    @output = capture_error { command }
+    @output = capture_output { command }
   end
 
   def when_i_run_the_command_expecting_an_error
@@ -59,6 +73,10 @@ describe "mavis schools add-programme-year-group" do
 
   def then_a_programme_not_found_error_message_is_displayed
     expect(@output).to include("Could not find programme.")
+  end
+
+  def then_a_validate_error_is_displayed
+    expect(@output).to include("Year group is not taught at the location")
   end
 
   def then_the_year_groups_are_added_to_the_school

--- a/spec/lib/programme_year_groups_spec.rb
+++ b/spec/lib/programme_year_groups_spec.rb
@@ -30,7 +30,7 @@ describe ProgrammeYearGroups do
       let(:team) { create(:team, programmes: [programme]) }
 
       before do
-        location = create(:school, team:)
+        location = create(:school, team:, year_groups: (0..13).to_a)
         create(
           :location_programme_year_group,
           location:,

--- a/spec/models/location_programme_year_group_spec.rb
+++ b/spec/models/location_programme_year_group_spec.rb
@@ -21,10 +21,22 @@
 #  fk_rails_...  (programme_id => programmes.id) ON DELETE => cascade
 #
 describe LocationProgrammeYearGroup do
-  subject { build(:location_programme_year_group) }
+  subject(:location_programme_year_group) do
+    build(:location_programme_year_group, location:)
+  end
+
+  let(:location) { create(:school) }
 
   describe "associations" do
     it { should belong_to(:location) }
     it { should belong_to(:programme) }
+  end
+
+  describe "validations" do
+    it "validates year group is suitable for the location" do
+      expect(location_programme_year_group).to validate_inclusion_of(
+        :year_group
+      ).in_array(location.year_groups)
+    end
   end
 end


### PR DESCRIPTION
This adds validation to the `LocationProgrammeYearGroup` model ensuring that the year group is suitable for the location. This should avoid a situation where a programme year group is added to a location, but the location doesn't include that year group meaning the patients don't appear correctly in sessions.

[Jira Issue - MAV-2136](https://nhsd-jira.digital.nhs.uk/browse/MAV-2136)