### PR TITLE
Reverse logic for patient lookups

### DIFF
--- a/app/controllers/programmes/base_controller.rb
+++ b/app/controllers/programmes/base_controller.rb
@@ -27,6 +27,5 @@ class Programmes::BaseController < ApplicationController
         .appear_in_programmes([@programme], academic_year: @academic_year)
         .not_archived(team: current_team)
         .pluck(:id)
-        .uniq
   end
 end


### PR DESCRIPTION
- Instead of searching for each patient ID whether it satisfies some existance criteria we instead search for all programme_id's which are linked to patient_id's via the same criteria
- This simplifies logic and should also boost performance

## Screenshots

## Pre-release tasks

- ...

## Post-release tasks

- ...
