### PR TITLE
Add crossorigin auth for manifest in non-prod

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,6 +54,7 @@ or set it with content_for(:page_title)."
   end
 
   def manifest_link_tag(name, **options)
+    options[:crossorigin] ||= "use-credentials" unless Rails.env.production?
     tag.link(href: manifest_path(name, manifest_digest), **options)
   end
 


### PR DESCRIPTION
Without this we get errors when retrieving the manifest behind basic auth.

Jira-Issue: [MAV-1975](https://nhsd-jira.digital.nhs.uk/browse/MAV-1975)