### PR TITLE
Add test to verify the consent status for conflicting consents

### DIFF
--- a/spec/lib/status_generator/vaccination_spec.rb
+++ b/spec/lib/status_generator/vaccination_spec.rb
@@ -56,6 +56,21 @@ describe StatusGenerator::Vaccination do
       it { should be(:could_not_vaccinate) }
     end
 
+    context "with a conflicting consents" do
+      before do
+        create(:consent, :given, patient:, programme:)
+        create(
+          :consent,
+          :refused,
+          patient:,
+          programme:,
+          parent: create(:parent)
+        )
+      end
+
+      it { should be(:could_not_vaccinate) }
+    end
+
     context "with a triage as unsafe to vaccination" do
       before { create(:triage, :do_not_vaccinate, patient:, programme:) }
 


### PR DESCRIPTION
This test comes off the back of discussions relating to the new design for the session overview page, specifically the programme status tallies.

The test confirms that if we get conflicting consent records, the consent status generator will return `could_not_vaccinate`.