### PR TITLE
Active Load balancer target groups

### DIFF
--- a/terraform/app/env/preview.tfvars
+++ b/terraform/app/env/preview.tfvars
@@ -17,4 +17,4 @@ valkey_node_type          = "cache.t4g.micro"
 valkey_log_retention_days = 3
 valkey_failover_enabled   = false
 
-active_target_group = "blue"
+active_target_group = "green"

--- a/terraform/app/env/production.tfvars
+++ b/terraform/app/env/production.tfvars
@@ -28,4 +28,4 @@ container_insights        = "enhanced"
 enable_backup_to_vault        = true
 enable_enhanced_db_monitoring = true
 
-active_target_group = "blue"
+active_target_group = "green"

--- a/terraform/app/env/training.tfvars
+++ b/terraform/app/env/training.tfvars
@@ -20,4 +20,4 @@ valkey_node_type          = "cache.t4g.micro"
 valkey_log_retention_days = 3
 valkey_failover_enabled   = false
 
-active_target_group = "green"
+active_target_group = "blue"


### PR DESCRIPTION
This change is a follow-up to #4781. It is needed because a deployment happened for the 5.0.0 release, which switched the active target groups again.