### PR TITLE
Fix issue saving session dates

### DIFF
--- a/app/controllers/draft_sessions_controller.rb
+++ b/app/controllers/draft_sessions_controller.rb
@@ -79,11 +79,13 @@ class DraftSessionsController < ApplicationController
       .with_index
       .reverse_each do |session_date, index|
       attributes = session_dates_attrs["session_date_#{index}"]
-      if attributes["_destroy"].present?
-        @draft_session.session_dates.delete_at(index)
-        jump_to("dates")
-      else
-        session_date.assign_attributes(attributes)
+      if attributes.present?
+        if attributes["_destroy"].present?
+          @draft_session.session_dates.delete_at(index)
+          jump_to("dates")
+        else
+          session_date.assign_attributes(attributes)
+        end
       end
     end
 

--- a/spec/features/manage_school_sessions_spec.rb
+++ b/spec/features/manage_school_sessions_spec.rb
@@ -51,6 +51,7 @@ describe "Manage school sessions" do
     then_they_can_give_consent
 
     when_the_deadline_has_passed
+    and_patients_have_been_seen
     then_they_can_no_longer_give_consent
     and_i_am_signed_in
 
@@ -59,6 +60,9 @@ describe "Manage school sessions" do
     then_i_see_the_school
 
     when_i_click_on_the_school
+    and_i_click_on_edit_dates
+    then_i_see_the_dates_page_but_cannot_change
+
     and_i_click_on_send_invitations
     then_i_see_the_send_invitations_page
 
@@ -181,6 +185,20 @@ describe "Manage school sessions" do
     click_on "Add session dates"
   end
 
+  def and_i_click_on_edit_dates
+    click_on "Edit session"
+    click_on "Change session dates"
+  end
+
+  def then_i_see_the_dates_page_but_cannot_change
+    expect(page).to have_content(
+      "Children have attended this session. It cannot be changed."
+    )
+
+    click_on "Continue"
+    click_on "Save changes"
+  end
+
   def then_i_see_the_dates_page
     expect(page).to have_content("When will sessions be held?")
   end
@@ -286,6 +304,15 @@ describe "Manage school sessions" do
 
   def when_the_deadline_has_passed
     travel_to(Time.zone.local(2024, 3, 12))
+  end
+
+  def and_patients_have_been_seen
+    create(
+      :attendance_record,
+      :present,
+      patient: @patient,
+      session: @session.reload
+    )
   end
 
   def then_they_can_no_longer_give_consent


### PR DESCRIPTION
This fixes an issue when trying to save session dates where one of the dates cannot be modified due to patients have already been seen at that date.

[Jira Issue - MAV-516](https://nhsd-jira.digital.nhs.uk/browse/MAV-516)
[Sentry Issue](https://good-machine.sentry.io/issues/6925585376/)