### PR TITLE
Allow `GovukNotifyPersonalisation` to handle `session = nil`

### DIFF
--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -4,7 +4,7 @@ module VaccinationMailerConcern
   extend ActiveSupport::Concern
 
   def send_vaccination_confirmation(vaccination_record)
-    parents = NotificationParentSelector.call(vaccination_record:)
+    parents = NotificationParentSelector.select_parents(vaccination_record:)
     return if parents.empty?
 
     template_name =
@@ -33,7 +33,7 @@ module VaccinationMailerConcern
   end
 
   def send_vaccination_deletion(vaccination_record)
-    parents = NotificationParentSelector.call(vaccination_record:)
+    parents = NotificationParentSelector.select_parents(vaccination_record:)
     return if parents.empty?
 
     sent_by = try(:current_user)

--- a/app/controllers/concerns/vaccination_mailer_concern.rb
+++ b/app/controllers/concerns/vaccination_mailer_concern.rb
@@ -4,7 +4,7 @@ module VaccinationMailerConcern
   extend ActiveSupport::Concern
 
   def send_vaccination_confirmation(vaccination_record)
-    parents = NotificationParentSelector.select_parents(vaccination_record:)
+    parents = NotificationParentSelector.new(vaccination_record:).parents
     return if parents.empty?
 
     template_name =
@@ -33,7 +33,7 @@ module VaccinationMailerConcern
   end
 
   def send_vaccination_deletion(vaccination_record)
-    parents = NotificationParentSelector.select_parents(vaccination_record:)
+    parents = NotificationParentSelector.new(vaccination_record:).parents
     return if parents.empty?
 
     sent_by = try(:current_user)

--- a/app/lib/already_had_notification_sender.rb
+++ b/app/lib/already_had_notification_sender.rb
@@ -34,18 +34,25 @@ class AlreadyHadNotificationSender
     parents = NotificationParentSelector.call(vaccination_record:, consents:)
 
     parents.each do |parent|
+      consents = parent.consents.where(patient: @vaccination_record.patient)
+
+      consent =
+        ConsentGrouper.call(consents, programme_id:, academic_year:).last
+
       if parent.phone_receive_updates
         SMSDeliveryJob.perform_later(
           :vaccination_discovered,
           parent:,
-          vaccination_record:
+          vaccination_record:,
+          consent:
         )
       end
 
       EmailDeliveryJob.perform_later(
         :vaccination_discovered,
         parent:,
-        vaccination_record:
+        vaccination_record:,
+        consent:
       )
     end
 

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -309,10 +309,7 @@ class GovukNotifyPersonalisation
     ].join("\n\n")
   end
 
-  delegate :privacy_notice_url,
-           :privacy_policy_url,
-           to: :team,
-           prefix: true
+  delegate :privacy_notice_url, :privacy_policy_url, to: :team, prefix: true
 
   def today_or_date_of_vaccination
     return if vaccination_record.nil?

--- a/app/lib/govuk_notify_personalisation.rb
+++ b/app/lib/govuk_notify_personalisation.rb
@@ -107,6 +107,8 @@ class GovukNotifyPersonalisation
   end
 
   def consent_deadline
+    return nil if session.nil?
+
     next_date = session.future_dates.first
 
     close_consent_at =
@@ -117,6 +119,7 @@ class GovukNotifyPersonalisation
 
   def consent_link
     return nil if session.nil? || programmes.empty?
+
     host +
       start_parent_interface_consent_forms_path(
         session,
@@ -173,41 +176,41 @@ class GovukNotifyPersonalisation
     if vaccination_record
       vaccination_record_location(vaccination_record)
     else
-      session.location.name
+      session&.location&.name
     end
   end
 
   def next_or_today_session_date
-    session.next_date(include_today: true)&.to_fs(:short_day_of_week)
+    session&.next_date(include_today: true)&.to_fs(:short_day_of_week)
   end
 
   def next_or_today_session_dates
     session
-      .today_or_future_dates
-      .map { it.to_fs(:short_day_of_week) }
-      .to_sentence
+      &.today_or_future_dates
+      &.map { it.to_fs(:short_day_of_week) }
+      &.to_sentence
   end
 
   def next_or_today_session_dates_or
     session
-      .today_or_future_dates
-      .map { it.to_fs(:short_day_of_week) }
-      .to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
+      &.today_or_future_dates
+      &.map { it.to_fs(:short_day_of_week) }
+      &.to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
   end
 
   def next_session_date
-    session.next_date(include_today: false)&.to_fs(:short_day_of_week)
+    session&.next_date(include_today: false)&.to_fs(:short_day_of_week)
   end
 
   def next_session_dates
-    session.future_dates.map { it.to_fs(:short_day_of_week) }.to_sentence
+    session&.future_dates&.map { it.to_fs(:short_day_of_week) }&.to_sentence
   end
 
   def next_session_dates_or
     session
-      .future_dates
-      .map { it.to_fs(:short_day_of_week) }
-      .to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
+      &.future_dates
+      &.map { it.to_fs(:short_day_of_week) }
+      &.to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
   end
 
   def outcome_administered
@@ -263,6 +266,8 @@ class GovukNotifyPersonalisation
   end
 
   def subsequent_session_dates_offered_message
+    return nil if session.nil?
+
     dates = session.future_dates.drop(1)
     return "" if dates.empty?
 
@@ -304,7 +309,10 @@ class GovukNotifyPersonalisation
     ].join("\n\n")
   end
 
