### PR TITLE
Allow submitting consent for an unscheduled session

### DIFF
--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -102,6 +102,7 @@ module ParentInterface
     end
 
     def check_if_past_deadline!
+      return if @session.unscheduled?
       return if @session.open_for_consent?
 
       redirect_to deadline_passed_parent_interface_consent_forms_path(

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -624,17 +624,10 @@ describe ConsentForm do
       context "with an unscheduled and scheduled school session" do
         before do
           create(:session, :unscheduled, location: school, team:, programmes:)
-        end
-
-        let!(:scheduled_school_session) do
           create(:session, :scheduled, location: school, team:, programmes:)
         end
 
-        # This intentionally returns the school session because the clinic session
-        # might not be scheduled with dates yet (which is usually the case early
-        # on at the beginning of the year), and without a session the user sees
-        # a page saying the deadline has passed.
-        it { should eq(scheduled_school_session) }
+        it { should eq(generic_clinic_session) }
       end
     end
 


### PR DESCRIPTION
When filling in a consent form and recording that the child goes to a different school to the one we thought, this ensures that the consent form doesn't show the "deadline passed" end state if the new school session is unscheduled. This situation could occur if the new school doesn't have dates yet, but will do in the future, meaning that submitting consent at this point is worth doing.

This partially reverts 63b0d9329aef8db8746201a27494703ab458ec65 which introduce this regression in this specific scenario.