### PR TITLE
Add `Delegatable` concern

### DIFF
--- a/app/models/concerns/delegatable.rb
+++ b/app/models/concerns/delegatable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Delegatable
+  extend ActiveSupport::Concern
+
+  def supports_delegation? = programmes.any?(&:supports_delegation?)
+
+  def pgd_supply_enabled? = supports_delegation? && !psd_enabled?
+end

--- a/app/models/draft_session.rb
+++ b/app/models/draft_session.rb
@@ -8,6 +8,7 @@ class DraftSession
   include ActiveRecord::AttributeMethods::Serialization
   include Consentable
   include DaysBeforeToWeeksBefore
+  include Delegatable
 
   attribute :days_before_consent_reminders, :integer
   attribute :location_id, :integer
@@ -36,7 +37,7 @@ class DraftSession
 
     steps << :register_attendance
 
-    steps << :delegation if session.supports_delegation?
+    steps << :delegation if supports_delegation?
 
     steps + %i[confirm]
   end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -32,6 +32,7 @@
 class Session < ApplicationRecord
   include Consentable
   include DaysBeforeToWeeksBefore
+  include Delegatable
 
   audited associated_with: :location
   has_associated_audits
@@ -203,10 +204,6 @@ class Session < ApplicationRecord
     return false if dates.empty?
     Date.current > dates.min
   end
-
-  def supports_delegation? = programmes.any?(&:supports_delegation?)
-
-  def pgd_supply_enabled? = supports_delegation? && !psd_enabled?
 
   def year_groups
     @year_groups ||= location_programme_year_groups.pluck_year_groups


### PR DESCRIPTION
This adds a concern which can be shared by both the `DraftSession` and `Session` models to avoid needing to determine whether a draft session supports delegation through the underlying session.