-  delegate :privacy_notice_url, :privacy_policy_url, to: :team, prefix: true
+  delegate :privacy_notice_url,
+           :privacy_policy_url,
+           to: :team,
+           prefix: true
 
   def today_or_date_of_vaccination
     return if vaccination_record.nil?

--- a/app/lib/notification_parent_selector.rb
+++ b/app/lib/notification_parent_selector.rb
@@ -5,54 +5,40 @@ class NotificationParentSelector
     @vaccination_record = vaccination_record
 
     @consents =
-      if consents.present?
-        consents
-      else
-        patient = @vaccination_record.patient
-
-        if patient.send_notifications? && @vaccination_record.notify_parents
+      consents ||
+        if patient.send_notifications? && vaccination_record.notify_parents
           patient.consents
         else
           []
         end
-      end
   end
 
-  def select_parents
-    consents = select_consents
-
-    consents
-      .map do |consent|
-        NotificationParentSelector.select_parents_from_consent(
-          consent:,
-          patient: @vaccination_record.patient
-        )
-      end
-      .flatten
-      .uniq
+  def parents_with_consent
+    if (self_consent = latest_consents.find(&:via_self_consent?))
+      patient
+        .parents
+        .select(&:contactable?)
+        .map { |parent| [parent, self_consent] }
+    else
+      latest_consents
+        .select(&:response_given?)
+        .filter_map do |consent|
+          parent = consent.parent
+          [parent, consent] if parent&.contactable?
+        end
+    end
   end
 
-  def self.select_parents_from_consent(consent:, patient:)
-    parents = (consent.via_self_consent? ? patient.parents : [consent.parent])
-
-    parents.select(&:contactable?)
-  end
-
-  def select_consents
-    programme_id = @vaccination_record.programme_id
-    academic_year = @vaccination_record.academic_year
-
-    consents = ConsentGrouper.call(@consents, programme_id:, academic_year:)
-
-    consents.select(&:response_provided?)
-  end
-
-  def self.select_parents(...) = new(...).select_parents
-  def self.select_consents(...) = new(...).select_consents
-
-  private_class_method :new
+  def parents = parents_with_consent.map(&:first)
 
   private
 
   attr_reader :vaccination_record, :consents
+
+  delegate :patient, :programme_id, :academic_year, to: :vaccination_record
+
+  def latest_consents
+    @latest_consents ||=
+      ConsentGrouper.call(consents, programme_id:, academic_year:)
+  end
 end

--- a/spec/lib/already_had_notification_sender_spec.rb
+++ b/spec/lib/already_had_notification_sender_spec.rb
@@ -163,11 +163,14 @@ describe AlreadyHadNotificationSender do
         end
 
         context "with withdrawn consents" do
