### PR TITLE
Rename `wait_for_jobs_to_finish`

### DIFF
--- a/spec/jobs/pds_cascading_search_job_spec.rb
+++ b/spec/jobs/pds_cascading_search_job_spec.rb
@@ -127,7 +127,7 @@ describe PDSCascadingSearchJob do
       it "skips wildcard name steps and completes search" do
         described_class.perform_now(patient_changeset)
 
-        wait_for_jobs_to_finish(described_class.to_s)
+        perform_enqueued_jobs_while_exists(only: described_class)
         perform_enqueued_jobs(only: ProcessPatientChangesetJob)
 
         patient_changeset.reload

--- a/spec/support/imports_helper.rb
+++ b/spec/support/imports_helper.rb
@@ -4,8 +4,8 @@ module ImportsHelper
   def wait_for_import_to_complete(import_class)
     perform_enqueued_jobs(only: ProcessImportJob)
 
-    wait_for_jobs_to_finish("PDSCascadingSearchJob")
-    wait_for_jobs_to_finish("ProcessPatientChangesetJob")
+    perform_enqueued_jobs_while_exists(only: PDSCascadingSearchJob)
+    perform_enqueued_jobs_while_exists(only: ProcessPatientChangesetJob)
 
     perform_enqueued_jobs(only: CommitPatientChangesetsJob)
     click_on_most_recent_import(import_class)
@@ -16,10 +16,12 @@ module ImportsHelper
              match: :first
   end
 
-  def wait_for_jobs_to_finish(job_class)
+  def perform_enqueued_jobs_while_exists(only:)
+    job_class = only.name
+
     # rubocop:disable Style/WhileUntilModifier
     while enqueued_jobs.any? { it["job_class"] == job_class }
-      perform_enqueued_jobs(only: job_class.constantize)
+      perform_enqueued_jobs(only:)
     end
     # rubocop:enable Style/WhileUntilModifier
   end


### PR DESCRIPTION
I think `perform_enqueued_jobs_while_exists` is clearer that it continuously runs jobs while they exist (therefore allowing jobs which create new jobs to fully finish).

Using `perform_enqueued_jobs` means we're using the same prefix as the method which only performs jobs once.