-          before do
-            first_consent.update!(
-              withdrawn_at: 1.day.ago,
-              notes: "Some notes",
-              reason_for_refusal: "personal_choice"
+          let!(:first_consent) do
+            create(
+              :consent,
+              :withdrawn,
+              patient:,
+              programme:,
+              parent: first_parent,
+              academic_year:
             )
           end
 

--- a/spec/lib/already_had_notification_sender_spec.rb
+++ b/spec/lib/already_had_notification_sender_spec.rb
@@ -87,13 +87,15 @@ describe AlreadyHadNotificationSender do
           expect(EmailDeliveryJob).to have_been_enqueued.with(
             :vaccination_discovered,
             parent: first_parent,
-            vaccination_record:
+            vaccination_record:,
+            consent: first_consent
           )
 
           expect(EmailDeliveryJob).to have_been_enqueued.with(
             :vaccination_discovered,
             parent: second_parent,
-            vaccination_record:
+            vaccination_record:,
+            consent: second_consent
           )
         end
 
@@ -103,13 +105,15 @@ describe AlreadyHadNotificationSender do
           expect(SMSDeliveryJob).to have_been_enqueued.with(
             :vaccination_discovered,
             parent: first_parent,
-            vaccination_record:
+            vaccination_record:,
+            consent: first_consent
           )
 
           expect(SMSDeliveryJob).not_to have_been_enqueued.with(
             :vaccination_discovered,
             parent: second_parent,
-            vaccination_record:
+            vaccination_record:,
+            consent: second_consent
           )
         end
 
@@ -145,13 +149,15 @@ describe AlreadyHadNotificationSender do
             expect(EmailDeliveryJob).not_to have_been_enqueued.with(
               :vaccination_discovered,
               parent: first_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: first_consent
             )
 
             expect(EmailDeliveryJob).to have_been_enqueued.with(
               :vaccination_discovered,
               parent: second_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: second_consent
             )
           end
         end
@@ -171,13 +177,15 @@ describe AlreadyHadNotificationSender do
             expect(EmailDeliveryJob).not_to have_been_enqueued.with(
               :vaccination_discovered,
               parent: first_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: first_consent
             )
 
             expect(EmailDeliveryJob).to have_been_enqueued.with(
               :vaccination_discovered,
               parent: second_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: second_consent
             )
           end
         end
@@ -196,13 +204,15 @@ describe AlreadyHadNotificationSender do
             expect(EmailDeliveryJob).not_to have_been_enqueued.with(
               :vaccination_discovered,
               parent: first_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: first_consent
             )
 
             expect(EmailDeliveryJob).to have_been_enqueued.with(
               :vaccination_discovered,
               parent: second_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: second_consent
             )
           end
         end
@@ -221,13 +231,15 @@ describe AlreadyHadNotificationSender do
             expect(EmailDeliveryJob).to have_been_enqueued.with(
               :vaccination_discovered,
               parent: first_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: first_consent
             )
 
             expect(EmailDeliveryJob).to have_been_enqueued.with(
               :vaccination_discovered,
               parent: second_parent,
-              vaccination_record:
+              vaccination_record:,
+              consent: second_consent
             )
           end
         end

--- a/spec/lib/govuk_notify_personalisation_spec.rb
+++ b/spec/lib/govuk_notify_personalisation_spec.rb
@@ -513,4 +513,13 @@ describe GovukNotifyPersonalisation do
       end
     end
   end
+
+  context "with session nil" do
+    let(:session) { nil }
+    let(:consent) { create(:consent, patient:) }
+
+    it "doesn't throw an error" do
+      expect { to_h }.not_to raise_error
+    end
+  end
 end

--- a/spec/lib/notification_parent_selector_spec.rb
+++ b/spec/lib/notification_parent_selector_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 describe NotificationParentSelector do
-  describe "#call" do
-    subject(:call) { described_class.call(vaccination_record:, consents:) }
+  describe "#select_parents" do
+    subject(:select_parents) do
+      described_class.select_parents(vaccination_record:, consents:)
+    end
 
     let(:programme) { create(:programme) }
     let(:academic_year) { AcademicYear.current }
@@ -59,7 +61,7 @@ describe NotificationParentSelector do
 
       context "when consents have responses" do
         it "returns contactable parents from consents with responses" do
-          expect(call).to contain_exactly(first_parent, second_parent)
+          expect(select_parents).to contain_exactly(first_parent, second_parent)
         end
       end
 
@@ -89,7 +91,7 @@ describe NotificationParentSelector do
         end
 
         it "returns parents only from consents with provided responses" do
-          expect(call).to contain_exactly(second_parent)
+          expect(select_parents).to contain_exactly(second_parent)
         end
       end
 
@@ -100,7 +102,7 @@ describe NotificationParentSelector do
         end
 
         it "returns only contactable parents" do
-          expect(call).to contain_exactly(second_parent)
+          expect(select_parents).to contain_exactly(second_parent)
         end
       end
 
@@ -128,7 +130,7 @@ describe NotificationParentSelector do
         end
 
         it "returns all patient parents instead of consent parents" do
-          expect(call).to contain_exactly(first_parent, second_parent)
+          expect(select_parents).to contain_exactly(first_parent, second_parent)
         end
 
         context "when some patient parents are not contactable" do
@@ -141,7 +143,7 @@ describe NotificationParentSelector do
           end
 
           it "returns only contactable patient parents" do
-            expect(call).to contain_exactly(second_parent)
+            expect(select_parents).to contain_exactly(second_parent)
           end
         end
       end
@@ -164,7 +166,7 @@ describe NotificationParentSelector do
       end
 
       it "returns empty array" do
-        expect(call).to eq([])
+        expect(select_parents).to eq([])
       end
     end
 
@@ -176,7 +178,7 @@ describe NotificationParentSelector do
       end
 
       it "returns empty array" do
-        expect(call).to eq([])
+        expect(select_parents).to eq([])
       end
     end
 
@@ -186,7 +188,7 @@ describe NotificationParentSelector do
       before { allow(ConsentGrouper).to receive(:call).and_return([]) }
 
       it "handles empty consents gracefully" do
-        expect(call).to eq([])
+        expect(select_parents).to eq([])
       end
 
       context "when grouped consents are empty" do
@@ -211,7 +213,7 @@ describe NotificationParentSelector do
         end
 
         it "returns empty array when no grouped consents" do
-          expect(call).to eq([])
+          expect(select_parents).to eq([])
         end
       end
     end
@@ -226,7 +228,7 @@ describe NotificationParentSelector do
       end
 
       it "returns empty array without processing consents" do
-        expect(described_class.call(vaccination_record:)).to eq([])
+        expect(described_class.select_parents(vaccination_record:)).to eq([])
       end
     end
   end

--- a/spec/lib/notification_parent_selector_spec.rb
+++ b/spec/lib/notification_parent_selector_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 describe NotificationParentSelector do
-  describe "#select_parents" do
-    subject(:select_parents) do
-      described_class.select_parents(vaccination_record:, consents:)
-    end
+  subject(:notification_parent_selector) do
+    described_class.new(vaccination_record:, consents:)
+  end
+
+  describe "#parents" do
+    subject(:parents) { notification_parent_selector.parents }
 
     let(:programme) { create(:programme) }
     let(:academic_year) { AcademicYear.current }
@@ -61,7 +63,7 @@ describe NotificationParentSelector do
 
       context "when consents have responses" do
         it "returns contactable parents from consents with responses" do
-          expect(select_parents).to contain_exactly(first_parent, second_parent)
+          expect(parents).to contain_exactly(first_parent, second_parent)
         end
       end
 
@@ -91,7 +93,7 @@ describe NotificationParentSelector do
         end
 
         it "returns parents only from consents with provided responses" do
-          expect(select_parents).to contain_exactly(second_parent)
+          expect(parents).to contain_exactly(second_parent)
         end
       end
 
@@ -102,7 +104,7 @@ describe NotificationParentSelector do
         end
 
         it "returns only contactable parents" do
-          expect(select_parents).to contain_exactly(second_parent)
+          expect(parents).to contain_exactly(second_parent)
         end
       end
 
@@ -130,7 +132,7 @@ describe NotificationParentSelector do
         end
 
         it "returns all patient parents instead of consent parents" do
-          expect(select_parents).to contain_exactly(first_parent, second_parent)
+          expect(parents).to contain_exactly(first_parent, second_parent)
         end
 
         context "when some patient parents are not contactable" do
@@ -143,7 +145,7 @@ describe NotificationParentSelector do
           end
 
           it "returns only contactable patient parents" do
-            expect(select_parents).to contain_exactly(second_parent)
+            expect(parents).to contain_exactly(second_parent)
           end
         end
       end
@@ -166,7 +168,7 @@ describe NotificationParentSelector do
       end
 
       it "returns empty array" do
-        expect(select_parents).to eq([])
+        expect(parents).to be_empty
       end
     end
 
@@ -178,7 +180,7 @@ describe NotificationParentSelector do
       end
 
       it "returns empty array" do
-        expect(select_parents).to eq([])
+        expect(parents).to be_empty
       end
     end
 
@@ -188,7 +190,7 @@ describe NotificationParentSelector do
       before { allow(ConsentGrouper).to receive(:call).and_return([]) }
 
       it "handles empty consents gracefully" do
-        expect(select_parents).to eq([])
+        expect(parents).to be_empty
       end
 
       context "when grouped consents are empty" do
@@ -213,7 +215,7 @@ describe NotificationParentSelector do
         end
 
         it "returns empty array when no grouped consents" do
-          expect(select_parents).to eq([])
+          expect(parents).to be_empty
         end
       end
     end
@@ -228,7 +230,7 @@ describe NotificationParentSelector do
       end
 
       it "returns empty array without processing consents" do
-        expect(described_class.select_parents(vaccination_record:)).to eq([])
+        expect(parents).to be_empty
       end
     end
   end


### PR DESCRIPTION
This fixes a bug for templates which don't need to reference a session.

[MAV-2204](https://nhsd-jira.digital.nhs.uk/browse/MAV-2204)